### PR TITLE
refactor(canon): narrow CanonLocalStorePort + drop CanonItem.revision…

### DIFF
--- a/apps/cloud-functions/src/adapters/firestoreCanonStore.ts
+++ b/apps/cloud-functions/src/adapters/firestoreCanonStore.ts
@@ -28,7 +28,6 @@ function fromDoc(data: Record<string, unknown>): CanonItem {
     ...(typeof data['unit'] === 'string' ? { unit: data['unit'] as CanonItemUnit } : {}),
     ...(typeof data['reasoning'] === 'string' ? { reasoning: data['reasoning'] as string } : {}),
     updatedAt: typeof data['updatedAt'] === 'string' ? data['updatedAt'] : '',
-    revision: typeof data['revision'] === 'number' ? data['revision'] : 0,
     deletedAt: typeof data['deletedAt'] === 'string' ? data['deletedAt'] : null,
   };
 }
@@ -77,20 +76,6 @@ export function createFirestoreCanonStore(db: Firestore): CanonLocalStorePort {
       } catch (err) {
         return failure(classify(err));
       }
-    },
-    // Cursor + pending-write hooks are local-store concerns; the CF runs against
-    // Firestore directly and never queues writes. Return ok with no-op values.
-    async getCursor() {
-      return success(null);
-    },
-    async setCursor() {
-      return success(undefined);
-    },
-    async enqueuePendingWrite() {
-      return success(undefined);
-    },
-    async drainPendingWrites() {
-      return success([]);
     },
   };
 }

--- a/apps/cloud-functions/tests/flows/matchOrCreateCanon.test.ts
+++ b/apps/cloud-functions/tests/flows/matchOrCreateCanon.test.ts
@@ -94,7 +94,6 @@ function makeItem(overrides: Partial<CanonItem> & { id: string; name: string }):
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };

--- a/apps/cloud-functions/tests/flows/matchOrCreateCanon.tracePropagation.test.ts
+++ b/apps/cloud-functions/tests/flows/matchOrCreateCanon.tracePropagation.test.ts
@@ -95,7 +95,6 @@ function makeItem(overrides: Partial<CanonItem> & { id: string; name: string }):
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };

--- a/apps/web-pwa/src/lib/canonService.ts
+++ b/apps/web-pwa/src/lib/canonService.ts
@@ -129,18 +129,6 @@ export function memCanonStore(seed: readonly CanonItem[]) {
       items.delete(id);
       return { kind: 'ok', value: undefined };
     },
-    async getCursor() {
-      return { kind: 'ok', value: null };
-    },
-    async setCursor() {
-      return { kind: 'ok', value: undefined };
-    },
-    async enqueuePendingWrite() {
-      return { kind: 'ok', value: undefined };
-    },
-    async drainPendingWrites() {
-      return { kind: 'ok', value: [] };
-    },
   };
   return { store, getUpserted: () => [...upserted] };
 }

--- a/apps/web-pwa/src/lib/e2eHooks.ts
+++ b/apps/web-pwa/src/lib/e2eHooks.ts
@@ -33,7 +33,6 @@ export function installE2EHooks(): void {
         needs_approval: input.needs_approval ?? false,
         shoppingBehavior: 'needed',
         updatedAt: '',
-        revision: 0,
         deletedAt: null,
       };
       // Fire-and-forget: setDoc hangs when the SDK network is disabled (offline

--- a/apps/web-pwa/tests/CanonCreatePage.test.ts
+++ b/apps/web-pwa/tests/CanonCreatePage.test.ts
@@ -58,7 +58,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };

--- a/apps/web-pwa/tests/CanonDetailPage.test.ts
+++ b/apps/web-pwa/tests/CanonDetailPage.test.ts
@@ -66,7 +66,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };

--- a/apps/web-pwa/tests/canonService.sync.test.ts
+++ b/apps/web-pwa/tests/canonService.sync.test.ts
@@ -48,7 +48,6 @@ function makeItem(id: string, overrides: Partial<CanonItem> = {}): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };

--- a/packages/adapters/firebase-sync/src/canonSubscription.ts
+++ b/packages/adapters/firebase-sync/src/canonSubscription.ts
@@ -23,7 +23,6 @@ function fromDoc(data: Record<string, unknown>): CanonItem {
     ...(typeof data['unit'] === 'string' ? { unit: data['unit'] as CanonItemUnit } : {}),
     ...(typeof data['reasoning'] === 'string' ? { reasoning: data['reasoning'] } : {}),
     updatedAt: typeof data['updatedAt'] === 'string' ? data['updatedAt'] : '',
-    revision: typeof data['revision'] === 'number' ? data['revision'] : 0,
     deletedAt: typeof data['deletedAt'] === 'string' ? data['deletedAt'] : null,
   };
 }

