### PR TITLE
ci(release): `pnpm release` — cut YYYYMM.X production releases

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -114,10 +114,21 @@ sits paused until the maintainer approves it, then deploys.
 ### Cutting a release (promote staging → production)
 
 1. Confirm the commit you want is live and healthy on staging.
-2. Publish a GitHub Release whose tag points at that commit
-   (`gh release create vX.Y.Z --target <sha>`).
+2. Run **`pnpm release`**. It computes the next tag, prints it, asks for
+   confirmation, then creates + publishes the GitHub Release.
 3. `deploy-production.yml` starts and **waits for approval** in the `production`
    Environment. Approve the run → it deploys that tag's commit to prod.
+
+**Release tags use `YYYYMM.X`** — calendar month + a counter that resets each
+month (`202606.1`, `202606.2`, … then `202607.1`). `pnpm release`
+(`scripts/cut-release.sh`) finds the highest `X` already used this month across
+published Releases and remote tags, increments it, and tags `main`'s HEAD.
+
+```bash
+pnpm release          # tag main's HEAD with the next YYYYMM.X
+pnpm release <ref>    # tag a specific branch / sha / tag instead of main
+pnpm release -y       # skip the confirmation prompt
+```
 
 ### Rollback / re-deploy
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "boundary:test": "sh .boundary-tests/run.sh",
     "provenance:check": "pnpm --filter @salt/ui-components provenance:check",
     "theme:check": "pnpm --filter @salt/ui-components theme:check",
+    "release": "bash scripts/cut-release.sh",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "format": "prettier --write \"**/*.{ts,js,svelte,css,html}\"",

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Cut a production release.
+#
+# Creates and publishes a GitHub Release whose tag follows YYYYMM.X, where X
+# auto-increments per calendar month: 202606.1, 202606.2, …, then 202607.1.
+# Publishing the Release triggers .github/workflows/deploy-production.yml, which
+# deploys the tagged commit to production *after* you approve the run in the
+# `production` GitHub Environment. See docs/releases.md.
+#
+# Usage:
+#   pnpm release          # tag main's current HEAD
+#   pnpm release <ref>    # tag a specific branch / sha / tag instead of main
+#   pnpm release -y       # skip the confirmation prompt
+#
+set -euo pipefail
+
+target="main"
+assume_yes=""
+for arg in "$@"; do
+  case "$arg" in
+    -y | --yes) assume_yes=1 ;;
+    *) target="$arg" ;;
+  esac
+done
+
+ym="$(date +%Y%m)"
+
+# Highest X already used this month. Checked against both published Releases and
+# remote tags (the latter catches a tag left behind by a half-finished release).
+# `max // 0` makes the first release of a month start at 1.
+max_releases="$(gh release list --limit 200 --json tagName \
+  --jq '[.[].tagName | select(test("^'"$ym"'\\.[0-9]+$")) | split(".")[1] | tonumber] | max // 0')"
+
+max_tags="$(git ls-remote --tags origin 2>/dev/null \
+  | sed -n 's#.*refs/tags/'"$ym"'\.\([0-9]\{1,\}\)$#\1#p' \
+  | sort -n | tail -1 || true)"
+max_tags="${max_tags:-0}"
+
+next_x="$max_releases"
+if [ "$max_tags" -gt "$next_x" ]; then next_x="$max_tags"; fi
+next_x=$((next_x + 1))
+tag="${ym}.${next_x}"
+
+echo "Release tag : $tag"
+echo "Target ref  : $target"
+echo "On publish  : deploy-production.yml runs, then waits for your approval in the 'production' Environment."
+
+if [ -z "$assume_yes" ]; then
+  read -r -p "Create and publish this release? [y/N] " reply || reply=""
+  case "$reply" in
+    [yY] | [yY][eE][sS]) ;;
+    *)
+      echo "Aborted."
+      exit 1
+      ;;
+  esac
+fi
+
+gh release create "$tag" --target "$target" --title "$tag" --generate-notes
+
+echo
+echo "Published $tag. Approve the deploy: Actions tab -> 'Deploy Production' -> Review deployments."


### PR DESCRIPTION
## What

Adds a one-command way to cut a production release: **`pnpm release`**.

Release tags use **`YYYYMM.X`** — calendar month + a counter that resets each month:
`202606.1`, `202606.2`, … then `202607.1`.

[`scripts/cut-release.sh`](scripts/cut-release.sh):
1. Computes `YYYYMM` for the current month.
2. Finds the highest `X` already used this month — across **both** published GitHub Releases and remote tags (the tag check catches a tag left behind by a half-finished release) — and increments it (`max // 0` → first release of a month is `.1`).
3. Prints the tag + target, asks for confirmation, then `gh release create`s and **publishes** it — which fires the gated `deploy-production.yml`.

```bash
pnpm release          # tag main's HEAD with the next YYYYMM.X
pnpm release <ref>    # tag a specific branch / sha / tag instead of main
pnpm release -y       # skip the confirmation prompt
```

## Changes
- `scripts/cut-release.sh` (new, executable).
- `package.json`: `release` script alias.
- `docs/releases.md`: cut-a-release runbook now uses `pnpm release` and documents the scheme.

## Notes
- Numbering ignores the existing `v0.1.0` release (doesn't match `YYYYMM.X`), so the first run produces `202606.1`. Verified the detection logic read-only: `max_releases=0, max_tags=0 → 202606.1`.
- Publishing still only *triggers* the deploy; the `production` Environment's required-reviewer gate is unchanged.

Refs #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)