### PR TITLE
feat(app-check): Firebase App Check (reCAPTCHA Enterprise, monitor-first) (#145)

### DIFF
--- a/apps/cloud-functions/src/callables/regenerateCanonIcon.ts
+++ b/apps/cloud-functions/src/callables/regenerateCanonIcon.ts
@@ -11,20 +11,26 @@ import { RegenerateCanonIconInputSchema } from '@salt/domain/schemas';
 // region is set explicitly (not via setGlobalOptions): this module is imported
 // at the top of index.ts, so the onCall runs before index.ts's
 // setGlobalOptions call — same reason the triggers pin their region inline.
-export const regenerateCanonIcon = onCall({ region: 'europe-west2' }, async (request) => {
-  if (!request.auth) {
-    throw new HttpsError('unauthenticated', 'Sign in required.');
-  }
-  const parsed = RegenerateCanonIconInputSchema.safeParse(request.data);
-  if (!parsed.success) {
-    throw new HttpsError('invalid-argument', 'Invalid request payload.');
-  }
-  const { canonId, hint } = parsed.data;
-  // Clear the icon (→ trigger regenerates) and carry the one-shot steer, if any.
-  // No hint clears any stale hint so the regeneration is plain.
-  await getFirestore()
-    .collection('canonItems')
-    .doc(canonId)
-    .update({ thumbnail: null, iconHint: hint ? hint : FieldValue.delete() });
-  return { ok: true } as const;
-});
+// enforceAppCheck monitor-first (#145): allowed-but-reported now; flip to `true`
+// alongside the index.ts callables at the enforcement step (this also fires AI
+// image generation, so it is part of the cost surface App Check protects).
+export const regenerateCanonIcon = onCall(
+  { region: 'europe-west2', enforceAppCheck: false },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Sign in required.');
+    }
+    const parsed = RegenerateCanonIconInputSchema.safeParse(request.data);
+    if (!parsed.success) {
+      throw new HttpsError('invalid-argument', 'Invalid request payload.');
+    }
+    const { canonId, hint } = parsed.data;
+    // Clear the icon (→ trigger regenerates) and carry the one-shot steer, if any.
+    // No hint clears any stale hint so the regeneration is plain.
+    await getFirestore()
+      .collection('canonItems')
+      .doc(canonId)
+      .update({ thumbnail: null, iconHint: hint ? hint : FieldValue.delete() });
+    return { ok: true } as const;
+  },
+);

--- a/apps/cloud-functions/src/index.ts
+++ b/apps/cloud-functions/src/index.ts
@@ -36,8 +36,15 @@ const geminiApiKey = defineSecret('GEMINI_API_KEY');
 // Optional — when unset, the flow falls back to firebase-functions/logger only.
 const ldSdkKey = defineSecret('LD_SDK_KEY');
 
