### PR TITLE
ci(release): production promotion + end-of-greenfield note (Phases 4 & 6)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,71 @@
+name: Deploy Production
+
+# Production is a deliberate promotion, never automatic. Publishing a GitHub
+# Release deploys that release's exact tagged commit to production — the same
+# commit already validated on staging. workflow_dispatch is a manual path for
+# re-deploy / rollback (deploy a chosen earlier tag). BOTH paths run in the
+# `production` GitHub Environment, whose required-reviewer rule is the approval
+# gate: nothing reaches prod until the maintainer approves the run.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or SHA to deploy to production (manual re-deploy / rollback)'
+        required: true
+
+permissions:
+  contents: read
+  id-token: write # WIF OIDC token
+
+# Never run two prod deploys at once; queue rather than cancel.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    # The approval gate. Also the source of WIF_PROVIDER / WIF_SERVICE_ACCOUNT —
+    # the production deployer SA is bound to attribute.environment/production, so
+    # only a job running in THIS environment can assume it (defence in depth on
+    # top of the manual approval).
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # On release: the published tag. On manual dispatch: the chosen ref.
+          ref: ${{ github.event.release.tag_name || inputs.ref }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.33.0'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Default Vite mode is production -> loads apps/web-pwa/.env.production
+      # (prod Firebase config + LD client-side ID). Output -> apps/web-pwa/dist.
+      - name: Build web-pwa (production)
+        run: pnpm --filter @salt/web-pwa build
+
+      - name: Authenticate to Google Cloud (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: s2-prod-e46bd
+          workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+          service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
+
+      # Deploys hosting, functions, firestore rules + indexes to production. The
+      # functions predeploy hook builds the workspace-free deploy artifact;
+      # GEMINI_API_KEY / LD_SDK_KEY are already in prod Secret Manager.
+      - name: Deploy to Firebase (production)
+        run: pnpm exec firebase deploy -P production --non-interactive --force

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ cloud-functions            →  shared-types, domain, ld-observability/server
   - **Adapter list reads & realtime subscriptions** → skip the invalid doc, log it, and return the valid subset; one corrupt doc must not fail the whole read. Stream-level errors still surface via `onError`.
   - **Callable CF entrypoints** → `throw new HttpsError('invalid-argument', …)`; this is the Firebase callable protocol for rejecting bad client input, not an internal seam.
   - **Firestore triggers** → log and return; there is no caller to surface a `Failure` to.
+- **Production schema changes need a back-compat check.** Pre-launch (greenfield) schema-shape changes are free. Once production holds real data, a schema-shape change must not break documents already written — keep it backward-compatible on read or run a one-off migration. See [docs/salt-architecture.md §1.1](docs/salt-architecture.md).
 
 ## Enforcement
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -169,7 +169,7 @@ A brand-new Firebase project needs one-time setup that the CI deployer SA
 - [x] Staging deploy workflow (`deploy-staging.yml` — on CI success on `main`)
 - [x] Staging first-deploy bootstrap (APIs + service agents) done
 - [x] **First end-to-end staging deploy verified** (CI/SA → https://s2-stage-ccb22.web.app)
-- [ ] Production first-deploy bootstrap (APIs done; owner bootstrap deploy still needed)
+- [x] Production first-deploy bootstrap (owner deploy done — functions + firestore + hosting live at https://s2-prod-e46bd.web.app)
 - [x] Production deploy workflow (`deploy-production.yml` — on GitHub Release, gated) — Phase 4
 - [x] ~~PR preview channels~~ — **dropped** (#126 reverted). The whole app sits behind an auth gate and magic-link sign-in can't run on a preview's unauthorized, per-PR origin, so a preview only ever shows the login page. Verify on the staging domain after merge instead.
 - [x] End-of-greenfield doc note (`salt-architecture.md` §1.1 + `CLAUDE.md`) — Phase 6

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -80,8 +80,9 @@ deploy job can see:
 | `staging`    | none (auto-deploy)   | staging WIF provider + service-account refs                 |
 | `production` | required reviewer (maintainer) = the approval gate | production WIF provider + service-account refs |
 
-PR preview deploys use **staging-scoped** config only; production secrets are
-never exposed to PR-triggered jobs.
+No PR-triggered jobs run against either Environment (per-PR Hosting previews were
+dropped — see Setup status); production secrets are scoped to release-triggered
+deploys only.
 
 #### WIF identifiers (provisioned — Phase 2)
 
@@ -91,11 +92,47 @@ them to `google-github-actions/auth` as `workload_identity_provider` +
 
 | Env          | `workload_identity_provider`                                                                  | `service_account`                            | Impersonation scope |
 | ------------ | --------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------------- |
-| `staging`    | `projects/946977631175/locations/global/workloadIdentityPools/github-actions/providers/github` | `gha-deployer@s2-stage-ccb22.iam.gserviceaccount.com` | repo `eggman0131/saltV2` (covers PR previews) |
+| `staging`    | `projects/946977631175/locations/global/workloadIdentityPools/github-actions/providers/github` | `gha-deployer@s2-stage-ccb22.iam.gserviceaccount.com` | repo `eggman0131/saltV2` |
 | `production` | `projects/140613398002/locations/global/workloadIdentityPools/github-actions/providers/github` | `gha-deployer@s2-prod-e46bd.iam.gserviceaccount.com`  | **only** the `production` GitHub Environment |
 
 The OIDC provider on both projects is restricted to
 `assertion.repository == 'eggman0131/saltV2'`; no long-lived key exists anywhere.
+
+## Deploying
+
+| Target       | Trigger                                   | Workflow                |
+| ------------ | ----------------------------------------- | ----------------------- |
+| `staging`    | every push to `main` (after CI passes)    | `deploy-staging.yml`    |
+| `production` | a **published GitHub Release** (gated)    | `deploy-production.yml` |
+
+**Production is a deliberate promotion, never automatic.** Publishing a GitHub
+Release deploys that release's exact tagged commit — the same commit already
+auto-deployed to and validated on staging. The job runs in the `production`
+GitHub Environment, whose required-reviewer rule is the approval gate: the run
+sits paused until the maintainer approves it, then deploys.
+
+### Cutting a release (promote staging → production)
+
+1. Confirm the commit you want is live and healthy on staging.
+2. Publish a GitHub Release whose tag points at that commit
+   (`gh release create vX.Y.Z --target <sha>`).
+3. `deploy-production.yml` starts and **waits for approval** in the `production`
+   Environment. Approve the run → it deploys that tag's commit to prod.
+
+### Rollback / re-deploy
+
+Production has no separate rollback build — you re-deploy a known-good tag:
+
+- **Re-deploy an earlier tag.** Run `deploy-production.yml` via
+  **workflow_dispatch** with `ref` set to the previous good tag (or SHA). It
+  goes through the same `production` approval gate and redeploys that commit's
+  artifacts (hosting + functions + firestore rules/indexes).
+- **Instant hosting-only rollback.** For a frontend-only regression, the
+  Firebase Hosting console's **one-click rollback** to the prior release is the
+  fastest path; it does not revert functions or rules.
+
+Either way, fixing forward (merge a fix → it auto-deploys to staging → cut a new
+release) is preferred when the issue isn't an emergency.
 
 ## First deploy to a fresh project (one-time bootstrap)
 
@@ -133,6 +170,6 @@ A brand-new Firebase project needs one-time setup that the CI deployer SA
 - [x] Staging first-deploy bootstrap (APIs + service agents) done
 - [x] **First end-to-end staging deploy verified** (CI/SA → https://s2-stage-ccb22.web.app)
 - [ ] Production first-deploy bootstrap (APIs done; owner bootstrap deploy still needed)
-- [ ] Production deploy workflow (on GitHub Release) — Phase 4
+- [x] Production deploy workflow (`deploy-production.yml` — on GitHub Release, gated) — Phase 4
 - [x] ~~PR preview channels~~ — **dropped** (#126 reverted). The whole app sits behind an auth gate and magic-link sign-in can't run on a preview's unauthorized, per-PR origin, so a preview only ever shows the login page. Verify on the staging domain after merge instead.
-- [ ] End-of-greenfield doc note — Phase 6
+- [x] End-of-greenfield doc note (`salt-architecture.md` §1.1 + `CLAUDE.md`) — Phase 6

--- a/docs/salt-architecture.md
+++ b/docs/salt-architecture.md
@@ -17,6 +17,12 @@ The architecture must remain framework‑agnostic, testable, and resilient to ch
 - **Last-write-wins per document.** No bespoke conflict resolution. If a specific document ever needs stronger guarantees, that is a per-document decision.
 - **Single-family workspace.** All authenticated members see all data; admin actions are gated per user.
 
+### 1.1 Schema evolution and production data
+
+Until the first production deploy, Salt is **greenfield** — no real data exists, so schema‑shape changes are free (drop a field, rename a collection, change a type) and **no migrations or back‑compat shims are written**.
+
+**That posture ends at launch.** Once production holds real family data, every schema‑shape change must account for documents already written: either keep the new shape backward‑compatible (tolerate old docs on read) or run an explicit one‑off migration. "Just change the shape" is no longer safe for production. Last‑write‑wins per document and the no‑tombstones / no‑soft‑delete rules are unchanged — this adds one standing gate: *does this change break existing production documents?*
+
 ---
 
 ## 2. Mono‑repo structure (logical modules)


### PR DESCRIPTION
## What

Closes out the last two phases of the release pipeline (#118), now that per-PR previews (Phase 5) are dropped (#131).

### Phase 4 — Production promotion behind approval gate
- **`deploy-production.yml`**: on a **published GitHub Release**, deploy that release's exact tagged commit — the same commit already validated on staging. Runs in the `production` GitHub Environment, whose required-reviewer rule **is** the approval gate. `workflow_dispatch(ref)` is the manual re-deploy / rollback path. `concurrency` queues rather than cancels.
- **`docs/releases.md`**: new **Deploying** section (staging auto / production gated), a *cut-a-release* runbook, and **rollback** docs — re-deploy a prior tag via `workflow_dispatch`, or Hosting console one-click for a frontend-only regression.

### Phase 6 — End of greenfield
- **`salt-architecture.md`** §1.1 *Schema evolution and production data*: once prod holds real family data, every schema-shape change must stay backward-compatible on read or run an explicit one-off migration.
- **`CLAUDE.md`**: adds the standing back-compat gate to the zod conventions, pointing at §1.1.

Also drops now-stale PR-preview references in `releases.md` left over after #131.

## Already in place (verified on GitHub, no code change needed)
- `staging` + `production` Environments exist; `production` has the required-reviewer gate (maintainer).
- `production` Environment has `WIF_PROVIDER` + `WIF_SERVICE_ACCOUNT` vars.

## Verification
- Pre-commit: `tsc --build` + dependency-cruiser pass. CI-config + docs only; no runtime code touched.
- Production workflow mirrors `deploy-staging.yml`'s build/deploy steps, retargeted to the `production` alias (storage already excluded, per #123). `vite build` defaults to production mode → loads `.env.production`.

## ⚠️ Maintainer dependency before first prod deploy
Production **first-deploy bootstrap** (owner-run `firebase deploy -P production` for the one-time gen2 service-agent IAM) is still outstanding — the SA can't do it. Documented in `releases.md` → *First deploy to a fresh project*. The workflow is correct but its first run will fail until that bootstrap is done.

Refs #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)