--- a/packages/adapters/firebase-sync/tests/realtimeSubscriptions.emulator.test.ts
+++ b/packages/adapters/firebase-sync/tests/realtimeSubscriptions.emulator.test.ts
@@ -33,7 +33,6 @@ function makeItem(id: string, name = 'Test'): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
   };
 }

--- a/packages/domain/src/canon/commands/createCanonItem.ts
+++ b/packages/domain/src/canon/commands/createCanonItem.ts
@@ -38,7 +38,6 @@ export function createCanonItem(
     ...(input.unit !== undefined ? { unit: input.unit } : {}),
     ...(input.reasoning !== undefined ? { reasoning: input.reasoning } : {}),
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
   });
 }

--- a/packages/domain/src/canon/commands/mergeCanonItems.ts
+++ b/packages/domain/src/canon/commands/mergeCanonItems.ts
@@ -29,7 +29,6 @@ export function mergeCanonItems(local: CanonItem, remote: CanonItem): CanonItem 
     ...(remote.reasoning !== undefined ? { reasoning: remote.reasoning } : {}),
     // Server-authoritative sync fields come from remote.
     updatedAt: remote.updatedAt,
-    revision: remote.revision,
     deletedAt: remote.deletedAt,
   };
 }

--- a/packages/domain/src/canon/entities/CanonItem.ts
+++ b/packages/domain/src/canon/entities/CanonItem.ts
@@ -18,8 +18,6 @@ export interface CanonItem {
   readonly unit?: CanonItemUnit;
   readonly reasoning?: string;
   // Sync fields — stamped server-side by the onCanonItemWritten CF trigger.
-  // New local items start with revision 0 and empty updatedAt until first sync.
   readonly updatedAt: string; // ISO-8601
-  readonly revision: number;
   readonly deletedAt: string | null; // null = live; non-null = soft-deleted tombstone
 }

--- a/packages/domain/src/canon/index.ts
+++ b/packages/domain/src/canon/index.ts
@@ -6,7 +6,7 @@
 export type { CanonItem, ShoppingBehavior, CanonItemUnit } from './entities/CanonItem.js';
 export type { Aisle } from './entities/Aisle.js';
 export type { AislesDocument } from './entities/AislesDocument.js';
-export type { CanonLocalStorePort, CursorScope } from './ports/CanonLocalStorePort.js';
+export type { CanonLocalStorePort } from './ports/CanonLocalStorePort.js';
 export type { AisleLocalStorePort } from './ports/AisleLocalStorePort.js';
 export type { CanonLookupPort } from './ports/CanonLookupPort.js';
 export type { IdGenerator } from './ports/IdGenerator.js';

--- a/packages/domain/src/canon/ports/CanonLocalStorePort.ts
+++ b/packages/domain/src/canon/ports/CanonLocalStorePort.ts
@@ -2,16 +2,9 @@ import type { ReadResult } from '@salt/shared-types';
 import type { DomainError } from '@salt/shared-types';
 import type { CanonItem } from '../entities/CanonItem.js';
 
