### PR TITLE
chore(web-pwa): show build version on Settings (#141 Phase 3 aid)

### DIFF
--- a/apps/web-pwa/src/env.d.ts
+++ b/apps/web-pwa/src/env.d.ts
@@ -20,3 +20,7 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+// Build stamp injected by Vite `define` (see vite.config.ts). Shown on Settings.
+declare const __APP_COMMIT__: string;
+declare const __APP_BUILD_TIME__: string;

--- a/apps/web-pwa/src/routes/settings/SettingsPage.svelte
+++ b/apps/web-pwa/src/routes/settings/SettingsPage.svelte
@@ -1,10 +1,25 @@
 <script lang="ts">
   import { FormPage, Text } from '@salt/ui-components';
   import { auth } from '../../lib/auth.svelte.js';
+
+  // Build stamp injected at build time (vite.config.ts). The timestamp makes
+  // every build distinct, so it doubles as the "did the PWA auto-update?" signal.
+  const commit = __APP_COMMIT__;
+  const builtAt = new Date(__APP_BUILD_TIME__);
+  const builtAtLabel = Number.isNaN(builtAt.getTime())
+    ? __APP_BUILD_TIME__
+    : builtAt.toLocaleString();
+  const environment = import.meta.env.MODE;
 </script>
 
 <div class="p-4 sm:p-6">
   <FormPage title="Settings" description="Manage your account." canSubmit={false}>
     <Text muted>Signed in as {auth.user?.email ?? '—'}</Text>
+
+    <div class="mt-6 space-y-1 border-t pt-4">
+      <Text muted>Environment: {environment}</Text>
+      <Text muted>Version: {commit}</Text>
+      <Text muted>Built: {builtAtLabel}</Text>
+    </div>
   </FormPage>
 </div>

--- a/apps/web-pwa/vite.config.ts
+++ b/apps/web-pwa/vite.config.ts
@@ -2,6 +2,24 @@ import { defineConfig, loadEnv } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { VitePWA } from 'vite-plugin-pwa';
 import { resolve } from 'path';
+import { execSync } from 'node:child_process';
+
+// Build stamp shown on the Settings screen. The git SHA identifies the code; the
+// build timestamp guarantees every build is distinct — so a re-dispatched deploy
+// of the same commit still produces a visibly new version, which is what lets us
+// validate the open-client PWA auto-update flow (issue #141 Phase 3) with a plain
+// workflow_dispatch re-deploy, no throwaway commit required.
+function gitShortSha(): string {
+  try {
+    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch {
+    return 'unknown';
+  }
+}
+const appCommit = gitShortSha();
+const buildTime = new Date().toISOString();
 
 // PWA identity is env-distinct (issue #141): staging installs as "Salt (Staging)"
 // with its own theme color so it is visually separable from prod on a device.
@@ -77,6 +95,10 @@ export default defineConfig(({ mode }) => {
         },
       }),
     ],
+    define: {
+      __APP_COMMIT__: JSON.stringify(appCommit),
+      __APP_BUILD_TIME__: JSON.stringify(buildTime),
+    },
     resolve: {
       alias: {
         $lib: resolve(__dirname, 'src/lib'),

--- a/apps/web-pwa/vitest.config.ts
+++ b/apps/web-pwa/vitest.config.ts
@@ -20,9 +20,15 @@ export default defineConfig({
     },
     conditions: ['browser'],
   },
-  define: Object.fromEntries(
-    Object.entries(TEST_ENV).map(([k, v]) => [`import.meta.env.${k}`, JSON.stringify(v)]),
-  ),
+  define: {
+    ...Object.fromEntries(
+      Object.entries(TEST_ENV).map(([k, v]) => [`import.meta.env.${k}`, JSON.stringify(v)]),
+    ),
+    // Build stamp globals (injected by vite.config.ts in real builds) — stubbed
+    // here so rendering Settings under vitest doesn't hit an undefined global.
+    __APP_COMMIT__: JSON.stringify('test'),
+    __APP_BUILD_TIME__: JSON.stringify('1970-01-01T00:00:00.000Z'),
+  },
   test: {
     name: '@salt/web-pwa',
     environment: 'jsdom',


### PR DESCRIPTION
Supports #141 Phase 3 — gives a visible, deploy-distinct signal for validating the open-client PWA auto-update flow.

## What
- Inject git short SHA + ISO build timestamp via Vite `define` ([vite.config.ts](apps/web-pwa/vite.config.ts)); globals declared in [env.d.ts](apps/web-pwa/src/env.d.ts).
- Surface them on [SettingsPage](apps/web-pwa/src/routes/settings/SettingsPage.svelte) alongside the env mode (`Environment / Version / Built`).
- Stub the globals in [vitest.config.ts](apps/web-pwa/vitest.config.ts) so rendering Settings under test can't hit an undefined global.

## Why the timestamp matters
The git SHA alone wouldn't change on a re-dispatched deploy of the same commit. Including the **build timestamp** makes every build distinct — so once this is live you can validate the open-client auto-update by simply re-running the **Deploy Staging** workflow (`workflow_dispatch`), no throwaway commit needed: leave the installed PWA open, re-deploy, and confirm the `Built:` value changes on its own after the update lands.

## Verified locally
Staging build bakes in the real SHA + timestamp; format, lint, typecheck, 88 web-pwa tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)