### PR TITLE
fix(web-pwa): complete magic-link sign-in across tabs and devices

### DIFF
--- a/apps/web-pwa/src/components/LoginPage.svelte
+++ b/apps/web-pwa/src/components/LoginPage.svelte
@@ -16,6 +16,16 @@
     }
   }
 
+  async function onComplete() {
+    if (!email || busy) return;
+    busy = true;
+    try {
+      await auth.completeWithEmail(email);
+    } finally {
+      busy = false;
+    }
+  }
+
   async function onDev() {
     if (!email || busy) return;
     busy = true;
@@ -38,6 +48,29 @@
           A sign-in link has been sent to <strong>{email}</strong>. Open it on this device to finish
           signing in.
         </p>
+      {:else if auth.needsEmail}
+        <form
+          class="space-y-4"
+          onsubmit={(e) => {
+            e.preventDefault();
+            void onComplete();
+          }}
+        >
+          <p class="text-sm text-muted-foreground">
+            Confirm the email you requested the sign-in link for to finish signing in.
+          </p>
+          <TextField
+            bind:value={email}
+            label="Email"
+            type="email"
+            placeholder="you@example.com"
+            required
+          />
+          {#if auth.error}
+            <p class="text-sm text-destructive">{auth.error}</p>
+          {/if}
+          <Button type="submit" disabled={!email || busy} loading={busy}>Complete sign-in</Button>
+        </form>
       {:else}
         <form
           class="space-y-4"

--- a/apps/web-pwa/src/lib/auth.svelte.ts
+++ b/apps/web-pwa/src/lib/auth.svelte.ts
@@ -4,13 +4,16 @@ import { identifyUser, identifyAnonymous } from './observability.js';
 
 const PENDING_EMAIL_KEY = 'salt:auth:pendingEmail';
 
-// Web-pwa is the composition layer for auth — it holds the pending email
-// (sessionStorage) so the firebase-sync adapter can stay stateless. The
+// Web-pwa is the composition layer for auth — it holds the pending email so
+// the firebase-sync adapter can stay stateless. We use localStorage (not
+// sessionStorage) because email clients open the magic link in a new tab or
+// window, which gets a fresh sessionStorage; localStorage is shared across
+// all tabs of the same browser, so the email survives the round-trip. The
 // adapter rule keeps browser-storage primitives out of adapters; this file
-// is in the app, which is allowed to touch sessionStorage directly.
+// is in the app, which is allowed to touch localStorage directly.
 function readPendingEmail(): string | null {
   try {
-    return window.sessionStorage.getItem(PENDING_EMAIL_KEY);
+    return window.localStorage.getItem(PENDING_EMAIL_KEY);
   } catch {
     return null;
   }
@@ -18,15 +21,15 @@ function readPendingEmail(): string | null {
 
 function writePendingEmail(email: string): void {
   try {
-    window.sessionStorage.setItem(PENDING_EMAIL_KEY, email);
+    window.localStorage.setItem(PENDING_EMAIL_KEY, email);
   } catch {
-    /* sessionStorage unavailable — magic link will prompt for email on return */
+    /* localStorage unavailable — magic link will prompt for email on return */
   }
 }
 
 function clearPendingEmail(): void {
   try {
-    window.sessionStorage.removeItem(PENDING_EMAIL_KEY);
+    window.localStorage.removeItem(PENDING_EMAIL_KEY);
   } catch {
     /* ignore */
   }
@@ -37,6 +40,13 @@ class AuthStore {
   loading = $state(true);
   error = $state<string | null>(null);
   linkSent = $state(false);
+  // True when we returned from a magic link but had no stored email to
+  // complete it (link opened on a different device/browser, or storage was
+  // cleared). The login UI prompts for the email and calls completeWithEmail.
+  needsEmail = $state(false);
+  // The magic-link URL we're waiting to complete, captured before any history
+  // rewrite so completeWithEmail can finish sign-in after the user re-enters.
+  private pendingUrl: string | null = null;
 
   constructor() {
     this.user = authProvider.getCurrentUser();
@@ -57,19 +67,37 @@ class AuthStore {
     }
     const email = readPendingEmail();
     if (!email) {
-      this.error = 'Sign-in link opened on a different device — re-enter your email.';
+      // Can't complete without the email (different device, or storage lost).
+      // Prompt for it instead of dead-ending — completeWithEmail finishes up.
+      this.pendingUrl = url;
+      this.needsEmail = true;
       this.loading = false;
       return;
     }
+    await this.finishSignIn(url, email);
+    this.loading = false;
+  }
+
+  // Complete sign-in for a magic-link URL once we have the email. Shared by
+  // the automatic path (stored email) and the manual re-entry path.
+  private async finishSignIn(url: string, email: string): Promise<void> {
     const result = await authProvider.completeMagicLink(url, email);
     if (result.kind === 'ok') {
       clearPendingEmail();
+      this.needsEmail = false;
+      this.pendingUrl = null;
       // Strip the magic-link params so a refresh doesn't re-trigger sign-in.
       window.history.replaceState({}, '', window.location.pathname);
     } else {
       this.error = formatError(result.error);
     }
-    this.loading = false;
+  }
+
+  // Called from the login UI when the user re-enters their email to finish a
+  // magic-link sign-in we couldn't complete automatically.
+  async completeWithEmail(email: string): Promise<void> {
+    this.error = null;
+    await this.finishSignIn(this.pendingUrl ?? window.location.href, email);
   }
 
   async sendLink(email: string): Promise<void> {


### PR DESCRIPTION
## What

Fixes magic-link sign-in dead-ending with **"Sign-in link opened on a different device — re-enter your email"** even on the same machine (surfaced live on staging after auth was provisioned in #128).

## Why it broke

Two bugs in the completion path:

1. **Pending email was stored in `sessionStorage`** (per-tab). Email clients open the magic link in a *new* tab, which gets a fresh, empty `sessionStorage`, so the email saved at send-time was missing at click-time.
2. **The fallback was a dead end** — `LoginPage` only offered "Send magic link" (sends a *new* link), with no way to complete the link just clicked.

## Changes

- `auth.svelte.ts`: pending email moved to **`localStorage`** (shared across tabs/windows of the same browser) → the common desktop "new tab" case now completes automatically. Lint only blocks IndexedDB *imports*; direct `localStorage` use in the app layer is an accepted exception (as the prior `sessionStorage` use was).
- `auth.svelte.ts`: when returning on a magic-link URL with no stored email, capture the URL and set a new `needsEmail` state (instead of dead-ending). New `AuthStore.completeWithEmail()` finishes sign-in via `signInWithEmailLink(url, enteredEmail)`. Extracted shared `finishSignIn()`.
- `LoginPage.svelte`: new "Confirm your email to finish signing in" branch that calls `completeWithEmail`. Recovers cross-device and mobile in-app-browser cases.

Matches Firebase's documented email-link pattern (persist email; prompt for it on return if missing).

## Verification

- `pnpm typecheck`, `pnpm lint`, dependency-cruiser (pre-commit), and `pnpm --filter @salt/web-pwa build` all pass.
- Needs live confirmation on staging after auto-deploy:
  - [ ] Magic link in a new tab, same browser → signs in automatically.
  - [ ] Magic link on a different device/browser → prompted for email → completes sign-in.

## Notes / out of scope

- Expired/invalid links (`auth/expired-action-code`) still render the generic "Sign-in failed." — separate DX nicety, not addressed here.

Closes #129. Follow-up to #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)