### PR TITLE
chore(storage): wire deploy pipeline + document bucket provisioning

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -64,7 +64,10 @@ jobs:
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
 
-      # Deploys hosting, functions, firestore rules + indexes to production. The
+      # Deploys hosting, functions, firestore rules + indexes, and storage rules
+      # (canon icons, #148) to production. Storage rules deploy requires the
+      # project's default Storage bucket to already be provisioned — a one-time
+      # setup outside this workflow (see docs/canon-icons.md §Storage). The
       # functions predeploy hook builds the workspace-free deploy artifact;
       # GEMINI_API_KEY / LD_SDK_KEY are already in prod Secret Manager.
       - name: Deploy to Firebase (production)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -81,7 +81,7 @@ jobs:
           # Allowlist of deploy-relevant paths. Any match -> deploy. apps/** and
           # packages/** already cover nested package.json files, so the bare
           # package.json anchor only matches the root manifest.
-          if echo "${changed}" | grep -Eq '^(apps/|packages/|firebase\.json$|firestore\.rules$|firestore\.indexes\.json$|package\.json$|pnpm-lock\.yaml$|\.github/workflows/deploy-staging\.yml$)'; then
+          if echo "${changed}" | grep -Eq '^(apps/|packages/|firebase\.json$|firestore\.rules$|firestore\.indexes\.json$|storage\.rules$|package\.json$|pnpm-lock\.yaml$|\.github/workflows/deploy-staging\.yml$)'; then
             echo "Deploy-relevant change detected -> deploy."
             echo "should_deploy=true" >> "$GITHUB_OUTPUT"
           else
@@ -120,8 +120,10 @@ jobs:
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
 
       # Deploys all targets in firebase.json: hosting, functions, firestore rules
-      # + indexes. (Storage is not deployed — unused; re-add when a feature needs
-      # it.) The functions predeploy hook builds the CF bundle; GEMINI_API_KEY /
+      # + indexes, and storage rules (canon icons, #148). Storage rules deploy
+      # requires the project's default Storage bucket to already be provisioned —
+      # a one-time setup outside this workflow (see docs/canon-icons.md §Storage).
+      # The functions predeploy hook builds the CF bundle; GEMINI_API_KEY /
       # LD_SDK_KEY are already in this project's Secret Manager.
       - name: Deploy to Firebase (staging)
         if: ${{ steps.guard.outputs.should_deploy == 'true' }}

--- a/docs/canon-icons.md
+++ b/docs/canon-icons.md
@@ -91,6 +91,28 @@ First use of Firebase Storage in the project. Adds a `storage` block to
   writes). Icons are non-sensitive, so public read keeps the client SDK-free: the
   browser just renders `<img src={thumbnail}>`, no Storage SDK in `firebase-sync`.
 
+### Provisioning (one-time, per environment)
+
+`firebase deploy` deploys `storage.rules` but does **not** create the project's
+default Storage bucket — and it hard-fails ("Firebase Storage has not been set up")
+if the bucket is missing. The default bucket is therefore provisioned once per
+project, **outside** the deploy workflows. Both buckets are **`EUROPE-WEST2`**
+(regional, matching the `europe-west2` Cloud Functions region that writes icons); the
+location is permanent.
+
+Provisioned via the Cloud Storage for Firebase API (singleton default-bucket create):
+
+```sh
+TOKEN=$(gcloud auth print-access-token)
+curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "https://firebasestorage.googleapis.com/v1beta/projects/<PROJECT>/defaultBucket" \
+  -d '{"location":"EUROPE-WEST2"}'
+```
+
+Done for both: `s2-stage-ccb22.firebasestorage.app` and `s2-prod-e46bd.firebasestorage.app`.
+(Equivalent to the Firebase Console Storage → "Get Started" flow.) The CF uses
+`getStorage().bucket()` — the default bucket — so no bucket name is hardcoded.
+
 ## Rendering
 
 A reusable **`<CanonIcon>`** in `@salt/ui-components`:


### PR DESCRIPTION
## What

Follow-up to canon icons (#148), which introduced Firebase Storage. The deploy pipeline and docs hadn't caught up with that, and the default Storage buckets needed one-time provisioning per environment.

## Changes

- **[deploy-staging.yml](.github/workflows/deploy-staging.yml)** — add `storage.rules` to the deploy-trigger allowlist so a storage-rules-only change actually triggers a staging deploy (previously it would be skipped as "docs/non-code only"). Refresh the stale `Storage is not deployed — unused` comment.
- **[deploy-production.yml](.github/workflows/deploy-production.yml)** — refresh the same stale comment.
- **[docs/canon-icons.md](docs/canon-icons.md) §Storage** — document the one-time, per-env default-bucket provisioning. `firebase deploy` ships `storage.rules` but does **not** create the bucket, and hard-fails (`Firebase Storage has not been set up`) if it's missing. Includes the exact Cloud Storage for Firebase API command.

## Infra already done (outside this PR)

- Default buckets provisioned in **EUROPE-WEST2** (matching the `europe-west2` CF that writes icons) for both `s2-stage-ccb22` and `s2-prod-e46bd`.
- Staging `storage.rules` is **live** (re-ran the deploy that had previously failed on the storage step before the bucket existed).
- Prod bucket is ready; prod rules deploy on the next Release publish. Verified the prod deployer SA has the same `roles/firebase.admin` that staging just used successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)