### PR TITLE
style: apply prettier to 6 ui-components svelte primitives

### DIFF
--- a/packages/ui-components/src/primitives/Dialog/DialogContent.svelte
+++ b/packages/ui-components/src/primitives/Dialog/DialogContent.svelte
@@ -10,9 +10,7 @@
 
   const ctx = DIALOG_CONTEXT.get();
 
-  const portalTo = $derived(
-    ctx.portal === false ? 'body' : (ctx.portal as string | HTMLElement),
-  );
+  const portalTo = $derived(ctx.portal === false ? 'body' : (ctx.portal as string | HTMLElement));
   const portalDisabled = $derived(ctx.portal === false);
 </script>
 

--- a/packages/ui-components/src/primitives/EditableRow/EditableRow.svelte
+++ b/packages/ui-components/src/primitives/EditableRow/EditableRow.svelte
@@ -22,7 +22,10 @@
     selected && (shaded ? 'ring-2 ring-ring' : 'ring-2 ring-ring border-ring'),
   )}
 >
-  <Checkbox checked={selected} {...(onToggleSelect !== undefined ? { onCheckedChange: onToggleSelect } : {})} />
+  <Checkbox
+    checked={selected}
+    {...onToggleSelect !== undefined ? { onCheckedChange: onToggleSelect } : {}}
+  />
   {#if narrow}
     <div class="flex-1 min-w-0 sm:hidden">
       {@render narrow()}

--- a/packages/ui-components/src/primitives/Popover/PopoverContent.svelte
+++ b/packages/ui-components/src/primitives/Popover/PopoverContent.svelte
@@ -16,9 +16,7 @@
 
   const ctx = POPOVER_CONTEXT.get();
 
-  const portalTo = $derived(
-    ctx.portal === false ? 'body' : (ctx.portal as string | HTMLElement),
-  );
+  const portalTo = $derived(ctx.portal === false ? 'body' : (ctx.portal as string | HTMLElement));
   const portalDisabled = $derived(ctx.portal === false);
 </script>
 

--- a/packages/ui-components/src/primitives/Sheet/SheetContent.svelte
+++ b/packages/ui-components/src/primitives/Sheet/SheetContent.svelte
@@ -10,9 +10,7 @@
 
   const ctx = SHEET_CONTEXT.get();
 
-  const portalTo = $derived(
-    ctx.portal === false ? 'body' : (ctx.portal as string | HTMLElement),
-  );
+  const portalTo = $derived(ctx.portal === false ? 'body' : (ctx.portal as string | HTMLElement));
   const portalDisabled = $derived(ctx.portal === false);
   const side = $derived(ctx.side);
 </script>

--- a/packages/ui-components/src/primitives/Switch/Switch.svelte
+++ b/packages/ui-components/src/primitives/Switch/Switch.svelte
@@ -44,7 +44,7 @@
     {disabled}
     {required}
     {value}
-    {...(name !== undefined ? { name } : {})}
+    {...name !== undefined ? { name } : {}}
     aria-describedby={fieldState.describedBy}
     class={switchRootVariants({ size })}
   >

--- a/packages/ui-components/src/primitives/Tooltip/Tooltip.svelte
+++ b/packages/ui-components/src/primitives/Tooltip/Tooltip.svelte
@@ -27,7 +27,12 @@
 
 <!-- Embed Provider so Tooltip.Root works standalone; TooltipProvider.svelte is for app-level shared config -->
 <Tooltip.Provider {delayDuration} {disableHoverableContent}>
-  <Tooltip.Root open={open ?? false} onOpenChange={handleOpenChange} {delayDuration} {disableHoverableContent}>
+  <Tooltip.Root
+    open={open ?? false}
+    onOpenChange={handleOpenChange}
+    {delayDuration}
+    {disableHoverableContent}
+  >
     {@render children?.()}
   </Tooltip.Root>
 </Tooltip.Provider>


### PR DESCRIPTION
## Summary
- PR #44 (TypeScript-error fixes) introduced 6 svelte primitives that don't satisfy `prettier --check`. Because CI was historically restricted, the failure surfaced only on PR #48's uplift run.
- Running `pnpm format` on the 6 files brings them back into compliance — pure whitespace/line-break changes, no behavioural diff.

## Test plan
- [ ] `pnpm format:check` passes locally
- [ ] CI green on this PR (format + typecheck + lint + boundary)