### PR TITLE
chore(icons): migrate lucide-svelte to @lucide/svelte (#146)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,54 @@ permissions:
   actions: read
 
 jobs:
+  # Decide whether a PR touches anything other than documentation. The heavy
+  # emulator + Playwright suites are skipped for docs-only PRs, but this
+  # workflow still TRIGGERS on every PR so the required status checks report
+  # (a skipped required job passes; an un-triggered one would block merge
+  # forever waiting on a context that never appears).
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.detect.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Non-PR events (push to main) always run the full suite — main is the
+          # deploy source and must stay genuinely green.
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "Event '$EVENT_NAME' is not a pull_request — running full CI."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+          echo "Changed files:"
+          echo "$changed"
+
+          # Documentation-only allowlist. Anything NOT matched here counts as
+          # code and triggers the full suite, so a mixed code+docs PR runs
+          # everything. Conservative by design.
+          non_doc=$(echo "$changed" | grep -vE '^(docs/|.*\.md$|LICENSE$)' || true)
+
+          if [ -n "$non_doc" ]; then
+            echo "Non-documentation changes detected — running full CI."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Documentation-only change — skipping emulator + e2e suites."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   ci:
     name: Lint, typecheck, test, boundary
     runs-on: ubuntu-latest
@@ -62,6 +110,9 @@ jobs:
   vitest-integration:
     name: Vitest integration (emulator)
     runs-on: ubuntu-latest
+    # Skipped (→ passes as a required check) for documentation-only PRs.
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -92,7 +143,9 @@ jobs:
     # Sequenced after the Vitest integration stack so the e2e composed stack
     # (docker-compose.test.yml, project test-emulators, 8081/9100/5002) is
     # never concurrent with the Vitest one — non-concurrent by design (#84).
-    needs: vitest-integration
+    # Skipped (→ passes as a required check) for documentation-only PRs.
+    needs: [changes, vitest-integration]
+    if: ${{ needs.changes.outputs.code == 'true' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/apps/kitchen-sink/src/sections/FeedbackSection.svelte
+++ b/apps/kitchen-sink/src/sections/FeedbackSection.svelte
@@ -44,7 +44,7 @@
   </div>
 
   <div class="subsection">
-    <h3 class="subsection-title">Icon (lucide-svelte)</h3>
+    <h3 class="subsection-title">Icon (@lucide/svelte)</h3>
     <div class="flex flex-wrap gap-4">
       {#each ['Bell', 'Check', 'ChevronDown', 'CircleAlert', 'Download', 'Heart', 'Home', 'Info', 'LogOut', 'Mail', 'Menu', 'Plus', 'Search', 'Settings', 'Star', 'Trash', 'User', 'X'] as name}
         <div class="flex flex-col items-center gap-1">

--- a/apps/web-pwa/package.json
+++ b/apps/web-pwa/package.json
@@ -17,12 +17,12 @@
     "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@lucide/svelte": "^1.17.0",
     "@salt/domain": "workspace:*",
     "@salt/firebase-sync": "workspace:*",
     "@salt/ld-observability": "workspace:*",
     "@salt/shared-types": "workspace:*",
     "@salt/ui-components": "workspace:*",
-    "lucide-svelte": "^0.460.1",
     "svelte": "^5.55.7",
     "svelte-spa-router": "^5.0.1"
   },

--- a/apps/web-pwa/src/lib/nav.ts
+++ b/apps/web-pwa/src/lib/nav.ts
@@ -1,10 +1,10 @@
-import { Home, Settings, Shield, ShoppingCart, Utensils } from 'lucide-svelte';
+import { Blender, Home, Settings, Shield, ShoppingCart } from '@lucide/svelte';
 import type { NavItem } from '@salt/ui-components';
 
 export const navItems: NavItem[] = [
   { id: 'home', label: 'Home', icon: Home, href: '#/' },
   { id: 'shopping', label: 'Shop', icon: ShoppingCart, href: '#/shopping' },
-  { id: 'equipment', label: 'Kitchen', icon: Utensils, href: '#/equipment' },
+  { id: 'equipment', label: 'Kitchen', icon: Blender, href: '#/equipment' },
   { id: 'settings', label: 'Settings', icon: Settings, href: '#/settings' },
 ];
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -19,10 +19,10 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.7.0",
+    "@lucide/svelte": "^1.17.0",
     "bits-ui": "^1.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
-    "lucide-svelte": "^0.460.0",
     "svelte": "^5.55.7",
     "svelte-dnd-action": "^0.9.69",
     "tailwind-merge": "^2.5.0"

--- a/packages/ui-components/src/layout/NavItem.types.ts
+++ b/packages/ui-components/src/layout/NavItem.types.ts
@@ -1,11 +1,12 @@
+import type { LucideIcon } from '@lucide/svelte';
+
 export interface NavItem {
   id: string;
   label: string;
-  // lucide-svelte ships Svelte 4-style class components (extends SvelteComponentTyped)
-  // which are not assignable to the Svelte 5 Component<> type under strict mode.
-  // `any` is intentional here — type safety on icon props is not worth the workaround.
-  // biome-ignore lint/suspicious/noExplicitAny: intentional for icon compatibility
-  icon: any;
+  // @lucide/svelte ships Svelte 5-native components typed as Component<LucideProps>,
+  // so the icon can be strongly typed (the old lucide-svelte Svelte 4 class-component
+  // workaround that forced `any` is no longer needed).
+  icon: LucideIcon;
   href: string;
   badge?: number;
 }

--- a/packages/ui-components/src/primitives/Combobox/ComboboxTrigger.svelte
+++ b/packages/ui-components/src/primitives/Combobox/ComboboxTrigger.svelte
@@ -1,6 +1,6 @@
 <!-- spec: ui-spec-v04.md §2 v0.4 -->
 <script lang="ts">
-  import { ChevronDown } from 'lucide-svelte';
+  import { ChevronDown } from '@lucide/svelte';
   import { cn } from '../../lib/cn';
   import { COMBOBOX_CONTEXT } from '../../headless/Combobox.headless.svelte';
   import { comboboxTriggerVariants } from './Combobox.variants';

--- a/packages/ui-components/src/primitives/Dialog/DialogClose.svelte
+++ b/packages/ui-components/src/primitives/Dialog/DialogClose.svelte
@@ -1,7 +1,7 @@
 <!-- spec: SPEC.md §8.6 v0.2.3 -->
 <script lang="ts">
   import { Dialog } from 'bits-ui';
-  import { X } from 'lucide-svelte';
+  import { X } from '@lucide/svelte';
   import { cn } from '../../lib/cn';
   import type { DialogPartProps } from './Dialog.types';
 

--- a/packages/ui-components/src/primitives/Icon/Icon.svelte
+++ b/packages/ui-components/src/primitives/Icon/Icon.svelte
@@ -1,6 +1,6 @@
 <!-- spec: SPEC.md §8.12 v0.2.3 -->
 <script lang="ts">
-  import * as icons from 'lucide-svelte';
+  import { icons } from '@lucide/svelte';
   import { cn } from '../../lib/cn';
   import type { IconProps } from './Icon.types';
 

--- a/packages/ui-components/src/primitives/Icon/Icon.types.ts
+++ b/packages/ui-components/src/primitives/Icon/Icon.types.ts
@@ -1,5 +1,5 @@
 // spec: SPEC.md §8.12 v0.2.3
-import type * as icons from 'lucide-svelte';
+import type { icons } from '@lucide/svelte';
 
 export type IconProps = {
   name: keyof typeof icons;

--- a/packages/ui-components/src/primitives/Select/SelectTrigger.svelte
+++ b/packages/ui-components/src/primitives/Select/SelectTrigger.svelte
@@ -1,6 +1,6 @@
 <!-- spec: SPEC.md §3 v0.3 -->
 <script lang="ts">
-  import { ChevronDown } from 'lucide-svelte';
+  import { ChevronDown } from '@lucide/svelte';
   import { cn } from '../../lib/cn';
   import { SELECT_CONTEXT } from '../../headless/Select.headless.svelte';
   import { selectTriggerVariants } from './Select.variants';

--- a/packages/ui-components/src/primitives/Sheet/SheetClose.svelte
+++ b/packages/ui-components/src/primitives/Sheet/SheetClose.svelte
@@ -1,7 +1,7 @@
 <!-- spec: SPEC.md §5 v0.3 -->
 <script lang="ts">
   import { Dialog } from 'bits-ui';
-  import { X } from 'lucide-svelte';
+  import { X } from '@lucide/svelte';
   import { cn } from '../../lib/cn';
   import type { SheetPartProps } from './Sheet.types';
 

--- a/packages/ui-components/src/primitives/Toast/ToastClose.svelte
+++ b/packages/ui-components/src/primitives/Toast/ToastClose.svelte
@@ -1,6 +1,6 @@
 <!-- spec: SPEC.md §6 v0.3 -->
 <script lang="ts">
-  import { X } from 'lucide-svelte';
+  import { X } from '@lucide/svelte';
   import { cn } from '../../lib/cn';
   import { TOAST_ITEM_CONTEXT } from '../../headless/Toast.headless.svelte';
   import type { ToastPartProps } from './Toast.types';

--- a/packages/ui-components/tests/Icon.types.test-d.ts
+++ b/packages/ui-components/tests/Icon.types.test-d.ts
@@ -1,5 +1,5 @@
 // spec: SPEC.md §8.12 v0.2.3
-// Type-level test: verifies Icon `name` prop is keyof typeof import('lucide-svelte').
+// Type-level test: verifies Icon `name` prop is keyof the @lucide/svelte `icons` namespace.
 import { expectTypeOf } from 'vitest';
 import type { IconProps } from '../src/primitives/Icon/Icon.types';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,7 +114,7 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.0.0
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.0
         version: 10.5.0(postcss@8.5.10)
@@ -126,10 +126,13 @@ importers:
         version: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
       vite:
         specifier: ^6.0.0
-        version: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   apps/web-pwa:
     dependencies:
+      '@lucide/svelte':
+        specifier: ^1.17.0
+        version: 1.17.0(svelte@5.55.7(@typescript-eslint/types@8.59.0))
       '@salt/domain':
         specifier: workspace:*
         version: link:../../packages/domain
@@ -145,9 +148,6 @@ importers:
       '@salt/ui-components':
         specifier: workspace:*
         version: link:../../packages/ui-components
-      lucide-svelte:
-        specifier: ^0.460.1
-        version: 0.460.1(svelte@5.55.7(@typescript-eslint/types@8.59.0))
       svelte:
         specifier: ^5.55.7
         version: 5.55.7(@typescript-eslint/types@8.59.0)
@@ -293,6 +293,9 @@ importers:
       '@floating-ui/dom':
         specifier: ^1.7.0
         version: 1.7.6
+      '@lucide/svelte':
+        specifier: ^1.17.0
+        version: 1.17.0(svelte@5.55.7(@typescript-eslint/types@8.59.0))
       bits-ui:
         specifier: ^1.0.0
         version: 1.8.0(svelte@5.55.7(@typescript-eslint/types@8.59.0))
@@ -302,9 +305,6 @@ importers:
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
-      lucide-svelte:
-        specifier: ^0.460.0
-        version: 0.460.1(svelte@5.55.7(@typescript-eslint/types@8.59.0))
       svelte:
         specifier: ^5.55.7
         version: 5.55.7(@typescript-eslint/types@8.59.0)
@@ -317,13 +317,13 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.0.0
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.2.0
-        version: 5.3.1(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
+        version: 5.3.1(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
       '@testing-library/user-event':
         specifier: ^14.5.0
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -2185,6 +2185,11 @@ packages:
 
   '@launchdarkly/session-replay@1.1.6':
     resolution: {integrity: sha512-GQjlH1cZq36Z9AYdJiBRE5K7ez2j/93EV3S1IbmlGYMryUbm/1pbwmcMFsU9cBlDdnZCiVMsAyu0ESS14T7yJQ==}
+
+  '@lucide/svelte@1.17.0':
+    resolution: {integrity: sha512-q06YCFBN5CO8cd1ADmLCxWRVMVb7xxvHzqC0lvNoxGa+FLW6Cd1Y1AOxgbQk4Iwe68vkAMCRveNHint4WoaVKg==}
+    peerDependencies:
+      svelte: ^5
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -5582,11 +5587,6 @@ packages:
   lsofi@2.0.0:
     resolution: {integrity: sha512-XTFlOBHeuXnUGuUQI0kBb4O4oQW7qCV7MRGQja1xNpxgrI/jptlly+/5126RiRold1zgyxY520qOZUZ31V0I2A==}
     engines: {node: '>=20.0.0'}
-
-  lucide-svelte@0.460.1:
-    resolution: {integrity: sha512-guJjJSeWlKivsEG51Xg41egunBMJcobhDmkLv/NYTXmXyCEwxMf1A+HX7RvDEKiXbXYgtLImih67tI08MSUOkA==}
-    peerDependencies:
-      svelte: ^3 || ^4 || ^5.0.0-next.42
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -9817,6 +9817,10 @@ snapshots:
     dependencies:
       highlight.run: 10.1.2
 
+  '@lucide/svelte@1.17.0(svelte@5.55.7(@typescript-eslint/types@8.59.0))':
+    dependencies:
+      svelte: 5.55.7(@typescript-eslint/types@8.59.0)
+
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.23)
@@ -10771,6 +10775,13 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      obug: 2.1.1
+      svelte: 5.55.7(@typescript-eslint/types@8.59.0)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -10778,12 +10789,22 @@ snapshots:
       svelte: 5.55.7(@typescript-eslint/types@8.59.0)
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       obug: 2.1.1
       svelte: 5.55.7(@typescript-eslint/types@8.59.0)
-      vite: 7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      deepmerge: 4.3.1
+      magic-string: 0.30.21
+      obug: 2.1.1
+      svelte: 5.55.7(@typescript-eslint/types@8.59.0)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -10795,15 +10816,15 @@ snapshots:
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vitefu: 1.1.3(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.55.7(@typescript-eslint/types@8.59.0)
-      vite: 7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@swc/helpers@0.5.21':
     dependencies:
@@ -10842,14 +10863,14 @@ snapshots:
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
-  '@testing-library/svelte@5.3.1(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)':
+  '@testing-library/svelte@5.3.1(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.55.7(@typescript-eslint/types@8.59.0))
       svelte: 5.55.7(@typescript-eslint/types@8.59.0)
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -11147,15 +11168,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-    optional: true
-
-  '@vitest/mocker@4.1.8(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.8(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -13926,10 +13938,6 @@ snapshots:
 
   lsofi@2.0.0: {}
 
-  lucide-svelte@0.460.1(svelte@5.55.7(@typescript-eslint/types@8.59.0)):
-    dependencies:
-      svelte: 5.55.7(@typescript-eslint/types@8.59.0)
-
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -15773,6 +15781,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      terser: 5.48.0
+      tsx: 4.21.0
+      yaml: 2.9.0
+
   vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
@@ -15785,22 +15809,6 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.6.1
-      terser: 5.48.0
-      tsx: 4.21.0
-      yaml: 2.9.0
-
-  vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.14
-      rollup: 4.60.4
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 25.6.0
-      fsevents: 2.3.3
-      jiti: 1.21.7
       terser: 5.48.0
       tsx: 4.21.0
       yaml: 2.9.0
@@ -15821,13 +15829,17 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
+  vitefu@1.1.3(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+    optionalDependencies:
+      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+
   vitefu@1.1.3(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitefu@1.1.3(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   vitest-axe@0.1.0(vitest@4.1.8):
     dependencies:
@@ -15837,7 +15849,7 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lodash-es: 4.18.1
       redent: 3.0.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
@@ -15860,37 +15872,6 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 25.6.0
-      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
-      jsdom: 25.0.1
-    transitivePeerDependencies:
-      - msw
-    optional: true
-
-  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
Closes #146.

## What

Migrates the design system and apps off the abandoned **`lucide-svelte`** (npm `latest` points at a stale 2022 release; the `0.5xx` line no longer tracks new icons) onto the maintained **`@lucide/svelte@^1.17.0`**, which carries the current icon set and ships Svelte 5-native components. Then switches the Kitchen nav icon to **Blender** (the original request that surfaced this — Blender isn't available in any `lucide-svelte` version).

## Changes

- Swap all ~11 import sites `'lucide-svelte'` → `'@lucide/svelte'`; drop `lucide-svelte` from both `package.json`s.
- `Icon.svelte` / `Icon.types.ts` use the package's named `icons` namespace export — narrower than `import *`, which in the new package also re-exports `Icon`/`defaultAttributes`.
- **`NavItem.icon` tightened off `any`** to `LucideIcon` (`Component<LucideProps>`): the new icons are real Svelte 5 components, so the old class-component workaround is no longer needed.
- Kitchen nav icon `Utensils` → `Blender`.
- Kitchen-sink demo heading label updated `(lucide-svelte)` → `(@lucide/svelte)`.

## Also bundled

A pre-existing local CI tweak that skips the emulator + Playwright suites for **documentation-only** PRs (the workflow still triggers so required checks report). Unrelated to the icon migration but folded in at the author's request.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm boundary:test` ✅ (17/17)
- `pnpm --filter @salt/web-pwa build` ✅ · `pnpm --filter @salt/kitchen-sink build` ✅
- `pnpm --filter @salt/ui-components test` ✅ (544 tests, incl. the `Icon.types.test-d.ts` type test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)