### PR TITLE
fix(e2e): replace fuser hard-kill with graceful stop in Playwright config

### DIFF
--- a/apps/web-pwa/playwright.config.ts
+++ b/apps/web-pwa/playwright.config.ts
@@ -28,16 +28,11 @@ export default defineConfig({
 
   webServer: [
     {
-      // fuser -k clears orphaned emulator Java subprocesses left behind when
-      // the Firebase CLI is killed (common in WSL). The reuseExistingServer
-      // check uses port 9099 (auth emulator) rather than the hub (4400) so
-      // that tests only start once the auth emulator is fully initialised —
-      // the hub responds before individual emulators are ready.
       command:
-        'fuser -k 8080/tcp 9099/tcp 5001/tcp 2>/dev/null; firebase emulators:start --project=demo-salt --only=auth,firestore,functions',
+        'node scripts/stop-emulators.mjs && firebase emulators:start --project=demo-salt --only=auth,firestore,functions',
       cwd: '../..',
       url: 'http://127.0.0.1:9099',
-      reuseExistingServer: true,
+      reuseExistingServer: false,
       timeout: 120_000,
       stdout: CI ? 'inherit' : 'pipe',
       stderr: CI ? 'inherit' : 'pipe',

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev:kitchen-sink": "pnpm --filter @salt/kitchen-sink dev",
     "dev:genkit": "pnpm --filter @salt/cloud-functions dev",
     "dev:emulators": "pnpm --filter @salt/cloud-functions build && GENKIT_ENV=dev GENKIT_TELEMETRY_SERVER=http://localhost:4033 firebase emulators:start --import=./.emulator-data --export-on-exit=./.emulator-data || true",
-    "test:emulator": "firebase emulators:exec --only=firestore,auth --project=demo-salt 'pnpm --filter @salt/firebase-sync test:emulator && pnpm --filter @salt/cloud-functions test:emulator'"
+    "test:emulator": "node scripts/stop-emulators.mjs && firebase emulators:exec --only=firestore,auth --project=demo-salt 'pnpm --filter @salt/firebase-sync test:emulator && pnpm --filter @salt/cloud-functions test:emulator'"
   },
   "lint-staged": {
     "*.{ts,js,svelte}": [

--- a/scripts/stop-emulators.mjs
+++ b/scripts/stop-emulators.mjs
@@ -10,7 +10,7 @@ import os from "os";
 import path from "path";
 
 const HUB_URL = "http://localhost:4400/emulators";
-const PORTS = [8080, 9099];
+const PORTS = [8080, 9099, 5001, 5000, 9199];
 const TIMEOUT_MS = 30_000;
 const POLL_INTERVAL_MS = 500;
 

--- a/scripts/stop-emulators.mjs
+++ b/scripts/stop-emulators.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Gracefully stops Firebase emulators via SIGTERM to the hub process.
+// SIGTERM lets the hub run its cleanup handlers, including --export-on-exit,
+// so dev data in .emulator-data/ is preserved.
+// Exits 0 in all cases — including when no hub is running — so CI is unaffected.
+
+import fs from "fs";
+import net from "net";
+import os from "os";
+import path from "path";
+
+const HUB_URL = "http://localhost:4400/emulators";
+const PORTS = [8080, 9099];
+const TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 500;
+
+async function hubIsRunning() {
+  try {
+    const res = await fetch(HUB_URL, { signal: AbortSignal.timeout(2000) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+function findHubPid() {
+  const tmp = os.tmpdir();
+  const files = fs.readdirSync(tmp).filter((f) => /^hub-.+\.json$/.test(f));
+  for (const file of files) {
+    try {
+      const data = JSON.parse(fs.readFileSync(path.join(tmp, file), "utf8"));
+      if (typeof data.pid === "number") return data.pid;
+    } catch {
+      // malformed or unreadable locator — skip
+    }
+  }
+  return null;
+}
+
+function portIsFree(port) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => server.close(() => resolve(true)));
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+async function waitForPorts() {
+  const deadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const checks = await Promise.all(PORTS.map(portIsFree));
+    if (checks.every(Boolean)) return true;
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  return false;
+}
+
+async function main() {
+  if (!(await hubIsRunning())) {
+    console.log("stop-emulators: no hub found, nothing to do.");
+    process.exit(0);
+  }
+
+  const pid = findHubPid();
+  if (pid === null) {
+    console.warn("stop-emulators: hub is running but locator file not found — cannot send SIGTERM.");
+    process.exit(0);
+  }
+
+  console.log(`stop-emulators: sending SIGTERM to hub process (pid ${pid})...`);
+  process.kill(pid, "SIGTERM");
+
+  const freed = await waitForPorts();
+  if (freed) {
+    console.log("stop-emulators: all ports free, emulators stopped.");
+  } else {
+    console.warn(
+      `stop-emulators: timed out after ${TIMEOUT_MS / 1000}s waiting for ports ${PORTS.join(", ")} — proceeding anyway.`
+    );
+  }
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
Fixes the two root causes of dev-data contamination in Playwright E2E runs: hard-killing emulators (bypassing --export-on-exit) and reusing whatever emulator state happened to be running.

- Used `node scripts/stop-emulators.mjs` not `../../scripts/...` because cwd is already set to repo root; ../../ would escape the repo entirely
- reuseExistingServer: false ensures every E2E run gets a clean emulator state rather than inheriting dev data

Closes #53 phase 3