### PR TITLE
ci(release): stop deploying unused Firebase Storage rules

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -68,8 +68,9 @@ jobs:
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
 
-      # Deploys all targets: hosting, functions, firestore rules + indexes, storage
-      # rules. The functions predeploy hook (firebase.json) builds the CF bundle;
-      # GEMINI_API_KEY / LD_SDK_KEY are already in this project's Secret Manager.
+      # Deploys all targets in firebase.json: hosting, functions, firestore rules
+      # + indexes. (Storage is not deployed — unused; re-add when a feature needs
+      # it.) The functions predeploy hook builds the CF bundle; GEMINI_API_KEY /
+      # LD_SDK_KEY are already in this project's Secret Manager.
       - name: Deploy to Firebase (staging)
         run: pnpm exec firebase deploy -P staging --non-interactive --force

--- a/firebase.json
+++ b/firebase.json
@@ -11,9 +11,6 @@
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
-  "storage": {
-    "rules": "storage.rules"
-  },
   "hosting": {
     "public": "apps/web-pwa/dist",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]


### PR DESCRIPTION
The first staging deploy got past WIF auth + the API checks, then failed on:

> Error: Firebase Storage has not been set up on project 's2-stage-ccb22'.

Firebase Storage is **unused** — no `firebase/storage` imports anywhere, `storage.rules` is a default deny-all, and no bucket is provisioned. Deploying rules for a non-existent bucket of an unused service is never correct, so this drops the `storage` block from `firebase.json` (keeping `storage.rules` as a ready template). We re-add the block and provision a bucket if/when a feature needs Storage (e.g. recipe images).

Refs #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)