-/** Identifies which entity scope the manifest cursor belongs to. */
-export type CursorScope = 'items' | 'aisles';
-
 export interface CanonLocalStorePort {
   upsert(item: CanonItem): Promise<ReadResult<CanonItem, DomainError>>;
   load(id: string): Promise<ReadResult<CanonItem | null, DomainError>>;
   list(): Promise<ReadResult<readonly CanonItem[], DomainError>>;
   delete(id: string): Promise<ReadResult<void, DomainError>>;
-  getCursor(scope: CursorScope): Promise<ReadResult<number | null, DomainError>>;
-  setCursor(scope: CursorScope, value: number): Promise<ReadResult<void, DomainError>>;
-  enqueuePendingWrite(item: CanonItem): Promise<ReadResult<void, DomainError>>;
-  drainPendingWrites(): Promise<ReadResult<CanonItem[], DomainError>>;
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -9,7 +9,6 @@ export type {
   Aisle,
   AislesDocument,
   CanonLocalStorePort,
-  CursorScope,
   AisleLocalStorePort,
   CanonLookupPort,
   IdGenerator,

--- a/packages/domain/tests/canon/approveCanonItem.test.ts
+++ b/packages/domain/tests/canon/approveCanonItem.test.ts
@@ -13,7 +13,6 @@ const base: CanonItem = {
   needs_approval: true,
   shoppingBehavior: 'needed',
   updatedAt: '',
-  revision: 0,
   deletedAt: null,
 };
 

--- a/packages/domain/tests/canon/canonItem.schema.test.ts
+++ b/packages/domain/tests/canon/canonItem.schema.test.ts
@@ -14,10 +14,6 @@ describe('CanonItem schema', () => {
       expectTypeOf<CanonItem['schemaVersion']>().toEqualTypeOf<4>();
     });
 
-    it('revision is a number', () => {
-      expectTypeOf<CanonItem['revision']>().toEqualTypeOf<number>();
-    });
-
     it('updatedAt is a string', () => {
       expectTypeOf<CanonItem['updatedAt']>().toEqualTypeOf<string>();
     });
@@ -31,11 +27,6 @@ describe('CanonItem schema', () => {
     it('newly created item has schemaVersion 4', () => {
       const result = createCanonItem({ name: 'Tomato' }, counterIds());
       expect(result.kind === 'ok' && result.value.schemaVersion).toBe(4);
-    });
-
-    it('newly created item has revision 0', () => {
-      const result = createCanonItem({ name: 'Tomato' }, counterIds());
-      expect(result.kind === 'ok' && result.value.revision).toBe(0);
     });
 
     it('newly created item has empty updatedAt (pre-sync sentinel)', () => {
@@ -53,7 +44,7 @@ describe('CanonItem schema', () => {
     it('a live item has deletedAt null', () => {
       const item: CanonItem = {
         id: 'x',
-        schemaVersion: 3,
+        schemaVersion: 4,
         name: 'Butter',
         synonyms: [],
         aisleId: null,
@@ -62,7 +53,6 @@ describe('CanonItem schema', () => {
         needs_approval: false,
         shoppingBehavior: 'needed',
         updatedAt: '2026-01-01T00:00:00.000Z',
-        revision: 3,
         deletedAt: null,
       };
       expect(item.deletedAt).toBeNull();
@@ -71,7 +61,7 @@ describe('CanonItem schema', () => {
     it('a tombstone item has a non-null deletedAt ISO string', () => {
       const tombstone: CanonItem = {
         id: 'x',
-        schemaVersion: 3,
+        schemaVersion: 4,
         name: 'Butter',
         synonyms: [],
         aisleId: null,
@@ -80,30 +70,10 @@ describe('CanonItem schema', () => {
         needs_approval: false,
         shoppingBehavior: 'needed',
         updatedAt: '2026-01-01T00:00:00.000Z',
-        revision: 4,
         deletedAt: '2026-01-02T00:00:00.000Z',
       };
       expect(tombstone.deletedAt).not.toBeNull();
       expect(typeof tombstone.deletedAt).toBe('string');
-    });
-
-    it('revision advances monotonically (higher revision = newer state)', () => {
-      const v1: CanonItem = {
-        id: 'x',
-        schemaVersion: 3,
-        name: 'A',
-        synonyms: [],
-        aisleId: null,
-        thumbnail: null,
-        embedding: null,
-        needs_approval: false,
-        shoppingBehavior: 'needed',
-        updatedAt: '',
-        revision: 1,
-        deletedAt: null,
-      };
-      const v2: CanonItem = { ...v1, revision: 2 };
-      expect(v2.revision).toBeGreaterThan(v1.revision);
     });
   });
 });

--- a/packages/domain/tests/canon/clientFastPathParity.integration.test.ts
+++ b/packages/domain/tests/canon/clientFastPathParity.integration.test.ts
@@ -36,7 +36,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };
@@ -55,10 +54,6 @@ function makeStore(initial: CanonItem[]): CanonLocalStorePort & { items: CanonIt
       return { kind: 'ok', value: item };
     },
     delete: async () => ({ kind: 'ok', value: undefined }),
-    getCursor: async () => ({ kind: 'ok', value: null }),
-    setCursor: async () => ({ kind: 'ok', value: undefined }),
-    enqueuePendingWrite: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingWrites: async () => ({ kind: 'ok', value: [] }),
   };
 }
 

--- a/packages/domain/tests/canon/createCanonItem.test.ts
+++ b/packages/domain/tests/canon/createCanonItem.test.ts
@@ -27,7 +27,6 @@ describe('createCanonItem', () => {
       needs_approval: true,
       shoppingBehavior: 'needed',
       updatedAt: '',
-      revision: 0,
       deletedAt: null,
     });
   });

--- a/packages/domain/tests/canon/createCanonLookup.test.ts
+++ b/packages/domain/tests/canon/createCanonLookup.test.ts
@@ -16,7 +16,6 @@ const seed: readonly CanonItem[] = [
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
   },
   {
@@ -30,7 +29,6 @@ const seed: readonly CanonItem[] = [
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
   },
 ];
@@ -107,7 +105,6 @@ describe('createCanonLookup', () => {
         needs_approval: false,
         shoppingBehavior: 'needed',
         updatedAt: '',
-        revision: 0,
         deletedAt: null,
       },
     ]);

--- a/packages/domain/tests/canon/deleteAisles.test.ts
+++ b/packages/domain/tests/canon/deleteAisles.test.ts
@@ -32,10 +32,6 @@ function makeCanonStore(initial: CanonItem[] = []): CanonLocalStorePort & { item
       return { kind: 'ok', value: item };
     },
     delete: async () => ({ kind: 'ok', value: undefined }),
-    getCursor: async () => ({ kind: 'ok', value: null }),
-    setCursor: async () => ({ kind: 'ok', value: undefined }),
-    enqueuePendingWrite: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingWrites: async () => ({ kind: 'ok', value: [] }),
   };
 }
 
@@ -48,7 +44,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };
@@ -100,10 +95,6 @@ describe('deleteAisles', () => {
       load: async () => ({ kind: 'ok', value: null }),
       upsert: async (item) => ({ kind: 'ok', value: item }),
       delete: async () => ({ kind: 'ok', value: undefined }),
-      getCursor: async () => ({ kind: 'ok', value: null }),
-      setCursor: async () => ({ kind: 'ok', value: undefined }),
-      enqueuePendingWrite: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingWrites: async () => ({ kind: 'ok', value: [] }),
     };
     const result = await deleteAisles({ ids: ['a1'] }, aisleStore, canonStore);
     expect(result.kind).toBe('err');

--- a/packages/domain/tests/canon/findClosestMatch.test.ts
+++ b/packages/domain/tests/canon/findClosestMatch.test.ts
@@ -12,7 +12,6 @@ function item(overrides: Partial<CanonItem> & { id: string; name: string }): Can
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };

--- a/packages/domain/tests/canon/getAisleUsage.test.ts
+++ b/packages/domain/tests/canon/getAisleUsage.test.ts
@@ -25,10 +25,6 @@ function makeCanonStore(initial: CanonItem[] = []): CanonLocalStorePort {
     load: async (id) => ({ kind: 'ok', value: items.find((i) => i.id === id) ?? null }),
     upsert: async (item) => ({ kind: 'ok', value: item }),
     delete: async () => ({ kind: 'ok', value: undefined }),
-    getCursor: async () => ({ kind: 'ok', value: null }),
-    setCursor: async () => ({ kind: 'ok', value: undefined }),
-    enqueuePendingWrite: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingWrites: async () => ({ kind: 'ok', value: [] }),
   };
 }
 
@@ -41,7 +37,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };
@@ -109,10 +104,6 @@ describe('getAisleUsage', () => {
       load: async () => ({ kind: 'ok', value: null }),
       upsert: async (item) => ({ kind: 'ok', value: item }),
       delete: async () => ({ kind: 'ok', value: undefined }),
-      getCursor: async () => ({ kind: 'ok', value: null }),
-      setCursor: async () => ({ kind: 'ok', value: undefined }),
-      enqueuePendingWrite: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingWrites: async () => ({ kind: 'ok', value: [] }),
     };
     const result = await getAisleUsage(aisleStore, canonStore);
     expect(result.kind).toBe('err');

--- a/packages/domain/tests/canon/matchOrCreate.test.ts
+++ b/packages/domain/tests/canon/matchOrCreate.test.ts
@@ -21,7 +21,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };
@@ -49,10 +48,6 @@ function makeStore(initial: CanonItem[] = []): CanonLocalStorePort & { items: Ca
       return { kind: 'ok', value: item };
     },
     delete: async () => ({ kind: 'ok', value: undefined }),
-    getCursor: async () => ({ kind: 'ok', value: null }),
-    setCursor: async () => ({ kind: 'ok', value: undefined }),
-    enqueuePendingWrite: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingWrites: async () => ({ kind: 'ok', value: [] }),
   };
 }
 
