### PR TITLE
feat(canon): move canon management behind the admin/operator menu (#157)

### DIFF
--- a/apps/web-pwa/e2e/aisles-seed.spec.ts
+++ b/apps/web-pwa/e2e/aisles-seed.spec.ts
@@ -2,17 +2,17 @@ import { test, expect } from './fixtures/test';
 import { signIn, uniqueEmail } from './helpers/auth';
 import { seedAisles } from './helpers/seed';
 
-test('seedAisles writes aisles that render on /canon/aisles', async ({ page }, testInfo) => {
+test('seedAisles writes aisles that render on /admin/canon/aisles', async ({ page }, testInfo) => {
   const email = uniqueEmail(testInfo.testId);
 
   await page.goto('/');
-  await signIn(page, email);
+  await signIn(page, email, { admin: true });
   await expect(page.getByText(email)).toBeVisible();
 
   const seeded = await seedAisles(page, ['Produce', 'Dairy']);
   expect(seeded.map((a) => a.name)).toEqual(['Produce', 'Dairy']);
 
-  await page.goto('/#/canon/aisles');
+  await page.goto('/#/admin/canon/aisles');
 
   await expect(page.getByRole('heading', { name: /manage aisles/i })).toBeVisible();
   await expect(page.getByText('Produce', { exact: true })).toBeVisible();

--- a/apps/web-pwa/e2e/helpers/auth.ts
+++ b/apps/web-pwa/e2e/helpers/auth.ts
@@ -15,7 +15,7 @@ export function uniqueEmail(testId: string): string {
 const FIRESTORE_EMULATOR = 'http://127.0.0.1:8081';
 const EMULATOR_PROJECT = 'demo-salt';
 
-async function seedMemberAllowlist(email: string): Promise<void> {
+async function seedMemberAllowlist(email: string, admin = false): Promise<void> {
   const id = email.trim().toLowerCase(); // matches normaliseMemberEmail / the blocking-fn lookup
   const url =
     `${FIRESTORE_EMULATOR}/v1/projects/${EMULATOR_PROJECT}/databases/(default)/documents/` +
@@ -26,7 +26,7 @@ async function seedMemberAllowlist(email: string): Promise<void> {
       schemaVersion: { integerValue: '1' },
       name: { stringValue: id.split('@')[0] },
       email: { stringValue: id },
-      admin: { booleanValue: false },
+      admin: { booleanValue: admin },
       sortOrder: { integerValue: '0' },
       icon: { nullValue: null },
       updatedAt: { stringValue: new Date().toISOString() },
@@ -46,13 +46,25 @@ async function waitForBridge(page: Page): Promise<void> {
   await page.waitForFunction(() => Boolean(window.__e2e), null, { timeout: 10_000 });
 }
 
-export async function signIn(page: Page, email: string): Promise<void> {
-  await seedMemberAllowlist(email);
+// `admin: true` seeds the allowlisted member with the admin flag, which the
+// client-side AdminGuard requires to render operator-area screens (e.g. canon
+// management, moved behind /admin in #157).
+export async function signIn(
+  page: Page,
+  email: string,
+  options: { admin?: boolean } = {},
+): Promise<void> {
+  await seedMemberAllowlist(email, options.admin ?? false);
   await waitForBridge(page);
   await page.evaluate((e) => window.__e2e!.devSignIn(e), email);
 }
 
-export async function gotoAndSignIn(page: Page, email: string, path = '/'): Promise<void> {
+export async function gotoAndSignIn(
+  page: Page,
+  email: string,
+  path = '/',
+  options: { admin?: boolean } = {},
+): Promise<void> {
   await page.goto(path);
-  await signIn(page, email);
+  await signIn(page, email, options);
 }

--- a/apps/web-pwa/e2e/issue-12-aisles.spec.ts
+++ b/apps/web-pwa/e2e/issue-12-aisles.spec.ts
@@ -11,9 +11,9 @@ test('add, reorder, and bulk-delete aisles unassigns referencing canon items', a
   const ui = aislesPage(page);
 
   await page.goto('/');
-  await signIn(page, email);
+  await signIn(page, email, { admin: true });
 
-  await page.goto('/#/canon/aisles');
+  await page.goto('/#/admin/canon/aisles');
   await expect(ui.heading).toBeVisible();
 
   await ui.addButton.click();

--- a/apps/web-pwa/e2e/issue-16-canon-create-detail.spec.ts
+++ b/apps/web-pwa/e2e/issue-16-canon-create-detail.spec.ts
@@ -17,15 +17,15 @@ async function createViaCombobox(page: import('@playwright/test').Page, name: st
 test('create truly new item → navigates to detail page', async ({ page }, testInfo) => {
   const email = uniqueEmail(testInfo.testId);
   await page.goto('/');
-  await signIn(page, email);
+  await signIn(page, email, { admin: true });
 
-  await page.goto('/#/canon/new');
+  await page.goto('/#/admin/canon/new');
   await expect(page.getByRole('heading', { name: /add item/i })).toBeVisible();
 
   await createViaCombobox(page, 'Garlic Powder');
 
-  // Should navigate away from /canon/new to a detail page
-  await expect(page).toHaveURL(/#\/canon\/(?!new)[a-z0-9-]+$/);
+  // Should navigate away from /admin/canon/new to a detail page
+  await expect(page).toHaveURL(/#\/admin\/canon\/(?!new)[a-z0-9-]+$/);
   await expect(page.getByRole('heading', { name: /garlic powder/i })).toBeVisible();
 });
 
@@ -34,11 +34,11 @@ test('pick existing from combobox → routes to detail without creating', async 
 }, testInfo) => {
   const email = uniqueEmail(testInfo.testId);
   await page.goto('/');
-  await signIn(page, email);
+  await signIn(page, email, { admin: true });
 
   const seeded = await seedCanonItem(page, { name: 'Olive Oil' });
 
-  await page.goto('/#/canon/new');
+  await page.goto('/#/admin/canon/new');
   await expect(page.getByRole('heading', { name: /add item/i })).toBeVisible();
 
   const ui = canonCreatePage(page);
@@ -46,7 +46,7 @@ test('pick existing from combobox → routes to detail without creating', async 
   await page.getByRole('option', { name: 'Olive Oil' }).click();
 
   // Navigates to the existing item's detail page, not a new one
-  await expect(page).toHaveURL(new RegExp(`#/canon/${seeded.id}$`));
+  await expect(page).toHaveURL(new RegExp(`#/admin/canon/${seeded.id}$`));
   // No new item should have been created
   const fetched = await getCanonItem(page, seeded.id);
   expect(fetched?.id).toBe(seeded.id);
@@ -55,28 +55,28 @@ test('pick existing from combobox → routes to detail without creating', async 
 test('create matching name → routes straight to existing item', async ({ page }, testInfo) => {
   const email = uniqueEmail(testInfo.testId);
   await page.goto('/');
-  await signIn(page, email);
+  await signIn(page, email, { admin: true });
 
   const seeded = await seedCanonItem(page, { name: 'Butter' });
 
-  await page.goto('/#/canon/new');
+  await page.goto('/#/admin/canon/new');
   await expect(page.getByRole('heading', { name: /add item/i })).toBeVisible();
 
   // Submit the plural — normaliseName singularizes it, giving a stage-1 match
   await createViaCombobox(page, 'Butters');
 
   // No confirm dialog — pipeline resolves to the existing item and we navigate straight in.
-  await expect(page).toHaveURL(new RegExp(`#/canon/${seeded.id}$`));
+  await expect(page).toHaveURL(new RegExp(`#/admin/canon/${seeded.id}$`));
 });
 
 test('detail page — rename item', async ({ page }, testInfo) => {
   const email = uniqueEmail(testInfo.testId);
   await page.goto('/');
-  await signIn(page, email);
+  await signIn(page, email, { admin: true });
 
   const seeded = await seedCanonItem(page, { name: 'Skim Milk' });
 
-  await page.goto(`/#/canon/${seeded.id}`);
+  await page.goto(`/#/admin/canon/${seeded.id}`);
   const ui = canonDetailPage(page);
   await expect(page.getByRole('heading', { name: /skim milk/i })).toBeVisible();
 
@@ -95,11 +95,11 @@ test('detail page — rename item', async ({ page }, testInfo) => {
 test('detail page — edit synonyms', async ({ page }, testInfo) => {
   const email = uniqueEmail(testInfo.testId);
   await page.goto('/');
-  await signIn(page, email);
+  await signIn(page, email, { admin: true });
 
   const seeded = await seedCanonItem(page, { name: 'Coriander' });
 
-  await page.goto(`/#/canon/${seeded.id}`);
+  await page.goto(`/#/admin/canon/${seeded.id}`);
   const ui = canonDetailPage(page);
   await expect(ui.synonymsInput).toBeVisible();
 
@@ -117,12 +117,12 @@ test('detail page — edit synonyms', async ({ page }, testInfo) => {
 test('detail page — change aisle', async ({ page }, testInfo) => {
   const email = uniqueEmail(testInfo.testId);
   await page.goto('/');
-  await signIn(page, email);
+  await signIn(page, email, { admin: true });
 
   const [aisle] = await seedAisles(page, ['Produce']);
   const seeded = await seedCanonItem(page, { name: 'Carrot' });
 
-  await page.goto(`/#/canon/${seeded.id}`);
+  await page.goto(`/#/admin/canon/${seeded.id}`);
   const ui = canonDetailPage(page);
   await ui.aisleTrigger.click();
   await page.getByRole('option', { name: 'Produce' }).click();
@@ -138,17 +138,17 @@ test('detail page — change aisle', async ({ page }, testInfo) => {
 test('detail page — delete item navigates back to canon list', async ({ page }, testInfo) => {
   const email = uniqueEmail(testInfo.testId);
   await page.goto('/');
-  await signIn(page, email);
+  await signIn(page, email, { admin: true });
 
   const seeded = await seedCanonItem(page, { name: 'Mango' });
 
-  await page.goto(`/#/canon/${seeded.id}`);
+  await page.goto(`/#/admin/canon/${seeded.id}`);
   const ui = canonDetailPage(page);
   await ui.deleteButton.click();
   await expect(ui.deleteDialog).toBeVisible();
   await ui.deleteConfirm.click();
 
-  await expect(page).toHaveURL(/#\/canon$/);
+  await expect(page).toHaveURL(/#\/admin\/canon$/);
 
   const deleted = await getCanonItem(page, seeded.id);
   expect(deleted).toBeNull();

--- a/apps/web-pwa/src/App.svelte
+++ b/apps/web-pwa/src/App.svelte
@@ -42,12 +42,15 @@
   const currentEmail = $derived(normaliseMemberEmail(auth.user?.email ?? ''));
   const isAdmin = $derived($members.some((m) => m.email === currentEmail && m.admin));
 
+  // Canon management now lives behind the operator area (#157), so its
+  // needs-approval backlog count rides on the Admin nav entry — visible only to
+  // admins, who are the ones who action the review queue.
   const needsApprovalCount = $derived($canonItems.filter((i) => i.needs_approval).length);
   const decoratedNavItems = $derived([
-    ...navItems.map((item) =>
-      item.id === 'canon' && needsApprovalCount > 0 ? { ...item, badge: needsApprovalCount } : item,
-    ),
-    ...(isAdmin ? [adminNavItem] : []),
+    ...navItems,
+    ...(isAdmin
+      ? [needsApprovalCount > 0 ? { ...adminNavItem, badge: needsApprovalCount } : adminNavItem]
+      : []),
   ]);
 </script>
 

--- a/apps/web-pwa/src/lib/nav.ts
+++ b/apps/web-pwa/src/lib/nav.ts
@@ -1,16 +1,17 @@
-import { BookOpen, Home, Settings, Shield, ShoppingCart, Utensils } from 'lucide-svelte';
+import { Home, Settings, Shield, ShoppingCart, Utensils } from 'lucide-svelte';
 import type { NavItem } from '@salt/ui-components';
 
 export const navItems: NavItem[] = [
   { id: 'home', label: 'Home', icon: Home, href: '#/' },
   { id: 'shopping', label: 'Shop', icon: ShoppingCart, href: '#/shopping' },
-  { id: 'canon', label: 'Items', icon: BookOpen, href: '#/canon' },
   { id: 'equipment', label: 'Kitchen', icon: Utensils, href: '#/equipment' },
   { id: 'settings', label: 'Settings', icon: Settings, href: '#/settings' },
 ];
 
-// Operator-area entry (issue #155). Appended to the nav only for admins —
-// see App.svelte. Cosmetic gating only; the real boundary is server-side.
+// Operator-area entry (issues #155, #157). Appended to the nav only for admins —
+// see App.svelte, which also hangs the canon needs-approval badge here now that
+// canon management lives behind the operator area. Cosmetic gating only; the
+// real boundary is server-side.
 export const adminNavItem: NavItem = {
   id: 'admin',
   label: 'Admin',

--- a/apps/web-pwa/src/routes/admin/AdminHomePage.svelte
+++ b/apps/web-pwa/src/routes/admin/AdminHomePage.svelte
@@ -3,15 +3,21 @@
   import { push } from 'svelte-spa-router';
   import AdminGuard from './AdminGuard.svelte';
 
-  // Operator home (issue #155). Members is the first and only tool for now;
-  // future cross-domain operator tools (backup, one-off data migrations /
-  // repairs) are added here as additional cards/routes — none are in scope yet.
+  // Operator home (issues #155, #157). Future cross-domain operator tools
+  // (backup, one-off data migrations / repairs) are added here as additional
+  // cards/routes.
   const tools = [
     {
       id: 'members',
       title: 'Members',
       description: 'Manage who can sign in and who is an admin.',
       href: '/admin/members',
+    },
+    {
+      id: 'canon',
+      title: 'Canon items',
+      description: 'Review and curate the shared item catalog and aisles.',
+      href: '/admin/canon',
     },
   ];
 </script>

--- a/apps/web-pwa/src/routes/canon/AisleManagementPage.svelte
+++ b/apps/web-pwa/src/routes/canon/AisleManagementPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { push } from 'svelte-spa-router';
+  import AdminGuard from '../admin/AdminGuard.svelte';
   import {
     Button,
     Checkbox,
@@ -225,278 +226,282 @@
   }
 </script>
 
-<div class="p-4 sm:p-6">
-  <ListPage
-    title="Manage Aisles"
-    description="Organise and sort your store aisles."
-    isLoading={$isLoadingAisles}
-    isEmpty={$aisles.length === 0 && !$isLoadingAisles}
-    bind:selectionMode
-  >
-    {#snippet actions()}
-      <Button size="sm" onclick={() => push('/canon')}>
-        <Icon name="ArrowLeft" size={16} />
-        Back
-      </Button>
-      <Button size="sm" data-testid="aisle-add-button" onclick={() => (addOpen = true)}>Add</Button>
-    {/snippet}
-    {#snippet selectionBar()}
-      <Checkbox
-        checked={allSelected ? true : someSelected ? 'indeterminate' : false}
-        onCheckedChange={toggleSelectAll}
-        label={selectedCount > 0 ? `${selectedCount} selected` : 'Select all'}
-      />
-      {#if selectedCount > 0}
-        <div class="flex items-center gap-2">
-          <Button variant="outline" size="sm" onclick={openMerge} disabled={selectedCount < 2}>
-            Merge…
-          </Button>
-          <Button
-            variant="destructive"
-            size="sm"
-            data-testid="bulk-delete-button"
-            onclick={() => (deleteOpen = true)}>Delete</Button
-          >
-          <Button variant="ghost" size="sm" onclick={() => (selected = new Set())}>Clear</Button>
-        </div>
-      {/if}
-    {/snippet}
+<AdminGuard>
+  <div class="p-4 sm:p-6">
+    <ListPage
+      title="Manage Aisles"
+      description="Organise and sort your store aisles."
+      isLoading={$isLoadingAisles}
+      isEmpty={$aisles.length === 0 && !$isLoadingAisles}
+      bind:selectionMode
+    >
+      {#snippet actions()}
+        <Button size="sm" onclick={() => push('/admin/canon')}>
+          <Icon name="ArrowLeft" size={16} />
+          Back
+        </Button>
+        <Button size="sm" data-testid="aisle-add-button" onclick={() => (addOpen = true)}
+          >Add</Button
+        >
+      {/snippet}
+      {#snippet selectionBar()}
+        <Checkbox
+          checked={allSelected ? true : someSelected ? 'indeterminate' : false}
+          onCheckedChange={toggleSelectAll}
+          label={selectedCount > 0 ? `${selectedCount} selected` : 'Select all'}
+        />
+        {#if selectedCount > 0}
+          <div class="flex items-center gap-2">
+            <Button variant="outline" size="sm" onclick={openMerge} disabled={selectedCount < 2}>
+              Merge…
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              data-testid="bulk-delete-button"
+              onclick={() => (deleteOpen = true)}>Delete</Button
+            >
+            <Button variant="ghost" size="sm" onclick={() => (selected = new Set())}>Clear</Button>
+          </div>
+        {/if}
+      {/snippet}
 
-    {#snippet children()}
-      <!-- Filter bar -->
-      <div class="mb-4 flex flex-wrap items-end gap-2">
-        <div class="flex-1">
-          <input
-            class="w-full rounded border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground"
-            placeholder="Filter aisles…"
-            type="search"
-            bind:value={filterText}
+      {#snippet children()}
+        <!-- Filter bar -->
+        <div class="mb-4 flex flex-wrap items-end gap-2">
+          <div class="flex-1">
+            <input
+              class="w-full rounded border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground"
+              placeholder="Filter aisles…"
+              type="search"
+              bind:value={filterText}
+            />
+          </div>
+          <Select value={showFilter} onValueChange={(v) => (showFilter = v as typeof showFilter)}>
+            <SelectTrigger class="w-36">
+              {showFilter === 'all' ? 'Show all' : showFilter === 'in-use' ? 'In use' : 'Empty'}
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Show all</SelectItem>
+              <SelectItem value="in-use">In use</SelectItem>
+              <SelectItem value="empty">Empty</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <!-- Sortable list -->
+        <SortableList
+          items={filteredAisles}
+          getId={(a) => a.id}
+          onReorder={handleReorder}
+          class="divide-y divide-border rounded border"
+        >
+          {#snippet row(aisle)}
+            <div data-testid={`aisle-row-${aisle.id}`} class="flex items-center gap-2 px-3 py-2">
+              {#if selectionMode}
+                <span data-testid={`aisle-row-checkbox-${aisle.id}`}>
+                  <Checkbox
+                    checked={selected.has(aisle.id)}
+                    onCheckedChange={() => toggleSelect(aisle.id)}
+                    labelledBy={`aisle-name-${aisle.id}`}
+                  />
+                </span>
+              {/if}
+
+              <span
+                data-testid={`aisle-drag-handle-${aisle.id}`}
+                class="cursor-grab text-muted-foreground"
+              >
+                <Icon name="GripVertical" size={16} />
+              </span>
+
+              {#if editingId === aisle.id}
+                <input
+                  bind:this={editInputEl}
+                  class="flex-1 rounded border border-input bg-background px-2 py-0.5 text-sm"
+                  bind:value={editingName}
+                  onblur={() => commitRename(aisle.id)}
+                  onkeydown={(e) => handleRenameKeydown(e, aisle.id)}
+                />
+              {:else}
+                <button
+                  id={`aisle-name-${aisle.id}`}
+                  class="flex-1 truncate text-left text-sm font-medium hover:underline"
+                  onclick={() => startRename(aisle)}
+                >
+                  {titleCase(aisle.name)}
+                </button>
+              {/if}
+
+              {#if ($aisleUsage.get(aisle.id) ?? 0) > 0}
+                <span class="shrink-0 text-xs text-muted-foreground">
+                  {$aisleUsage.get(aisle.id)}
+                </span>
+              {/if}
+            </div>
+          {/snippet}
+        </SortableList>
+      {/snippet}
+    </ListPage>
+  </div>
+
+  <!-- Add dialog -->
+  <Dialog
+    bind:open={addOpen}
+    onOpenChange={(v) => {
+      if (!v) {
+        addText = '';
+        addError = '';
+      }
+    }}
+  >
+    <DialogContent>
+      <div data-testid="aisle-add-dialog">
+        <DialogHeader>
+          <DialogTitle>Add aisles</DialogTitle>
+        </DialogHeader>
+        <div class="py-2">
+          <TextArea
+            label="Aisle name(s)"
+            description="Enter one per line to add multiple at once."
+            placeholder="Produce&#10;Dairy&#10;Bakery"
+            rows={4}
+            bind:value={addText}
+            onkeydown={handleAddKeydown}
+            error={addError}
+            data-testid="aisle-add-textarea"
           />
         </div>
-        <Select value={showFilter} onValueChange={(v) => (showFilter = v as typeof showFilter)}>
-          <SelectTrigger class="w-36">
-            {showFilter === 'all' ? 'Show all' : showFilter === 'in-use' ? 'In use' : 'Empty'}
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">Show all</SelectItem>
-            <SelectItem value="in-use">In use</SelectItem>
-            <SelectItem value="empty">Empty</SelectItem>
-          </SelectContent>
-        </Select>
+        <DialogFooter>
+          <Button variant="outline" onclick={() => (addOpen = false)} disabled={addBusy}
+            >Cancel</Button
+          >
+          <Button
+            data-testid="aisle-add-submit"
+            onclick={handleAdd}
+            loading={addBusy}
+            disabled={addBusy}>Add</Button
+          >
+        </DialogFooter>
       </div>
+    </DialogContent>
+  </Dialog>
 
-      <!-- Sortable list -->
-      <SortableList
-        items={filteredAisles}
-        getId={(a) => a.id}
-        onReorder={handleReorder}
-        class="divide-y divide-border rounded border"
-      >
-        {#snippet row(aisle)}
-          <div data-testid={`aisle-row-${aisle.id}`} class="flex items-center gap-2 px-3 py-2">
-            {#if selectionMode}
-              <span data-testid={`aisle-row-checkbox-${aisle.id}`}>
-                <Checkbox
-                  checked={selected.has(aisle.id)}
-                  onCheckedChange={() => toggleSelect(aisle.id)}
-                  labelledBy={`aisle-name-${aisle.id}`}
-                />
-              </span>
-            {/if}
-
-            <span
-              data-testid={`aisle-drag-handle-${aisle.id}`}
-              class="cursor-grab text-muted-foreground"
-            >
-              <Icon name="GripVertical" size={16} />
-            </span>
-
-            {#if editingId === aisle.id}
-              <input
-                bind:this={editInputEl}
-                class="flex-1 rounded border border-input bg-background px-2 py-0.5 text-sm"
-                bind:value={editingName}
-                onblur={() => commitRename(aisle.id)}
-                onkeydown={(e) => handleRenameKeydown(e, aisle.id)}
-              />
-            {:else}
-              <button
-                id={`aisle-name-${aisle.id}`}
-                class="flex-1 truncate text-left text-sm font-medium hover:underline"
-                onclick={() => startRename(aisle)}
-              >
-                {titleCase(aisle.name)}
-              </button>
-            {/if}
-
-            {#if ($aisleUsage.get(aisle.id) ?? 0) > 0}
-              <span class="shrink-0 text-xs text-muted-foreground">
-                {$aisleUsage.get(aisle.id)}
-              </span>
-            {/if}
-          </div>
-        {/snippet}
-      </SortableList>
-    {/snippet}
-  </ListPage>
-</div>
-
-<!-- Add dialog -->
-<Dialog
-  bind:open={addOpen}
-  onOpenChange={(v) => {
-    if (!v) {
-      addText = '';
-      addError = '';
-    }
-  }}
->
-  <DialogContent>
-    <div data-testid="aisle-add-dialog">
-      <DialogHeader>
-        <DialogTitle>Add aisles</DialogTitle>
-      </DialogHeader>
-      <div class="py-2">
-        <TextArea
-          label="Aisle name(s)"
-          description="Enter one per line to add multiple at once."
-          placeholder="Produce&#10;Dairy&#10;Bakery"
-          rows={4}
-          bind:value={addText}
-          onkeydown={handleAddKeydown}
-          error={addError}
-          data-testid="aisle-add-textarea"
-        />
+  <!-- Bulk delete dialog -->
+  <Dialog
+    bind:open={deleteOpen}
+    onOpenChange={(v) => {
+      if (!v) deleteError = '';
+    }}
+  >
+    <DialogContent>
+      <div data-testid="bulk-delete-dialog">
+        <DialogHeader>
+          <DialogTitle>Delete aisles</DialogTitle>
+          <DialogDescription>
+            These items will become unassigned and flagged for review.
+          </DialogDescription>
+        </DialogHeader>
+        {#if deleteAffectedItems.length > 0}
+          <ul class="max-h-48 divide-y divide-border overflow-y-auto rounded border py-1">
+            {#each deleteAffectedItems as item (item.id)}
+              <li class="px-3 py-2 text-sm">{titleCase(item.name)}</li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="py-2 text-sm text-muted-foreground">No items reference the selected aisles.</p>
+        {/if}
+        {#if deleteError}
+          <p class="text-sm text-destructive">{deleteError}</p>
+        {/if}
+        <DialogFooter>
+          <Button variant="outline" onclick={() => (deleteOpen = false)} disabled={deleteBusy}>
+            Cancel
+          </Button>
+          <Button
+            data-testid="bulk-delete-confirm"
+            variant="destructive"
+            onclick={handleBulkDelete}
+            loading={deleteBusy}
+            disabled={deleteBusy}
+          >
+            Continue
+          </Button>
+        </DialogFooter>
       </div>
-      <DialogFooter>
-        <Button variant="outline" onclick={() => (addOpen = false)} disabled={addBusy}
-          >Cancel</Button
-        >
-        <Button
-          data-testid="aisle-add-submit"
-          onclick={handleAdd}
-          loading={addBusy}
-          disabled={addBusy}>Add</Button
-        >
-      </DialogFooter>
-    </div>
-  </DialogContent>
-</Dialog>
+    </DialogContent>
+  </Dialog>
 
-<!-- Bulk delete dialog -->
-<Dialog
-  bind:open={deleteOpen}
-  onOpenChange={(v) => {
-    if (!v) deleteError = '';
-  }}
->
-  <DialogContent>
-    <div data-testid="bulk-delete-dialog">
+  <!-- Bulk merge dialog -->
+  <Dialog
+    bind:open={mergeOpen}
+    onOpenChange={(v) => {
+      if (!v) {
+        mergeError = '';
+      }
+    }}
+  >
+    <DialogContent>
       <DialogHeader>
-        <DialogTitle>Delete aisles</DialogTitle>
+        <DialogTitle>Merge aisles</DialogTitle>
         <DialogDescription>
-          These items will become unassigned and flagged for review.
+          Choose a target aisle. Items from the other selected aisles will be moved or unassigned.
         </DialogDescription>
       </DialogHeader>
-      {#if deleteAffectedItems.length > 0}
-        <ul class="max-h-48 divide-y divide-border overflow-y-auto rounded border py-1">
-          {#each deleteAffectedItems as item (item.id)}
-            <li class="px-3 py-2 text-sm">{titleCase(item.name)}</li>
-          {/each}
-        </ul>
-      {:else}
-        <p class="py-2 text-sm text-muted-foreground">No items reference the selected aisles.</p>
-      {/if}
-      {#if deleteError}
-        <p class="text-sm text-destructive">{deleteError}</p>
+      <div class="space-y-4 py-2">
+        <Select value={mergeTargetId} onValueChange={(v: string) => (mergeTargetId = v)}>
+          <SelectTrigger>
+            {mergeTargetId
+              ? titleCase($aisles.find((a) => a.id === mergeTargetId)?.name ?? 'Pick target…')
+              : 'Pick target aisle…'}
+          </SelectTrigger>
+          <SelectContent>
+            {#each [...selected] as id (id)}
+              {@const a = $aisles.find((a) => a.id === id)}
+              {#if a}
+                <SelectItem value={a.id}>{titleCase(a.name)}</SelectItem>
+              {/if}
+            {/each}
+          </SelectContent>
+        </Select>
+
+        {#if mergeAffectedItems.length > 0}
+          <div class="max-h-64 divide-y divide-border overflow-y-auto rounded border">
+            {#each mergeAffectedItems as item (item.id)}
+              <div class="flex items-center justify-between gap-4 px-3 py-2">
+                <span class="min-w-0 flex-1 truncate text-sm">{titleCase(item.name)}</span>
+                <RadioGroup
+                  label={titleCase(item.name)}
+                  value={mergeChoices.get(item.id) ?? 'move'}
+                  orientation="horizontal"
+                  class="sr-only-label"
+                  onValueChange={(v: string) => mergeChoices.set(item.id, v as 'move' | 'unassign')}
+                >
+                  <RadioGroupItem value="move" label="Move" />
+                  <RadioGroupItem value="unassign" label="Unassign" />
+                </RadioGroup>
+              </div>
+            {/each}
+          </div>
+        {:else if mergeSourceIds.length > 0}
+          <p class="text-sm text-muted-foreground">No items reference these aisles.</p>
+        {/if}
+      </div>
+      {#if mergeError}
+        <p class="text-sm text-destructive">{mergeError}</p>
       {/if}
       <DialogFooter>
-        <Button variant="outline" onclick={() => (deleteOpen = false)} disabled={deleteBusy}>
+        <Button variant="outline" onclick={() => (mergeOpen = false)} disabled={mergeBusy}>
           Cancel
         </Button>
         <Button
-          data-testid="bulk-delete-confirm"
-          variant="destructive"
-          onclick={handleBulkDelete}
-          loading={deleteBusy}
-          disabled={deleteBusy}
+          onclick={handleBulkMerge}
+          loading={mergeBusy}
+          disabled={mergeBusy || !mergeTargetId || mergeSourceIds.length === 0}
         >
-          Continue
+          Merge
         </Button>
       </DialogFooter>
-    </div>
-  </DialogContent>
-</Dialog>
-
-<!-- Bulk merge dialog -->
-<Dialog
-  bind:open={mergeOpen}
-  onOpenChange={(v) => {
-    if (!v) {
-      mergeError = '';
-    }
-  }}
->
-  <DialogContent>
-    <DialogHeader>
-      <DialogTitle>Merge aisles</DialogTitle>
-      <DialogDescription>
-        Choose a target aisle. Items from the other selected aisles will be moved or unassigned.
-      </DialogDescription>
-    </DialogHeader>
-    <div class="space-y-4 py-2">
-      <Select value={mergeTargetId} onValueChange={(v: string) => (mergeTargetId = v)}>
-        <SelectTrigger>
-          {mergeTargetId
-            ? titleCase($aisles.find((a) => a.id === mergeTargetId)?.name ?? 'Pick target…')
-            : 'Pick target aisle…'}
-        </SelectTrigger>
-        <SelectContent>
-          {#each [...selected] as id (id)}
-            {@const a = $aisles.find((a) => a.id === id)}
-            {#if a}
-              <SelectItem value={a.id}>{titleCase(a.name)}</SelectItem>
-            {/if}
-          {/each}
-        </SelectContent>
-      </Select>
-
-      {#if mergeAffectedItems.length > 0}
-        <div class="max-h-64 divide-y divide-border overflow-y-auto rounded border">
-          {#each mergeAffectedItems as item (item.id)}
-            <div class="flex items-center justify-between gap-4 px-3 py-2">
-              <span class="min-w-0 flex-1 truncate text-sm">{titleCase(item.name)}</span>
-              <RadioGroup
-                label={titleCase(item.name)}
-                value={mergeChoices.get(item.id) ?? 'move'}
-                orientation="horizontal"
-                class="sr-only-label"
-                onValueChange={(v: string) => mergeChoices.set(item.id, v as 'move' | 'unassign')}
-              >
-                <RadioGroupItem value="move" label="Move" />
-                <RadioGroupItem value="unassign" label="Unassign" />
-              </RadioGroup>
-            </div>
-          {/each}
-        </div>
-      {:else if mergeSourceIds.length > 0}
-        <p class="text-sm text-muted-foreground">No items reference these aisles.</p>
-      {/if}
-    </div>
-    {#if mergeError}
-      <p class="text-sm text-destructive">{mergeError}</p>
-    {/if}
-    <DialogFooter>
-      <Button variant="outline" onclick={() => (mergeOpen = false)} disabled={mergeBusy}>
-        Cancel
-      </Button>
-      <Button
-        onclick={handleBulkMerge}
-        loading={mergeBusy}
-        disabled={mergeBusy || !mergeTargetId || mergeSourceIds.length === 0}
-      >
-        Merge
-      </Button>
-    </DialogFooter>
-  </DialogContent>
-</Dialog>
+    </DialogContent>
+  </Dialog>
+</AdminGuard>

--- a/apps/web-pwa/src/routes/canon/CanonCreatePage.svelte
+++ b/apps/web-pwa/src/routes/canon/CanonCreatePage.svelte
@@ -19,6 +19,7 @@
   import { aisles } from '../../lib/aisleService.js';
   import { addToast } from '../../lib/toastStore.js';
   import { titleCase } from '../../lib/titleCase.js';
+  import AdminGuard from '../admin/AdminGuard.svelte';
 
   let comboItems = $derived($canonItems.map((c) => ({ value: c.id, label: titleCase(c.name) })));
 
@@ -40,7 +41,7 @@
   // Selecting an existing item from the combobox navigates to its detail page
   function handleValueChange(id: string): void {
     if ($canonItems.some((c) => c.id === id)) {
-      push(`/canon/${id}`);
+      push(`/admin/canon/${id}`);
     }
   }
 
@@ -63,87 +64,92 @@
         ? `Added ${titleCase(item.name)}`
         : `Matched to ${titleCase(item.name)}`;
     addToast(toastMessage, 'success');
-    push(`/canon/${item.id}`);
+    push(`/admin/canon/${item.id}`);
   }
 </script>
 
-<div class="p-4 sm:p-6">
-  <div class="flex flex-col gap-6">
-    <header class="flex flex-col gap-1">
-      <h1 class="text-xl font-semibold tracking-tight text-foreground">Add item</h1>
-      <p class="text-sm text-muted-foreground">
-        Search for an existing item or type a new name to add one.
-      </p>
-    </header>
-
-    <div class="flex flex-col gap-4">
-      <!-- Name combobox -->
-      <div class="flex flex-col gap-1.5">
-        <label class="text-sm font-medium" for="item-combobox">Name</label>
-        <Combobox
-          items={comboItems}
-          allowCustom={true}
-          {filterFn}
-          onValueChange={handleValueChange}
-          onCreate={handleCreate}
-          placeholder="Search or type a new item…"
-        >
-          <ComboboxField>
-            <ComboboxInput />
-          </ComboboxField>
-          <ComboboxContent>
-            {#snippet children({ filteredItems, showCreate })}
-              {#each filteredItems as item, i (item.value)}
-                <ComboboxItem {item} index={i} />
-              {/each}
-              {#if showCreate}
-                <ComboboxCreate />
-              {/if}
-              {#if filteredItems.length === 0 && !showCreate}
-                <ComboboxEmpty>No matches found</ComboboxEmpty>
-              {/if}
-            {/snippet}
-          </ComboboxContent>
-        </Combobox>
-      </div>
-
-      <!-- Optional aisle -->
-      <div class="flex flex-col gap-1.5">
-        <p class="text-sm font-medium">
-          Aisle <span class="font-normal text-muted-foreground">(optional)</span>
+<AdminGuard>
+  <div class="p-4 sm:p-6">
+    <div class="flex flex-col gap-6">
+      <header class="flex flex-col gap-1">
+        <h1 class="text-xl font-semibold tracking-tight text-foreground">Add item</h1>
+        <p class="text-sm text-muted-foreground">
+          Search for an existing item or type a new name to add one.
         </p>
-        <Select value={selectedAisleId ?? ''} onValueChange={(v) => (selectedAisleId = v || null)}>
-          <SelectTrigger>
-            {selectedAisleId
-              ? titleCase($aisles.find((a) => a.id === selectedAisleId)?.name ?? 'Unknown')
-              : 'No aisle'}
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="">No aisle</SelectItem>
-            {#each $aisles as aisle (aisle.id)}
-              <SelectItem value={aisle.id}>{titleCase(aisle.name)}</SelectItem>
-            {/each}
-          </SelectContent>
-        </Select>
+      </header>
+
+      <div class="flex flex-col gap-4">
+        <!-- Name combobox -->
+        <div class="flex flex-col gap-1.5">
+          <label class="text-sm font-medium" for="item-combobox">Name</label>
+          <Combobox
+            items={comboItems}
+            allowCustom={true}
+            {filterFn}
+            onValueChange={handleValueChange}
+            onCreate={handleCreate}
+            placeholder="Search or type a new item…"
+          >
+            <ComboboxField>
+              <ComboboxInput />
+            </ComboboxField>
+            <ComboboxContent>
+              {#snippet children({ filteredItems, showCreate })}
+                {#each filteredItems as item, i (item.value)}
+                  <ComboboxItem {item} index={i} />
+                {/each}
+                {#if showCreate}
+                  <ComboboxCreate />
+                {/if}
+                {#if filteredItems.length === 0 && !showCreate}
+                  <ComboboxEmpty>No matches found</ComboboxEmpty>
+                {/if}
+              {/snippet}
+            </ComboboxContent>
+          </Combobox>
+        </div>
+
+        <!-- Optional aisle -->
+        <div class="flex flex-col gap-1.5">
+          <p class="text-sm font-medium">
+            Aisle <span class="font-normal text-muted-foreground">(optional)</span>
+          </p>
+          <Select
+            value={selectedAisleId ?? ''}
+            onValueChange={(v) => (selectedAisleId = v || null)}
+          >
+            <SelectTrigger>
+              {selectedAisleId
+                ? titleCase($aisles.find((a) => a.id === selectedAisleId)?.name ?? 'Unknown')
+                : 'No aisle'}
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">No aisle</SelectItem>
+              {#each $aisles as aisle (aisle.id)}
+                <SelectItem value={aisle.id}>{titleCase(aisle.name)}</SelectItem>
+              {/each}
+            </SelectContent>
+          </Select>
+        </div>
       </div>
-    </div>
 
-    {#if pending}
-      <div
-        data-testid="canon-create-pending"
-        class="flex items-center gap-2 text-sm text-muted-foreground"
-      >
-        <Spinner size={16} />
-        Checking for matches…
+      {#if pending}
+        <div
+          data-testid="canon-create-pending"
+          class="flex items-center gap-2 text-sm text-muted-foreground"
+        >
+          <Spinner size={16} />
+          Checking for matches…
+        </div>
+      {/if}
+
+      {#if errorMessage}
+        <p class="text-sm text-destructive">{errorMessage}</p>
+      {/if}
+
+      <div class="flex justify-end gap-2 border-t border-border pt-4">
+        <Button variant="ghost" onclick={() => push('/admin/canon')}>Cancel</Button>
       </div>
-    {/if}
-
-    {#if errorMessage}
-      <p class="text-sm text-destructive">{errorMessage}</p>
-    {/if}
-
-    <div class="flex justify-end gap-2 border-t border-border pt-4">
-      <Button variant="ghost" onclick={() => push('/canon')}>Cancel</Button>
     </div>
   </div>
-</div>
+</AdminGuard>

--- a/apps/web-pwa/src/routes/canon/CanonDetailPage.svelte
+++ b/apps/web-pwa/src/routes/canon/CanonDetailPage.svelte
@@ -47,6 +47,7 @@
   import { titleCase } from '../../lib/titleCase.js';
   import { CANON_ICON_HIDDEN } from '@salt/domain';
   import type { ShoppingBehavior, CanonItemUnit } from '@salt/shared-types';
+  import AdminGuard from '../admin/AdminGuard.svelte';
 
   let { params }: { params: Record<string, string> } = $props();
 
@@ -178,7 +179,7 @@
         : {}),
     });
     approveBusy = false;
-    push('/canon');
+    push('/admin/canon');
   }
 
   const aisleItems = $derived([
@@ -197,7 +198,7 @@
     splitBusy = false;
     if (result.kind === 'ok') {
       addToast(`Split "${titleCase(last)}" into a new item`, 'success');
-      push(`/canon/${result.value.id}`);
+      push(`/admin/canon/${result.value.id}`);
     }
   }
 
@@ -254,178 +255,356 @@
     if (result.kind === 'ok') {
       deleteOpen = false;
       addToast(`Deleted ${name}`, 'success');
-      push('/canon');
+      push('/admin/canon');
     }
   }
 </script>
 
-<div class="p-4 sm:p-6">
-  {#if !item}
-    <div class="flex flex-col gap-4">
-      <div>
-        <Button variant="ghost" size="sm" onclick={() => push('/canon')}>
-          {#snippet leading()}
-            <Icon name="ArrowLeft" size={16} />
-          {/snippet}
-          Items
-        </Button>
+<AdminGuard>
+  <div class="p-4 sm:p-6">
+    {#if !item}
+      <div class="flex flex-col gap-4">
+        <div>
+          <Button variant="ghost" size="sm" onclick={() => push('/admin/canon')}>
+            {#snippet leading()}
+              <Icon name="ArrowLeft" size={16} />
+            {/snippet}
+            Items
+          </Button>
+        </div>
+        <Text muted>Item not found.</Text>
       </div>
-      <Text muted>Item not found.</Text>
-    </div>
-  {:else}
-    <DetailPage title={titleCase(item.name)} onBack={() => push('/canon')} backLabel="Items">
-      {#snippet titleSlot()}
-        {#if editingNameActive}
-          <input
-            bind:this={nameInput}
-            data-testid="canon-detail-name-input"
-            class="text-2xl font-semibold tracking-tight text-foreground bg-transparent border-b border-foreground/30 outline-none w-full min-w-0"
-            value={editingName}
-            oninput={(e) => (editingName = e.currentTarget.value)}
-            onkeydown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                saveName();
-                editingNameActive = false;
-              } else if (e.key === 'Escape') {
+    {:else}
+      <DetailPage
+        title={titleCase(item.name)}
+        onBack={() => push('/admin/canon')}
+        backLabel="Items"
+      >
+        {#snippet titleSlot()}
+          {#if editingNameActive}
+            <input
+              bind:this={nameInput}
+              data-testid="canon-detail-name-input"
+              class="text-2xl font-semibold tracking-tight text-foreground bg-transparent border-b border-foreground/30 outline-none w-full min-w-0"
+              value={editingName}
+              oninput={(e) => (editingName = e.currentTarget.value)}
+              onkeydown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  saveName();
+                  editingNameActive = false;
+                } else if (e.key === 'Escape') {
+                  editingName = item!.name;
+                  editingNameActive = false;
+                }
+              }}
+              onblur={() => {
                 editingName = item!.name;
                 editingNameActive = false;
-              }
-            }}
-            onblur={() => {
-              editingName = item!.name;
-              editingNameActive = false;
-            }}
-          />
-        {:else}
-          <div class="min-w-0">
-            <div class="flex items-center gap-2">
-              <h1 class="text-2xl font-semibold tracking-tight text-foreground truncate">
-                {titleCase(item.name)}
-              </h1>
-              <button
-                class="text-muted-foreground hover:text-foreground transition-colors shrink-0"
-                onclick={() => {
-                  editingName = item!.name;
-                  editingNameActive = true;
-                  nameError = '';
-                }}
-                aria-label="Edit name"
-                type="button"
-              >
-                <Icon name="Pencil" size={14} />
-              </button>
-            </div>
-            {#if nameError}
-              <span class="text-sm text-destructive">{nameError}</span>
-            {/if}
-          </div>
-        {/if}
-      {/snippet}
-
-      {#snippet actions()}
-        {#if item.synonyms.length > 0}
-          <Button
-            data-testid="canon-detail-split-button"
-            variant="outline"
-            size="sm"
-            onclick={handleSplit}
-            loading={splitBusy}
-            disabled={splitBusy}
-          >
-            {#snippet leading()}
-              <Icon name="Split" size={16} />
-            {/snippet}
-            Split
-          </Button>
-        {/if}
-        <Button
-          data-testid="canon-detail-delete-button"
-          variant="destructive"
-          size="sm"
-          onclick={() => (deleteOpen = true)}
-        >
-          {#snippet leading()}
-            <Icon name="Trash2" size={16} />
-          {/snippet}
-          Delete
-        </Button>
-      {/snippet}
-
-      <div class="flex flex-col gap-6">
-        <!-- Icon (Tier-1 pictogram) -->
-        <section class="flex flex-col gap-2" data-testid="canon-detail-icon-section">
-          <h2 class="text-sm font-medium text-foreground">Icon</h2>
-          <div class="flex items-center gap-3">
-            <CanonIcon thumbnail={item.thumbnail} name={item.name} size={48} />
-            <div class="flex gap-2">
-              <Button
-                data-testid="canon-detail-icon-regenerate"
-                variant="outline"
-                size="sm"
-                onclick={openRegenerateDialog}
-                disabled={iconBusy}
-              >
-                {#snippet leading()}
-                  <Icon name="RefreshCw" size={16} />
-                {/snippet}
-                Regenerate
-              </Button>
-              {#if iconHidden}
-                <Button
-                  data-testid="canon-detail-icon-unhide"
-                  variant="outline"
-                  size="sm"
-                  onclick={handleUnhideIcon}
-                  loading={iconBusy}
-                  disabled={iconBusy}
+              }}
+            />
+          {:else}
+            <div class="min-w-0">
+              <div class="flex items-center gap-2">
+                <h1 class="text-2xl font-semibold tracking-tight text-foreground truncate">
+                  {titleCase(item.name)}
+                </h1>
+                <button
+                  class="text-muted-foreground hover:text-foreground transition-colors shrink-0"
+                  onclick={() => {
+                    editingName = item!.name;
+                    editingNameActive = true;
+                    nameError = '';
+                  }}
+                  aria-label="Edit name"
+                  type="button"
                 >
-                  {#snippet leading()}
-                    <Icon name="Eye" size={16} />
-                  {/snippet}
-                  Unhide
-                </Button>
-              {:else}
-                <Button
-                  data-testid="canon-detail-icon-hide"
-                  variant="outline"
-                  size="sm"
-                  onclick={handleHideIcon}
-                  loading={iconBusy}
-                  disabled={iconBusy}
-                >
-                  {#snippet leading()}
-                    <Icon name="EyeOff" size={16} />
-                  {/snippet}
-                  Hide
-                </Button>
+                  <Icon name="Pencil" size={14} />
+                </button>
+              </div>
+              {#if nameError}
+                <span class="text-sm text-destructive">{nameError}</span>
               {/if}
             </div>
-          </div>
-        </section>
+          {/if}
+        {/snippet}
 
-        <!-- Approval — all AI-assigned fields -->
-        {#if item.needs_approval}
-          <section
-            class="flex flex-col gap-4 rounded border border-amber-300 bg-amber-50 p-4 dark:border-amber-700 dark:bg-amber-950/30"
-            data-testid="canon-detail-approval-section"
+        {#snippet actions()}
+          {#if item.synonyms.length > 0}
+            <Button
+              data-testid="canon-detail-split-button"
+              variant="outline"
+              size="sm"
+              onclick={handleSplit}
+              loading={splitBusy}
+              disabled={splitBusy}
+            >
+              {#snippet leading()}
+                <Icon name="Split" size={16} />
+              {/snippet}
+              Split
+            </Button>
+          {/if}
+          <Button
+            data-testid="canon-detail-delete-button"
+            variant="destructive"
+            size="sm"
+            onclick={() => (deleteOpen = true)}
           >
-            <h2 class="text-sm font-semibold text-amber-800 dark:text-amber-300">
-              Review before approving
-            </h2>
+            {#snippet leading()}
+              <Icon name="Trash2" size={16} />
+            {/snippet}
+            Delete
+          </Button>
+        {/snippet}
 
-            {#if item.reasoning}
-              <p
-                class="text-sm text-amber-900 dark:text-amber-200"
-                data-testid="canon-detail-reasoning"
+        <div class="flex flex-col gap-6">
+          <!-- Icon (Tier-1 pictogram) -->
+          <section class="flex flex-col gap-2" data-testid="canon-detail-icon-section">
+            <h2 class="text-sm font-medium text-foreground">Icon</h2>
+            <div class="flex items-center gap-3">
+              <CanonIcon thumbnail={item.thumbnail} name={item.name} size={48} />
+              <div class="flex gap-2">
+                <Button
+                  data-testid="canon-detail-icon-regenerate"
+                  variant="outline"
+                  size="sm"
+                  onclick={openRegenerateDialog}
+                  disabled={iconBusy}
+                >
+                  {#snippet leading()}
+                    <Icon name="RefreshCw" size={16} />
+                  {/snippet}
+                  Regenerate
+                </Button>
+                {#if iconHidden}
+                  <Button
+                    data-testid="canon-detail-icon-unhide"
+                    variant="outline"
+                    size="sm"
+                    onclick={handleUnhideIcon}
+                    loading={iconBusy}
+                    disabled={iconBusy}
+                  >
+                    {#snippet leading()}
+                      <Icon name="Eye" size={16} />
+                    {/snippet}
+                    Unhide
+                  </Button>
+                {:else}
+                  <Button
+                    data-testid="canon-detail-icon-hide"
+                    variant="outline"
+                    size="sm"
+                    onclick={handleHideIcon}
+                    loading={iconBusy}
+                    disabled={iconBusy}
+                  >
+                    {#snippet leading()}
+                      <Icon name="EyeOff" size={16} />
+                    {/snippet}
+                    Hide
+                  </Button>
+                {/if}
+              </div>
+            </div>
+          </section>
+
+          <!-- Approval — all AI-assigned fields -->
+          {#if item.needs_approval}
+            <section
+              class="flex flex-col gap-4 rounded border border-amber-300 bg-amber-50 p-4 dark:border-amber-700 dark:bg-amber-950/30"
+              data-testid="canon-detail-approval-section"
+            >
+              <h2 class="text-sm font-semibold text-amber-800 dark:text-amber-300">
+                Review before approving
+              </h2>
+
+              {#if item.reasoning}
+                <p
+                  class="text-sm text-amber-900 dark:text-amber-200"
+                  data-testid="canon-detail-reasoning"
+                >
+                  {item.reasoning}
+                </p>
+              {/if}
+
+              <!-- Aisle -->
+              <div class="flex flex-col gap-1.5">
+                <span class="text-sm font-medium text-foreground">Aisle</span>
+                <div class="flex items-center gap-2">
+                  <div class="flex-1" data-testid="canon-detail-aisle-select">
+                    <Combobox
+                      items={aisleItems}
+                      value={item.aisleId ?? ''}
+                      onValueChange={saveAisle}
+                      restrict
+                    >
+                      <ComboboxField>
+                        <ComboboxInput placeholder="Search aisles…" />
+                        <ComboboxTrigger />
+                      </ComboboxField>
+                      <ComboboxContent>
+                        {#snippet children({ filteredItems })}
+                          {#each filteredItems as cbItem, i (cbItem.value)}
+                            <ComboboxItem item={cbItem} index={i} />
+                          {/each}
+                          {#if filteredItems.length === 0}
+                            <ComboboxEmpty>No aisles match.</ComboboxEmpty>
+                          {/if}
+                        {/snippet}
+                      </ComboboxContent>
+                    </Combobox>
+                  </div>
+                  {#if aisleBusy}
+                    <Spinner size={16} />
+                  {/if}
+                </div>
+              </div>
+
+              <!-- Synonyms -->
+              <TextField
+                label="Synonyms"
+                description="Separate multiple synonyms with commas."
+                value={editingSynonyms}
+                onValueChange={(v) => (editingSynonyms = v)}
+                error={synonymsError}
+                placeholder="e.g. Butter, Unsalted butter"
+                data-testid="canon-detail-synonyms-input"
+                disabled={synonymsBusy}
+                onkeydown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    saveSynonyms();
+                  }
+                }}
+                onblur={saveSynonyms}
+              />
+
+              <!-- Shopping behavior -->
+              <RadioGroup
+                label="Shopping behavior"
+                orientation="horizontal"
+                value={pendingBehavior}
+                onValueChange={(v) => (pendingBehavior = v as ShoppingBehavior)}
               >
-                {item.reasoning}
-              </p>
-            {/if}
+                <RadioGroupItem value="stocked" label="Stocked" />
+                <RadioGroupItem value="check" label="Check" />
+                <RadioGroupItem value="needed" label="Needed" />
+              </RadioGroup>
 
-            <!-- Aisle -->
-            <div class="flex flex-col gap-1.5">
-              <span class="text-sm font-medium text-foreground">Aisle</span>
+              <!-- Threshold + unit -->
+              <div class="flex gap-2 items-end">
+                <div class="flex-1">
+                  <TextField
+                    label="Quantity threshold (optional)"
+                    type="number"
+                    value={editingThreshold}
+                    onValueChange={(v) => (editingThreshold = v)}
+                    placeholder="e.g. 500"
+                    data-testid="canon-detail-threshold-input"
+                  />
+                </div>
+                <div class="w-28">
+                  <Select
+                    value={editingUnit}
+                    onValueChange={(v) => (editingUnit = v as CanonItemUnit)}
+                  >
+                    <SelectTrigger data-testid="canon-detail-unit-select"
+                      >{editingUnit}</SelectTrigger
+                    >
+                    <SelectContent>
+                      <SelectItem value="g">g</SelectItem>
+                      <SelectItem value="ml">ml</SelectItem>
+                      <SelectItem value="count">count</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div>
+                <Button
+                  data-testid="canon-detail-approve-button"
+                  onclick={handleApprove}
+                  loading={approveBusy}
+                  disabled={approveBusy}
+                >
+                  Approve
+                </Button>
+              </div>
+            </section>
+          {/if}
+
+          <!-- Shopping behavior (approved only) -->
+          {#if !item.needs_approval}
+            <section class="flex flex-col gap-2" data-testid="canon-detail-behavior-section">
+              <div class="flex items-center gap-2">
+                <RadioGroup
+                  label="Shopping behavior"
+                  orientation="horizontal"
+                  value={item.shoppingBehavior}
+                  onValueChange={saveShoppingBehavior}
+                  disabled={behaviorBusy}
+                >
+                  <RadioGroupItem value="stocked" label="Stocked" />
+                  <RadioGroupItem value="check" label="Check" />
+                  <RadioGroupItem value="needed" label="Needed" />
+                </RadioGroup>
+                {#if behaviorBusy}
+                  <Spinner size={16} />
+                {/if}
+              </div>
+            </section>
+          {/if}
+
+          <!-- Quantity threshold (approved only) -->
+          {#if !item.needs_approval}
+            <section class="flex flex-col gap-2" data-testid="canon-detail-threshold-section">
+              <h2 class="text-sm font-medium text-foreground">Quantity threshold</h2>
+              <div class="flex gap-2 items-end">
+                <div class="flex-1">
+                  <TextField
+                    label=""
+                    type="number"
+                    value={editingThreshold}
+                    onValueChange={(v) => (editingThreshold = v)}
+                    placeholder="e.g. 500"
+                    data-testid="canon-detail-threshold-input"
+                  />
+                </div>
+                <div class="w-28">
+                  <Select
+                    value={editingUnit}
+                    onValueChange={(v) => (editingUnit = v as CanonItemUnit)}
+                    disabled={thresholdBusy}
+                  >
+                    <SelectTrigger data-testid="canon-detail-unit-select"
+                      >{editingUnit}</SelectTrigger
+                    >
+                    <SelectContent>
+                      <SelectItem value="g">g</SelectItem>
+                      <SelectItem value="ml">ml</SelectItem>
+                      <SelectItem value="count">count</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button
+                  data-testid="canon-detail-threshold-save"
+                  variant="outline"
+                  onclick={saveThreshold}
+                  loading={thresholdBusy}
+                  disabled={thresholdBusy}
+                >
+                  Save
+                </Button>
+              </div>
+            </section>
+          {/if}
+
+          <!-- Aisle (approved only) -->
+          {#if !item.needs_approval}
+            <section class="flex flex-col gap-2">
+              <h2 class="text-sm font-medium text-foreground">Aisle</h2>
               <div class="flex items-center gap-2">
                 <div class="flex-1" data-testid="canon-detail-aisle-select">
                   <Combobox
@@ -454,275 +633,105 @@
                   <Spinner size={16} />
                 {/if}
               </div>
-            </div>
+            </section>
+          {/if}
 
-            <!-- Synonyms -->
-            <TextField
-              label="Synonyms"
-              description="Separate multiple synonyms with commas."
-              value={editingSynonyms}
-              onValueChange={(v) => (editingSynonyms = v)}
-              error={synonymsError}
-              placeholder="e.g. Butter, Unsalted butter"
-              data-testid="canon-detail-synonyms-input"
-              disabled={synonymsBusy}
-              onkeydown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                  saveSynonyms();
-                }
-              }}
-              onblur={saveSynonyms}
-            />
+          <!-- Synonyms (approved only) -->
+          {#if !item.needs_approval}
+            <section class="flex flex-col gap-2">
+              <TextField
+                label="Synonyms"
+                description="Separate multiple synonyms with commas."
+                value={editingSynonyms}
+                onValueChange={(v) => (editingSynonyms = v)}
+                error={synonymsError}
+                placeholder="e.g. Butter, Unsalted butter"
+                data-testid="canon-detail-synonyms-input"
+                disabled={synonymsBusy}
+                onkeydown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    saveSynonyms();
+                  }
+                }}
+                onblur={saveSynonyms}
+              />
+            </section>
+          {/if}
+        </div>
+      </DetailPage>
+    {/if}
+  </div>
 
-            <!-- Shopping behavior -->
-            <RadioGroup
-              label="Shopping behavior"
-              orientation="horizontal"
-              value={pendingBehavior}
-              onValueChange={(v) => (pendingBehavior = v as ShoppingBehavior)}
-            >
-              <RadioGroupItem value="stocked" label="Stocked" />
-              <RadioGroupItem value="check" label="Check" />
-              <RadioGroupItem value="needed" label="Needed" />
-            </RadioGroup>
-
-            <!-- Threshold + unit -->
-            <div class="flex gap-2 items-end">
-              <div class="flex-1">
-                <TextField
-                  label="Quantity threshold (optional)"
-                  type="number"
-                  value={editingThreshold}
-                  onValueChange={(v) => (editingThreshold = v)}
-                  placeholder="e.g. 500"
-                  data-testid="canon-detail-threshold-input"
-                />
-              </div>
-              <div class="w-28">
-                <Select
-                  value={editingUnit}
-                  onValueChange={(v) => (editingUnit = v as CanonItemUnit)}
-                >
-                  <SelectTrigger data-testid="canon-detail-unit-select">{editingUnit}</SelectTrigger
-                  >
-                  <SelectContent>
-                    <SelectItem value="g">g</SelectItem>
-                    <SelectItem value="ml">ml</SelectItem>
-                    <SelectItem value="count">count</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-
-            <div>
-              <Button
-                data-testid="canon-detail-approve-button"
-                onclick={handleApprove}
-                loading={approveBusy}
-                disabled={approveBusy}
-              >
-                Approve
-              </Button>
-            </div>
-          </section>
-        {/if}
-
-        <!-- Shopping behavior (approved only) -->
-        {#if !item.needs_approval}
-          <section class="flex flex-col gap-2" data-testid="canon-detail-behavior-section">
-            <div class="flex items-center gap-2">
-              <RadioGroup
-                label="Shopping behavior"
-                orientation="horizontal"
-                value={item.shoppingBehavior}
-                onValueChange={saveShoppingBehavior}
-                disabled={behaviorBusy}
-              >
-                <RadioGroupItem value="stocked" label="Stocked" />
-                <RadioGroupItem value="check" label="Check" />
-                <RadioGroupItem value="needed" label="Needed" />
-              </RadioGroup>
-              {#if behaviorBusy}
-                <Spinner size={16} />
-              {/if}
-            </div>
-          </section>
-        {/if}
-
-        <!-- Quantity threshold (approved only) -->
-        {#if !item.needs_approval}
-          <section class="flex flex-col gap-2" data-testid="canon-detail-threshold-section">
-            <h2 class="text-sm font-medium text-foreground">Quantity threshold</h2>
-            <div class="flex gap-2 items-end">
-              <div class="flex-1">
-                <TextField
-                  label=""
-                  type="number"
-                  value={editingThreshold}
-                  onValueChange={(v) => (editingThreshold = v)}
-                  placeholder="e.g. 500"
-                  data-testid="canon-detail-threshold-input"
-                />
-              </div>
-              <div class="w-28">
-                <Select
-                  value={editingUnit}
-                  onValueChange={(v) => (editingUnit = v as CanonItemUnit)}
-                  disabled={thresholdBusy}
-                >
-                  <SelectTrigger data-testid="canon-detail-unit-select">{editingUnit}</SelectTrigger
-                  >
-                  <SelectContent>
-                    <SelectItem value="g">g</SelectItem>
-                    <SelectItem value="ml">ml</SelectItem>
-                    <SelectItem value="count">count</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <Button
-                data-testid="canon-detail-threshold-save"
-                variant="outline"
-                onclick={saveThreshold}
-                loading={thresholdBusy}
-                disabled={thresholdBusy}
-              >
-                Save
-              </Button>
-            </div>
-          </section>
-        {/if}
-
-        <!-- Aisle (approved only) -->
-        {#if !item.needs_approval}
-          <section class="flex flex-col gap-2">
-            <h2 class="text-sm font-medium text-foreground">Aisle</h2>
-            <div class="flex items-center gap-2">
-              <div class="flex-1" data-testid="canon-detail-aisle-select">
-                <Combobox
-                  items={aisleItems}
-                  value={item.aisleId ?? ''}
-                  onValueChange={saveAisle}
-                  restrict
-                >
-                  <ComboboxField>
-                    <ComboboxInput placeholder="Search aisles…" />
-                    <ComboboxTrigger />
-                  </ComboboxField>
-                  <ComboboxContent>
-                    {#snippet children({ filteredItems })}
-                      {#each filteredItems as cbItem, i (cbItem.value)}
-                        <ComboboxItem item={cbItem} index={i} />
-                      {/each}
-                      {#if filteredItems.length === 0}
-                        <ComboboxEmpty>No aisles match.</ComboboxEmpty>
-                      {/if}
-                    {/snippet}
-                  </ComboboxContent>
-                </Combobox>
-              </div>
-              {#if aisleBusy}
-                <Spinner size={16} />
-              {/if}
-            </div>
-          </section>
-        {/if}
-
-        <!-- Synonyms (approved only) -->
-        {#if !item.needs_approval}
-          <section class="flex flex-col gap-2">
-            <TextField
-              label="Synonyms"
-              description="Separate multiple synonyms with commas."
-              value={editingSynonyms}
-              onValueChange={(v) => (editingSynonyms = v)}
-              error={synonymsError}
-              placeholder="e.g. Butter, Unsalted butter"
-              data-testid="canon-detail-synonyms-input"
-              disabled={synonymsBusy}
-              onkeydown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                  saveSynonyms();
-                }
-              }}
-              onblur={saveSynonyms}
-            />
-          </section>
-        {/if}
-      </div>
-    </DetailPage>
-  {/if}
-</div>
-
-<!-- Regenerate icon dialog — optional additive prompt steer -->
-<Dialog bind:open={regenerateOpen}>
-  <DialogContent>
-    <div class="flex flex-col gap-4" data-testid="canon-detail-regenerate-dialog">
-      <DialogHeader>
-        <DialogTitle>Regenerate icon</DialogTitle>
-        <DialogDescription>
-          Optionally add guidance for the new icon. Leave blank to just try again.
-        </DialogDescription>
-      </DialogHeader>
-      <TextField
-        label="Extra guidance (optional)"
-        value={regenerateHint}
-        onValueChange={(v) => (regenerateHint = v)}
-        placeholder="e.g. show it as a tin, sliced, make it greener"
-        data-testid="canon-detail-regenerate-hint"
-        disabled={iconBusy}
-        onkeydown={(e) => {
-          if (e.key === 'Enter') {
-            e.preventDefault();
-            handleRegenerateIcon();
-          }
-        }}
-      />
-      <DialogFooter>
-        <Button variant="outline" onclick={() => (regenerateOpen = false)} disabled={iconBusy}>
-          Cancel
-        </Button>
-        <Button
-          data-testid="canon-detail-regenerate-confirm"
-          onclick={handleRegenerateIcon}
-          loading={iconBusy}
+  <!-- Regenerate icon dialog — optional additive prompt steer -->
+  <Dialog bind:open={regenerateOpen}>
+    <DialogContent>
+      <div class="flex flex-col gap-4" data-testid="canon-detail-regenerate-dialog">
+        <DialogHeader>
+          <DialogTitle>Regenerate icon</DialogTitle>
+          <DialogDescription>
+            Optionally add guidance for the new icon. Leave blank to just try again.
+          </DialogDescription>
+        </DialogHeader>
+        <TextField
+          label="Extra guidance (optional)"
+          value={regenerateHint}
+          onValueChange={(v) => (regenerateHint = v)}
+          placeholder="e.g. show it as a tin, sliced, make it greener"
+          data-testid="canon-detail-regenerate-hint"
           disabled={iconBusy}
-        >
-          Regenerate
-        </Button>
-      </DialogFooter>
-    </div>
-  </DialogContent>
-</Dialog>
+          onkeydown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              handleRegenerateIcon();
+            }
+          }}
+        />
+        <DialogFooter>
+          <Button variant="outline" onclick={() => (regenerateOpen = false)} disabled={iconBusy}>
+            Cancel
+          </Button>
+          <Button
+            data-testid="canon-detail-regenerate-confirm"
+            onclick={handleRegenerateIcon}
+            loading={iconBusy}
+            disabled={iconBusy}
+          >
+            Regenerate
+          </Button>
+        </DialogFooter>
+      </div>
+    </DialogContent>
+  </Dialog>
 
-<!-- Delete confirm dialog -->
-<Dialog
-  bind:open={deleteOpen}
-  onOpenChange={(v) => {
-    if (!v) deleteBusy = false;
-  }}
->
-  <DialogContent>
-    <div class="flex flex-col gap-4" data-testid="canon-detail-delete-dialog">
-      <DialogHeader>
-        <DialogTitle>Delete "{titleCase(item?.name ?? '')}"?</DialogTitle>
-        <DialogDescription>This action cannot be undone.</DialogDescription>
-      </DialogHeader>
-      <DialogFooter>
-        <Button variant="outline" onclick={() => (deleteOpen = false)} disabled={deleteBusy}>
-          Cancel
-        </Button>
-        <Button
-          data-testid="canon-detail-delete-confirm"
-          variant="destructive"
-          onclick={handleDelete}
-          loading={deleteBusy}
-          disabled={deleteBusy}
-        >
-          Delete
-        </Button>
-      </DialogFooter>
-    </div>
-  </DialogContent>
-</Dialog>
+  <!-- Delete confirm dialog -->
+  <Dialog
+    bind:open={deleteOpen}
+    onOpenChange={(v) => {
+      if (!v) deleteBusy = false;
+    }}
+  >
+    <DialogContent>
+      <div class="flex flex-col gap-4" data-testid="canon-detail-delete-dialog">
+        <DialogHeader>
+          <DialogTitle>Delete "{titleCase(item?.name ?? '')}"?</DialogTitle>
+          <DialogDescription>This action cannot be undone.</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onclick={() => (deleteOpen = false)} disabled={deleteBusy}>
+            Cancel
+          </Button>
+          <Button
+            data-testid="canon-detail-delete-confirm"
+            variant="destructive"
+            onclick={handleDelete}
+            loading={deleteBusy}
+            disabled={deleteBusy}
+          >
+            Delete
+          </Button>
+        </DialogFooter>
+      </div>
+    </DialogContent>
+  </Dialog>
+</AdminGuard>

--- a/apps/web-pwa/src/routes/canon/CanonListPage.svelte
+++ b/apps/web-pwa/src/routes/canon/CanonListPage.svelte
@@ -25,6 +25,7 @@
   import { aisles } from '../../lib/aisleService.js';
   import { titleCase } from '../../lib/titleCase.js';
   import CanonListRow from './CanonListRow.svelte';
+  import AdminGuard from '../admin/AdminGuard.svelte';
 
   // Filter / display state
   let filterText = $state('');
@@ -142,156 +143,160 @@
   }
 </script>
 
-<ListPage
-  title="Items"
-  description="Your canonical item database."
-  isLoading={$isLoadingAisles}
-  isEmpty={$canonItems.length === 0}
-  class="p-4 sm:p-6"
-  bind:selectionMode
->
-  {#snippet actions()}
-    <Button size="sm" onclick={() => push('/canon/new')}>Add item</Button>
-    <Button
-      variant="ghost"
-      size="sm"
-      onclick={() => push('/canon/aisles')}
-      data-testid="canon-aisles-btn"
-      aria-label="Manage aisles"
-    >
-      <Icon name="Store" size={16} />
-    </Button>
-  {/snippet}
-
-  {#snippet selectionBar()}
-    <Checkbox
-      checked={allSelected ? true : someSelected ? 'indeterminate' : false}
-      onCheckedChange={toggleAll}
-      label={selectedCount > 0 ? `${selectedCount} selected` : 'Select all'}
-    />
-    {#if selectedCount > 0}
-      <div class="flex items-center gap-2">
-        {#if selectedApprovalIds.length > 0}
-          <Button variant="outline" size="sm" onclick={handleBulkApprove}>
-            Approve ({selectedApprovalIds.length})
-          </Button>
-        {/if}
-        <Button variant="destructive" size="sm" onclick={() => (deleteOpen = true)}>Delete</Button>
-        <Button variant="ghost" size="sm" onclick={() => (selected = new Set())}>Clear</Button>
-      </div>
-    {/if}
-  {/snippet}
-
-  {#snippet children()}
-    <!-- Filter bar -->
-    <div class="mb-4 flex flex-wrap items-end gap-2">
-      <div class="flex-1">
-        <input
-          class="w-full rounded border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground"
-          placeholder="Filter items…"
-          type="search"
-          bind:value={filterText}
-        />
-      </div>
-      <Select
-        value={approvalPlacement}
-        onValueChange={(v) => (approvalPlacement = v as typeof approvalPlacement)}
+<AdminGuard>
+  <ListPage
+    title="Items"
+    description="Your canonical item database."
+    isLoading={$isLoadingAisles}
+    isEmpty={$canonItems.length === 0}
+    class="p-4 sm:p-6"
+    bind:selectionMode
+  >
+    {#snippet actions()}
+      <Button size="sm" onclick={() => push('/admin/canon/new')}>Add item</Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onclick={() => push('/admin/canon/aisles')}
+        data-testid="canon-aisles-btn"
+        aria-label="Manage aisles"
       >
-        <SelectTrigger class="w-40">
-          {approvalPlacement === 'top' ? 'Pending at top' : 'Pending in aisles'}
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="top">Pending at top</SelectItem>
-          <SelectItem value="in-aisles">Pending in aisles</SelectItem>
-        </SelectContent>
-      </Select>
-    </div>
+        <Icon name="Store" size={16} />
+      </Button>
+    {/snippet}
 
-    <!-- Pending-at-top section -->
-    {#if topApprovalItems.length > 0}
-      <div class="mb-4">
-        <div class="mb-1 flex items-center justify-between">
-          <h3
-            class="text-xs font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400"
-          >
-            Needs Review ({topApprovalItems.length})
-          </h3>
-          {#if selectionMode}
-            <button
-              class="text-xs text-muted-foreground underline-offset-2 hover:underline"
-              onclick={selectPending}
-            >
-              Select all pending
-            </button>
+    {#snippet selectionBar()}
+      <Checkbox
+        checked={allSelected ? true : someSelected ? 'indeterminate' : false}
+        onCheckedChange={toggleAll}
+        label={selectedCount > 0 ? `${selectedCount} selected` : 'Select all'}
+      />
+      {#if selectedCount > 0}
+        <div class="flex items-center gap-2">
+          {#if selectedApprovalIds.length > 0}
+            <Button variant="outline" size="sm" onclick={handleBulkApprove}>
+              Approve ({selectedApprovalIds.length})
+            </Button>
           {/if}
+          <Button variant="destructive" size="sm" onclick={() => (deleteOpen = true)}>Delete</Button
+          >
+          <Button variant="ghost" size="sm" onclick={() => (selected = new Set())}>Clear</Button>
         </div>
-        <ul class="flex flex-col gap-1">
-          {#each topApprovalItems as item (item.id)}
-            <CanonListRow
-              {item}
-              aisles={$aisles}
-              selected={selected.has(item.id)}
-              onToggleSelect={selectionMode ? () => toggleItem(item.id) : undefined}
-            />
-          {/each}
-        </ul>
-      </div>
-    {/if}
+      {/if}
+    {/snippet}
 
-    <!-- Grouped by aisle -->
-    {#if aisleGroups.length > 0}
-      <div class="flex flex-col gap-4">
-        {#each aisleGroups as group (group.aisleId ?? '__unassigned__')}
-          <div>
-            <h3 class="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              {group.aisleName}
-            </h3>
-            <ul class="flex flex-col gap-1">
-              {#each group.items as item (item.id)}
-                <CanonListRow
-                  {item}
-                  aisles={$aisles}
-                  selected={selected.has(item.id)}
-                  onToggleSelect={selectionMode ? () => toggleItem(item.id) : undefined}
-                />
-              {/each}
-            </ul>
-          </div>
-        {/each}
-      </div>
-    {:else if filteredItems.length === 0 && filterText !== ''}
-      <p class="py-4 text-center text-sm text-muted-foreground">No items match "{filterText}".</p>
-    {/if}
-  {/snippet}
-</ListPage>
-
-<!-- Bulk delete confirmation dialog -->
-<Dialog
-  bind:open={deleteOpen}
-  onOpenChange={(v) => {
-    if (!v) deleteBusy = false;
-  }}
->
-  <DialogContent>
-    <div class="flex flex-col gap-4" data-testid="canon-list-bulk-delete-dialog">
-      <DialogHeader>
-        <DialogTitle>Delete {selected.size} {selected.size === 1 ? 'item' : 'items'}?</DialogTitle>
-        <DialogDescription>This action cannot be undone.</DialogDescription>
-      </DialogHeader>
-      <DialogFooter>
-        <Button variant="outline" onclick={() => (deleteOpen = false)} disabled={deleteBusy}>
-          Cancel
-        </Button>
-        <Button
-          data-testid="canon-list-bulk-delete-confirm"
-          variant="destructive"
-          onclick={handleBulkDelete}
-          loading={deleteBusy}
-          disabled={deleteBusy}
+    {#snippet children()}
+      <!-- Filter bar -->
+      <div class="mb-4 flex flex-wrap items-end gap-2">
+        <div class="flex-1">
+          <input
+            class="w-full rounded border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground"
+            placeholder="Filter items…"
+            type="search"
+            bind:value={filterText}
+          />
+        </div>
+        <Select
+          value={approvalPlacement}
+          onValueChange={(v) => (approvalPlacement = v as typeof approvalPlacement)}
         >
-          Delete
-        </Button>
-      </DialogFooter>
-    </div>
-  </DialogContent>
-</Dialog>
+          <SelectTrigger class="w-40">
+            {approvalPlacement === 'top' ? 'Pending at top' : 'Pending in aisles'}
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="top">Pending at top</SelectItem>
+            <SelectItem value="in-aisles">Pending in aisles</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <!-- Pending-at-top section -->
+      {#if topApprovalItems.length > 0}
+        <div class="mb-4">
+          <div class="mb-1 flex items-center justify-between">
+            <h3
+              class="text-xs font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400"
+            >
+              Needs Review ({topApprovalItems.length})
+            </h3>
+            {#if selectionMode}
+              <button
+                class="text-xs text-muted-foreground underline-offset-2 hover:underline"
+                onclick={selectPending}
+              >
+                Select all pending
+              </button>
+            {/if}
+          </div>
+          <ul class="flex flex-col gap-1">
+            {#each topApprovalItems as item (item.id)}
+              <CanonListRow
+                {item}
+                aisles={$aisles}
+                selected={selected.has(item.id)}
+                onToggleSelect={selectionMode ? () => toggleItem(item.id) : undefined}
+              />
+            {/each}
+          </ul>
+        </div>
+      {/if}
+
+      <!-- Grouped by aisle -->
+      {#if aisleGroups.length > 0}
+        <div class="flex flex-col gap-4">
+          {#each aisleGroups as group (group.aisleId ?? '__unassigned__')}
+            <div>
+              <h3 class="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {group.aisleName}
+              </h3>
+              <ul class="flex flex-col gap-1">
+                {#each group.items as item (item.id)}
+                  <CanonListRow
+                    {item}
+                    aisles={$aisles}
+                    selected={selected.has(item.id)}
+                    onToggleSelect={selectionMode ? () => toggleItem(item.id) : undefined}
+                  />
+                {/each}
+              </ul>
+            </div>
+          {/each}
+        </div>
+      {:else if filteredItems.length === 0 && filterText !== ''}
+        <p class="py-4 text-center text-sm text-muted-foreground">No items match "{filterText}".</p>
+      {/if}
+    {/snippet}
+  </ListPage>
+
+  <!-- Bulk delete confirmation dialog -->
+  <Dialog
+    bind:open={deleteOpen}
+    onOpenChange={(v) => {
+      if (!v) deleteBusy = false;
+    }}
+  >
+    <DialogContent>
+      <div class="flex flex-col gap-4" data-testid="canon-list-bulk-delete-dialog">
+        <DialogHeader>
+          <DialogTitle>Delete {selected.size} {selected.size === 1 ? 'item' : 'items'}?</DialogTitle
+          >
+          <DialogDescription>This action cannot be undone.</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onclick={() => (deleteOpen = false)} disabled={deleteBusy}>
+            Cancel
+          </Button>
+          <Button
+            data-testid="canon-list-bulk-delete-confirm"
+            variant="destructive"
+            onclick={handleBulkDelete}
+            loading={deleteBusy}
+            disabled={deleteBusy}
+          >
+            Delete
+          </Button>
+        </DialogFooter>
+      </div>
+    </DialogContent>
+  </Dialog>
+</AdminGuard>

--- a/apps/web-pwa/src/routes/canon/CanonListRow.svelte
+++ b/apps/web-pwa/src/routes/canon/CanonListRow.svelte
@@ -85,7 +85,7 @@
   {#snippet narrow()}
     <button
       class="flex min-w-0 flex-1 items-center justify-between text-left"
-      onclick={() => push(`/canon/${item.id}`)}
+      onclick={() => push(`/admin/canon/${item.id}`)}
     >
       <Text>{titleCase(item.name)}</Text>
       {#if item.needs_approval}
@@ -101,7 +101,7 @@
   {#snippet wide()}
     <button
       class="min-w-[120px] flex-1 truncate text-left text-sm font-medium"
-      onclick={() => push(`/canon/${item.id}`)}
+      onclick={() => push(`/admin/canon/${item.id}`)}
       data-testid="canon-list-row-name"
     >
       {titleCase(item.name)}

--- a/apps/web-pwa/src/routes/index.ts
+++ b/apps/web-pwa/src/routes/index.ts
@@ -19,10 +19,6 @@ import NotFound from './NotFound.svelte';
 // More-specific static routes must precede parameterised ones when using a Map.
 export const routes: RouteDefinition = new Map([
   ['/', HomePage],
-  ['/canon', CanonListPage],
-  ['/canon/aisles', AisleManagementPage],
-  ['/canon/new', CanonCreatePage],
-  ['/canon/:id', CanonDetailPage],
   ['/equipment', EquipmentListPage],
   ['/equipment/new', EquipmentCapturePage],
   ['/equipment/:id', EquipmentEditPage],
@@ -31,9 +27,15 @@ export const routes: RouteDefinition = new Map([
   ['/shopping/lists', ShoppingListsManagePage],
   ['/shopping/:listId', ShoppingListPage],
   ['/settings', SettingsPage],
-  // Operator area (issue #155). Both routes are guarded client-side by
+  // Operator area (issues #155, #157). All routes are guarded client-side by
   // AdminGuard; the real boundary is server-side (rules + CF admin checks).
+  // Canon management lives here (not the user nav) because approving/curating
+  // canon records is an operator activity — see #157.
   ['/admin', AdminHomePage],
   ['/admin/members', AdminMembersPage],
+  ['/admin/canon', CanonListPage],
+  ['/admin/canon/aisles', AisleManagementPage],
+  ['/admin/canon/new', CanonCreatePage],
+  ['/admin/canon/:id', CanonDetailPage],
   ['*', NotFound],
 ]);

--- a/apps/web-pwa/tests/CanonCreatePage.test.ts
+++ b/apps/web-pwa/tests/CanonCreatePage.test.ts
@@ -5,7 +5,7 @@ import type { CanonItem } from '@salt/domain';
 
 // ─── Mock stores (hoisted so vi.mock factories can reference them) ─────────────
 
-const { mockCanonItems, mockAisles } = vi.hoisted(() => {
+const { mockCanonItems, mockAisles, mockMembers, mockIsLoading, mockAuth } = vi.hoisted(() => {
   function makeStore<T>(initial: T) {
     let value = initial;
     const subs = new Set<(v: T) => void>();
@@ -26,6 +26,10 @@ const { mockCanonItems, mockAisles } = vi.hoisted(() => {
   return {
     mockCanonItems: makeStore<CanonItem[]>([]),
     mockAisles: makeStore<{ id: string; name: string; position: number }[]>([]),
+    // AdminGuard (canon now lives behind /admin, #157) reads these.
+    mockMembers: makeStore<{ email: string; admin: boolean }[]>([]),
+    mockIsLoading: makeStore<boolean>(false),
+    mockAuth: { user: { email: 'admin@e.org' } as { email: string } | null },
   };
 });
 
@@ -33,6 +37,11 @@ const { mockCanonItems, mockAisles } = vi.hoisted(() => {
 
 vi.mock('svelte-spa-router', () => ({ push: vi.fn() }));
 vi.mock('../src/lib/toastStore.js', () => ({ addToast: vi.fn() }));
+vi.mock('../src/lib/auth.svelte.js', () => ({ auth: mockAuth }));
+vi.mock('../src/lib/membersService.js', () => ({
+  members: mockMembers,
+  isLoadingMembers: mockIsLoading,
+}));
 vi.mock('../src/lib/canonService.js', () => ({
   canonItems: mockCanonItems,
   addCanonItem: vi.fn(),
@@ -80,6 +89,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockCanonItems._set([]);
   mockAisles._set([]);
+  // Pass AdminGuard: signed-in user is an admin member (#157).
+  mockAuth.user = { email: 'admin@e.org' };
+  mockIsLoading._set(false);
+  mockMembers._set([{ email: 'admin@e.org', admin: true }]);
 });
 
 // ─── Helper: open combobox and type ───────────────────────────────────────────
@@ -165,7 +178,7 @@ describe('CanonCreatePage', () => {
           expect.stringContaining('Garlic'),
           'success',
         );
-        expect(vi.mocked(push)).toHaveBeenCalledWith('/canon/g1');
+        expect(vi.mocked(push)).toHaveBeenCalledWith('/admin/canon/g1');
       });
     });
   });
@@ -178,7 +191,7 @@ describe('CanonCreatePage', () => {
       await openAndType('olive oil');
       await userEvent.click(screen.getByRole('option', { name: /Create "olive oil"/ }));
 
-      await waitFor(() => expect(vi.mocked(push)).toHaveBeenCalledWith('/canon/oo1'));
+      await waitFor(() => expect(vi.mocked(push)).toHaveBeenCalledWith('/admin/canon/oo1'));
     });
   });
 
@@ -190,7 +203,7 @@ describe('CanonCreatePage', () => {
       await openAndType('liquid gold');
       await userEvent.click(screen.getByRole('option', { name: /Create "liquid gold"/ }));
 
-      await waitFor(() => expect(vi.mocked(push)).toHaveBeenCalledWith('/canon/oo1'));
+      await waitFor(() => expect(vi.mocked(push)).toHaveBeenCalledWith('/admin/canon/oo1'));
     });
   });
 
@@ -202,7 +215,7 @@ describe('CanonCreatePage', () => {
       await userEvent.click(screen.getByRole('option', { name: 'Olive Oil' }));
 
       await waitFor(() => {
-        expect(vi.mocked(push)).toHaveBeenCalledWith('/canon/oo1');
+        expect(vi.mocked(push)).toHaveBeenCalledWith('/admin/canon/oo1');
       });
       expect(vi.mocked(addCanonItem)).not.toHaveBeenCalled();
     });

--- a/apps/web-pwa/tests/CanonDetailPage.icon.test.ts
+++ b/apps/web-pwa/tests/CanonDetailPage.icon.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
 import type { CanonItem } from '@salt/domain';
 
-const { mockCanonItems, mockAisles } = vi.hoisted(() => {
+const { mockCanonItems, mockAisles, mockMembers, mockIsLoading, mockAuth } = vi.hoisted(() => {
   function makeStore<T>(initial: T) {
     let value = initial;
     const subs = new Set<(v: T) => void>();
@@ -23,11 +23,20 @@ const { mockCanonItems, mockAisles } = vi.hoisted(() => {
   return {
     mockCanonItems: makeStore<CanonItem[]>([]),
     mockAisles: makeStore<{ id: string; name: string; order: number }[]>([]),
+    // AdminGuard (canon now lives behind /admin, #157) reads these.
+    mockMembers: makeStore<{ email: string; admin: boolean }[]>([]),
+    mockIsLoading: makeStore<boolean>(false),
+    mockAuth: { user: { email: 'admin@e.org' } as { email: string } | null },
   };
 });
 
 vi.mock('svelte-spa-router', () => ({ push: vi.fn() }));
 vi.mock('../src/lib/toastStore.js', () => ({ addToast: vi.fn() }));
+vi.mock('../src/lib/auth.svelte.js', () => ({ auth: mockAuth }));
+vi.mock('../src/lib/membersService.js', () => ({
+  members: mockMembers,
+  isLoadingMembers: mockIsLoading,
+}));
 vi.mock('../src/lib/aisleService.js', () => ({
   aisles: mockAisles,
   initAisles: vi.fn().mockResolvedValue(undefined),
@@ -80,6 +89,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockAisles._set([]);
   mockCanonItems._set([]);
+  // Pass AdminGuard: signed-in user is an admin member (#157).
+  mockAuth.user = { email: 'admin@e.org' };
+  mockIsLoading._set(false);
+  mockMembers._set([{ email: 'admin@e.org', admin: true }]);
 });
 
 describe('CanonDetailPage — icon escape hatch', () => {

--- a/apps/web-pwa/tests/CanonDetailPage.test.ts
+++ b/apps/web-pwa/tests/CanonDetailPage.test.ts
@@ -5,7 +5,7 @@ import type { CanonItem } from '@salt/domain';
 
 // ─── Mock stores (hoisted so vi.mock factories can reference them) ─────────────
 
-const { mockCanonItems, mockAisles } = vi.hoisted(() => {
+const { mockCanonItems, mockAisles, mockMembers, mockIsLoading, mockAuth } = vi.hoisted(() => {
   function makeStore<T>(initial: T) {
     let value = initial;
     const subs = new Set<(v: T) => void>();
@@ -26,6 +26,10 @@ const { mockCanonItems, mockAisles } = vi.hoisted(() => {
   return {
     mockCanonItems: makeStore<CanonItem[]>([]),
     mockAisles: makeStore<{ id: string; name: string; position: number }[]>([]),
+    // AdminGuard (canon now lives behind /admin, #157) reads these.
+    mockMembers: makeStore<{ email: string; admin: boolean }[]>([]),
+    mockIsLoading: makeStore<boolean>(false),
+    mockAuth: { user: { email: 'admin@e.org' } as { email: string } | null },
   };
 });
 
@@ -33,6 +37,11 @@ const { mockCanonItems, mockAisles } = vi.hoisted(() => {
 
 vi.mock('svelte-spa-router', () => ({ push: vi.fn() }));
 vi.mock('../src/lib/toastStore.js', () => ({ addToast: vi.fn() }));
+vi.mock('../src/lib/auth.svelte.js', () => ({ auth: mockAuth }));
+vi.mock('../src/lib/membersService.js', () => ({
+  members: mockMembers,
+  isLoadingMembers: mockIsLoading,
+}));
 vi.mock('../src/lib/canonService.js', () => ({
   canonItems: mockCanonItems,
   updateCanonItemName: vi.fn(),
@@ -85,6 +94,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockCanonItems._set([]);
   mockAisles._set([]);
+  // Pass AdminGuard: signed-in user is an admin member (#157).
+  mockAuth.user = { email: 'admin@e.org' };
+  mockIsLoading._set(false);
+  mockMembers._set([{ email: 'admin@e.org', admin: true }]);
 });
 
 // Helper: render with a known item in the store
@@ -252,7 +265,7 @@ describe('CanonDetailPage', () => {
       });
     });
 
-    it('shows a toast and navigates to /canon after successful delete', async () => {
+    it('shows a toast and navigates to /admin/canon after successful delete', async () => {
       vi.mocked(deleteCanonItem).mockResolvedValueOnce({ kind: 'ok', value: undefined });
       setupWithItem();
       await userEvent.click(screen.getByTestId('canon-detail-delete-button'));
@@ -267,7 +280,7 @@ describe('CanonDetailPage', () => {
           expect.stringContaining('Olive Oil'),
           'success',
         );
-        expect(vi.mocked(push)).toHaveBeenCalledWith('/canon');
+        expect(vi.mocked(push)).toHaveBeenCalledWith('/admin/canon');
       });
     });
   });


### PR DESCRIPTION
Closes #157.

## Why

Canon item management was a first-class bottom-nav tab ("Items"), but curating canon is operator stewardship, not an everyday family activity. The `needs_approval` queue flags canon *records* that are newly created or changed (a synonym accreted) — the person adding "milk" to a list has no special authority over the shared milk record. So canon management moves behind the operator area introduced in #155.

The guard here is **deliberately cosmetic** — protection against *accidental* damage (a mis-tap on bulk-delete, idle fiddling), not adversarial users. Canon **writes stay open** to any signed-in user, because `matchOrCreate` creates/mutates canon records as a side effect of ordinary flows (add-to-list today, recipes next). Admin-gating canon writes in Firestore rules would break the core add-item flow, so it is intentionally out of scope.

## What

**Routes & guard**
- `/canon/*` → `/admin/canon/*`; the list, create, detail, and aisle pages wrap themselves in `AdminGuard` (the #155 pattern). All internal navigation rewritten.

**Nav surface**
- Drop the "Items" bottom-nav tab.
- Add a "Canon items" card to the operator home.
- Move the `needs_approval` count badge from the (removed) Items tab onto the **Admin** nav entry — visible only to admins, who action the queue.

**Tests**
- e2e `signIn` helper can seed an allowlisted member with `admin: true`; the canon-navigating specs (`aisles-seed`, `issue-12-aisles`, `issue-16-canon-create-detail`) sign in as admin and use `/admin/canon*`.
- Canon page unit tests gain admin auth/members guard mocks so `AdminGuard` renders the page; path assertions updated.

## Verification

Local (all green): `pnpm typecheck`, `pnpm lint`, dependency-cruiser boundaries, web-pwa unit suite (115 passed), production build. The Playwright e2e specs run in CI (WSL2 free-port blackhole makes local Playwright unreliable).

## Out of scope (by design)

No Firestore rules / CF changes — the threat model is accidental damage, and the canon write path must remain open for the matching pipeline. See #157 and the in-code comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
