### PR TITLE
Potential fix for code scanning alert no. 5: Replacement of a substring with itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   ci:
     name: Lint, typecheck, test, boundary

--- a/packages/ui-components/scripts/generate-tokens.ts
+++ b/packages/ui-components/scripts/generate-tokens.ts
@@ -34,7 +34,7 @@ for (const [key, value] of Object.entries(colorsTheme)) {
 }
 writeFileSync(
   join(tokensDir, 'colors.ts'),
-  HEADER.replace('§3.3', '§3.3').replace('§4.1', '§3.3') + colorLines.join('\n') + '\n',
+  HEADER.replace('§4.1', '§3.3') + colorLines.join('\n') + '\n',
 );
 
 // --- radius.ts ---


### PR DESCRIPTION
Potential fix for [https://github.com/eggman0131/saltV2/security/code-scanning/5](https://github.com/eggman0131/saltV2/security/code-scanning/5)

The fix is to remove the no-op replacement call and keep only the meaningful transformation.

Best fix (without changing functionality): in `packages/ui-components/scripts/generate-tokens.ts`, update the `writeFileSync` call for `colors.ts` so the header expression no longer does `.replace('§3.3', '§3.3')`. Keep `.replace('§4.1', '§3.3')` as-is, since that is the only effective replacement in that expression.

No imports, new methods, or new definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