+// App Check enforcement for every callable. Monitor-first (#145): unverified
+// requests are still allowed but reported to App Check metrics. Flip this single
+// line to `true` once staging metrics confirm legitimate traffic verifies — that
+// is the enforcement step of the rollout (callables first, the AI cost surface).
+const APP_CHECK_ENFORCEMENT = { enforceAppCheck: false } as const;
+
 export const embedText = onCallGenkit(
   {
+    ...APP_CHECK_ENFORCEMENT,
     secrets: [geminiApiKey],
     authPolicy: isSignedIn(),
   },
@@ -46,6 +53,7 @@ export const embedText = onCallGenkit(
 
 export const arbitrateCanon = onCallGenkit(
   {
+    ...APP_CHECK_ENFORCEMENT,
     secrets: [geminiApiKey],
     authPolicy: isSignedIn(),
   },
@@ -69,6 +77,7 @@ export const arbitrateCanon = onCallGenkit(
 // sites at once.
 export const matchOrCreateCanon = onCall(
   {
+    ...APP_CHECK_ENFORCEMENT,
     secrets: [geminiApiKey, ldSdkKey],
   },
   async (request) => {
@@ -91,6 +100,7 @@ export const matchOrCreateCanon = onCall(
 
 export const identifyEquipment = onCallGenkit(
   {
+    ...APP_CHECK_ENFORCEMENT,
     secrets: [geminiApiKey],
     authPolicy: isSignedIn(),
   },
@@ -99,6 +109,7 @@ export const identifyEquipment = onCallGenkit(
 
 export const populateEquipmentEntry = onCallGenkit(
   {
+    ...APP_CHECK_ENFORCEMENT,
     secrets: [geminiApiKey],
     authPolicy: isSignedIn(),
   },

--- a/apps/web-pwa/.env.production
+++ b/apps/web-pwa/.env.production
@@ -4,6 +4,10 @@ VITE_FIREBASE_PROJECT_ID=s2-prod-e46bd
 VITE_FIREBASE_STORAGE_BUCKET=s2-prod-e46bd.firebasestorage.app
 VITE_FIREBASE_MESSAGING_SENDER_ID=140613398002
 VITE_FIREBASE_APP_ID=1:140613398002:web:243461e61158bc134b0f6b
+# App Check (issue #145) — reCAPTCHA Enterprise site key (public). Enforcement is
+# monitor-first and configured server-side. No debug token is ever registered for
+# prod (a standing bypass credential has no place in production).
+VITE_FIREBASE_APPCHECK_SITE_KEY=6LfmyRMtAAAAAF-Vrt8ttEspu7HN7snIzXAxW26D
 VITE_USE_EMULATORS=false
 VITE_LD_CLIENT_SIDE_ID=69f21ef273926f0abe0b9f0a
 # PWA install identity (issue #141) — prod brand: orange.

--- a/apps/web-pwa/.env.staging
+++ b/apps/web-pwa/.env.staging
@@ -4,6 +4,10 @@ VITE_FIREBASE_PROJECT_ID=s2-stage-ccb22
 VITE_FIREBASE_STORAGE_BUCKET=s2-stage-ccb22.firebasestorage.app
 VITE_FIREBASE_MESSAGING_SENDER_ID=946977631175
 VITE_FIREBASE_APP_ID=1:946977631175:web:5ee65c4f75c6ed312007e2
+# App Check (issue #145) — reCAPTCHA Enterprise site key (public). Enforcement is
+# monitor-first and configured server-side. Debug token (if any) is injected at
+# build time via an untracked env / CI secret, never stored here.
+VITE_FIREBASE_APPCHECK_SITE_KEY=6LdRnBMtAAAAABc0gGMMWCB4Z6ck10VIGI1KVij6
 VITE_LD_CLIENT_SIDE_ID=69f21ef273926f0abe0b9f09
 VITE_USE_EMULATORS=false
 # PWA install identity (issue #141) — staging is visually distinct from prod:

--- a/apps/web-pwa/src/env.d.ts
+++ b/apps/web-pwa/src/env.d.ts
@@ -15,6 +15,11 @@ interface ImportMetaEnv {
   readonly VITE_FIREBASE_MESSAGING_SENDER_ID: string;
   readonly VITE_FIREBASE_APP_ID: string;
   readonly VITE_USE_EMULATORS: string;
+  // App Check (issue #145). Site key is public; absent in dev/emulator builds.
+  // Debug token is injected only for unattested real-backend access (untracked
+  // env / CI secret) — never committed or shipped in a deployed bundle.
+  readonly VITE_FIREBASE_APPCHECK_SITE_KEY?: string;
+  readonly VITE_FIREBASE_APPCHECK_DEBUG_TOKEN?: string;
 }
 
 interface ImportMeta {

--- a/apps/web-pwa/src/lib/firebase.ts
+++ b/apps/web-pwa/src/lib/firebase.ts
@@ -1,4 +1,9 @@
-import { initFirebase, createFirebaseAuth, type FirebaseOptions } from '@salt/firebase-sync';
+import {
+  initFirebase,
+  createFirebaseAuth,
+  type FirebaseOptions,
+  type AppCheckConfig,
+} from '@salt/firebase-sync';
 import { createLDErrorReportingAdapter } from '@salt/ld-observability';
 
 export const useEmulators = import.meta.env.VITE_USE_EMULATORS === 'true';
@@ -25,6 +30,19 @@ const options: FirebaseOptions = useEmulators
       appId: import.meta.env.VITE_FIREBASE_APP_ID,
     };
 
-initFirebase(options, useEmulators, !useEmulators);
+// App Check (issue #145). Only configured for real backends; under emulators
+// initFirebase skips it. The site key is public; the optional debug token is for
+// unattested local/CI access to a real backend and must come from an untracked
+// env / CI secret, never a committed/deployed value.
+const appCheckSiteKey = import.meta.env.VITE_FIREBASE_APPCHECK_SITE_KEY;
+const appCheckDebugToken = import.meta.env.VITE_FIREBASE_APPCHECK_DEBUG_TOKEN;
+const appCheck: AppCheckConfig | undefined = appCheckSiteKey
+  ? {
+      siteKey: appCheckSiteKey,
+      ...(appCheckDebugToken ? { debugToken: appCheckDebugToken } : {}),
+    }
+  : undefined;
+
+initFirebase(options, useEmulators, !useEmulators, appCheck);
 
 export const authProvider = createFirebaseAuth(createLDErrorReportingAdapter());

--- a/packages/adapters/firebase-sync/src/index.ts
+++ b/packages/adapters/firebase-sync/src/index.ts
@@ -1,5 +1,6 @@
 export type { FirebaseOptions } from 'firebase/app';
 export { initFirebase, setFirestoreNetwork } from './init.js';
+export type { AppCheckConfig } from './init.js';
 export { createFirebaseAuth } from './auth.js';
 export { subscribeCanonItems, upsertCanonItem, deleteCanonItem } from './canonSubscription.js';
 export { subscribeAisles, saveAisles } from './aisleSubscription.js';

--- a/packages/adapters/firebase-sync/src/init.ts
+++ b/packages/adapters/firebase-sync/src/init.ts
@@ -10,17 +10,48 @@ import {
 } from 'firebase/firestore';
 import { getFunctions, connectFunctionsEmulator } from 'firebase/functions';
 import { getAuth } from 'firebase/auth';
+import { initializeAppCheck, ReCaptchaEnterpriseProvider } from 'firebase/app-check';
 import { connectAuthEmulatorOnce } from './auth.js';
 
 let emulatorsConnected = false;
+
+export interface AppCheckConfig {
+  /** reCAPTCHA Enterprise site key. Public — it ships in the client bundle. */
+  siteKey: string;
+  /**
+   * App Check debug token, for unattested environments (local dev or CI hitting a
+   * real Firebase backend). When set, the SDK uses the debug provider instead of
+   * reCAPTCHA. MUST NOT be baked into a deployed bundle — it bypasses attestation.
+   */
+  debugToken?: string;
+}
 
 export function initFirebase(
   options: FirebaseOptions,
   useEmulators = false,
   usePersistentCache = false,
+  appCheck?: AppCheckConfig,
 ): void {
   const isNew = getApps().length === 0;
   const app = isNew ? initializeApp(options) : getApp();
+
+  // App Check attests that requests come from our genuine app, protecting the
+  // Gemini/Genkit callables (the real cost surface) plus Firestore/Storage.
+  // Skipped under emulators: the emulator suite runs against a `demo-*` project
+  // that has no App Check backend and the emulators don't enforce App Check, so
+  // initialising it there is pure noise. Enforcement itself is configured
+  // server-side (monitor-first — see cloud-functions). Must run before any other
+  // Firebase service is used so tokens attach to their requests.
+  if (isNew && !useEmulators && appCheck?.siteKey) {
+    if (appCheck.debugToken) {
+      (globalThis as { FIREBASE_APPCHECK_DEBUG_TOKEN?: string }).FIREBASE_APPCHECK_DEBUG_TOKEN =
+        appCheck.debugToken;
+    }
+    initializeAppCheck(app, {
+      provider: new ReCaptchaEnterpriseProvider(appCheck.siteKey),
+      isTokenAutoRefreshEnabled: true,
+    });
+  }
 
   if (isNew && usePersistentCache) {
     initializeFirestore(app, { localCache: persistentLocalCache() });


### PR DESCRIPTION
Part of #145 (rollout steps 1–2: wire + monitor mode). The enforcement flip is a separate follow-up.

## What

Adds Firebase App Check to attest that requests come from our genuine app, protecting the **Gemini/Genkit callable cost surface** (the real driver) plus Firestore/Storage. **Monitor-first**: nothing is rejected yet — tokens are minted and reported to App Check metrics; enforcement is a one-line follow-up once staging metrics confirm legitimate traffic verifies.

Provider is **reCAPTCHA Enterprise** (not v3) — reCAPTCHA Classic key management has been retired into the Cloud console and Google steers new integrations to Enterprise; same invisible UX, 10k assessments/month free. See the [decision trail on #145](https://github.com/eggman0131/saltV2/issues/145#issuecomment-4650370562).

## Changes

- **`firebase-sync/init.ts`** — `initializeAppCheck` with `ReCaptchaEnterpriseProvider` (`isTokenAutoRefreshEnabled`), initialised before any other Firebase service so tokens attach. New optional `AppCheckConfig` param (site key + optional debug token), exported from the package barrel. **Skipped under emulators** — the suite runs a `demo-*` project that has no App Check backend and emulators don't enforce, so init there is pure noise.
- **`web-pwa`** — passes the public site key from `VITE_FIREBASE_APPCHECK_SITE_KEY`; the optional debug token (`VITE_FIREBASE_APPCHECK_DEBUG_TOKEN`) is for unattested *real-backend* access only and must come from an untracked env / CI secret — never committed or shipped. Site keys added to `.env.staging` / `.env.production`; `env.d.ts` updated.
- **`cloud-functions`** — `enforceAppCheck: false` on every callable: the five in `index.ts` via a shared `APP_CHECK_ENFORCEMENT` constant (single flip site) plus the `regenerateCanonIcon` icon-regen callable (also fires AI image gen). Orthogonal to the dormant trace-propagation plumbing and `withAiTimeout`.

## Provisioning (already done, via gcloud / App Check REST API)

- reCAPTCHA Enterprise score-based web keys created in both projects; site keys registered with App Check.
- Debug token registered for **staging only** (never prod — a standing bypass credential has no place in production).
- Enforcement left **off** (monitor) on all services by default.

## Design note

Original decision #4 said "debug token in dev/emulator/e2e/Vitest too." Those all run the demo project against emulators, where App Check isn't enforced and can't be exchanged — so a debug token there is a no-op. Implemented the honest version: skip under emulators, keep debug-token plumbing for real-backend unattested access. Net effect matches intent.

## Verification

- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm boundary:test` ✅ (17/17)
- `pnpm --filter @salt/web-pwa build` ✅ · `pnpm --filter @salt/cloud-functions build` ✅
- `pnpm --filter @salt/firebase-sync test` ✅ (95 tests)

## After merge (rollout continues)

1. Deploy to staging; confirm verified tokens appear in App Check metrics and dev/e2e/emulator paths still pass.
2. Flip `APP_CHECK_ENFORCEMENT` → `true` (callables first), then enable Firestore/Storage enforcement, on staging; validate.
3. Promote enforcement to prod via the normal release path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)