### PR TITLE
ci(deploy): skip staging deploy on docs/non-code-only merges (#135)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -42,26 +42,77 @@ jobs:
         with:
           # Auto: the exact commit CI validated. Manual: current main HEAD.
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # fetch-depth: 2 brings down the merged commit + its first parent so
+          # the guard step below can diff them. (Manual runs don't diff.)
+          fetch-depth: 2
+
+      # workflow_run triggers cannot use paths/paths-ignore, so the deploy-vs-skip
+      # decision is computed here instead. Deploy only when the merged commit
+      # touched a deploy-relevant path; manual runs always deploy. Allowlist, not
+      # denylist, and fail-safe toward deploying: any error resolving the diff
+      # defaults to should_deploy=true so we never silently skip a real change.
+      - name: Determine whether a deploy-relevant path changed
+        id: guard
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual dispatch — always deploy."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          head="${{ github.event.workflow_run.head_sha }}"
+          # First parent of the merged commit = previous main HEAD (squash/merge
+          # commits to main have a single first parent).
+          if ! base="$(git rev-parse "${head}^" 2>/dev/null)"; then
+            echo "Could not resolve parent of ${head}; defaulting to deploy."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! changed="$(git diff --name-only "${base}" "${head}" 2>/dev/null)"; then
+            echo "git diff failed; defaulting to deploy."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed files between ${base} and ${head}:"
+          echo "${changed}"
+
+          # Allowlist of deploy-relevant paths. Any match -> deploy. apps/** and
+          # packages/** already cover nested package.json files, so the bare
+          # package.json anchor only matches the root manifest.
+          if echo "${changed}" | grep -Eq '^(apps/|packages/|firebase\.json$|firestore\.rules$|firestore\.indexes\.json$|package\.json$|pnpm-lock\.yaml$|\.github/workflows/deploy-staging\.yml$)'; then
+            echo "Deploy-relevant change detected -> deploy."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No deploy-relevant change (docs/non-code only) -> skip deploy."
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: pnpm/action-setup@v4
+        if: ${{ steps.guard.outputs.should_deploy == 'true' }}
         with:
           version: '10.33.0'
 
       - uses: actions/setup-node@v4
+        if: ${{ steps.guard.outputs.should_deploy == 'true' }}
         with:
           node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: ${{ steps.guard.outputs.should_deploy == 'true' }}
         run: pnpm install --frozen-lockfile
 
       # Builds the PWA with --mode staging so Vite loads apps/web-pwa/.env.staging
       # (staging Firebase config + LD client-side ID). Output -> apps/web-pwa/dist,
       # which firebase.json hosting serves.
       - name: Build web-pwa (staging)
+        if: ${{ steps.guard.outputs.should_deploy == 'true' }}
         run: pnpm --filter @salt/web-pwa build:staging
 
       - name: Authenticate to Google Cloud (WIF)
+        if: ${{ steps.guard.outputs.should_deploy == 'true' }}
         uses: google-github-actions/auth@v2
         with:
           project_id: s2-stage-ccb22
@@ -73,4 +124,5 @@ jobs:
       # it.) The functions predeploy hook builds the CF bundle; GEMINI_API_KEY /
       # LD_SDK_KEY are already in this project's Secret Manager.
       - name: Deploy to Firebase (staging)
+        if: ${{ steps.guard.outputs.should_deploy == 'true' }}
         run: pnpm exec firebase deploy -P staging --non-interactive --force

--- a/docs/design/ui-spec-v02.md
+++ b/docs/design/ui-spec-v02.md
@@ -204,6 +204,7 @@ All interactive primitives must:
 - Dark mode via `.dark` class on `<html>` (see §4.5).
 - `class` prop merged last via `cn()`.
 - No inline `style` attributes except for numeric transforms (`transform: scaleX(...)` on Progress, `transform: translate3d(...)` on Switch thumb, etc.).
+- **Base radius for surfaces.** Cards, list rows, and field frames use the base `rounded` (4px) radius (`--salt-radius`, §4.1). Larger surfaces that read as "floating panels" (Dialog, Popover, Sheet) keep `rounded-lg` (10px). Do not introduce a fourth radius for these surfaces without amending this rule.
 
 ---
 
@@ -690,6 +691,7 @@ Salt adopts the shadcn token scheme, emitted as CSS variables on `:root` and `.d
 
 ### Radius
 
+- `rounded` → `--salt-radius` (4px) — **base/default radius**; see the card-and-row rule in §2.3
 - `rounded-sm` → `--salt-radius-sm` (2px)
 - `rounded-md` → `--salt-radius-md` (6px)
 - `rounded-lg` → `--salt-radius-lg` (10px)
@@ -1367,7 +1369,7 @@ content: 'z-tooltip rounded-md bg-foreground text-background px-2 py-1 text-xs s
 ### Styling
 
 ```
-card: 'rounded-lg border bg-card text-card-foreground shadow-sm'
+card: 'rounded border bg-card text-card-foreground shadow-sm'
 header: 'flex flex-col gap-1.5 p-6'
 title: 'text-lg font-semibold leading-none tracking-tight'
 description: 'text-sm text-muted-foreground'

--- a/docs/design/ui-spec-v04.md
+++ b/docs/design/ui-spec-v04.md
@@ -1,7 +1,7 @@
 # Salt 2.0 — UI Primitives Specification (v0.4)
 
 **Status:** Planning  
-**Scope:** `@salt/ui-components` — Combobox; ListPage Selection Mode  
+**Scope:** `@salt/ui-components` — Combobox (incl. `ComboboxField`); ListPage Selection Mode (incl. `titleSlot`); SelectableList; EditableRow  
 **Audience:** AI code-generation agents + human contributors
 
 > Rule: If anything is missing or ambiguous → STOP → extend this spec → regenerate.  
@@ -16,8 +16,10 @@ All global rules, architecture, naming, styling, and testing conventions from v0
 
 v0.4 introduces:
 
-- **Combobox** — text input + popup listbox + filtering + optional custom values
-- **ListPage Selection Mode** — app-wide hide-by-default multi-select pattern (§9)
+- **Combobox** — text input + popup listbox + filtering + optional custom values, with the optional `ComboboxField` joined-input frame (§3.4)
+- **ListPage Selection Mode** — app-wide hide-by-default multi-select pattern, plus the `titleSlot` header override (§9)
+- **SelectableList** — list template with `selectionMode`-gated per-row checkboxes (§10)
+- **EditableRow** — single-row primitive with an `onToggleSelect`-gated checkbox (§11)
 
 APG pattern: **Autocomplete (Listbox)**.
 
@@ -50,6 +52,7 @@ A text input that:
 ## 2. Parts
 
 - `Combobox.svelte` (Root)
+- `ComboboxField.svelte` (optional input frame — joins input + trigger; see §3.4)
 - `ComboboxInput.svelte`
 - `ComboboxTrigger.svelte` (optional caret button)
 - `ComboboxContent.svelte`
@@ -89,6 +92,48 @@ A text input that:
 - `onValueChange: (value: string) => void`
 - `onOpenChange: (open: boolean) => void`
 - `onCreate?: (value: string) => void` — fired when a new custom value is created (only if `allowCustom`)
+
+### 3.3 `ComboboxInput` props — HTML attribute forwarding
+
+`ComboboxInput` accepts its own `class` plus **any standard `<input>` attribute**, which is spread onto the underlying `<input>` element. This lets callers attach `data-testid`, `disabled`, `name`, `aria-label`, `required`, etc. without `ComboboxInput` enumerating each one.
+
+```ts
+type ComboboxInputProps = Omit<
+  HTMLInputAttributes,
+  // props ComboboxInput owns and the headless layer controls — callers may NOT override these:
+  | 'class' | 'id' | 'role' | 'type'
+  | 'aria-expanded' | 'aria-controls' | 'aria-autocomplete' | 'aria-activedescendant'
+  | 'value' | 'placeholder' | 'autocomplete'
+  | 'onclick' | 'oninput' | 'onkeydown' | 'onblur'
+> & { class?: string }
+```
+
+Contract:
+
+- Forwarded attributes are spread **before** the component's own bindings, so the owned props above always win and cannot be clobbered by a caller.
+- The ARIA/role/value/handler props are owned by the headless layer (§5.1) and are therefore excluded from the forwarded set — passing them is a type error.
+- `placeholder` is supplied via the `Combobox` root prop (§3.1), not on `ComboboxInput`.
+
+### 3.4 `ComboboxField` (optional input frame)
+
+`ComboboxField` is an optional wrapper that visually joins the `ComboboxInput` with an adjacent control (e.g. a `ComboboxTrigger` caret button) into a single bordered frame, and registers itself as the floating anchor for the popup. When no `ComboboxField` wraps it, `ComboboxInput` registers itself as the anchor instead.
+
+| Name       | Type                  | Default | Notes                          |
+| ---------- | --------------------- | ------- | ------------------------------ |
+| `class`    | `string \| undefined` | —       | Merged onto the frame `<div>`  |
+| `children` | `Snippet`             | —       | The input and any sibling part |
+
+**Styling (joined-input contract):**
+
+```
+'salt-focus-ring-within flex items-stretch rounded
+ [&>input]:flex-1
+ [&>input:not(:last-child)]:rounded-r-none
+ [&>input:not(:last-child)]:border-r-0'
+```
+
+- The `:not(:last-child)` guard means a **standalone** input (no sibling rendered after it) keeps its own right border and right-side radius — the squared-off right edge only applies when a trailing sibling (e.g. trigger) is present to butt against. This avoids a clipped right border on single-input comboboxes.
+- The frame uses the base `rounded` (4px) radius per the surface-radius rule (ui-spec-v02 §2.3).
 
 ---
 
@@ -375,12 +420,14 @@ Pattern precedent: iOS Reminders, Apple Mail, Google Tasks, Todoist.
 ### Default state (selection mode off)
 - No per-row select checkboxes are visible.
 - The `selectionBar` snippet is not rendered.
-- The header shows a "Select" ghost button (only when a `selectionBar` snippet is provided).
+- The header shows a "Select" `outline`, `size="sm"` button (only when a `selectionBar` snippet is provided).
 
 ### Selection mode on
 - The `selectionBar` snippet is rendered in the grey bar between toolbar and content.
 - Per-row select controls become visible (consuming pages gate them on their page-local `selectionMode` — see §9.4).
-- The "Select" button is replaced by a "Done" ghost button in the header.
+- The "Select" button is replaced by a "Done" `outline`, `size="sm"` button in the header.
+
+> Button variant: the Select/Done toggle uses `variant="outline"` (not `ghost`) so it reads as an affordance against the header background and lines up with the `size="sm"` convention documented on the `actions` prop.
 
 ### Exiting selection mode
 - Tapping "Done" sets `selectionMode = false` inside `ListPage`, which propagates back to the consuming page via the binding.
@@ -392,6 +439,25 @@ Pattern precedent: iOS Reminders, Apple Mail, Google Tasks, Todoist.
 One new prop: `selectionMode?: boolean` (bindable, default `false`). Consuming pages bind to it to observe and react to mode state. The "Select"/"Done" toggle still appears automatically whenever a `selectionBar` snippet is provided — the page never needs to manage the toggle itself.
 
 `ListPageProps` is an open interface that extends `Omit<HTMLAttributes<HTMLElement>, 'class'>`. Any attribute valid on `<section>` is accepted and spread onto the root `<section>` element (e.g. `data-*`, `aria-*`, `id`). The `class` prop is reserved and handled internally.
+
+### `titleSlot` — custom header title
+
+`titleSlot?: Snippet`. When provided, it **replaces** the default `<h1>{title}</h1>` in the page header. When omitted, the page renders the default `<h1>` from the `title` string.
+
+Use this when a page needs an interactive element in place of a static heading — e.g. a `Combobox` for switching between shopping lists, or an editable title. The `title` string prop is still required (it remains the accessible/programmatic name and the fallback); `titleSlot` only overrides the *rendered* heading.
+
+```svelte
+<ListPage title="Shopping list">
+  {#snippet titleSlot()}
+    <ListSwitcherCombobox … />
+  {/snippet}
+</ListPage>
+```
+
+Contract:
+
+- `titleSlot` and `title` are not mutually exclusive — `title` must always be passed; `titleSlot` is the optional visual override.
+- A `titleSlot` that renders no heading element should still provide an accessible name for the region (the page's `title` covers the section's labelling).
 
 ## 9.4 Consuming-page contract (bindable prop)
 
@@ -459,3 +525,74 @@ Do **not** call `LIST_PAGE_CONTEXT.get()` in a consuming page's own `<script>` b
 
 - Do not re-implement the "Select"/"Done" toggle in consuming pages.
 - Do not call `LIST_PAGE_CONTEXT.get()` from a consuming page's `<script>` block — it is outside the context tree and will throw.
+
+---
+
+# 10. SelectableList (template)
+
+## 10.1 Overview
+
+`SelectableList<T>` renders a vertical list of rows from an `items` array, each row produced by a caller-supplied `row` snippet, with an optional per-row select `Checkbox` driven by a bound `selected` Set. It is the row-rendering counterpart to `ListPage`'s Selection Mode (§9): a consuming page typically passes its own `selectionMode` down so the checkboxes appear only while selecting.
+
+## 10.2 Props
+
+| Name            | Type                                                       | Default          | Notes                                                       |
+| --------------- | ---------------------------------------------------------- | ---------------- | ----------------------------------------------------------- |
+| `items`         | `T[]` where `T extends { id: string }`                     | —                | Rows to render; keyed by `item.id`                          |
+| `selected`      | `Set<string>` (bindable)                                   | `new Set()`      | IDs currently selected                                      |
+| `selectionMode` | `boolean`                                                  | `false`          | When `false`, the per-row `Checkbox` is **not rendered**    |
+| `row`           | `Snippet<[T, { selected: boolean; toggle: () => void }]>`  | —                | Renders each row's content; receives the item + row helpers |
+| `class`         | `string \| undefined`                                      | —                | Merged onto the `<ul>`                                      |
+
+## 10.3 Behaviour
+
+- **`selectionMode` gates the checkbox.** When `selectionMode` is `false` (the default), no `Checkbox` is rendered and the list reads as a plain, clean list. When `true`, each row renders a leading `Checkbox` bound to membership in `selected`.
+- Toggling a row's checkbox (or calling the `toggle` helper passed into the `row` snippet) adds/removes that `item.id` from `selected` immutably (a new `Set` is assigned so bindings react).
+- Selected rows get a `ring-2 ring-ring border-ring` treatment on the row container.
+- Rows use the base `rounded` (4px) surface radius (ui-spec-v02 §2.3).
+
+> **Default-off is a deliberate, behaviour-breaking contract.** A caller that does not pass `selectionMode` gets **no** checkboxes. This matches the app-wide hide-by-default selection pattern (§9.2); it is not a regression.
+
+## 10.4 Accessibility
+
+- The list root is a `<ul>`; each row is an `<li>`.
+- When rendered, the `Checkbox` carries the selection state for assistive tech; the `row` snippet is responsible for the row's own accessible label/content.
+
+## 10.5 Testing requirements
+
+- Checkbox is **absent** when `selectionMode={false}` (default) and **present** when `selectionMode={true}`.
+- Toggling a checkbox updates the bound `selected` Set (add and remove).
+- Selected rows reflect the selected styling.
+- `row` snippet receives the correct `selected` flag and a working `toggle`.
+
+---
+
+# 11. EditableRow (primitive)
+
+## 11.1 Overview
+
+`EditableRow` is a single list-row primitive with an optional leading select `Checkbox` and responsive `narrow` / `wide` content snippets. It is used by pages that render editable rows (e.g. canon, aisles, equipment) and want a consistent row chrome with optional multi-select.
+
+## 11.2 Props
+
+| Name             | Type                  | Default | Notes                                                            |
+| ---------------- | --------------------- | ------- | ---------------------------------------------------------------- |
+| `selected`       | `boolean`             | `false` | Whether the row is selected (drives ring styling + checkbox)     |
+| `shaded`         | `boolean`             | `false` | Amber "needs attention" styling instead of the default surface   |
+| `onToggleSelect` | `(() => void) \| undefined` | `undefined` | Select handler. **When `undefined`, the `Checkbox` is not rendered** |
+| `narrow`         | `Snippet`             | —       | Row content shown below the `sm` breakpoint                      |
+| `wide`           | `Snippet`             | —       | Row content shown at/above the `sm` breakpoint                   |
+
+## 11.3 Behaviour
+
+- **`onToggleSelect` presence gates the checkbox.** When `onToggleSelect` is `undefined` (the default), no leading `Checkbox` is rendered. When a handler is passed, the `Checkbox` appears, reflects `selected`, and calls `onToggleSelect` on change. This mirrors `SelectableList.selectionMode` (§10.3): a page passes `onToggleSelect` only while in selection mode.
+- `shaded` switches the row to the amber attention palette; `selected` adds a `ring-2 ring-ring` treatment in both palettes.
+- The row uses the base `rounded` (4px) surface radius (ui-spec-v02 §2.3).
+- `narrow` is shown on small screens (`sm:hidden`); `wide` is shown from `sm` upward (`hidden sm:flex`).
+
+## 11.4 Testing requirements
+
+- `Checkbox` is **absent** when `onToggleSelect` is `undefined` and **present** when a handler is passed.
+- The `Checkbox` reflects `selected` and invokes `onToggleSelect` on change.
+- `shaded` and `selected` styling render as specified.
+- `narrow` and `wide` snippets render at the correct breakpoints.

--- a/packages/ui-components/src/primitives/Card/Card.svelte
+++ b/packages/ui-components/src/primitives/Card/Card.svelte
@@ -1,4 +1,4 @@
-<!-- spec: SPEC.md §8.9 v0.2.3 -->
+<!-- spec: ui-spec-v02.md §8.9 v0.2 -->
 <script lang="ts">
   import { cn } from '../../lib/cn';
   import type { CardProps } from './Card.types';

--- a/packages/ui-components/src/primitives/Combobox/ComboboxField.svelte
+++ b/packages/ui-components/src/primitives/Combobox/ComboboxField.svelte
@@ -1,4 +1,4 @@
-<!-- spec: ui-spec-v04.md §5 v0.4 -->
+<!-- spec: ui-spec-v04.md §3.4 v0.4 -->
 <script lang="ts">
   import { cn } from '../../lib/cn';
   import { COMBOBOX_CONTEXT } from '../../headless/Combobox.headless.svelte';

--- a/packages/ui-components/src/primitives/EditableRow/EditableRow.svelte
+++ b/packages/ui-components/src/primitives/EditableRow/EditableRow.svelte
@@ -1,4 +1,4 @@
-<!-- spec: ui-spec-v04.md §7 v0.4 -->
+<!-- spec: ui-spec-v04.md §11 v0.4 -->
 <script lang="ts">
   import { cn } from '../../lib/cn';
   import Checkbox from '../../primitives/Checkbox/Checkbox.svelte';

--- a/packages/ui-components/src/templates/ListPage/ListPage.svelte
+++ b/packages/ui-components/src/templates/ListPage/ListPage.svelte
@@ -1,4 +1,4 @@
-<!-- spec: SPEC.md §9.1 v0.4.0 -->
+<!-- spec: ui-spec-v04.md §9 v0.4 -->
 <script lang="ts">
   import { cn } from '../../lib/cn';
   import Spinner from '../../primitives/Spinner/Spinner.svelte';

--- a/packages/ui-components/src/templates/ListPage/ListPage.types.ts
+++ b/packages/ui-components/src/templates/ListPage/ListPage.types.ts
@@ -1,4 +1,4 @@
-// spec: SPEC.md §9.1 v0.2.3
+// spec: ui-spec-v04.md §9 v0.4
 import type { Snippet } from 'svelte';
 import type { HTMLAttributes } from 'svelte/elements';
 

--- a/packages/ui-components/src/templates/SelectableList/SelectableList.svelte
+++ b/packages/ui-components/src/templates/SelectableList/SelectableList.svelte
@@ -1,4 +1,4 @@
-<!-- spec: SPEC.md §9.4 v0.2.3 -->
+<!-- spec: ui-spec-v04.md §10 v0.4 -->
 <script lang="ts" generics="T extends SelectableListItem">
   import { cn } from '../../lib/cn';
   import Checkbox from '../../primitives/Checkbox/Checkbox.svelte';

--- a/packages/ui-components/src/templates/SelectableList/SelectableList.types.ts
+++ b/packages/ui-components/src/templates/SelectableList/SelectableList.types.ts
@@ -1,4 +1,4 @@
-// spec: SPEC.md §9.4 v0.2.3
+// spec: ui-spec-v04.md §10 v0.4
 import type { Snippet } from 'svelte';
 
 export type SelectableListItem = { id: string };


### PR DESCRIPTION
Closes #135.

## What

`deploy-staging.yml` triggers on `workflow_run` (CI completed on `main`) with no path filtering, so every merge — including docs-only ones like #134 — ran a full `firebase deploy`. `workflow_run` triggers can't use `paths`/`paths-ignore`, so the skip lives **inside the deploy job** as a changed-files guard.

## How

**Phase 1 — detection** ([guard step](.github/workflows/deploy-staging.yml#L54-L90))
- `fetch-depth: 2` on checkout so the guard can diff the merged commit against its first parent.
- `guard` step emits `should_deploy`:
  - `workflow_dispatch` → `true` (manual always deploys, never diffs).
  - Otherwise diff `head_sha^ .. head_sha` against an **allowlist**: `apps/`, `packages/`, `firebase.json`, `firestore.rules`, `firestore.indexes.json`, root `package.json`, `pnpm-lock.yaml`, and `deploy-staging.yml` itself → `true`, else `false`.
  - **Fail-safe toward deploying**: any failure resolving the parent or diff defaults to `true` — never silently skip a real change.

**Phase 2 — gate** ([L92-128](.github/workflows/deploy-staging.yml#L92-L128))
- Every step after the guard (pnpm/node setup, install, build, WIF auth, `firebase deploy`) is gated on `should_deploy == 'true'`. A docs-only merge runs only checkout + guard, then reports green with no build/deploy.

## Out of scope / untouched
Per the issue constraints: `ci.yml` (stays unfiltered, `main` remains CI-verified), `deploy-production.yml`, WIF auth values, the `concurrency` group, the `workflow_run`/`workflow_dispatch` trigger block, and the `firebase deploy` command/flags. Comment-only edits inside source files still touch `packages/**` and therefore still deploy — detecting "comment-only" is explicitly out of scope.

## Verification
- YAML parses; Prettier `format:check` clean; typecheck + dependency-cruiser clean on commit.
- Ran the allowlist regex against 14 cases (docs-only → skip, `.svelte` provenance comment → deploy, root vs nested `package.json`, `ci.yml` → skip, mixed docs+code → deploy, etc.) — all pass.
- **Phase 3 (observational) is post-merge**: confirming a docs-only merge skips, a code/config merge deploys, and a manual `workflow_dispatch` deploys can only be observed once this lands on `main`. Will capture run links then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)