### PR TITLE
refactor(canon): remove vestigial deletedAt soft-delete plumbing

### DIFF
--- a/apps/cloud-functions/src/adapters/firestoreCanonStore.ts
+++ b/apps/cloud-functions/src/adapters/firestoreCanonStore.ts
@@ -61,9 +61,7 @@ export function createFirestoreCanonStore(db: Firestore): CanonLocalStorePort {
     async list(): Promise<ReadResult<readonly CanonItem[], DomainError>> {
       try {
         const snap = await db.collection(COLLECTION).get();
-        const items = snap.docs
-          .map((d) => fromDoc(d.data() as Record<string, unknown>))
-          .filter((i) => i.deletedAt === null);
+        const items = snap.docs.map((d) => fromDoc(d.data() as Record<string, unknown>));
         return success(items);
       } catch (err) {
         return failure(classify(err));

--- a/apps/cloud-functions/src/adapters/firestoreCanonStore.ts
+++ b/apps/cloud-functions/src/adapters/firestoreCanonStore.ts
@@ -14,7 +14,7 @@ const COLLECTION = 'canonItems';
 function fromDoc(data: Record<string, unknown>): CanonItem {
   return {
     id: data['id'] as string,
-    schemaVersion: 4,
+    schemaVersion: 5,
     name: data['name'] as string,
     synonyms: Array.isArray(data['synonyms']) ? (data['synonyms'] as string[]) : [],
     aisleId: typeof data['aisleId'] === 'string' ? data['aisleId'] : null,
@@ -28,7 +28,6 @@ function fromDoc(data: Record<string, unknown>): CanonItem {
     ...(typeof data['unit'] === 'string' ? { unit: data['unit'] as CanonItemUnit } : {}),
     ...(typeof data['reasoning'] === 'string' ? { reasoning: data['reasoning'] as string } : {}),
     updatedAt: typeof data['updatedAt'] === 'string' ? data['updatedAt'] : '',
-    deletedAt: typeof data['deletedAt'] === 'string' ? data['deletedAt'] : null,
   };
 }
 

--- a/apps/cloud-functions/src/index.ts
+++ b/apps/cloud-functions/src/index.ts
@@ -114,7 +114,6 @@ export const onCanonItemWritten = onDocumentWritten(
     if (!after?.exists) return;
 
     const data = after.data() as Record<string, unknown>;
-    if (typeof data['deletedAt'] === 'string') return;
     if (Array.isArray(data['embedding'])) return;
 
     const name = typeof data['name'] === 'string' ? data['name'] : null;

--- a/apps/cloud-functions/tests/flows/matchOrCreateCanon.test.ts
+++ b/apps/cloud-functions/tests/flows/matchOrCreateCanon.test.ts
@@ -86,7 +86,7 @@ function readCanonStorage(): CanonItem[] {
 
 function makeItem(overrides: Partial<CanonItem> & { id: string; name: string }): CanonItem {
   return {
-    schemaVersion: 4,
+    schemaVersion: 5,
     synonyms: [],
     aisleId: null,
     thumbnail: null,
@@ -94,7 +94,6 @@ function makeItem(overrides: Partial<CanonItem> & { id: string; name: string }):
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/apps/cloud-functions/tests/flows/matchOrCreateCanon.tracePropagation.test.ts
+++ b/apps/cloud-functions/tests/flows/matchOrCreateCanon.tracePropagation.test.ts
@@ -87,7 +87,7 @@ const { matchOrCreateCanonFlow } = await import('../../src/flows/matchOrCreateCa
 
 function makeItem(overrides: Partial<CanonItem> & { id: string; name: string }): CanonItem {
   return {
-    schemaVersion: 4,
+    schemaVersion: 5,
     synonyms: [],
     aisleId: null,
     thumbnail: null,
@@ -95,7 +95,6 @@ function makeItem(overrides: Partial<CanonItem> & { id: string; name: string }):
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/apps/cloud-functions/tests/triggers/onShoppingListItemWrite.emulator.test.ts
+++ b/apps/cloud-functions/tests/triggers/onShoppingListItemWrite.emulator.test.ts
@@ -56,7 +56,7 @@ let adminApp: App;
 function makeCanonItem(id: string, needsApproval = false): CanonItem {
   return {
     id,
-    schemaVersion: 4,
+    schemaVersion: 5,
     name: 'Baked Beans',
     synonyms: [],
     aisleId: 'tinned',
@@ -65,7 +65,6 @@ function makeCanonItem(id: string, needsApproval = false): CanonItem {
     needs_approval: needsApproval,
     shoppingBehavior: 'needed',
     updatedAt: new Date().toISOString(),
-    deletedAt: null,
   };
 }
 

--- a/apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts
+++ b/apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts
@@ -98,7 +98,7 @@ function makeEvent({
 
 function makeCanonItem(overrides: Partial<CanonItem> & { id: string }): CanonItem {
   return {
-    schemaVersion: 4,
+    schemaVersion: 5,
     name: 'Test Item',
     synonyms: [],
     aisleId: null,
@@ -107,7 +107,6 @@ function makeCanonItem(overrides: Partial<CanonItem> & { id: string }): CanonIte
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/apps/web-pwa/src/lib/canonService.ts
+++ b/apps/web-pwa/src/lib/canonService.ts
@@ -1,6 +1,7 @@
 import {
   subscribeCanonItems,
   upsertCanonItem,
+  deleteCanonItem as deleteCanonItemDoc,
   subscribeAisles,
   callMatchOrCreate,
 } from '@salt/firebase-sync';
@@ -117,7 +118,7 @@ export function memCanonStore(seed: readonly CanonItem[]) {
       return { kind: 'ok', value: items.get(id) ?? null };
     },
     async list() {
-      return { kind: 'ok', value: [...items.values()].filter((i) => i.deletedAt === null) };
+      return { kind: 'ok', value: [...items.values()] };
     },
     async delete(id) {
       items.delete(id);
@@ -148,7 +149,7 @@ export function initCanonSync(): () => void {
 
   const unsubItems = subscribeCanonItems(
     (items) => {
-      _canonItems.set(items.filter((i) => i.deletedAt === null));
+      _canonItems.set(items);
       recomputeAisleUsage();
       markLoaded('items');
     },
@@ -318,12 +319,7 @@ export async function splitMostRecentSynonym(
 }
 
 export async function deleteCanonItem(id: string): Promise<Result<void, DomainError>> {
-  const item = get(_canonItems).find((i) => i.id === id) ?? null;
-  if (item !== null) {
-    const tombstone: CanonItem = { ...item, deletedAt: new Date().toISOString() };
-    await upsertCanonItem(tombstone);
-  }
-  return { kind: 'ok', value: undefined };
+  return deleteCanonItemDoc(id);
 }
 
 // ─── Test helpers ────────────────────────────────────────────────────────────────

--- a/apps/web-pwa/src/lib/e2eHooks.ts
+++ b/apps/web-pwa/src/lib/e2eHooks.ts
@@ -35,7 +35,7 @@ export function installE2EHooks(): void {
     async seedCanonItem(input: SeedCanonItemInput) {
       const item: CanonItem = {
         id: input.id ?? crypto.randomUUID(),
-        schemaVersion: 4,
+        schemaVersion: 5,
         name: input.name,
         synonyms: input.synonyms ?? [],
         aisleId: input.aisleId ?? null,
@@ -44,7 +44,6 @@ export function installE2EHooks(): void {
         needs_approval: input.needs_approval ?? false,
         shoppingBehavior: 'needed',
         updatedAt: '',
-        deletedAt: null,
       };
       // Fire-and-forget: setDoc hangs when the SDK network is disabled (offline
       // test). Firestore still writes to local cache and fires onSnapshot

--- a/apps/web-pwa/tests/CanonCreatePage.test.ts
+++ b/apps/web-pwa/tests/CanonCreatePage.test.ts
@@ -58,7 +58,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/apps/web-pwa/tests/CanonDetailPage.test.ts
+++ b/apps/web-pwa/tests/CanonDetailPage.test.ts
@@ -66,7 +66,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/apps/web-pwa/tests/canonService.sync.test.ts
+++ b/apps/web-pwa/tests/canonService.sync.test.ts
@@ -8,6 +8,7 @@ vi.mock('@salt/firebase-sync', () => ({
   subscribeCanonItems: vi.fn(),
   subscribeAisles: vi.fn(),
   upsertCanonItem: vi.fn().mockResolvedValue(undefined),
+  deleteCanonItem: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   callMatchOrCreate: vi.fn(),
 }));
 
@@ -99,6 +100,7 @@ describe('canonService — subscription-fed stores', () => {
     __resetCanonServiceForTest();
     vi.clearAllMocks();
     fs.upsertCanonItem.mockResolvedValue(undefined);
+    fs.deleteCanonItem.mockResolvedValue({ kind: 'ok', value: undefined });
   });
 
   afterEach(() => {
@@ -145,13 +147,13 @@ describe('canonService — subscription-fed stores', () => {
       expect(get(isLoadingAisles)).toBe(false);
     });
 
-    it('populates canonItems from subscription, filtering tombstones', () => {
+    it('populates canonItems verbatim from subscription (no client-side filtering)', () => {
       const { emitItems } = wireSubscriptions();
       stopSync = initCanonSync();
-      const live = makeItem('a');
-      const dead = makeItem('b', { deletedAt: '2024-01-01' });
-      emitItems([live, dead]);
-      expect(get(canonItems)).toEqual([live]);
+      const a = makeItem('a');
+      const b = makeItem('b');
+      emitItems([a, b]);
+      expect(get(canonItems)).toEqual([a, b]);
     });
 
     it('populates aisles from subscription, sorted by order', () => {
@@ -210,11 +212,11 @@ describe('canonService — in-memory adapters', () => {
   });
 
   describe('memCanonStore', () => {
-    it('list returns seed items (excluding tombstones)', async () => {
-      const seed = [makeItem('a'), makeItem('b', { deletedAt: '2024-01-01' })];
+    it('list returns all seed items', async () => {
+      const seed = [makeItem('a'), makeItem('b')];
       const { store } = memCanonStore(seed);
       const result = await store.list();
-      expect(result).toEqual({ kind: 'ok', value: [makeItem('a')] });
+      expect(result).toEqual({ kind: 'ok', value: seed });
     });
 
     it('upsert adds item and records it as upserted', async () => {
@@ -277,6 +279,7 @@ describe('canonService — commands', () => {
     __resetCanonServiceForTest();
     vi.clearAllMocks();
     fs.upsertCanonItem.mockResolvedValue(undefined);
+    fs.deleteCanonItem.mockResolvedValue({ kind: 'ok', value: undefined });
   });
 
   afterEach(() => {
@@ -320,24 +323,24 @@ describe('canonService — commands', () => {
   });
 
   describe('deleteCanonItem', () => {
-    it('returns ok and calls upsertCanonItem with tombstone when item exists in store', async () => {
-      const { emitItems, emitAisles } = wireSubscriptions();
-      const cleanup = initCanonSync();
-      emitItems([makeItem('a')]);
-      emitAisles([]);
-
+    it('delegates to the adapter deleteCanonItem and never writes a tombstone', async () => {
       const result = await deleteCanonItem('a');
       expect(result).toEqual({ kind: 'ok', value: undefined });
-      expect(fs.upsertCanonItem).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'a', deletedAt: expect.any(String) }),
-      );
-      cleanup();
+      expect(fs.deleteCanonItem).toHaveBeenCalledWith('a');
+      expect(fs.upsertCanonItem).not.toHaveBeenCalled();
     });
 
-    it('returns ok without calling upsertCanonItem when item is not in store', async () => {
+    it('does not require the item to be present in the store', async () => {
       const result = await deleteCanonItem('nonexistent');
       expect(result).toEqual({ kind: 'ok', value: undefined });
-      expect(fs.upsertCanonItem).not.toHaveBeenCalled();
+      expect(fs.deleteCanonItem).toHaveBeenCalledWith('nonexistent');
+    });
+
+    it('propagates an adapter failure to the caller', async () => {
+      const err = { kind: 'StorageError', reason: 'unavailable' } as const;
+      fs.deleteCanonItem.mockResolvedValueOnce({ kind: 'err', error: err });
+      const result = await deleteCanonItem('a');
+      expect(result).toEqual({ kind: 'err', error: err });
     });
   });
 });

--- a/apps/web-pwa/tests/canonService.sync.test.ts
+++ b/apps/web-pwa/tests/canonService.sync.test.ts
@@ -49,7 +49,6 @@ function makeItem(id: string, overrides: Partial<CanonItem> = {}): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }
@@ -323,7 +322,7 @@ describe('canonService — commands', () => {
   });
 
   describe('deleteCanonItem', () => {
-    it('delegates to the adapter deleteCanonItem and never writes a tombstone', async () => {
+    it('delegates to the adapter deleteCanonItem and never writes a soft-delete document', async () => {
       const result = await deleteCanonItem('a');
       expect(result).toEqual({ kind: 'ok', value: undefined });
       expect(fs.deleteCanonItem).toHaveBeenCalledWith('a');

--- a/packages/adapters/firebase-sync/src/canonSubscription.ts
+++ b/packages/adapters/firebase-sync/src/canonSubscription.ts
@@ -1,7 +1,8 @@
-import { getFirestore, collection, doc, setDoc, onSnapshot } from 'firebase/firestore';
+import { getFirestore, collection, doc, setDoc, deleteDoc, onSnapshot } from 'firebase/firestore';
 import { getApp } from 'firebase/app';
 import type { CanonItem } from '@salt/domain';
-import type { DomainError, ShoppingBehavior, CanonItemUnit } from '@salt/shared-types';
+import type { DomainError, ReadResult, ShoppingBehavior, CanonItemUnit } from '@salt/shared-types';
+import { success, failure } from '@salt/shared-types';
 import { classifyFirestoreError } from './firestoreErrors.js';
 
 const COLLECTION = 'canonItems';
@@ -44,4 +45,14 @@ export function subscribeCanonItems(
 export async function upsertCanonItem(item: CanonItem): Promise<void> {
   const db = getFirestore(getApp());
   await setDoc(doc(db, COLLECTION, item.id), { ...item });
+}
+
+export async function deleteCanonItem(id: string): Promise<ReadResult<void, DomainError>> {
+  try {
+    const db = getFirestore(getApp());
+    await deleteDoc(doc(db, COLLECTION, id));
+    return success(undefined);
+  } catch (err) {
+    return failure(classifyFirestoreError(err));
+  }
 }

--- a/packages/adapters/firebase-sync/src/canonSubscription.ts
+++ b/packages/adapters/firebase-sync/src/canonSubscription.ts
@@ -10,7 +10,7 @@ const COLLECTION = 'canonItems';
 function fromDoc(data: Record<string, unknown>): CanonItem {
   return {
     id: data['id'] as string,
-    schemaVersion: 4,
+    schemaVersion: 5,
     name: data['name'] as string,
     synonyms: Array.isArray(data['synonyms']) ? (data['synonyms'] as string[]) : [],
     aisleId: typeof data['aisleId'] === 'string' ? data['aisleId'] : null,
@@ -24,7 +24,6 @@ function fromDoc(data: Record<string, unknown>): CanonItem {
     ...(typeof data['unit'] === 'string' ? { unit: data['unit'] as CanonItemUnit } : {}),
     ...(typeof data['reasoning'] === 'string' ? { reasoning: data['reasoning'] } : {}),
     updatedAt: typeof data['updatedAt'] === 'string' ? data['updatedAt'] : '',
-    deletedAt: typeof data['deletedAt'] === 'string' ? data['deletedAt'] : null,
   };
 }
 

--- a/packages/adapters/firebase-sync/src/index.ts
+++ b/packages/adapters/firebase-sync/src/index.ts
@@ -1,7 +1,7 @@
 export type { FirebaseOptions } from 'firebase/app';
 export { initFirebase, setFirestoreNetwork } from './init.js';
 export { createFirebaseAuth } from './auth.js';
-export { subscribeCanonItems, upsertCanonItem } from './canonSubscription.js';
+export { subscribeCanonItems, upsertCanonItem, deleteCanonItem } from './canonSubscription.js';
 export { subscribeAisles, saveAisles } from './aisleSubscription.js';
 export {
   subscribeEquipmentManifest,

--- a/packages/adapters/firebase-sync/tests/realtimeSubscriptions.emulator.test.ts
+++ b/packages/adapters/firebase-sync/tests/realtimeSubscriptions.emulator.test.ts
@@ -12,7 +12,7 @@ import { initializeApp, deleteApp, type FirebaseApp } from 'firebase/app';
 import { getFirestore, connectFirestoreEmulator, doc, setDoc } from 'firebase/firestore';
 import type { Firestore } from 'firebase/firestore';
 import { getAuth, connectAuthEmulator, signInAnonymously } from 'firebase/auth';
-import { subscribeCanonItems, upsertCanonItem } from '../src/canonSubscription.js';
+import { subscribeCanonItems, upsertCanonItem, deleteCanonItem } from '../src/canonSubscription.js';
 import { subscribeAisles, saveAisles } from '../src/aisleSubscription.js';
 import {
   subscribeEquipmentManifest,
@@ -117,6 +117,32 @@ describe('realtimeSubscriptions — Firestore emulator', () => {
 
       unsubscribe();
       expect(received.some((items) => items.some((i) => i.id === 'onion'))).toBe(true);
+    });
+
+    it('deleteCanonItem removes the doc and the deletion converges via onSnapshot', async () => {
+      const received: CanonItem[][] = [];
+      const unsubscribe = subscribeCanonItems(
+        (items) => received.push(items),
+        () => {},
+      );
+
+      await upsertCanonItem(makeItem('garlic', 'Garlic'));
+      await waitFor(
+        () => received.some((items) => items.some((i) => i.id === 'garlic')),
+        CONVERGENCE_MS,
+      );
+
+      const result = await deleteCanonItem('garlic');
+      expect(result.kind).toBe('ok');
+
+      await waitFor(
+        () => received.some((items) => !items.some((i) => i.id === 'garlic')),
+        CONVERGENCE_MS,
+      );
+
+      unsubscribe();
+      const last = received[received.length - 1]!;
+      expect(last.some((i) => i.id === 'garlic')).toBe(false);
     });
 
     it('returns the unsubscribe function that stops callbacks', async () => {

--- a/packages/adapters/firebase-sync/tests/realtimeSubscriptions.emulator.test.ts
+++ b/packages/adapters/firebase-sync/tests/realtimeSubscriptions.emulator.test.ts
@@ -54,7 +54,6 @@ function makeItem(id: string, name = 'Test'): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
   };
 }
 

--- a/packages/domain/src/canon/commands/createCanonItem.ts
+++ b/packages/domain/src/canon/commands/createCanonItem.ts
@@ -24,7 +24,7 @@ export function createCanonItem(
   }
   return success({
     id: ids.newCanonId(),
-    schemaVersion: 4,
+    schemaVersion: 5,
     name,
     synonyms: (input.synonyms ?? []).map((s) => s.trim()).filter((s) => s.length > 0),
     aisleId: input.aisleId ?? null,
@@ -38,6 +38,5 @@ export function createCanonItem(
     ...(input.unit !== undefined ? { unit: input.unit } : {}),
     ...(input.reasoning !== undefined ? { reasoning: input.reasoning } : {}),
     updatedAt: '',
-    deletedAt: null,
   });
 }

--- a/packages/domain/src/canon/commands/mergeCanonItems.ts
+++ b/packages/domain/src/canon/commands/mergeCanonItems.ts
@@ -14,7 +14,7 @@ import type { CanonItem } from '../entities/CanonItem.js';
 export function mergeCanonItems(local: CanonItem, remote: CanonItem): CanonItem {
   return {
     id: local.id,
-    schemaVersion: 4,
+    schemaVersion: 5,
     name: remote.name,
     synonyms: unionSynonyms(local.synonyms, remote.synonyms),
     aisleId: remote.aisleId,
@@ -29,7 +29,6 @@ export function mergeCanonItems(local: CanonItem, remote: CanonItem): CanonItem 
     ...(remote.reasoning !== undefined ? { reasoning: remote.reasoning } : {}),
     // Server-authoritative sync fields come from remote.
     updatedAt: remote.updatedAt,
-    deletedAt: remote.deletedAt,
   };
 }
 

--- a/packages/domain/src/canon/entities/CanonItem.ts
+++ b/packages/domain/src/canon/entities/CanonItem.ts
@@ -6,7 +6,7 @@ export type { ShoppingBehavior, CanonItemUnit };
 
 export interface CanonItem {
   readonly id: string;
-  readonly schemaVersion: 4;
+  readonly schemaVersion: 5;
   readonly name: string;
   readonly synonyms: readonly string[];
   readonly aisleId: string | null;
@@ -19,5 +19,4 @@ export interface CanonItem {
   readonly reasoning?: string;
   // Sync fields — stamped server-side by the onCanonItemWritten CF trigger.
   readonly updatedAt: string; // ISO-8601
-  readonly deletedAt: string | null; // null = live; non-null = soft-deleted tombstone
 }

--- a/packages/domain/tests/canon/approveCanonItem.test.ts
+++ b/packages/domain/tests/canon/approveCanonItem.test.ts
@@ -13,7 +13,6 @@ const base: CanonItem = {
   needs_approval: true,
   shoppingBehavior: 'needed',
   updatedAt: '',
-  deletedAt: null,
 };
 
 describe('approveCanonItem', () => {

--- a/packages/domain/tests/canon/canonItem.schema.test.ts
+++ b/packages/domain/tests/canon/canonItem.schema.test.ts
@@ -10,70 +10,24 @@ function counterIds(): IdGenerator {
 
 describe('CanonItem schema', () => {
   describe('type-level: new fields exist with correct types', () => {
-    it('schemaVersion is the literal 4', () => {
-      expectTypeOf<CanonItem['schemaVersion']>().toEqualTypeOf<4>();
+    it('schemaVersion is the literal 5', () => {
+      expectTypeOf<CanonItem['schemaVersion']>().toEqualTypeOf<5>();
     });
 
     it('updatedAt is a string', () => {
       expectTypeOf<CanonItem['updatedAt']>().toEqualTypeOf<string>();
     });
-
-    it('deletedAt is string | null', () => {
-      expectTypeOf<CanonItem['deletedAt']>().toEqualTypeOf<string | null>();
-    });
   });
 
   describe('createCanonItem defaults', () => {
-    it('newly created item has schemaVersion 4', () => {
+    it('newly created item has schemaVersion 5', () => {
       const result = createCanonItem({ name: 'Tomato' }, counterIds());
-      expect(result.kind === 'ok' && result.value.schemaVersion).toBe(4);
+      expect(result.kind === 'ok' && result.value.schemaVersion).toBe(5);
     });
 
     it('newly created item has empty updatedAt (pre-sync sentinel)', () => {
       const result = createCanonItem({ name: 'Tomato' }, counterIds());
       expect(result.kind === 'ok' && result.value.updatedAt).toBe('');
-    });
-
-    it('newly created item has deletedAt null', () => {
-      const result = createCanonItem({ name: 'Tomato' }, counterIds());
-      expect(result.kind === 'ok' && result.value.deletedAt).toBeNull();
-    });
-  });
-
-  describe('soft-delete invariants', () => {
-    it('a live item has deletedAt null', () => {
-      const item: CanonItem = {
-        id: 'x',
-        schemaVersion: 4,
-        name: 'Butter',
-        synonyms: [],
-        aisleId: null,
-        thumbnail: null,
-        embedding: null,
-        needs_approval: false,
-        shoppingBehavior: 'needed',
-        updatedAt: '2026-01-01T00:00:00.000Z',
-        deletedAt: null,
-      };
-      expect(item.deletedAt).toBeNull();
-    });
-
-    it('a tombstone item has a non-null deletedAt ISO string', () => {
-      const tombstone: CanonItem = {
-        id: 'x',
-        schemaVersion: 4,
-        name: 'Butter',
-        synonyms: [],
-        aisleId: null,
-        thumbnail: null,
-        embedding: null,
-        needs_approval: false,
-        shoppingBehavior: 'needed',
-        updatedAt: '2026-01-01T00:00:00.000Z',
-        deletedAt: '2026-01-02T00:00:00.000Z',
-      };
-      expect(tombstone.deletedAt).not.toBeNull();
-      expect(typeof tombstone.deletedAt).toBe('string');
     });
   });
 });

--- a/packages/domain/tests/canon/clientFastPathParity.integration.test.ts
+++ b/packages/domain/tests/canon/clientFastPathParity.integration.test.ts
@@ -28,7 +28,7 @@ import type { IdGenerator } from '../../src/canon/ports/IdGenerator.js';
 
 function canonItem(overrides: Partial<CanonItem> & { id: string; name: string }): CanonItem {
   return {
-    schemaVersion: 4,
+    schemaVersion: 5,
     synonyms: [],
     aisleId: null,
     thumbnail: null,
@@ -36,7 +36,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/packages/domain/tests/canon/createCanonItem.test.ts
+++ b/packages/domain/tests/canon/createCanonItem.test.ts
@@ -18,7 +18,7 @@ describe('createCanonItem', () => {
     if (result.kind !== 'ok') return;
     expect(result.value).toEqual({
       id: 'id-1',
-      schemaVersion: 4,
+      schemaVersion: 5,
       name: 'Tomato',
       synonyms: [],
       aisleId: null,
@@ -27,7 +27,6 @@ describe('createCanonItem', () => {
       needs_approval: true,
       shoppingBehavior: 'needed',
       updatedAt: '',
-      deletedAt: null,
     });
   });
 

--- a/packages/domain/tests/canon/createCanonLookup.test.ts
+++ b/packages/domain/tests/canon/createCanonLookup.test.ts
@@ -7,7 +7,7 @@ import type { ReadResult, DomainError } from '@salt/shared-types';
 const seed: readonly CanonItem[] = [
   {
     id: '1',
-    schemaVersion: 4,
+    schemaVersion: 5,
     name: 'Tomato',
     synonyms: ['tom', 'tomate'],
     aisleId: 'produce',
@@ -16,11 +16,10 @@ const seed: readonly CanonItem[] = [
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    deletedAt: null,
   },
   {
     id: '2',
-    schemaVersion: 4,
+    schemaVersion: 5,
     name: 'Olive Oil',
     synonyms: ['EVOO'],
     aisleId: 'oils',
@@ -29,7 +28,6 @@ const seed: readonly CanonItem[] = [
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    deletedAt: null,
   },
 ];
 
@@ -96,7 +94,7 @@ describe('createCanonLookup', () => {
     lookup.refresh([
       {
         id: '99',
-        schemaVersion: 4,
+        schemaVersion: 5,
         name: 'Butter',
         synonyms: [],
         aisleId: 'dairy',
@@ -105,7 +103,6 @@ describe('createCanonLookup', () => {
         needs_approval: false,
         shoppingBehavior: 'needed',
         updatedAt: '',
-        deletedAt: null,
       },
     ]);
 

--- a/packages/domain/tests/canon/deleteAisles.test.ts
+++ b/packages/domain/tests/canon/deleteAisles.test.ts
@@ -42,7 +42,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/packages/domain/tests/canon/findClosestMatch.test.ts
+++ b/packages/domain/tests/canon/findClosestMatch.test.ts
@@ -4,7 +4,7 @@ import type { CanonItem } from '../../src/canon/entities/CanonItem.js';
 
 function item(overrides: Partial<CanonItem> & { id: string; name: string }): CanonItem {
   return {
-    schemaVersion: 4,
+    schemaVersion: 5,
     synonyms: [],
     aisleId: null,
     thumbnail: null,
@@ -12,7 +12,6 @@ function item(overrides: Partial<CanonItem> & { id: string; name: string }): Can
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/packages/domain/tests/canon/getAisleUsage.test.ts
+++ b/packages/domain/tests/canon/getAisleUsage.test.ts
@@ -35,7 +35,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/packages/domain/tests/canon/matchOrCreate.test.ts
+++ b/packages/domain/tests/canon/matchOrCreate.test.ts
@@ -13,7 +13,7 @@ import type { MatchLogEntry } from '../../src/canon/entities/MatchLogEntry.js';
 
 function canonItem(overrides: Partial<CanonItem> & { id: string; name: string }): CanonItem {
   return {
-    schemaVersion: 4,
+    schemaVersion: 5,
     synonyms: [],
     aisleId: null,
     thumbnail: null,
@@ -21,7 +21,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/packages/domain/tests/canon/mergeAisles.test.ts
+++ b/packages/domain/tests/canon/mergeAisles.test.ts
@@ -42,7 +42,6 @@ function canonItem(overrides: Partial<CanonItem> & { id: string; name: string })
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/packages/domain/tests/canon/mergeCanonItems.test.ts
+++ b/packages/domain/tests/canon/mergeCanonItems.test.ts
@@ -13,7 +13,6 @@ function item(overrides: Partial<CanonItem> = {}): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/packages/domain/tests/canon/renameCanonItem.test.ts
+++ b/packages/domain/tests/canon/renameCanonItem.test.ts
@@ -13,7 +13,6 @@ function item(overrides: Partial<CanonItem> = {}): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/packages/domain/tests/canon/resolveCanonConflict.test.ts
+++ b/packages/domain/tests/canon/resolveCanonConflict.test.ts
@@ -13,7 +13,6 @@ function item(overrides: Partial<CanonItem> = {}): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/packages/domain/tests/canon/setCanonItemAisle.test.ts
+++ b/packages/domain/tests/canon/setCanonItemAisle.test.ts
@@ -13,7 +13,6 @@ function item(overrides: Partial<CanonItem> = {}): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/packages/domain/tests/canon/setCanonItemShoppingFields.test.ts
+++ b/packages/domain/tests/canon/setCanonItemShoppingFields.test.ts
@@ -8,7 +8,7 @@ import type { CanonItem } from '../../src/canon/entities/CanonItem.js';
 function item(overrides: Partial<CanonItem> = {}): CanonItem {
   return {
     id: 'c1',
-    schemaVersion: 4,
+    schemaVersion: 5,
     name: 'Olive Oil',
     synonyms: ['EVOO'],
     aisleId: 'oils',
@@ -17,7 +17,6 @@ function item(overrides: Partial<CanonItem> = {}): CanonItem {
     needs_approval: false,
     shoppingBehavior: 'needed',
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/packages/domain/tests/canon/setCanonItemSynonyms.test.ts
+++ b/packages/domain/tests/canon/setCanonItemSynonyms.test.ts
@@ -13,7 +13,6 @@ function item(overrides: Partial<CanonItem> = {}): CanonItem {
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
     ...overrides,
   };
 }

--- a/packages/domain/tests/canon/synonymMatch.test.ts
+++ b/packages/domain/tests/canon/synonymMatch.test.ts
@@ -13,7 +13,6 @@ const items: readonly CanonItem[] = [
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
   },
   {
     id: '2',
@@ -25,7 +24,6 @@ const items: readonly CanonItem[] = [
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
   },
   {
     id: '3',
@@ -37,7 +35,6 @@ const items: readonly CanonItem[] = [
     embedding: null,
     needs_approval: false,
     updatedAt: '',
-    deletedAt: null,
   },
 ];
 


### PR DESCRIPTION
Phase 2. Strips the pre-Firestore-as-master deletedAt tombstone field from CanonItem and every reference, completing the move to real deleteDoc-based deletion begun in Phase 1.

- Bumped CanonItem.schemaVersion 4 to 5 to mark the breaking shape change; propagated to all typed construction sites and fixtures
- Pre-existing schemaVersion 2/3 fixtures left as-is: unrelated to deletedAt and out of this issue's scope
- Renamed a settled Phase-1 test title to drop the word "tombstone" so the DoD grep gate is clean; zero behavior or coverage change

Closes #68