### PR TITLE
ci(release): package cloud-functions as a workspace-free deploy artifact

### DIFF
--- a/apps/cloud-functions/package.json
+++ b/apps/cloud-functions/package.json
@@ -8,7 +8,7 @@
     "node": "22"
   },
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:firebase-admin --external:firebase-admin/* --external:firebase-functions --external:firebase-functions/* --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
+    "build": "rm -rf dist && esbuild src/index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:firebase-admin --external:firebase-admin/* --external:firebase-functions --external:firebase-functions/* --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\" && node scripts/write-deploy-package.mjs && npm install --prefix dist --omit=dev --no-audit --no-fund --loglevel=error",
     "dev": "NODE_OPTIONS='--disable-warning=DEP0040' genkit start --port 4001 -- tsx --env-file=.secret.local --watch src/dev.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/apps/cloud-functions/scripts/write-deploy-package.mjs
+++ b/apps/cloud-functions/scripts/write-deploy-package.mjs
@@ -1,0 +1,39 @@
+// Emits dist/package.json — the package manifest that ships to Cloud Functions.
+//
+// The esbuild bundle (dist/index.js) inlines everything EXCEPT the two
+// --external packages (firebase-admin, firebase-functions). So the deployed
+// artifact's only real runtime dependencies are those two. Crucially it must
+// contain NO `workspace:*` deps: Cloud Build runs plain `npm install` against
+// this file and cannot resolve pnpm's workspace protocol (EUNSUPPORTEDPROTOCOL).
+//
+// firebase.json points functions.source at dist/, so THIS file (not the source
+// package.json with its workspace deps) is what gets uploaded.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const src = JSON.parse(readFileSync(resolve(pkgRoot, 'package.json'), 'utf8'));
+
+const pick = (name) => {
+  const v = src.dependencies?.[name];
+  if (!v) throw new Error(`expected ${name} in cloud-functions dependencies`);
+  return v;
+};
+
+const deployPkg = {
+  name: 'salt-cloud-functions',
+  type: 'module',
+  // Relative to dist/, which is the deployed source root.
+  main: 'index.js',
+  // Drives the deployed Node runtime (nodejs22) — must be present.
+  engines: src.engines,
+  dependencies: {
+    'firebase-admin': pick('firebase-admin'),
+    'firebase-functions': pick('firebase-functions'),
+  },
+};
+
+writeFileSync(resolve(pkgRoot, 'dist/package.json'), JSON.stringify(deployPkg, null, 2) + '\n');
+console.log('wrote dist/package.json (deploy artifact: firebase-admin, firebase-functions)');

--- a/firebase.json
+++ b/firebase.json
@@ -1,9 +1,9 @@
 {
   "functions": [
     {
-      "source": "apps/cloud-functions",
+      "source": "apps/cloud-functions/dist",
       "codebase": "default",
-      "ignore": ["node_modules", ".git", "**/*.test.ts"],
+      "ignore": ["node_modules", ".git"],
       "predeploy": ["pnpm --filter @salt/cloud-functions build"]
     }
   ],


### PR DESCRIPTION
The first staging functions deploy failed in Cloud Build with `npm error code EUNSUPPORTEDPROTOCOL` — npm can't resolve the pnpm `workspace:*` deps (`@salt/domain`, `@salt/shared-types`, `@salt/ld-observability`) in the uploaded `package.json`. Never surfaced before because functions only ran in the emulator.

The esbuild bundle already inlines everything except `firebase-admin` / `firebase-functions` (the only `--external`s), so the deploy artifact needs only those two.

## Changes
- `apps/cloud-functions` build now: cleans `dist`, emits the bundle, writes a **minimal generated `package.json`** (only the two SDKs, zero `workspace:*`), and installs those SDKs into `dist/node_modules` so firebase-tools' Gen2 **discovery** can locate the Functions SDK.
- `firebase.json` `functions.source` → `apps/cloud-functions/dist`. `node_modules` is ignored on upload; Cloud Build reinstalls from the clean lockfile.

## Verification
Deployed all 7 functions to **staging** successfully (5 callables + 2 Firestore triggers with the correct `firestore.document.v1.written` trigger type). 

The `source` change also affects the e2e emulator stack (it loads `apps/cloud-functions/dist/index.js`) — **this PR's e2e job is the regression check** for that.

Refs #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)