@@ -479,10 +474,6 @@ describe('error paths', () => {
       load: async () => ({ kind: 'ok', value: null }),
       upsert: async (i) => ({ kind: 'ok', value: i }),
       delete: async () => ({ kind: 'ok', value: undefined }),
-      getCursor: async () => ({ kind: 'ok', value: null }),
-      setCursor: async () => ({ kind: 'ok', value: undefined }),
-      enqueuePendingWrite: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingWrites: async () => ({ kind: 'ok', value: [] }),
     };
     idCounter = 0;
     const result = await matchOrCreate(
@@ -506,10 +497,6 @@ describe('error paths', () => {
       load: async () => ({ kind: 'ok', value: null }),
       upsert: async () => ({ kind: 'err', error: { kind: 'StorageError', reason: 'unavailable' } }),
       delete: async () => ({ kind: 'ok', value: undefined }),
-      getCursor: async () => ({ kind: 'ok', value: null }),
-      setCursor: async () => ({ kind: 'ok', value: undefined }),
-      enqueuePendingWrite: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingWrites: async () => ({ kind: 'ok', value: [] }),
     };
     idCounter = 0;
     const result = await matchOrCreate(

--- a/packages/domain/tests/canon/mergeAisles.test.ts
+++ b/packages/domain/tests/canon/mergeAisles.test.ts
@@ -32,10 +32,6 @@ function makeCanonStore(initial: CanonItem[] = []): CanonLocalStorePort & { item
       return { kind: 'ok', value: item };
     },
     delete: async () => ({ kind: 'ok', value: undefined }),
-    getCursor: async () => ({ kind: 'ok', value: null }),
-    setCursor: async () => ({ kind: 'ok', value: undefined }),
-    enqueuePendingWrite: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingWrites: async () => ({ kind: 'ok', value: [] }),
   };
 }
 
@@ -48,7 +44,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };
@@ -142,10 +137,6 @@ describe('mergeAisles', () => {
       load: async () => ({ kind: 'ok', value: null }),
       upsert: async (item) => ({ kind: 'ok', value: item }),
       delete: async () => ({ kind: 'ok', value: undefined }),
-      getCursor: async () => ({ kind: 'ok', value: null }),
-      setCursor: async () => ({ kind: 'ok', value: undefined }),
-      enqueuePendingWrite: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingWrites: async () => ({ kind: 'ok', value: [] }),
     };
     const result = await mergeAisles(
       { targetId: 'target', sourceIds: ['src1'], perItemChoices: [] },

--- a/packages/domain/tests/canon/mergeCanonItems.test.ts
+++ b/packages/domain/tests/canon/mergeCanonItems.test.ts
@@ -13,7 +13,6 @@ function item(overrides: Partial<CanonItem> = {}): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };

--- a/packages/domain/tests/canon/ports.contract.test.ts
+++ b/packages/domain/tests/canon/ports.contract.test.ts
@@ -1,39 +1,37 @@
 import { describe, it, expectTypeOf } from 'vitest';
-import type {
-  CanonLocalStorePort,
-  CursorScope,
-  AisleLocalStorePort,
-  CanonItem,
-  Aisle,
-} from '@salt/domain';
+import type { CanonLocalStorePort, AisleLocalStorePort, CanonItem, Aisle } from '@salt/domain';
 import type { ReadResult, DomainError } from '@salt/shared-types';
-
-// ─── CursorScope ────────────────────────────────────────────────────────────
-
-describe('CursorScope', () => {
-  it("is the union 'items' | 'aisles'", () => {
-    expectTypeOf<CursorScope>().toEqualTypeOf<'items' | 'aisles'>();
-  });
-});
 
 // ─── CanonLocalStorePort ────────────────────────────────────────────────────
 
 describe('CanonLocalStorePort', () => {
-  it('getCursor accepts CursorScope and returns number | null', () => {
-    expectTypeOf<CanonLocalStorePort['getCursor']>().toEqualTypeOf<
-      (scope: CursorScope) => Promise<ReadResult<number | null, DomainError>>
+  it('exposes only { upsert, load, list, delete }', () => {
+    expectTypeOf<keyof CanonLocalStorePort>().toEqualTypeOf<
+      'upsert' | 'load' | 'list' | 'delete'
     >();
   });
 
-  it('setCursor accepts CursorScope and number', () => {
-    expectTypeOf<CanonLocalStorePort['setCursor']>().toEqualTypeOf<
-      (scope: CursorScope, value: number) => Promise<ReadResult<void, DomainError>>
+  it('upsert accepts CanonItem and returns ReadResult<CanonItem>', () => {
+    expectTypeOf<CanonLocalStorePort['upsert']>().toEqualTypeOf<
+      (item: CanonItem) => Promise<ReadResult<CanonItem, DomainError>>
     >();
   });
 
-  it('drainPendingWrites returns CanonItem array', () => {
-    expectTypeOf<CanonLocalStorePort['drainPendingWrites']>().toEqualTypeOf<
-      () => Promise<ReadResult<CanonItem[], DomainError>>
+  it('load accepts id and returns ReadResult<CanonItem | null>', () => {
+    expectTypeOf<CanonLocalStorePort['load']>().toEqualTypeOf<
+      (id: string) => Promise<ReadResult<CanonItem | null, DomainError>>
+    >();
+  });
+
+  it('list returns ReadResult<readonly CanonItem[]>', () => {
+    expectTypeOf<CanonLocalStorePort['list']>().toEqualTypeOf<
+      () => Promise<ReadResult<readonly CanonItem[], DomainError>>
+    >();
+  });
+
+  it('delete accepts id and returns ReadResult<void>', () => {
+    expectTypeOf<CanonLocalStorePort['delete']>().toEqualTypeOf<
+      (id: string) => Promise<ReadResult<void, DomainError>>
     >();
   });
 });

--- a/packages/domain/tests/canon/renameCanonItem.test.ts
+++ b/packages/domain/tests/canon/renameCanonItem.test.ts
@@ -13,7 +13,6 @@ function item(overrides: Partial<CanonItem> = {}): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };

--- a/packages/domain/tests/canon/resolveCanonConflict.test.ts
+++ b/packages/domain/tests/canon/resolveCanonConflict.test.ts
@@ -13,7 +13,6 @@ function item(overrides: Partial<CanonItem> = {}): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };

--- a/packages/domain/tests/canon/setCanonItemAisle.test.ts
+++ b/packages/domain/tests/canon/setCanonItemAisle.test.ts
@@ -13,7 +13,6 @@ function item(overrides: Partial<CanonItem> = {}): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };

--- a/packages/domain/tests/canon/setCanonItemShoppingFields.test.ts
+++ b/packages/domain/tests/canon/setCanonItemShoppingFields.test.ts
@@ -17,7 +17,6 @@ function item(overrides: Partial<CanonItem> = {}): CanonItem {
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };

--- a/packages/domain/tests/canon/setCanonItemSynonyms.test.ts
+++ b/packages/domain/tests/canon/setCanonItemSynonyms.test.ts
@@ -13,7 +13,6 @@ function item(overrides: Partial<CanonItem> = {}): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
     ...overrides,
   };

--- a/packages/domain/tests/canon/synonymMatch.test.ts
+++ b/packages/domain/tests/canon/synonymMatch.test.ts
@@ -13,7 +13,6 @@ const items: readonly CanonItem[] = [
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
   },
   {
@@ -26,7 +25,6 @@ const items: readonly CanonItem[] = [
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
   },
   {
@@ -39,7 +37,6 @@ const items: readonly CanonItem[] = [
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    revision: 0,
     deletedAt: null,
   },
 ];


### PR DESCRIPTION
… (issue #43 phase 2)

Removes the unused cursor + pending-write surface from the canon-item port and the per-item revision counter from the canon entity, matching the post-refactor architecture where Firestore is the live data layer.

- CanonLocalStorePort is now { upsert, load, list, delete }; the four cursor/queue methods and the CursorScope type were no-ops with zero callers and are deleted outright (greenfield, no compat shim).
- CanonItem.revision was server-stamped but never read after the manifest-cursor design was abandoned; deleting it lets the CF stop emitting it and keeps the wire schema honest.
- Every CanonStore mock and CanonItem fixture across domain / web-pwa / cloud-functions / firebase-sync tests was updated in lockstep so the narrowed port has no stale shape lying around to drift back in.
- Aisle-side narrowing (AisleLocalStorePort + AislesDocument.revision) is intentionally deferred to phase 3 — kept the seam clean so each phase compiles and tests independently.

Closes #43 phase 2