### PR TITLE
ci(release): add manual workflow_dispatch to staging deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,11 +3,16 @@ name: Deploy Staging
 # Runs after the CI workflow finishes successfully on main. main is protected
 # (PR + required status checks), so this is the post-merge, post-green deploy of
 # the exact merged commit — the trunk-based "merge to main -> staging" path.
+#
+# workflow_dispatch is a manual escape hatch: re-deploy staging on demand, or
+# deploy when an unrelated CI flake is blocking the automatic trigger. It runs
+# the current main HEAD.
 on:
   workflow_run:
     workflows: ['CI']
     types: [completed]
     branches: [main]
+  workflow_dispatch: {}
 
 # id-token: write is REQUIRED for Workload Identity Federation — it lets the job
 # mint the short-lived OIDC token that google-github-actions/auth exchanges for
@@ -25,8 +30,9 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to staging
-    # Only deploy when CI actually passed (workflow_run also fires on failure).
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Auto path: only when CI passed (workflow_run also fires on failure).
+    # Manual path: always allowed (deliberate maintainer action).
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     # Scopes WIF_PROVIDER / WIF_SERVICE_ACCOUNT to the staging GitHub Environment.
     environment: staging
@@ -34,8 +40,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Deploy the exact commit CI validated, not whatever is newest on main.
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # Auto: the exact commit CI validated. Manual: current main HEAD.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to `deploy-staging.yml` so staging can be deployed on demand — and so we can verify the full WIF + `firebase deploy` path now, independent of the flaky emulator test that's blocking the automatic `workflow_run` trigger.

- The automatic path still requires CI green (`workflow_run.conclusion == 'success'`).
- Manual dispatch is allowed unconditionally (deliberate maintainer action) and deploys current `main` HEAD.

Follow-up: separate issue to stabilize the flaky `realtimeSubscriptions` emulator test that gates deploys.

Refs #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)