### PR TITLE
refactor(canon): narrow AisleLocalStorePort + drop AislesDocument.rev…

### DIFF
--- a/apps/cloud-functions/src/adapters/firestoreAisleStore.ts
+++ b/apps/cloud-functions/src/adapters/firestoreAisleStore.ts
@@ -21,31 +21,20 @@ function classify(_err: unknown): DomainError {
 
 export function createFirestoreAisleStore(db: Firestore): AisleLocalStorePort {
   return {
-    async load(): Promise<
-      ReadResult<
-        { readonly aisles: readonly Aisle[]; readonly revision: number } | null,
-        DomainError
-      >
-    > {
+    async load(): Promise<ReadResult<readonly Aisle[] | null, DomainError>> {
       try {
         const snap = await db.collection(AISLES_COLLECTION).doc(AISLES_DOC_ID).get();
         if (!snap.exists) return success(null);
         const data = snap.data() as Record<string, unknown>;
-        return success({ aisles: fromDoc(data), revision: 0 });
+        return success(fromDoc(data));
       } catch (err) {
         return failure(classify(err));
       }
     },
-    // matchOrCreate never writes aisles. Keep these as ok no-ops so the port
+    // matchOrCreate never writes aisles. Kept as an ok no-op so the port
     // contract stays satisfied without exposing an unused write path.
     async save() {
       return success(undefined);
-    },
-    async enqueuePendingSave() {
-      return success(undefined);
-    },
-    async drainPendingSave() {
-      return success(null);
     },
   };
 }

--- a/apps/web-pwa/src/lib/canonService.ts
+++ b/apps/web-pwa/src/lib/canonService.ts
@@ -94,17 +94,11 @@ export function memAisleStore(seed: readonly Aisle[]) {
   let written: readonly Aisle[] | null = null;
   const store: AisleLocalStorePort = {
     async load() {
-      return { kind: 'ok', value: { aisles: written ?? seed, revision: 0 } };
+      return { kind: 'ok', value: written ?? seed };
     },
-    async save(aisles, _revision) {
+    async save(aisles) {
       written = aisles;
       return { kind: 'ok', value: undefined };
-    },
-    async enqueuePendingSave() {
-      return { kind: 'ok', value: undefined };
-    },
-    async drainPendingSave() {
-      return { kind: 'ok', value: null };
     },
   };
   return { store, getWritten: () => written };

--- a/apps/web-pwa/tests/canonService.sync.test.ts
+++ b/apps/web-pwa/tests/canonService.sync.test.ts
@@ -185,13 +185,13 @@ describe('canonService — in-memory adapters', () => {
       const seed = [makeAisle('a1', 'Produce')];
       const { store } = memAisleStore(seed);
       const result = await store.load();
-      expect(result).toEqual({ kind: 'ok', value: { aisles: seed, revision: 0 } });
+      expect(result).toEqual({ kind: 'ok', value: seed });
     });
 
     it('save captures the new aisles', async () => {
       const { store, getWritten } = memAisleStore([]);
       const newAisles = [makeAisle('a1', 'Dairy')];
-      await store.save(newAisles, 0);
+      await store.save(newAisles);
       expect(getWritten()).toEqual(newAisles);
     });
 
@@ -203,9 +203,9 @@ describe('canonService — in-memory adapters', () => {
     it('load reflects saved aisles after save', async () => {
       const { store } = memAisleStore([]);
       const updated = [makeAisle('b', 'Bakery')];
-      await store.save(updated, 0);
+      await store.save(updated);
       const result = await store.load();
-      expect((result as { kind: 'ok'; value: { aisles: Aisle[] } }).value.aisles).toEqual(updated);
+      expect((result as { kind: 'ok'; value: readonly Aisle[] }).value).toEqual(updated);
     });
   });
 

--- a/packages/domain/src/canon/commands/createAisle.ts
+++ b/packages/domain/src/canon/commands/createAisle.ts
@@ -21,9 +21,7 @@ export async function createAisle(
   const loadResult = await store.load();
   if (loadResult.kind === 'err') return loadResult;
 
-  const stored = loadResult.value;
-  const existing = stored?.aisles ?? [];
-  const revision = stored?.revision ?? 0;
+  const existing = loadResult.value ?? [];
   const nameLower = name.toLowerCase();
   if (existing.some((a) => a.name.toLowerCase() === nameLower)) {
     return failure({ kind: 'ValidationError', code: ErrorCode.DUPLICATE_AISLE_NAME });
@@ -32,7 +30,7 @@ export async function createAisle(
   const maxOrder = existing.reduce((max, a) => Math.max(max, a.order), -1);
   const newAisle: Aisle = { id: ids.newAisleId(), name, order: maxOrder + 1 };
 
-  const saveResult = await store.save([...existing, newAisle], revision);
+  const saveResult = await store.save([...existing, newAisle]);
   if (saveResult.kind === 'err') return saveResult;
 
   return success(newAisle);

--- a/packages/domain/src/canon/commands/createAislesBulk.ts
+++ b/packages/domain/src/canon/commands/createAislesBulk.ts
@@ -32,9 +32,7 @@ export async function createAislesBulk(
   const loadResult = await store.load();
   if (loadResult.kind === 'err') return loadResult;
 
-  const stored = loadResult.value;
-  const existing = stored?.aisles ?? [];
-  const revision = stored?.revision ?? 0;
+  const existing = loadResult.value ?? [];
   const existingLower = new Set(existing.map((a) => a.name.toLowerCase()));
   const collision = deduped.find((n) => existingLower.has(n.toLowerCase()));
   if (collision !== undefined) {
@@ -48,7 +46,7 @@ export async function createAislesBulk(
     order: maxOrder + 1 + i,
   }));
 
-  const saveResult = await store.save([...existing, ...newAisles], revision);
+  const saveResult = await store.save([...existing, ...newAisles]);
   if (saveResult.kind === 'err') return saveResult;
 
   return success(newAisles);

--- a/packages/domain/src/canon/commands/deleteAisles.ts
+++ b/packages/domain/src/canon/commands/deleteAisles.ts
@@ -17,12 +17,10 @@ export async function deleteAisles(
   const loadResult = await store.load();
   if (loadResult.kind === 'err') return loadResult;
 
-  const stored = loadResult.value;
-  const existing = stored?.aisles ?? [];
-  const revision = stored?.revision ?? 0;
+  const existing = loadResult.value ?? [];
   const remaining = existing.filter((a) => !deletedSet.has(a.id));
 
-  const saveResult = await store.save(remaining, revision);
+  const saveResult = await store.save(remaining);
   if (saveResult.kind === 'err') return saveResult;
 
   const canonResult = await canonStore.list();

--- a/packages/domain/src/canon/commands/matchOrCreate.ts
+++ b/packages/domain/src/canon/commands/matchOrCreate.ts
@@ -201,7 +201,7 @@ function extrasFromNew(arb: ArbitrationNew): ArbitrationExtras {
 
 async function loadAisles(aisleStore: AisleLocalStorePort) {
   const aislesResult = await aisleStore.load();
-  return aislesResult.kind === 'ok' ? (aislesResult.value?.aisles ?? []) : [];
+  return aislesResult.kind === 'ok' ? (aislesResult.value ?? []) : [];
 }
 
 function logArbitration(

--- a/packages/domain/src/canon/commands/mergeAisles.ts
+++ b/packages/domain/src/canon/commands/mergeAisles.ts
@@ -43,12 +43,10 @@ export async function mergeAisles(
   const loadResult = await store.load();
   if (loadResult.kind === 'err') return loadResult;
 
-  const stored = loadResult.value;
-  const existing = stored?.aisles ?? [];
-  const revision = stored?.revision ?? 0;
+  const existing = loadResult.value ?? [];
   const remaining = existing.filter((a) => !sourceSet.has(a.id));
 
-  const saveResult = await store.save(remaining, revision);
+  const saveResult = await store.save(remaining);
   if (saveResult.kind === 'err') return saveResult;
 
   return success(undefined);

--- a/packages/domain/src/canon/commands/renameAisle.ts
+++ b/packages/domain/src/canon/commands/renameAisle.ts
@@ -20,9 +20,7 @@ export async function renameAisle(
   const loadResult = await store.load();
   if (loadResult.kind === 'err') return loadResult;
 
-  const stored = loadResult.value;
-  const existing = stored?.aisles ?? [];
-  const revision = stored?.revision ?? 0;
+  const existing = loadResult.value ?? [];
   const target = existing.find((a) => a.id === input.id);
   if (!target) {
     return failure({ kind: 'NotFound', resource: 'aisle', id: input.id });
@@ -36,7 +34,7 @@ export async function renameAisle(
   const renamed: Aisle = { ...target, name: newName };
   const updated = existing.map((a) => (a.id === input.id ? renamed : a));
 
-  const saveResult = await store.save(updated, revision);
+  const saveResult = await store.save(updated);
   if (saveResult.kind === 'err') return saveResult;
 
   return success(renamed);

--- a/packages/domain/src/canon/commands/reorderAisles.ts
+++ b/packages/domain/src/canon/commands/reorderAisles.ts
@@ -14,9 +14,7 @@ export async function reorderAisles(
   const loadResult = await store.load();
   if (loadResult.kind === 'err') return loadResult;
 
-  const stored = loadResult.value;
-  const existing = stored?.aisles ?? [];
-  const revision = stored?.revision ?? 0;
+  const existing = loadResult.value ?? [];
   const byId = new Map(existing.map((a) => [a.id, a]));
 
   const reordered: Aisle[] = [];
@@ -32,7 +30,7 @@ export async function reorderAisles(
     if (!inList.has(aisle.id)) reordered.push({ ...aisle, order: tail++ });
   }
 
-  const saveResult = await store.save(reordered, revision);
+  const saveResult = await store.save(reordered);
   if (saveResult.kind === 'err') return saveResult;
 
   return success(reordered);

--- a/packages/domain/src/canon/entities/AislesDocument.ts
+++ b/packages/domain/src/canon/entities/AislesDocument.ts
@@ -1,11 +1,10 @@
 import type { Aisle } from './Aisle.js';
 
 // Wire shape of the canonData/aisles Firestore document.
-// The aisles array is stored as a single document; revision and updatedAt are
-// stamped server-side by the onAislesWritten CF trigger.
+// The aisles array is stored as a single document; updatedAt is stamped
+// server-side by the onAislesWritten CF trigger.
 export interface AislesDocument {
   readonly schemaVersion: 1;
-  readonly revision: number;
   readonly updatedAt: string; // ISO-8601
   readonly aisles: readonly Aisle[];
 }

--- a/packages/domain/src/canon/entities/AislesDocument.ts
+++ b/packages/domain/src/canon/entities/AislesDocument.ts
@@ -1,8 +1,7 @@
 import type { Aisle } from './Aisle.js';
 
 // Wire shape of the canonData/aisles Firestore document.
-// The aisles array is stored as a single document; updatedAt is stamped
-// server-side by the onAislesWritten CF trigger.
+// The aisles array is stored as a single document; updatedAt is stamped client-side by saveAisles (see firebase-sync/aisleSubscription.ts).
 export interface AislesDocument {
   readonly schemaVersion: 1;
   readonly updatedAt: string; // ISO-8601

--- a/packages/domain/src/canon/ports/AisleLocalStorePort.ts
+++ b/packages/domain/src/canon/ports/AisleLocalStorePort.ts
@@ -3,17 +3,6 @@ import type { DomainError } from '@salt/shared-types';
 import type { Aisle } from '../entities/Aisle.js';
 
 export interface AisleLocalStorePort {
-  /** Persists the full aisles list at the given revision. */
-  save(aisles: readonly Aisle[], revision: number): Promise<ReadResult<void, DomainError>>;
-  /** Returns the stored aisles and their current revision, or null if never written. */
-  load(): Promise<
-    ReadResult<{ readonly aisles: readonly Aisle[]; readonly revision: number } | null, DomainError>
-  >;
-  /**
-   * Overwrites any pending save with the new aisles list.
-   * Depth-1 queue: last local write wins before sync drains it.
-   */
-  enqueuePendingSave(aisles: readonly Aisle[]): Promise<ReadResult<void, DomainError>>;
-  /** Returns and clears the pending aisles list, or null if nothing is queued. */
-  drainPendingSave(): Promise<ReadResult<readonly Aisle[] | null, DomainError>>;
+  save(aisles: readonly Aisle[]): Promise<ReadResult<void, DomainError>>;
+  load(): Promise<ReadResult<readonly Aisle[] | null, DomainError>>;
 }

--- a/packages/domain/src/canon/queries/getAisleUsage.ts
+++ b/packages/domain/src/canon/queries/getAisleUsage.ts
@@ -11,7 +11,7 @@ export async function getAisleUsage(
   if (aisleResult.kind === 'err') return aisleResult;
   if (canonResult.kind === 'err') return canonResult;
 
-  const aisles = aisleResult.value?.aisles ?? [];
+  const aisles = aisleResult.value ?? [];
   const usage = new Map<string, number>(aisles.map((a) => [a.id, 0]));
   for (const item of canonResult.value) {
     if (item.aisleId !== null && usage.has(item.aisleId)) {

--- a/packages/domain/src/canon/queries/listAisles.ts
+++ b/packages/domain/src/canon/queries/listAisles.ts
@@ -9,6 +9,6 @@ export async function listAisles(
   const loadResult = await store.load();
   if (loadResult.kind === 'err') return loadResult;
 
-  const aisles = loadResult.value?.aisles ?? [];
+  const aisles = loadResult.value ?? [];
   return success([...aisles].sort((a, b) => a.order - b.order));
 }

--- a/packages/domain/tests/canon/aislesDocument.schema.test.ts
+++ b/packages/domain/tests/canon/aislesDocument.schema.test.ts
@@ -8,10 +8,6 @@ describe('AislesDocument schema', () => {
       expectTypeOf<AislesDocument['schemaVersion']>().toEqualTypeOf<1>();
     });
 
-    it('revision is a number', () => {
-      expectTypeOf<AislesDocument['revision']>().toEqualTypeOf<number>();
-    });
-
     it('updatedAt is a string', () => {
       expectTypeOf<AislesDocument['updatedAt']>().toEqualTypeOf<string>();
     });
@@ -22,21 +18,18 @@ describe('AislesDocument schema', () => {
   });
 
   describe('wrapper-doc defaults and invariants', () => {
-    it('accepts a valid document with zero revision', () => {
+    it('accepts a valid empty document', () => {
       const doc: AislesDocument = {
         schemaVersion: 1,
-        revision: 0,
         updatedAt: '',
         aisles: [],
       };
-      expect(doc.revision).toBe(0);
       expect(doc.aisles).toHaveLength(0);
     });
 
     it('accepts a document with populated aisles', () => {
       const doc: AislesDocument = {
         schemaVersion: 1,
-        revision: 5,
         updatedAt: '2026-01-01T00:00:00.000Z',
         aisles: [
           { id: 'a1', name: 'Produce', order: 0 },
@@ -44,20 +37,12 @@ describe('AislesDocument schema', () => {
         ],
       };
       expect(doc.aisles).toHaveLength(2);
-      expect(doc.revision).toBe(5);
-    });
-
-    it('revision advances monotonically (higher = newer)', () => {
-      const v1: AislesDocument = { schemaVersion: 1, revision: 3, updatedAt: '', aisles: [] };
-      const v2: AislesDocument = { ...v1, revision: 4 };
-      expect(v2.revision).toBeGreaterThan(v1.revision);
     });
 
     it('individual Aisle entities are unchanged from their own schema', () => {
       const aisle: Aisle = { id: 'a1', name: 'Produce', order: 0 };
       const doc: AislesDocument = {
         schemaVersion: 1,
-        revision: 1,
         updatedAt: '2026-01-01T00:00:00.000Z',
         aisles: [aisle],
       };

--- a/packages/domain/tests/canon/clientFastPathParity.integration.test.ts
+++ b/packages/domain/tests/canon/clientFastPathParity.integration.test.ts
@@ -58,10 +58,8 @@ function makeStore(initial: CanonItem[]): CanonLocalStorePort & { items: CanonIt
 }
 
 const aisleStore: AisleLocalStorePort = {
-  load: async () => ({ kind: 'ok', value: { aisles: [], revision: 0 } }),
+  load: async () => ({ kind: 'ok', value: [] }),
   save: async () => ({ kind: 'ok', value: undefined }),
-  enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-  drainPendingSave: async () => ({ kind: 'ok', value: null }),
 };
 
 // AI ports that throw if invoked — guarantees the fast-path-eligible cases

--- a/packages/domain/tests/canon/createAisle.test.ts
+++ b/packages/domain/tests/canon/createAisle.test.ts
@@ -13,14 +13,12 @@ function makeAisleStore(initial: Aisle[] = []): AisleLocalStorePort & { items: A
   const items = [...initial];
   return {
     items,
-    load: async () => ({ kind: 'ok', value: { aisles: items, revision: 0 } }),
+    load: async () => ({ kind: 'ok', value: items }),
     save: async (aisles) => {
       items.length = 0;
       items.push(...aisles);
       return { kind: 'ok', value: undefined };
     },
-    enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingSave: async () => ({ kind: 'ok', value: null }),
   };
 }
 
@@ -68,8 +66,6 @@ describe('createAisle', () => {
     const store: AisleLocalStorePort = {
       load: async () => ({ kind: 'err', error: { kind: 'StorageError', reason: 'unavailable' } }),
       save: async () => ({ kind: 'ok', value: undefined }),
-      enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingSave: async () => ({ kind: 'ok', value: null }),
     };
     const result = await createAisle({ name: 'Produce' }, makeIds(), store);
     expect(result.kind).toBe('err');
@@ -81,8 +77,6 @@ describe('createAisle', () => {
     const store: AisleLocalStorePort = {
       load: async () => ({ kind: 'ok', value: null }),
       save: async () => ({ kind: 'err', error: { kind: 'StorageError', reason: 'unavailable' } }),
-      enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingSave: async () => ({ kind: 'ok', value: null }),
     };
     const result = await createAisle({ name: 'Produce' }, makeIds(), store);
     expect(result.kind).toBe('err');

--- a/packages/domain/tests/canon/createAislesBulk.test.ts
+++ b/packages/domain/tests/canon/createAislesBulk.test.ts
@@ -12,14 +12,12 @@ function makeIds(): IdGenerator {
 function makeAisleStore(initial: Aisle[] = []): AisleLocalStorePort {
   const items = [...initial];
   return {
-    load: async () => ({ kind: 'ok', value: { aisles: items, revision: 0 } }),
+    load: async () => ({ kind: 'ok', value: items }),
     save: async (aisles) => {
       items.length = 0;
       items.push(...aisles);
       return { kind: 'ok', value: undefined };
     },
-    enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingSave: async () => ({ kind: 'ok', value: null }),
   };
 }
 
@@ -76,8 +74,6 @@ describe('createAislesBulk', () => {
     const store: AisleLocalStorePort = {
       load: async () => ({ kind: 'err', error: { kind: 'StorageError', reason: 'unavailable' } }),
       save: async () => ({ kind: 'ok', value: undefined }),
-      enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingSave: async () => ({ kind: 'ok', value: null }),
     };
     const result = await createAislesBulk({ names: ['Produce'] }, makeIds(), store);
     expect(result.kind).toBe('err');

--- a/packages/domain/tests/canon/deleteAisles.test.ts
+++ b/packages/domain/tests/canon/deleteAisles.test.ts
@@ -8,14 +8,12 @@ function makeAisleStore(initial: Aisle[] = []): AisleLocalStorePort & { items: A
   const items = [...initial];
   return {
     items,
-    load: async () => ({ kind: 'ok', value: { aisles: items, revision: 0 } }),
+    load: async () => ({ kind: 'ok', value: items }),
     save: async (aisles) => {
       items.length = 0;
       items.push(...aisles);
       return { kind: 'ok', value: undefined };
     },
-    enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingSave: async () => ({ kind: 'ok', value: null }),
   };
 }
 
@@ -81,8 +79,6 @@ describe('deleteAisles', () => {
     const store: AisleLocalStorePort = {
       load: async () => ({ kind: 'err', error: { kind: 'StorageError', reason: 'unavailable' } }),
       save: async () => ({ kind: 'ok', value: undefined }),
-      enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingSave: async () => ({ kind: 'ok', value: null }),
     };
     const result = await deleteAisles({ ids: ['a1'] }, store, makeCanonStore());
     expect(result.kind).toBe('err');

--- a/packages/domain/tests/canon/getAisleUsage.test.ts
+++ b/packages/domain/tests/canon/getAisleUsage.test.ts
@@ -7,14 +7,12 @@ import type { CanonItem } from '../../src/canon/entities/CanonItem.js';
 function makeAisleStore(initial: Aisle[] = []): AisleLocalStorePort {
   const items = [...initial];
   return {
-    load: async () => ({ kind: 'ok', value: { aisles: items, revision: 0 } }),
+    load: async () => ({ kind: 'ok', value: items }),
     save: async (aisles) => {
       items.length = 0;
       items.push(...aisles);
       return { kind: 'ok', value: undefined };
     },
-    enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingSave: async () => ({ kind: 'ok', value: null }),
   };
 }
 
@@ -90,8 +88,6 @@ describe('getAisleUsage', () => {
     const aisleStore: AisleLocalStorePort = {
       load: async () => ({ kind: 'err', error: { kind: 'StorageError', reason: 'unavailable' } }),
       save: async () => ({ kind: 'ok', value: undefined }),
-      enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingSave: async () => ({ kind: 'ok', value: null }),
     };
     const result = await getAisleUsage(aisleStore, makeCanonStore());
     expect(result.kind).toBe('err');

--- a/packages/domain/tests/canon/listAisles.test.ts
+++ b/packages/domain/tests/canon/listAisles.test.ts
@@ -6,14 +6,12 @@ import type { Aisle } from '../../src/canon/entities/Aisle.js';
 function makeAisleStore(initial: Aisle[] = []): AisleLocalStorePort {
   const items = [...initial];
   return {
-    load: async () => ({ kind: 'ok', value: { aisles: items, revision: 0 } }),
+    load: async () => ({ kind: 'ok', value: items }),
     save: async (aisles) => {
       items.length = 0;
       items.push(...aisles);
       return { kind: 'ok', value: undefined };
     },
-    enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingSave: async () => ({ kind: 'ok', value: null }),
   };
 }
 
@@ -41,8 +39,6 @@ describe('listAisles', () => {
     const store: AisleLocalStorePort = {
       load: async () => ({ kind: 'ok', value: null }),
       save: async () => ({ kind: 'ok', value: undefined }),
-      enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingSave: async () => ({ kind: 'ok', value: null }),
     };
     const result = await listAisles(store);
     expect(result.kind).toBe('ok');
@@ -54,8 +50,6 @@ describe('listAisles', () => {
     const store: AisleLocalStorePort = {
       load: async () => ({ kind: 'err', error: { kind: 'StorageError', reason: 'unavailable' } }),
       save: async () => ({ kind: 'ok', value: undefined }),
-      enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingSave: async () => ({ kind: 'ok', value: null }),
     };
     const result = await listAisles(store);
     expect(result.kind).toBe('err');

--- a/packages/domain/tests/canon/matchOrCreate.test.ts
+++ b/packages/domain/tests/canon/matchOrCreate.test.ts
@@ -53,20 +53,16 @@ function makeStore(initial: CanonItem[] = []): CanonLocalStorePort & { items: Ca
 
 function makeAisleStore(): AisleLocalStorePort {
   return {
-    load: async () => ({ kind: 'ok', value: { aisles: [], revision: 0 } }),
+    load: async () => ({ kind: 'ok', value: [] }),
     save: async () => ({ kind: 'ok', value: undefined }),
-    enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingSave: async () => ({ kind: 'ok', value: null }),
   };
 }
 
 function makeAisleStoreWithAisles(): AisleLocalStorePort {
   const aisles = [{ id: 'produce', name: 'Produce', order: 1 }];
   return {
-    load: async () => ({ kind: 'ok', value: { aisles, revision: 0 } }),
+    load: async () => ({ kind: 'ok', value: aisles }),
     save: async () => ({ kind: 'ok', value: undefined }),
-    enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingSave: async () => ({ kind: 'ok', value: null }),
   };
 }
 

--- a/packages/domain/tests/canon/mergeAisles.test.ts
+++ b/packages/domain/tests/canon/mergeAisles.test.ts
@@ -8,14 +8,12 @@ function makeAisleStore(initial: Aisle[] = []): AisleLocalStorePort & { items: A
   const items = [...initial];
   return {
     items,
-    load: async () => ({ kind: 'ok', value: { aisles: items, revision: 0 } }),
+    load: async () => ({ kind: 'ok', value: items }),
     save: async (aisles) => {
       items.length = 0;
       items.push(...aisles);
       return { kind: 'ok', value: undefined };
     },
-    enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingSave: async () => ({ kind: 'ok', value: null }),
   };
 }
 

--- a/packages/domain/tests/canon/ports.contract.test.ts
+++ b/packages/domain/tests/canon/ports.contract.test.ts
@@ -39,31 +39,18 @@ describe('CanonLocalStorePort', () => {
 // ─── AisleLocalStorePort ────────────────────────────────────────────────────
 
 describe('AisleLocalStorePort', () => {
-  it('save accepts aisles + revision and returns ReadResult<void>', () => {
+  it('exposes only { save, load }', () => {
+    expectTypeOf<keyof AisleLocalStorePort>().toEqualTypeOf<'save' | 'load'>();
+  });
+
+  it('save accepts aisles and returns ReadResult<void>', () => {
     expectTypeOf<AisleLocalStorePort['save']>().toEqualTypeOf<
-      (aisles: readonly Aisle[], revision: number) => Promise<ReadResult<void, DomainError>>
-    >();
-  });
-
-  it('load returns { aisles, revision } | null', () => {
-    expectTypeOf<AisleLocalStorePort['load']>().toEqualTypeOf<
-      () => Promise<
-        ReadResult<
-          { readonly aisles: readonly Aisle[]; readonly revision: number } | null,
-          DomainError
-        >
-      >
-    >();
-  });
-
-  it('enqueuePendingSave accepts aisles and returns ReadResult<void>', () => {
-    expectTypeOf<AisleLocalStorePort['enqueuePendingSave']>().toEqualTypeOf<
       (aisles: readonly Aisle[]) => Promise<ReadResult<void, DomainError>>
     >();
   });
 
-  it('drainPendingSave returns aisles | null', () => {
-    expectTypeOf<AisleLocalStorePort['drainPendingSave']>().toEqualTypeOf<
+  it('load returns readonly Aisle[] | null', () => {
+    expectTypeOf<AisleLocalStorePort['load']>().toEqualTypeOf<
       () => Promise<ReadResult<readonly Aisle[] | null, DomainError>>
     >();
   });

--- a/packages/domain/tests/canon/renameAisle.test.ts
+++ b/packages/domain/tests/canon/renameAisle.test.ts
@@ -7,14 +7,12 @@ import { ErrorCode } from '@salt/shared-types';
 function makeAisleStore(initial: Aisle[] = []): AisleLocalStorePort {
   const items = [...initial];
   return {
-    load: async () => ({ kind: 'ok', value: { aisles: items, revision: 0 } }),
+    load: async () => ({ kind: 'ok', value: items }),
     save: async (aisles) => {
       items.length = 0;
       items.push(...aisles);
       return { kind: 'ok', value: undefined };
     },
-    enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingSave: async () => ({ kind: 'ok', value: null }),
   };
 }
 
@@ -68,8 +66,6 @@ describe('renameAisle', () => {
     const store: AisleLocalStorePort = {
       load: async () => ({ kind: 'err', error: { kind: 'StorageError', reason: 'unavailable' } }),
       save: async () => ({ kind: 'ok', value: undefined }),
-      enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingSave: async () => ({ kind: 'ok', value: null }),
     };
     const result = await renameAisle({ id: 'a1', newName: 'X' }, store);
     expect(result.kind).toBe('err');

--- a/packages/domain/tests/canon/reorderAisles.test.ts
+++ b/packages/domain/tests/canon/reorderAisles.test.ts
@@ -7,14 +7,12 @@ function makeAisleStore(initial: Aisle[] = []): AisleLocalStorePort & { items: A
   const items = [...initial];
   return {
     items,
-    load: async () => ({ kind: 'ok', value: { aisles: items, revision: 0 } }),
+    load: async () => ({ kind: 'ok', value: items }),
     save: async (aisles) => {
       items.length = 0;
       items.push(...aisles);
       return { kind: 'ok', value: undefined };
     },
-    enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-    drainPendingSave: async () => ({ kind: 'ok', value: null }),
   };
 }
 
@@ -58,8 +56,6 @@ describe('reorderAisles', () => {
     const store: AisleLocalStorePort = {
       load: async () => ({ kind: 'err', error: { kind: 'StorageError', reason: 'unavailable' } }),
       save: async () => ({ kind: 'ok', value: undefined }),
-      enqueuePendingSave: async () => ({ kind: 'ok', value: undefined }),
-      drainPendingSave: async () => ({ kind: 'ok', value: null }),
     };
     const result = await reorderAisles({ orderedIds: ['a1'] }, store);
     expect(result.kind).toBe('err');


### PR DESCRIPTION
…ision (issue #43 phase 3)

Final aisle-side cleanup that finishes the canon scrub started in #32. The aisle-document revision counter and the enqueuePendingSave / drainPendingSave queue methods were dead scaffolding from the pre-Firestore-master architecture; removing them brings the aisle port into line with the canon port narrowed in phase 2.

- load() now returns readonly Aisle[] | null directly instead of { aisles, revision } | null. The wrapper carried no information once revision was deleted, so the bare-array shape removes one unwrap site at every caller.
- firestoreAisleStore.save is intentionally left as an ok no-op rather than removed: matchOrCreate is the only CF-side aisle consumer and never writes, but stripping save from the port would force a second AisleReadOnlyPort type. Keeping the no-op preserves the single-port contract at the cost of one documented dead branch.
- Pre-existing canon-item schemaVersion drift in fixtures (Phase 2 deviation #1) is left untouched: Phase 3 only edited the aisle-document side of those fixtures, which had no drift to correct.

Closes #43 phase 3