### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/packages/ui-components/scripts/check-provenance.ts
+++ b/packages/ui-components/scripts/check-provenance.ts
@@ -11,8 +11,8 @@ const SRC_ROOT = join(PKG_ROOT, 'src');
 const SCAN_DIRS = ['headless', 'primitives', 'lib'];
 
 // §3.8: .svelte files use <!-- spec: ... --> and .ts/.svelte.ts files use // spec: ...
-const SVELTE_HEADER = /^<!-- spec: [\w.-]+\.md §\S+(?:,\s*§\S+)* v\d+\.\d+(\.\d+)? -->/;
-const TS_HEADER = /^\/\/ spec: [\w.-]+\.md §\S+(?:,\s*§\S+)* v\d+\.\d+(\.\d+)?/;
+const SVELTE_HEADER = /^<!-- spec: [\w.-]+\.md §[^\s,]+(?:,\s*§[^\s,]+)* v\d+\.\d+(\.\d+)? -->/;
+const TS_HEADER = /^\/\/ spec: [\w.-]+\.md §[^\s,]+(?:,\s*§[^\s,]+)* v\d+\.\d+(\.\d+)?/;
 
 function collectFiles(dir: string): string[] {
   const results: string[] = [];


### PR DESCRIPTION
Potential fix for [https://github.com/eggman0131/saltV2/security/code-scanning/4](https://github.com/eggman0131/saltV2/security/code-scanning/4)

Use a non-overlapping character class for section identifiers instead of `\S+`.  
The safest fix is to prevent `\S+` from consuming delimiters used by the repeated list structure (comma and whitespace). Replace each `§\S+` with `§[^\s,]+` in both header regexes, so each section token cannot absorb commas and compete with the `(?:,\s* ... )*` repetition.

In `packages/ui-components/scripts/check-provenance.ts`, update:

- `SVELTE_HEADER` (line 14)
- `TS_HEADER` (line 15)

No imports, helper methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
