### PR TITLE
chore(config): drop local-store config drift (issue #43 phase 1)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -44,16 +44,9 @@ module.exports = {
       to: { path: '^packages/(?!shared-types|domain)' },
     },
     {
-      name: 'local-store-no-firebase',
-      severity: 'error',
-      comment: '@salt/local-store must not import Firebase SDKs. Sync lives in @salt/firebase-sync.',
-      from: { path: '^packages/adapters/local-store' },
-      to: { path: '^node_modules/firebase' },
-    },
-    {
       name: 'firebase-sync-no-indexeddb',
       severity: 'error',
-      comment: '@salt/firebase-sync must not import browser storage. Local persistence lives in @salt/local-store.',
+      comment: '@salt/firebase-sync must not import browser storage. Offline reads/writes are handled by Firestore\'s persistentLocalCache.',
       from: { path: '^packages/adapters/firebase-sync' },
       to: { path: '^node_modules/(idb|idb-keyval|dexie)' },
     },
@@ -74,16 +67,9 @@ module.exports = {
     {
       name: 'adapters-no-cross-import',
       severity: 'error',
-      comment: 'local-store, firebase-sync, and ld-observability must not import each other. Compose them at the application layer.',
-      from: { path: '^packages/adapters/(local-store|firebase-sync|ld-observability)' },
-      to: { path: '^packages/adapters/(local-store|firebase-sync|ld-observability)', pathNot: '$0' },
-    },
-    {
-      name: 'cloud-functions-no-local-store',
-      severity: 'error',
-      comment: 'Cloud Functions run server-side and must not import @salt/local-store.',
-      from: { path: '^apps/cloud-functions' },
-      to: { path: '^packages/adapters/local-store' },
+      comment: 'firebase-sync and ld-observability must not import each other. Compose them at the application layer.',
+      from: { path: '^packages/adapters/(firebase-sync|ld-observability)' },
+      to: { path: '^packages/adapters/(firebase-sync|ld-observability)', pathNot: '$0' },
     },
     {
       name: 'cloud-functions-no-ld-observability-browser',

--- a/apps/cloud-functions/package.json
+++ b/apps/cloud-functions/package.json
@@ -23,7 +23,6 @@
     "@genkit-ai/google-genai": "^1.33.0",
     "@opentelemetry/sdk-trace-node": "^1.25.1",
     "@salt/domain": "workspace:*",
-    "@salt/firebase-sync": "workspace:*",
     "@salt/ld-observability": "workspace:*",
     "@salt/shared-types": "workspace:*",
     "firebase-admin": "^13.4.0",

--- a/docs/design/ui-spec-v02.md
+++ b/docs/design/ui-spec-v02.md
@@ -73,7 +73,7 @@ Allowed imports:
 
 Forbidden:
 
-- All Salt app/domain packages (`@salt/domain`, `@salt/local-store`, `@salt/firebase-sync`, `@salt/web-pwa`, `@salt/cloud-functions`)
+- All Salt app/domain packages (`@salt/domain`, `@salt/firebase-sync`, `@salt/ld-observability`, `@salt/web-pwa`, `@salt/cloud-functions`)
 - Firebase SDKs
 - Node built-ins
 - Browser APIs except inside Svelte actions or `$effect` blocks

--- a/docs/domain-implementation.md
+++ b/docs/domain-implementation.md
@@ -230,30 +230,32 @@ Canon does not know:
 - shopping lists
 - UI
 - Firebase
-- IndexedDB
+- browser storage (IndexedDB, localStorage, etc.)
 
 6.2 Ports
 ---------
-Canon exposes four sync-related ports via its `index.ts` (in addition to
-CanonLookupPort):
+Canon exposes the following sync-related ports via its `index.ts` (in
+addition to CanonLookupPort):
 
 CanonLocalStorePort
-  IndexedDB persistence for canon items — implemented by @salt/local-store
+  in-memory cache for canon items — backs live Firestore subscriptions in
+  the web client (web-pwa) and read-through reads in the cloud-functions
+  matcher
 
 CanonSyncTransportPort
-  pull/push/subscribe for canon items — implemented by @salt/firebase-sync
+  pull/subscribe for canon items — implemented by @salt/firebase-sync
 
 AisleLocalStorePort
-  IndexedDB persistence for the aisles document — implemented by @salt/local-store
+  in-memory cache for the aisles document — same pattern as above
 
 AisleSyncTransportPort
-  pull/push/subscribe for the aisles document — implemented by @salt/firebase-sync
+  pull/subscribe for the aisles document — implemented by @salt/firebase-sync
 
-Both scopes share the same manifest pattern (single `canonManifest/global`
-document with per-scope revision counters: `itemsRevision` and
-`aislesRevision`). The cursors are stored in local-store keyed
-`manifestCursor:items` and `manifestCursor:aisles`. Clients subscribe to
-the one manifest document instead of listening to any collection.
+Firestore is the live data layer: clients subscribe directly to the
+canon collections and the aisles document, and offline reads/writes are
+handled by Firestore's `persistentLocalCache`. There is no separate
+manifest document, no per-scope revision counter, and no app-managed
+cursor — the SDK owns durability.
 
 CanonLookupPort
   canonicalisation logic used by other modules — implemented by canon's

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -37,5 +37,6 @@ On failure:
   buttons, dialog containers, drag handles) but content assertions stay on roles/labels.
 - **Isolation** — fresh browser context per test; per-test unique emails (`e2e-${testId}@salt.test`).
   Firestore is cleared once per file in `globalSetup`.
-- **Seeding** — write through the existing `@salt/local-store` adapter (not raw IndexedDB) so tests
-  exercise real persistence code paths.
+- **Seeding** — write through the existing `@salt/firebase-sync` adapter so tests exercise the
+  real Firestore persistence code paths (Firestore is the live data layer; offline reads/writes
+  go through its `persistentLocalCache`).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,7 +39,7 @@ const ELEMENTS = [
 
 // Import specifier patterns that must never appear in certain layers.
 const FIREBASE_PKGS = ['firebase', 'firebase/*', 'firebase-admin', 'firebase-admin/*'];
-// Browser storage packages forbidden everywhere (no local-store remains to own them).
+// Browser storage packages forbidden everywhere — Firestore's persistentLocalCache is the offline layer.
 const INDEXEDDB_PKGS = ['idb', 'idb/*', 'idb-keyval', 'idb-keyval/*', 'dexie', 'dexie/*'];
 const SALT_APP_IMPORTS = [
   '@salt/web-pwa',
@@ -163,7 +163,7 @@ export default [
             },
             {
               from: 'cloud-functions',
-              allow: ['shared-types', 'domain', 'firebase-sync', 'ld-observability'],
+              allow: ['shared-types', 'domain', 'ld-observability'],
             },
           ],
         },

--- a/packages/adapters/ld-observability/package.json
+++ b/packages/adapters/ld-observability/package.json
@@ -18,8 +18,6 @@
   },
   "dependencies": {
     "@launchdarkly/js-client-sdk": "^4.6.3",
-    "@launchdarkly/js-server-sdk-common": "^2.18.6",
-    "@launchdarkly/node-server-sdk": "^9.10.13",
     "@launchdarkly/observability": "^1.0.0",
     "@launchdarkly/session-replay": "^1.1.6",
     "@opentelemetry/api": "1.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       '@salt/domain':
         specifier: workspace:*
         version: link:../../packages/domain
-      '@salt/firebase-sync':
-        specifier: workspace:*
-        version: link:../../packages/adapters/firebase-sync
       '@salt/ld-observability':
         specifier: workspace:*
         version: link:../../packages/adapters/ld-observability
@@ -215,12 +212,6 @@ importers:
       '@launchdarkly/js-client-sdk':
         specifier: ^4.6.3
         version: 4.6.3
-      '@launchdarkly/js-server-sdk-common':
-        specifier: ^2.18.6
-        version: 2.18.6
-      '@launchdarkly/node-server-sdk':
-        specifier: ^9.10.13
-        version: 9.10.13
       '@launchdarkly/observability':
         specifier: ^1.0.0
         version: 1.1.6
@@ -1506,15 +1497,6 @@ packages:
 
   '@launchdarkly/js-sdk-common@2.24.2':
     resolution: {integrity: sha512-SuWfR90NZ1ttGxz/2AeavfFXy/sFnFE7PhEBfg4mv0beTF9LeZwVa4XJsVeBe0Zb1PcuUQt7kn4VmFCctQIAzA==}
-
-  '@launchdarkly/js-sdk-common@2.24.3':
-    resolution: {integrity: sha512-KQaaHJcFOKvdiLIcS9f70tYLyENOmBvKI9sEKiMc43BwTwDW3AS0jyoKyCw3jCQL/sYv1+oX3VLk1urbdphGPg==}
-
-  '@launchdarkly/js-server-sdk-common@2.18.6':
-    resolution: {integrity: sha512-oc4ZJa7cuBuWN62PFR3Kcok+qVcm5XX4/5YEvcvg6cvqSRdte/8JYZ6AVAnJ9YFfYWoedpUSmFe9VXTBG/mWQw==}
-
-  '@launchdarkly/node-server-sdk@9.10.13':
-    resolution: {integrity: sha512-trN7DWtYO7BccQsMariHuIIw+QT1deqaj6jWECoT+FBlEW/Ws/oHQLX+HV2dMqKGASeofd66u+UxMTU5apGY4A==}
 
   '@launchdarkly/observability@1.1.6':
     resolution: {integrity: sha512-1giCEXw1X7FmePRpzt/O63dokP/aGLp9YcsDjfQmOe9+eBG6XYmCcSacAZfGQA8cNEE9MAmrMPce9GymVN5xKA==}
@@ -4326,10 +4308,6 @@ packages:
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
-  launchdarkly-eventsource@2.2.0:
-    resolution: {integrity: sha512-u38fYlLSq/m6oFz0MS1/76Sj2xzlYhTKZ+sf/vju6PA86PMc6fPlY5k8CdU79edLXjNwsvIQTDvDNy3llDqB8A==}
-    engines: {node: '>=0.12.0'}
-
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
@@ -5381,11 +5359,6 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.5.4:
-    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
-    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.7.4:
@@ -7685,21 +7658,6 @@ snapshots:
       '@launchdarkly/js-client-sdk-common': 1.26.1
 
   '@launchdarkly/js-sdk-common@2.24.2': {}
-
-  '@launchdarkly/js-sdk-common@2.24.3': {}
-
-  '@launchdarkly/js-server-sdk-common@2.18.6':
-    dependencies:
-      '@launchdarkly/js-sdk-common': 2.24.3
-      semver: 7.5.4
-
-  '@launchdarkly/node-server-sdk@9.10.13':
-    dependencies:
-      '@launchdarkly/js-server-sdk-common': 2.18.6
-      https-proxy-agent: 7.0.6
-      launchdarkly-eventsource: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@launchdarkly/observability@1.1.6':
     dependencies:
@@ -11197,8 +11155,6 @@ snapshots:
 
   kuler@2.0.0: {}
 
-  launchdarkly-eventsource@2.2.0: {}
-
   lazystream@1.0.1:
     dependencies:
       readable-stream: 2.3.8
@@ -12264,10 +12220,6 @@ snapshots:
       semver: 6.3.1
 
   semver@6.3.1: {}
-
-  semver@7.5.4:
-    dependencies:
-      lru-cache: 6.0.0
 
   semver@7.7.4: {}
 


### PR DESCRIPTION
Brings ESLint, dependency-cruiser, package.json deps, and the architecture docs back in line with the actual package set after @salt/local-store was removed. Mechanical cleanup only — zero runtime code touched.

- Trimmed adapters-no-cross-import to (firebase-sync|ld-observability) and removed the two local-store-targeted dep-cruiser rules; the package they guarded has not existed for some time
- Dropped @salt/firebase-sync from cloud-functions and removed it from the ESLint cloud-functions allow list together, so any future CF→firebase-sync import is rejected at both the dep-graph and lint layer
- Dropped @launchdarkly/{js-server-sdk-common,node-server-sdk}: nothing in the workspace imports them; the LD Node SDK we actually use ships via @launchdarkly/observability and @opentelemetry/sdk-trace-node
- docs/domain-implementation.md §6.2 rewritten to the post-Phase-3 narrowed port shape (in-memory caches, no manifest doc, no per-scope revision counter) so the doc doesn't have to be re-touched after Phases 2 and 3
- Left the "local-store concerns" comment in firestoreCanonStore.ts:81 alone — Phase 2 deletes the entire no-op cursor block it sits in

Closes #43 phase 1