### PR TITLE
test(firebase-sync): retry flaky emulator realtime-subscription tests

### DIFF
--- a/packages/adapters/firebase-sync/vitest.emulator.config.ts
+++ b/packages/adapters/firebase-sync/vitest.emulator.config.ts
@@ -27,5 +27,12 @@ export default defineConfig({
     // hit the emulator (init, anon sign-in, data clear).
     testTimeout: 20_000,
     hookTimeout: 30_000,
+    // Stopgap for the flaky Firestore realtime Listen stream (issue #122): on CI
+    // the gRPC Listen stream intermittently breaks with a bogus multi-GB
+    // RESOURCE_EXHAUSTED, after which the subscription delivers nothing and every
+    // waitFor times out. A longer timeout can't help (the stream is dead), but a
+    // retry re-runs on a fresh subscription and clears the transient. This masks
+    // the symptom; the root fix (emulator cold-start / teardown) stays in #122.
+    retry: 2,
   },
 });


### PR DESCRIPTION
Stopgap for #122. The Firestore realtime `Listen` gRPC stream intermittently breaks on CI with a bogus multi-GB `RESOURCE_EXHAUSTED`, so subscriptions deliver nothing and every `waitFor` times out — it failed CI **4× today** and blocked merges/deploys.

Adds vitest `retry: 2` to the emulator config so a transient stream break re-runs on a fresh subscription. A longer timeout can't help (the stream is dead); a retry can.

This masks the symptom to unblock the pipeline; the root cause (emulator cold-start / teardown, tied to the dockerization decision) stays tracked in #122. **This PR's own CI is the proof** — the emulator suite should now survive a transient break.

Refs #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)