### PR TITLE
feat(ui): promote shopping contextual action mode into ListPage template (#115)

### DIFF
--- a/apps/kitchen-sink/src/sections/TemplatesSection.svelte
+++ b/apps/kitchen-sink/src/sections/TemplatesSection.svelte
@@ -7,6 +7,7 @@
     EmptyState,
     ErrorState,
     Button,
+    Checkbox,
     TextField,
     TextArea,
     Switch,
@@ -24,16 +25,84 @@
   let listMode = $state<ListMode>('data');
 
   type Note = { id: string; title: string; updated: string };
-  const sampleNotes: Note[] = [
+  let sampleNotes = $state<Note[]>([
     { id: 'n1', title: 'Pantry restock', updated: '2 hours ago' },
     { id: 'n2', title: 'Sourdough recipe', updated: 'Yesterday' },
     { id: 'n3', title: 'Weekly meal plan', updated: '3 days ago' },
-  ];
+  ]);
 
   let search = $state('');
   const filteredNotes = $derived(
     sampleNotes.filter((n) => n.title.toLowerCase().includes(search.toLowerCase())),
   );
+
+  // ── ListPage contextual action mode (selection) demo ────────────────────────
+  let listSelectionMode = $state(false);
+  let listSelected = $state(new Set<string>());
+  let lastListAction = $state<string | null>(null);
+
+  $effect(() => {
+    if (!listSelectionMode) listSelected = new Set();
+  });
+
+  const noteIds = $derived(filteredNotes.map((n) => n.id));
+  const listSelectedCount = $derived(noteIds.filter((id) => listSelected.has(id)).length);
+  const allNotesSelected = $derived(
+    noteIds.length > 0 && noteIds.every((id) => listSelected.has(id)),
+  );
+  const someNotesSelected = $derived(
+    noteIds.some((id) => listSelected.has(id)) && !allNotesSelected,
+  );
+
+  function toggleNote(id: string) {
+    const next = new Set(listSelected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    listSelected = next;
+  }
+
+  function toggleAllNotes() {
+    listSelected = allNotesSelected ? new Set() : new Set(noteIds);
+  }
+
+  const listBulkActions: BulkAction[] = $derived([
+    {
+      id: 'archive',
+      label: 'Archive',
+      icon: 'Archive',
+      onSelect: () => {
+        lastListAction = `Archived ${listSelectedCount} note(s)`;
+        listSelectionMode = false;
+      },
+    },
+    {
+      kind: 'picker',
+      id: 'move',
+      label: 'Move',
+      icon: 'FolderInput',
+      sheetTitle: `Move ${listSelectedCount} note(s) to…`,
+      targets: [
+        { id: 'recipes', label: 'Recipes' },
+        { id: 'archive-folder', label: 'Archive' },
+      ],
+      onPick: (target) => {
+        lastListAction = `Moved ${listSelectedCount} note(s) to ${target}`;
+        listSelectionMode = false;
+      },
+    },
+    {
+      id: 'delete',
+      label: 'Delete',
+      icon: 'Trash2',
+      variant: 'destructive',
+      onSelect: () => {
+        const ids = new Set(listSelected);
+        sampleNotes = sampleNotes.filter((n) => !ids.has(n.id));
+        lastListAction = `Deleted ${ids.size} note(s)`;
+        listSelectionMode = false;
+      },
+    },
+  ]);
 
   // ── FormPage demo ───────────────────────────────────────────────────────────
   let formTitle = $state('');
@@ -58,25 +127,7 @@
     { id: 'd', name: 'Basil', tag: 'produce' },
   ]);
   let selected = $state(new Set<string>());
-  let lastBulk = $state<string | null>(null);
-
-  const bulkActions: BulkAction[] = [
-    {
-      id: 'archive',
-      label: 'Archive',
-      variant: 'outline',
-      onAction: (ids) => (lastBulk = `Archived ${ids.length} item(s)`),
-    },
-    {
-      id: 'delete',
-      label: 'Delete',
-      variant: 'destructive',
-      onAction: (ids) => {
-        items = items.filter((i) => !ids.includes(i.id));
-        lastBulk = `Deleted ${ids.length} item(s)`;
-      },
-    },
-  ];
+  let selectableSelectionMode = $state(true);
 </script>
 
 <section id="templates">
@@ -110,8 +161,20 @@
         isLoading={listMode === 'loading'}
         isError={listMode === 'error'}
         isEmpty={listMode === 'empty' || (listMode === 'data' && filteredNotes.length === 0)}
+        bind:selectionMode={listSelectionMode}
+        selectionCount={listSelectedCount}
+        bulkActions={listBulkActions}
       >
         {#snippet actions()}
+          {#if listSelectionMode}
+            <Button size="sm" variant="outline" onclick={() => (listSelectionMode = false)}>
+              Done
+            </Button>
+          {:else}
+            <Button size="sm" variant="outline" onclick={() => (listSelectionMode = true)}>
+              Select
+            </Button>
+          {/if}
           <Button size="sm">
             {#snippet leading()}
               <Icon name="Plus" size={14} />
@@ -122,6 +185,14 @@
 
         {#snippet toolbar()}
           <TextField placeholder="Search notes…" bind:value={search} class="max-w-xs" />
+        {/snippet}
+
+        {#snippet selectionBar()}
+          <Checkbox
+            checked={allNotesSelected ? true : someNotesSelected ? 'indeterminate' : false}
+            onCheckedChange={toggleAllNotes}
+            label={listSelectedCount > 0 ? `${listSelectedCount} selected` : 'Select all'}
+          />
         {/snippet}
 
         {#snippet empty()}
@@ -137,16 +208,25 @@
 
         <ul class="flex flex-col gap-2">
           {#each filteredNotes as note (note.id)}
-            <li
-              class="flex items-center justify-between px-3 py-2 rounded-md border border-border bg-card"
-            >
-              <span class="text-sm font-medium">{note.title}</span>
+            <li class="flex items-center gap-3 px-3 py-2 rounded-md border border-border bg-card">
+              {#if listSelectionMode}
+                <Checkbox
+                  checked={listSelected.has(note.id)}
+                  onCheckedChange={() => toggleNote(note.id)}
+                  label=""
+                  aria-label={`Select ${note.title}`}
+                />
+              {/if}
+              <span class="flex-1 text-sm font-medium">{note.title}</span>
               <span class="text-xs text-muted-foreground">{note.updated}</span>
             </li>
           {/each}
         </ul>
       </ListPage>
     </div>
+    {#if lastListAction}
+      <p class="mt-3 text-sm text-muted-foreground">{lastListAction}</p>
+    {/if}
   </div>
 
   <!-- FormPage -->
@@ -229,11 +309,20 @@
   <!-- SelectableList -->
   <div class="subsection">
     <h3 class="subsection-title">SelectableList</h3>
+    <p class="text-sm text-muted-foreground mb-3 max-w-2xl">
+      Row-level helper: renders each row with an optional selection checkbox and tracks the selected
+      set. Bulk actions themselves live on <code class="text-xs">ListPage</code>'s contextual action
+      bar (above), not here.
+    </p>
+    <div class="flex items-center gap-2 mb-3">
+      <Switch label="Selection mode" bind:checked={selectableSelectionMode} />
+      <span class="text-xs text-muted-foreground">{selected.size} selected</span>
+    </div>
     <div class="rounded-lg border border-border p-6 bg-background max-w-2xl">
       {#if items.length === 0}
         <EmptyState title="All cleared" description="You deleted everything." />
       {:else}
-        <SelectableList {items} bind:selected {bulkActions}>
+        <SelectableList {items} bind:selected selectionMode={selectableSelectionMode}>
           {#snippet row(item)}
             <div class="flex items-center justify-between gap-3">
               <span class="text-sm font-medium">{item.name}</span>
@@ -241,9 +330,6 @@
             </div>
           {/snippet}
         </SelectableList>
-      {/if}
-      {#if lastBulk}
-        <p class="mt-4 text-sm text-muted-foreground">{lastBulk}</p>
       {/if}
     </div>
   </div>

--- a/apps/web-pwa/e2e/equipment-capture.spec.ts
+++ b/apps/web-pwa/e2e/equipment-capture.spec.ts
@@ -174,16 +174,30 @@ test.describe('equipment — capture, edit, and persistence', () => {
       .filter({ has: page.locator('[data-equipment-id="to-delete"]') });
     await row.getByRole('checkbox').click();
 
-    await page.getByRole('button', { name: /^delete$/i }).click();
+    // Bulk delete uses the shared deferred-delete + Undo snackbar (no confirm
+    // dialog, no soft-delete): the row hides immediately and the real delete
+    // commits only once the Undo toast lapses.
+    await page.getByTestId('equipment-bulk-delete').click();
 
-    await expect(page.getByTestId('equipment-delete-dialog')).toBeVisible();
-    await page.getByTestId('equipment-delete-confirm').click();
+    const undo = page.getByRole('button', { name: /undo/i });
+    await expect(undo).toBeVisible({ timeout: SYNC_TIMEOUT });
 
+    // Row hides right away.
     await expect(
       page
         .getByTestId('equipment-list')
         .getByTestId('equipment-list-item')
         .filter({ hasText: 'Old Blender' }),
-    ).not.toBeVisible({ timeout: SYNC_TIMEOUT });
+    ).toHaveCount(0, { timeout: SYNC_TIMEOUT });
+
+    // Let the snackbar lapse — the delete commits to Firestore and survives a reload.
+    await expect(undo).toHaveCount(0, { timeout: SYNC_TIMEOUT });
+    await page.reload();
+    await expect(
+      page
+        .getByTestId('equipment-list')
+        .getByTestId('equipment-list-item')
+        .filter({ hasText: 'Old Blender' }),
+    ).toHaveCount(0, { timeout: SYNC_TIMEOUT });
   });
 });

--- a/apps/web-pwa/e2e/shopping-list-bulk-delete.spec.ts
+++ b/apps/web-pwa/e2e/shopping-list-bulk-delete.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Shopping list bulk delete + Undo E2E tests (issue #115).
+ *
+ * Exercises the contextual-action-mode delete that lives in the shared ListPage
+ * template: selecting items, deleting via the bottom action bar, and the
+ * deferred-delete + Undo snackbar (no confirm dialog, no soft-delete). Two
+ * outcomes are covered:
+ *   - Undo within the window → the item reappears and is never deleted.
+ *   - Letting the toast lapse → the delete commits to Firestore (survives reload).
+ */
+import { expect, test } from './fixtures/test';
+import { gotoAndSignIn, uniqueEmail } from './helpers/auth';
+
+const SYNC_TIMEOUT = 15_000;
+
+async function createListWithItem(
+  page: import('@playwright/test').Page,
+  itemText: string,
+): Promise<string> {
+  await page.goto('/#/shopping');
+  await expect(page).toHaveURL(/#\/shopping\/new/, { timeout: 10_000 });
+  await page.getByTestId('shopping-create-list-name').fill('Weekly shop');
+  await page.getByRole('button', { name: /create/i }).click();
+  await expect(page).toHaveURL(/#\/shopping\/(?!new)[a-z0-9-]+$/, { timeout: SYNC_TIMEOUT });
+
+  await page.getByTestId('shopping-item-input').fill(itemText);
+  await page.getByTestId('shopping-item-add-btn').click();
+  await expect(page.getByTestId('shopping-item-row').filter({ hasText: itemText })).toBeVisible({
+    timeout: SYNC_TIMEOUT,
+  });
+
+  return page.url();
+}
+
+async function selectAndDelete(
+  page: import('@playwright/test').Page,
+  itemText: string,
+): Promise<void> {
+  // Enter selection mode and tick the item's row checkbox.
+  await page.getByRole('button', { name: /^select$/i }).click();
+  const row = page.getByTestId('shopping-item-row').filter({ hasText: itemText });
+  await row.getByRole('checkbox').first().click();
+
+  // The contextual bottom bar's Delete action (rendered by the ListPage template).
+  const deleteBtn = page.getByTestId('shopping-bulk-delete');
+  await expect(deleteBtn).toBeVisible({ timeout: SYNC_TIMEOUT });
+  await deleteBtn.click();
+}
+
+test.describe('shopping list — bulk delete + undo', () => {
+  test('delete then Undo restores the item (nothing is deleted)', async ({ page }, testInfo) => {
+    test.setTimeout(90_000);
+    const email = uniqueEmail(testInfo.testId);
+    await gotoAndSignIn(page, email);
+
+    const listUrl = await createListWithItem(page, 'apples');
+
+    await selectAndDelete(page, 'apples');
+
+    // The row hides immediately and the Undo snackbar appears.
+    await expect(page.getByTestId('shopping-item-row').filter({ hasText: 'apples' })).toHaveCount(
+      0,
+      { timeout: SYNC_TIMEOUT },
+    );
+    const undo = page.getByRole('button', { name: /undo/i });
+    await expect(undo).toBeVisible({ timeout: SYNC_TIMEOUT });
+
+    // Undo cancels the deferred delete — the item comes back.
+    await undo.click();
+    await expect(page.getByTestId('shopping-item-row').filter({ hasText: 'apples' })).toBeVisible({
+      timeout: SYNC_TIMEOUT,
+    });
+
+    // It is genuinely still there after a reload (never committed to Firestore).
+    await page.goto(listUrl);
+    await expect(page).toHaveURL(/#\/shopping\/(?!new)[a-z0-9-]+$/, { timeout: SYNC_TIMEOUT });
+    await expect(page.getByTestId('shopping-item-row').filter({ hasText: 'apples' })).toBeVisible({
+      timeout: SYNC_TIMEOUT,
+    });
+  });
+
+  test('delete then letting the toast lapse commits the delete', async ({ page }, testInfo) => {
+    test.setTimeout(90_000);
+    const email = uniqueEmail(testInfo.testId);
+    await gotoAndSignIn(page, email);
+
+    const listUrl = await createListWithItem(page, 'bananas');
+
+    await selectAndDelete(page, 'bananas');
+
+    // Row hides immediately; do NOT press Undo. Wait for the snackbar to lapse,
+    // which commits the delete.
+    const undo = page.getByRole('button', { name: /undo/i });
+    await expect(undo).toBeVisible({ timeout: SYNC_TIMEOUT });
+    await expect(undo).toHaveCount(0, { timeout: SYNC_TIMEOUT });
+
+    // After a reload the item is gone — the deferred delete committed to Firestore.
+    await page.goto(listUrl);
+    await expect(page).toHaveURL(/#\/shopping\/(?!new)[a-z0-9-]+$/, { timeout: SYNC_TIMEOUT });
+    await expect(page.getByText('Your list is empty')).toBeVisible({ timeout: SYNC_TIMEOUT });
+    await expect(page.getByTestId('shopping-item-row').filter({ hasText: 'bananas' })).toHaveCount(
+      0,
+    );
+  });
+});

--- a/apps/web-pwa/src/lib/deferredDelete.svelte.ts
+++ b/apps/web-pwa/src/lib/deferredDelete.svelte.ts
@@ -17,12 +17,6 @@ import { addToast } from './toastStore.js';
 export function createDeferredDelete() {
   let pending = $state(new Set<string>());
 
-  // Undo window for the snackbar. Deliberately longer than the Toast default
-  // (5s): this is a destructive bulk action, so the user gets a comfortable
-  // window to react — which also keeps the undo path off a wall-clock race in
-  // slower environments (e.g. CI).
-  const UNDO_WINDOW_MS = 10_000;
-
   function unhide(ids: readonly string[]): void {
     const next = new Set(pending);
     for (const id of ids) next.delete(id);
@@ -49,7 +43,7 @@ export function createDeferredDelete() {
     request(
       ids: readonly string[],
       commit: (ids: readonly string[]) => Promise<void> | void,
-      opts: { noun?: string; nounPlural?: string; durationMs?: number } = {},
+      opts: { noun?: string; nounPlural?: string } = {},
     ): void {
       if (ids.length === 0) return;
       const list = [...ids];
@@ -61,7 +55,6 @@ export function createDeferredDelete() {
 
       let undone = false;
       addToast(`${list.length} ${label} deleted`, 'default', {
-        duration: opts.durationMs ?? UNDO_WINDOW_MS,
         action: {
           label: 'Undo',
           onClick: () => {

--- a/apps/web-pwa/src/lib/deferredDelete.svelte.ts
+++ b/apps/web-pwa/src/lib/deferredDelete.svelte.ts
@@ -17,6 +17,12 @@ import { addToast } from './toastStore.js';
 export function createDeferredDelete() {
   let pending = $state(new Set<string>());
 
+  // Undo window for the snackbar. Deliberately longer than the Toast default
+  // (5s): this is a destructive bulk action, so the user gets a comfortable
+  // window to react — which also keeps the undo path off a wall-clock race in
+  // slower environments (e.g. CI).
+  const UNDO_WINDOW_MS = 10_000;
+
   function unhide(ids: readonly string[]): void {
     const next = new Set(pending);
     for (const id of ids) next.delete(id);
@@ -43,7 +49,7 @@ export function createDeferredDelete() {
     request(
       ids: readonly string[],
       commit: (ids: readonly string[]) => Promise<void> | void,
-      opts: { noun?: string; nounPlural?: string } = {},
+      opts: { noun?: string; nounPlural?: string; durationMs?: number } = {},
     ): void {
       if (ids.length === 0) return;
       const list = [...ids];
@@ -55,6 +61,7 @@ export function createDeferredDelete() {
 
       let undone = false;
       addToast(`${list.length} ${label} deleted`, 'default', {
+        duration: opts.durationMs ?? UNDO_WINDOW_MS,
         action: {
           label: 'Undo',
           onClick: () => {

--- a/apps/web-pwa/src/lib/deferredDelete.svelte.ts
+++ b/apps/web-pwa/src/lib/deferredDelete.svelte.ts
@@ -1,0 +1,74 @@
+import { addToast } from './toastStore.js';
+
+/**
+ * Deferred bulk delete + Undo snackbar — the contextual-action-mode delete
+ * pattern, shared by every list page (shopping, equipment, canon, …).
+ *
+ * Selected ids are hidden immediately, but the real delete (`commit`) only runs
+ * once the Undo toast lapses. Pressing Undo cancels the commit, so nothing is
+ * ever deleted and no restore/tombstone path is required — true to
+ * Firestore-as-master (no soft-delete). On both the lapse-commit and the failure
+ * case the ids are unhidden: success removes them from the source list anyway,
+ * and a failed commit should reveal them again.
+ *
+ * Lives in `web-pwa` (not `@salt/ui-components`) because it depends on the
+ * app-level toast store; `ListPage` itself stays toast-free.
+ */
+export function createDeferredDelete() {
+  let pending = $state(new Set<string>());
+
+  function unhide(ids: readonly string[]): void {
+    const next = new Set(pending);
+    for (const id of ids) next.delete(id);
+    pending = next;
+  }
+
+  return {
+    /** Reactive set of ids currently hidden pending commit. */
+    get pendingIds(): ReadonlySet<string> {
+      return pending;
+    },
+    isPending(id: string): boolean {
+      return pending.has(id);
+    },
+    /** Drop the currently-hidden items from a list for rendering. */
+    visible<T extends { id: string }>(items: readonly T[]): T[] {
+      return items.filter((i) => !pending.has(i.id));
+    },
+    /**
+     * Hide `ids` and schedule `commit` behind an Undo toast. `commit` runs only
+     * if the user lets the toast lapse, and is responsible for surfacing its own
+     * failure toast. `noun`/`nounPlural` shape the message ("3 items deleted").
+     */
+    request(
+      ids: readonly string[],
+      commit: (ids: readonly string[]) => Promise<void> | void,
+      opts: { noun?: string; nounPlural?: string } = {},
+    ): void {
+      if (ids.length === 0) return;
+      const list = [...ids];
+      pending = new Set([...pending, ...list]);
+
+      const noun = opts.noun ?? 'item';
+      const nounPlural = opts.nounPlural ?? `${noun}s`;
+      const label = list.length === 1 ? noun : nounPlural;
+
+      let undone = false;
+      addToast(`${list.length} ${label} deleted`, 'default', {
+        action: {
+          label: 'Undo',
+          onClick: () => {
+            undone = true;
+            unhide(list);
+          },
+        },
+        onDismiss: () => {
+          if (undone) return;
+          void Promise.resolve(commit(list)).finally(() => unhide(list));
+        },
+      });
+    },
+  };
+}
+
+export type DeferredDelete = ReturnType<typeof createDeferredDelete>;

--- a/apps/web-pwa/src/routes/canon/AisleManagementPage.svelte
+++ b/apps/web-pwa/src/routes/canon/AisleManagementPage.svelte
@@ -20,6 +20,7 @@
     SelectTrigger,
     SortableList,
     TextArea,
+    type BulkAction,
   } from '@salt/ui-components';
   import {
     aisles,
@@ -192,6 +193,27 @@
     mergeOpen = true;
   }
 
+  // Contextual bottom action bar. Merge needs ≥2 aisles; both actions open their
+  // existing dialogs (structural ops with disclosure / per-item choices).
+  const bulkActions = $derived<BulkAction[]>([
+    {
+      id: 'merge',
+      label: 'Merge',
+      icon: 'Merge',
+      disabled: selectedCount < 2,
+      testId: 'bulk-merge-button',
+      onSelect: openMerge,
+    },
+    {
+      id: 'delete',
+      label: 'Delete',
+      icon: 'Trash2',
+      variant: 'destructive',
+      testId: 'bulk-delete-button',
+      onSelect: () => (deleteOpen = true),
+    },
+  ]);
+
   async function handleBulkDelete() {
     deleteBusy = true;
     deleteError = '';
@@ -234,6 +256,8 @@
       isLoading={$isLoadingAisles}
       isEmpty={$aisles.length === 0 && !$isLoadingAisles}
       bind:selectionMode
+      selectionCount={selectedCount}
+      {bulkActions}
     >
       {#snippet actions()}
         <Button size="sm" onclick={() => push('/admin/canon')}>
@@ -250,20 +274,6 @@
           onCheckedChange={toggleSelectAll}
           label={selectedCount > 0 ? `${selectedCount} selected` : 'Select all'}
         />
-        {#if selectedCount > 0}
-          <div class="flex items-center gap-2">
-            <Button variant="outline" size="sm" onclick={openMerge} disabled={selectedCount < 2}>
-              Merge…
-            </Button>
-            <Button
-              variant="destructive"
-              size="sm"
-              data-testid="bulk-delete-button"
-              onclick={() => (deleteOpen = true)}>Delete</Button
-            >
-            <Button variant="ghost" size="sm" onclick={() => (selected = new Set())}>Clear</Button>
-          </div>
-        {/if}
       {/snippet}
 
       {#snippet children()}

--- a/apps/web-pwa/src/routes/canon/CanonListPage.svelte
+++ b/apps/web-pwa/src/routes/canon/CanonListPage.svelte
@@ -2,18 +2,13 @@
   import {
     Button,
     Checkbox,
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
     Icon,
     ListPage,
     Select,
     SelectContent,
     SelectItem,
     SelectTrigger,
+    type BulkAction,
   } from '@salt/ui-components';
   import { push } from 'svelte-spa-router';
   import {
@@ -24,6 +19,8 @@
   } from '../../lib/canonService.js';
   import { aisles } from '../../lib/aisleService.js';
   import { titleCase } from '../../lib/titleCase.js';
+  import { addToast } from '../../lib/toastStore.js';
+  import { createDeferredDelete } from '../../lib/deferredDelete.svelte.js';
   import CanonListRow from './CanonListRow.svelte';
   import AdminGuard from '../admin/AdminGuard.svelte';
 
@@ -40,14 +37,15 @@
     if (!selectionMode) selected = new Set();
   });
 
-  // Delete dialog
-  let deleteOpen = $state(false);
-  let deleteBusy = $state(false);
+  // Deferred bulk delete (hide immediately, commit on undo-lapse — no confirm dialog).
+  const deferredDelete = createDeferredDelete();
 
-  // Derived: filtered items
+  // Derived: filtered items (pending-delete items are hidden while the undo toast is up)
   const filteredItems = $derived(
-    $canonItems.filter(
-      (i) => filterText === '' || i.name.toLowerCase().includes(filterText.toLowerCase()),
+    deferredDelete.visible(
+      $canonItems.filter(
+        (i) => filterText === '' || i.name.toLowerCase().includes(filterText.toLowerCase()),
+      ),
     ),
   );
 
@@ -134,13 +132,41 @@
     selected = new Set([...selected].filter((id) => !selectedApprovalIds.includes(id)));
   }
 
-  async function handleBulkDelete() {
-    deleteBusy = true;
-    await Promise.all([...selected].map((id) => deleteCanonItem(id)));
-    deleteBusy = false;
-    deleteOpen = false;
-    selected = new Set();
+  function handleBulkDelete() {
+    if (selectedCount === 0) return;
+    const ids = [...selected].filter((id) => allVisibleIds.includes(id));
+    selectionMode = false; // the $effect on selectionMode clears `selected`
+    deferredDelete.request(ids, async (delIds) => {
+      const results = await Promise.all(delIds.map((id) => deleteCanonItem(id)));
+      if (results.some((r) => r.kind !== 'ok')) {
+        addToast('Failed to delete some items.', 'destructive');
+      }
+    });
   }
+
+  // Contextual bottom action bar. Approve only appears when pending items are
+  // selected; Delete is always available and uses deferred-delete + undo.
+  const bulkActions = $derived<BulkAction[]>([
+    ...(selectedApprovalIds.length > 0
+      ? [
+          {
+            id: 'approve',
+            label: `Approve (${selectedApprovalIds.length})`,
+            icon: 'Check',
+            testId: 'canon-bulk-approve',
+            onSelect: () => void handleBulkApprove(),
+          } satisfies BulkAction,
+        ]
+      : []),
+    {
+      id: 'delete',
+      label: 'Delete',
+      icon: 'Trash2',
+      variant: 'destructive',
+      testId: 'canon-list-bulk-delete',
+      onSelect: handleBulkDelete,
+    },
+  ]);
 </script>
 
 <AdminGuard>
@@ -151,6 +177,8 @@
     isEmpty={$canonItems.length === 0}
     class="p-4 sm:p-6"
     bind:selectionMode
+    selectionCount={selectedCount}
+    {bulkActions}
   >
     {#snippet actions()}
       <Button size="sm" onclick={() => push('/admin/canon/new')}>Add item</Button>
@@ -171,18 +199,6 @@
         onCheckedChange={toggleAll}
         label={selectedCount > 0 ? `${selectedCount} selected` : 'Select all'}
       />
-      {#if selectedCount > 0}
-        <div class="flex items-center gap-2">
-          {#if selectedApprovalIds.length > 0}
-            <Button variant="outline" size="sm" onclick={handleBulkApprove}>
-              Approve ({selectedApprovalIds.length})
-            </Button>
-          {/if}
-          <Button variant="destructive" size="sm" onclick={() => (deleteOpen = true)}>Delete</Button
-          >
-          <Button variant="ghost" size="sm" onclick={() => (selected = new Set())}>Clear</Button>
-        </div>
-      {/if}
     {/snippet}
 
     {#snippet children()}
@@ -267,36 +283,4 @@
       {/if}
     {/snippet}
   </ListPage>
-
-  <!-- Bulk delete confirmation dialog -->
-  <Dialog
-    bind:open={deleteOpen}
-    onOpenChange={(v) => {
-      if (!v) deleteBusy = false;
-    }}
-  >
-    <DialogContent>
-      <div class="flex flex-col gap-4" data-testid="canon-list-bulk-delete-dialog">
-        <DialogHeader>
-          <DialogTitle>Delete {selected.size} {selected.size === 1 ? 'item' : 'items'}?</DialogTitle
-          >
-          <DialogDescription>This action cannot be undone.</DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button variant="outline" onclick={() => (deleteOpen = false)} disabled={deleteBusy}>
-            Cancel
-          </Button>
-          <Button
-            data-testid="canon-list-bulk-delete-confirm"
-            variant="destructive"
-            onclick={handleBulkDelete}
-            loading={deleteBusy}
-            disabled={deleteBusy}
-          >
-            Delete
-          </Button>
-        </DialogFooter>
-      </div>
-    </DialogContent>
-  </Dialog>
 </AdminGuard>

--- a/apps/web-pwa/src/routes/equipment/EquipmentListPage.svelte
+++ b/apps/web-pwa/src/routes/equipment/EquipmentListPage.svelte
@@ -2,15 +2,10 @@
   import {
     Button,
     Checkbox,
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
     ListPage,
     SelectableList,
     Spinner,
+    type BulkAction,
   } from '@salt/ui-components';
   import { push } from 'svelte-spa-router';
   import {
@@ -19,20 +14,22 @@
     removeEquipmentItems,
   } from '../../lib/equipmentService.js';
   import { addToast } from '../../lib/toastStore.js';
+  import { createDeferredDelete } from '../../lib/deferredDelete.svelte.js';
 
   let selectionMode = $state(false);
   let selected = $state(new Set<string>());
-  let showDeleteDialog = $state(false);
-  let deleteBusy = $state(false);
 
   $effect(() => {
     if (!selectionMode) selected = new Set();
   });
 
+  const deferredDelete = createDeferredDelete();
+
   const items = $derived($equipment?.items ?? []);
   const sorted = $derived([...items].sort((a, b) => a.name.localeCompare(b.name)));
+  const visibleItems = $derived(deferredDelete.visible(sorted));
 
-  const allIds = $derived(sorted.map((i) => i.id));
+  const allIds = $derived(visibleItems.map((i) => i.id));
   const allSelected = $derived(allIds.length > 0 && allIds.every((id) => selected.has(id)));
   const someSelected = $derived(allIds.some((id) => selected.has(id)) && !allSelected);
   const selectedCount = $derived(allIds.filter((id) => selected.has(id)).length);
@@ -41,27 +38,37 @@
     selected = allSelected ? new Set() : new Set(allIds);
   }
 
-  async function handleDelete(): Promise<void> {
+  function handleBulkDelete(): void {
     if (selectedCount === 0) return;
-    deleteBusy = true;
-    const ids = [...selected];
-    const result = await removeEquipmentItems(ids);
-    deleteBusy = false;
-    showDeleteDialog = false;
-    selected = new Set();
-    if (result.kind !== 'ok') {
-      addToast('Failed to delete items.', 'error');
-    }
+    const ids = [...selected].filter((id) => allIds.includes(id));
+    selectionMode = false; // the $effect on selectionMode clears `selected`
+    deferredDelete.request(ids, async (delIds) => {
+      const result = await removeEquipmentItems([...delIds]);
+      if (result.kind !== 'ok') addToast('Failed to delete items.', 'destructive');
+    });
   }
+
+  const bulkActions = $derived<BulkAction[]>([
+    {
+      id: 'delete',
+      label: 'Delete',
+      icon: 'Trash2',
+      variant: 'destructive',
+      testId: 'equipment-bulk-delete',
+      onSelect: handleBulkDelete,
+    },
+  ]);
 </script>
 
 <ListPage
   title="Kitchen"
   description="Your equipment manifest."
   isLoading={$isLoadingEquipment}
-  isEmpty={items.length === 0}
+  isEmpty={visibleItems.length === 0}
   class="p-4 sm:p-6"
   bind:selectionMode
+  selectionCount={selectedCount}
+  {bulkActions}
 >
   {#snippet actions()}
     <Button size="sm" onclick={() => push('/equipment/new')}>Add equipment</Button>
@@ -73,19 +80,11 @@
       onCheckedChange={toggleAll}
       label={selectedCount > 0 ? `${selectedCount} selected` : 'Select all'}
     />
-    {#if selectedCount > 0}
-      <div class="flex items-center gap-2">
-        <Button variant="destructive" size="sm" onclick={() => (showDeleteDialog = true)}>
-          Delete
-        </Button>
-        <Button variant="ghost" size="sm" onclick={() => (selected = new Set())}>Clear</Button>
-      </div>
-    {/if}
   {/snippet}
 
   {#snippet children()}
     <div data-testid="equipment-list">
-      <SelectableList items={sorted} bind:selected {selectionMode}>
+      <SelectableList items={visibleItems} bind:selected {selectionMode}>
         {#snippet row(item)}
           <button
             class="w-full text-left text-sm font-medium hover:underline"
@@ -110,38 +109,6 @@
     </div>
   {/snippet}
 </ListPage>
-
-<Dialog
-  open={showDeleteDialog}
-  onOpenChange={(v) => {
-    if (!v) showDeleteDialog = false;
-  }}
->
-  <DialogContent>
-    <div class="flex flex-col gap-4" data-testid="equipment-delete-dialog">
-      <DialogHeader>
-        <DialogTitle>
-          Delete {selectedCount} item{selectedCount === 1 ? '' : 's'}?
-        </DialogTitle>
-        <DialogDescription>This cannot be undone.</DialogDescription>
-      </DialogHeader>
-      <DialogFooter>
-        <Button variant="outline" onclick={() => (showDeleteDialog = false)} disabled={deleteBusy}>
-          Cancel
-        </Button>
-        <Button
-          variant="destructive"
-          onclick={handleDelete}
-          loading={deleteBusy}
-          disabled={deleteBusy}
-          data-testid="equipment-delete-confirm"
-        >
-          Delete
-        </Button>
-      </DialogFooter>
-    </div>
-  </DialogContent>
-</Dialog>
 
 {#if $isLoadingEquipment}
   <div class="flex items-center justify-center py-8">

--- a/apps/web-pwa/src/routes/shopping/ShoppingListPage.svelte
+++ b/apps/web-pwa/src/routes/shopping/ShoppingListPage.svelte
@@ -50,6 +50,8 @@
     moveSelectedItems,
   } from '../../lib/shoppingListService.svelte.js';
   import { addToast } from '../../lib/toastStore.js';
+  import { createDeferredDelete } from '../../lib/deferredDelete.svelte.js';
+  import type { BulkAction } from '@salt/ui-components';
 
   interface Props {
     params: { listId: string };
@@ -90,9 +92,9 @@
   // Selected items are hidden immediately, but the real Firestore delete is only
   // committed once the undo window closes. Pressing Undo cancels the commit, so
   // nothing is ever deleted — no soft-delete / restore plumbing required.
-  let pendingDeleteIds = $state(new Set<string>());
+  const deferredDelete = createDeferredDelete();
 
-  const visibleItems = $derived($itemsForActiveList.filter((i) => !pendingDeleteIds.has(i.id)));
+  const visibleItems = $derived(deferredDelete.visible($itemsForActiveList));
 
   const grouped = $derived(groupItemsByAisle(visibleItems, canonMap, aisleInfos));
 
@@ -277,42 +279,15 @@
   // ─── Bulk actions ─────────────────────────────────────────────────────────────
 
   let bulkBusy = $state(false);
-  let moveSheetOpen = $state(false);
-
-  function unhidePending(ids: readonly string[]): void {
-    const next = new Set(pendingDeleteIds);
-    for (const id of ids) next.delete(id);
-    pendingDeleteIds = next;
-  }
-
-  async function commitBulkDelete(ids: readonly string[]): Promise<void> {
-    const result = await removeItems(params.listId, ids);
-    if (result.kind !== 'ok') {
-      addToast('Failed to delete items.', 'destructive');
-    }
-    // Either the items are gone from Firestore (success) or the delete failed and
-    // they should reappear — in both cases stop hiding them.
-    unhidePending(ids);
-  }
 
   function handleBulkDelete(): void {
     if (selectedCount === 0) return;
     const ids = [...selected].filter((id) => allItemIds.includes(id));
     // Hide immediately and leave selection mode; commit (or undo) when the toast resolves.
-    pendingDeleteIds = new Set([...pendingDeleteIds, ...ids]);
     selectionMode = false; // the $effect on selectionMode clears `selected`
-    let undone = false;
-    addToast(`${ids.length} item${ids.length === 1 ? '' : 's'} deleted`, 'default', {
-      action: {
-        label: 'Undo',
-        onClick: () => {
-          undone = true;
-          unhidePending(ids);
-        },
-      },
-      onDismiss: () => {
-        if (!undone) void commitBulkDelete(ids);
-      },
+    deferredDelete.request(ids, async (delIds) => {
+      const result = await removeItems(params.listId, delIds);
+      if (result.kind !== 'ok') addToast('Failed to delete items.', 'destructive');
     });
   }
 
@@ -338,7 +313,6 @@
     const ids = [...selected];
     const result = await moveSelectedItems(params.listId, targetListId, ids);
     bulkBusy = false;
-    moveSheetOpen = false;
     if (result.kind !== 'ok') {
       addToast('Failed to move items.', 'destructive');
     } else {
@@ -350,6 +324,48 @@
     const result = await clearChecked(params.listId);
     if (result.kind !== 'ok') addToast('Failed to clear checked items.', 'destructive');
   }
+
+  // Contextual bottom action bar, supplied to ListPage. The template owns the bar
+  // chrome, the move picker sheet, and the BottomNav takeover.
+  const bulkActions = $derived<BulkAction[]>([
+    {
+      id: 'check',
+      label: 'Check',
+      icon: 'CircleCheck',
+      disabled: bulkBusy,
+      testId: 'shopping-bulk-check',
+      onSelect: () => void handleBulkCheck(),
+    },
+    {
+      id: 'uncheck',
+      label: 'Uncheck',
+      icon: 'Circle',
+      disabled: bulkBusy,
+      testId: 'shopping-bulk-uncheck',
+      onSelect: () => void handleBulkUncheck(),
+    },
+    {
+      kind: 'picker',
+      id: 'move',
+      label: 'Move',
+      icon: 'FolderInput',
+      disabled: bulkBusy || otherLists.length === 0,
+      testId: 'shopping-bulk-move-select',
+      sheetTitle: `Move ${selectedCount} item${selectedCount === 1 ? '' : 's'} to…`,
+      targets: otherLists.map((l) => ({ id: l.id, label: l.name })),
+      optionTestId: 'shopping-bulk-move-option',
+      onPick: (id) => void handleMoveTo(id),
+    },
+    {
+      id: 'delete',
+      label: 'Delete',
+      icon: 'Trash2',
+      variant: 'destructive',
+      disabled: bulkBusy,
+      testId: 'shopping-bulk-delete',
+      onSelect: handleBulkDelete,
+    },
+  ]);
 
   // ─── Item row helper ──────────────────────────────────────────────────────────
 
@@ -389,7 +405,9 @@
     isLoading={$isLoadingShoppingList}
     {isEmpty}
     bind:selectionMode
-    class="p-4 sm:p-6 {selectionMode ? 'pb-24' : ''}"
+    selectionCount={selectedCount}
+    {bulkActions}
+    class="p-4 sm:p-6"
     data-testid="shopping-list-page"
   >
     {#snippet actions()}
@@ -755,82 +773,6 @@
     {/snippet}
   </ListPage>
 {/if}
-
-<!-- Contextual bulk-action bar: while selecting, it occupies the bottom slot and
-     covers the app's bottom nav (Android-style contextual action mode). -->
-{#if selectionMode && selectedCount > 0}
-  <div
-    class="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-card pb-[env(safe-area-inset-bottom)]"
-    role="toolbar"
-    aria-label="Bulk actions"
-    data-testid="shopping-bulk-bar"
-  >
-    <div class="mx-auto flex w-full max-w-lg items-stretch">
-      <button
-        type="button"
-        class="flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-xs text-foreground transition-colors hover:bg-accent disabled:opacity-40"
-        onclick={handleBulkCheck}
-        disabled={bulkBusy}
-        data-testid="shopping-bulk-check"
-      >
-        <Icon name="CircleCheck" size={20} />
-        Check
-      </button>
-      <button
-        type="button"
-        class="flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-xs text-foreground transition-colors hover:bg-accent disabled:opacity-40"
-        onclick={handleBulkUncheck}
-        disabled={bulkBusy}
-        data-testid="shopping-bulk-uncheck"
-      >
-        <Icon name="Circle" size={20} />
-        Uncheck
-      </button>
-      <button
-        type="button"
-        class="flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-xs text-foreground transition-colors hover:bg-accent disabled:opacity-40"
-        onclick={() => (moveSheetOpen = true)}
-        disabled={bulkBusy || otherLists.length === 0}
-        data-testid="shopping-bulk-move-select"
-      >
-        <Icon name="FolderInput" size={20} />
-        Move
-      </button>
-      <button
-        type="button"
-        class="flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-xs text-destructive transition-colors hover:bg-destructive/10 disabled:opacity-40"
-        onclick={handleBulkDelete}
-        disabled={bulkBusy}
-        data-testid="shopping-bulk-delete"
-      >
-        <Icon name="Trash2" size={20} />
-        Delete
-      </button>
-    </div>
-  </div>
-{/if}
-
-<!-- Move-to-list sheet -->
-<Sheet bind:open={moveSheetOpen}>
-  <SheetContent side="bottom" class="flex flex-col gap-2 p-4 pb-8">
-    <SheetHeader>
-      <SheetTitle>Move {selectedCount} item{selectedCount === 1 ? '' : 's'} to…</SheetTitle>
-    </SheetHeader>
-    <div class="flex flex-col">
-      {#each otherLists as list (list.id)}
-        <button
-          type="button"
-          class="w-full rounded px-3 py-3 text-left text-sm transition-colors hover:bg-accent disabled:opacity-40"
-          onclick={() => handleMoveTo(list.id)}
-          disabled={bulkBusy}
-          data-testid="shopping-bulk-move-option"
-        >
-          {list.name}
-        </button>
-      {/each}
-    </div>
-  </SheetContent>
-</Sheet>
 
 <!-- Edit item sheet -->
 <Sheet

--- a/apps/web-pwa/tests/EquipmentListPage.test.ts
+++ b/apps/web-pwa/tests/EquipmentListPage.test.ts
@@ -38,6 +38,7 @@ vi.mock('../src/lib/equipmentService.js', () => ({
 import EquipmentListPage from '../src/routes/equipment/EquipmentListPage.svelte';
 import { push } from 'svelte-spa-router';
 import { removeEquipmentItems } from '../src/lib/equipmentService.js';
+import { addToast } from '../src/lib/toastStore.js';
 
 function item(
   id: string,
@@ -132,36 +133,71 @@ describe('EquipmentListPage', () => {
     await waitFor(() => expect(screen.getByText(/2 selected/i)).toBeInTheDocument());
   });
 
-  it('clear button deselects all items', async () => {
+  it('toggling select-all off deselects all items and hides the bulk action bar', async () => {
     mockEquipment._set(manifest([item('a', 'Blender')]));
     render(EquipmentListPage);
     await userEvent.click(screen.getByRole('button', { name: /^select$/i }));
     await userEvent.click(screen.getByRole('checkbox', { name: /select all/i }));
-    await waitFor(() => screen.getByRole('button', { name: /clear/i }));
-    await userEvent.click(screen.getByRole('button', { name: /clear/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument(),
+    );
+    // The select-all checkbox now reads "1 selected"; clicking it again clears the selection.
+    await userEvent.click(screen.getByRole('checkbox', { name: /1 selected/i }));
     await waitFor(() =>
       expect(screen.queryByRole('button', { name: /^delete$/i })).not.toBeInTheDocument(),
     );
   });
 
-  it('multi-select confirm-and-delete flow calls removeEquipmentItems', async () => {
+  it('multi-select delete hides the item immediately and commits on undo-toast dismiss', async () => {
     mockEquipment._set(manifest([item('to-delete', 'Old Blender')]));
     render(EquipmentListPage);
 
     await userEvent.click(screen.getByRole('button', { name: /^select$/i }));
-    const checkbox = screen.getByRole('checkbox', { name: /select all/i });
-    await userEvent.click(checkbox);
+    await userEvent.click(screen.getByRole('checkbox', { name: /select all/i }));
 
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument(),
     );
     await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
 
-    await waitFor(() => screen.getByTestId('equipment-delete-dialog'));
-    await userEvent.click(screen.getByTestId('equipment-delete-confirm'));
+    // Deferred-delete: the row is hidden immediately and an Undo toast is raised,
+    // but the real delete has not run yet (no confirm dialog).
+    await waitFor(() =>
+      expect(screen.queryByTestId('equipment-list-item')).not.toBeInTheDocument(),
+    );
+    expect(vi.mocked(addToast)).toHaveBeenCalledTimes(1);
+    const [message, , options] = vi.mocked(addToast).mock.calls[0]!;
+    expect(message).toMatch(/deleted/i);
+    expect(options?.action?.label).toBe('Undo');
+    expect(vi.mocked(removeEquipmentItems)).not.toHaveBeenCalled();
 
-    await waitFor(() => {
-      expect(vi.mocked(removeEquipmentItems)).toHaveBeenCalledWith(['to-delete']);
-    });
+    // Letting the toast lapse commits the delete.
+    options?.onDismiss?.();
+    await waitFor(() =>
+      expect(vi.mocked(removeEquipmentItems)).toHaveBeenCalledWith(['to-delete']),
+    );
+  });
+
+  it('undoing the delete keeps the item and never calls removeEquipmentItems', async () => {
+    mockEquipment._set(manifest([item('keep', 'Old Blender')]));
+    render(EquipmentListPage);
+
+    await userEvent.click(screen.getByRole('button', { name: /^select$/i }));
+    await userEvent.click(screen.getByRole('checkbox', { name: /select all/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument(),
+    );
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('equipment-list-item')).not.toBeInTheDocument(),
+    );
+    const [, , options] = vi.mocked(addToast).mock.calls[0]!;
+
+    // Undo reveals the item; a subsequent dismiss must not commit the delete.
+    options?.action?.onClick?.();
+    await waitFor(() => expect(screen.getByTestId('equipment-list-item')).toBeInTheDocument());
+    options?.onDismiss?.();
+    expect(vi.mocked(removeEquipmentItems)).not.toHaveBeenCalled();
   });
 });

--- a/docs/design/ui-spec-v03.md
+++ b/docs/design/ui-spec-v03.md
@@ -367,6 +367,22 @@ APG pattern: **Alert / Status / Live Region**.
 - Action:
   - `ToastAction` must be a focusable element (e.g. `<button>`)
 
+### 6.6 Undo-able toast (app-level `action` / `onDismiss`)
+
+The `Toast` / `ToastAction` parts above are the primitives. The **undo-able toast** is an app-level composition over them, driven by the web-pwa `toastStore` (`addToast(message, variant, options)`), used by the deferred-delete pattern (ui-spec-v04 §9.3.3). Two options matter:
+
+- **`action: { label, onClick }`** — renders a `ToastAction` button (e.g. "Undo"). Pressing it runs `onClick` and dismisses the toast.
+- **`onDismiss()`** — called when the toast closes via **timeout or the close button**, but **not** when the action button is pressed. This is what lets a caller defer work (commit a delete) only if the user *let the toast lapse* rather than undoing.
+
+```ts
+addToast('3 items deleted', 'default', {
+  action: { label: 'Undo', onClick: () => unhide(ids) }, // pressed → no commit
+  onDismiss: () => commit(ids),                           // lapsed → commit
+});
+```
+
+The store lives in the app (`apps/web-pwa/src/lib/toastStore.ts`) and is wired into `ToastViewport` in `App.svelte`; `@salt/ui-components` owns only the `Toast`/`ToastAction` primitives. Relocating the store into the design system remains possible but is intentionally deferred.
+
 ---
 
 ## 7. Testing Requirements (v0.3)

--- a/docs/design/ui-spec-v04.md
+++ b/docs/design/ui-spec-v04.md
@@ -17,7 +17,7 @@ All global rules, architecture, naming, styling, and testing conventions from v0
 v0.4 introduces:
 
 - **Combobox** — text input + popup listbox + filtering + optional custom values, with the optional `ComboboxField` joined-input frame (§3.4)
-- **ListPage Selection Mode** — app-wide hide-by-default multi-select pattern, plus the `titleSlot` header override (§9)
+- **ListPage Selection Mode** — app-wide hide-by-default multi-select with a **contextual bottom action bar** (`bulkActions`, incl. a move/target-picker sheet) that replaces the `BottomNav`, plus deferred-delete + Undo and the `titleSlot` header override (§9)
 - **SelectableList** — list template with `selectionMode`-gated per-row checkboxes (§10)
 - **EditableRow** — single-row primitive with an `onToggleSelect`-gated checkbox (§11)
 
@@ -411,34 +411,120 @@ Rationale:
 
 ## 9.1 Overview
 
-`ListPage` supports an app-wide **Selection Mode** pattern: multi-select is hidden by default; the list is "clean" with only each row's primary action visible. A built-in **"Select" button** in the page header switches into selection mode, revealing the `selectionBar` and per-row select controls. A **"Done" button** (replacing "Select" in the header) exits selection mode.
+`ListPage` supports an app-wide **Selection Mode** built around a **contextual action mode** (Android-style): multi-select is hidden by default; the list is "clean" with only each row's primary action visible. A built-in **"Select" button** in the page header switches into selection mode, revealing the top **select-all** control (`selectionBar`) and per-row select controls. A **"Done" button** (replacing "Select" in the header) exits selection mode.
 
-Pattern precedent: iOS Reminders, Apple Mail, Google Tasks, Todoist.
+Once at least one item is selected, bulk actions appear in a **contextual bottom action bar** that the template renders and that **replaces** the app's `BottomNav` (it is painted over the nav at a higher z-index, not stacked above it). Pages declare these actions declaratively via the `bulkActions` prop — they do **not** render their own bottom bar. A `picker`-type action (e.g. "Move to…") opens a template-owned bottom `Sheet` of targets. Bulk **delete** uses **deferred-delete + an Undo snackbar** — items hide immediately and the real delete commits only when the undo window lapses; there is **no confirm dialog** and **no soft-delete/tombstones** (see §9.3.3).
+
+Pattern precedent: Android contextual action bar; iOS Reminders/Mail multi-select.
 
 ## 9.2 Behaviour
 
 ### Default state (selection mode off)
 - No per-row select checkboxes are visible.
-- The `selectionBar` snippet is not rendered.
+- The `selectionBar` (top select-all) snippet is not rendered, and no contextual bottom bar is shown.
 - The header shows a "Select" `outline`, `size="sm"` button (only when a `selectionBar` snippet is provided).
 
 ### Selection mode on
-- The `selectionBar` snippet is rendered in the grey bar between toolbar and content.
+- The `selectionBar` snippet (typically a single select-all `Checkbox`) is rendered in the bar between toolbar and content.
 - Per-row select controls become visible (consuming pages gate them on their page-local `selectionMode` — see §9.4).
 - The "Select" button is replaced by a "Done" `outline`, `size="sm"` button in the header.
+- **Once `selectionCount > 0`**, the contextual bottom action bar (`bulkActions`) appears, replacing the `BottomNav`; the template reserves matching bottom content padding so the last rows are not hidden behind it.
 
 > Button variant: the Select/Done toggle uses `variant="outline"` (not `ghost`) so it reads as an affordance against the header background and lines up with the `size="sm"` convention documented on the `actions` prop.
 
 ### Exiting selection mode
 - Tapping "Done" sets `selectionMode = false` inside `ListPage`, which propagates back to the consuming page via the binding.
-- The `selectionBar` is hidden again; per-row controls disappear.
+- The `selectionBar`, per-row controls, and the contextual bottom bar are all hidden again; the `BottomNav` returns.
 - Consuming pages clear their `selected` Set by reacting to `selectionMode` becoming `false` (see §9.5).
 
 ## 9.3 `ListPage` props changes
 
-One new prop: `selectionMode?: boolean` (bindable, default `false`). Consuming pages bind to it to observe and react to mode state. The "Select"/"Done" toggle still appears automatically whenever a `selectionBar` snippet is provided — the page never needs to manage the toggle itself.
+Three selection-related props:
+
+- `selectionMode?: boolean` (bindable, default `false`). Consuming pages bind to it to observe and react to mode state. The "Select"/"Done" toggle still appears automatically whenever a `selectionBar` snippet is provided — the page never needs to manage the toggle itself.
+- `selectionCount?: number` (default `0`). The number of currently-selected items. Drives contextual-bar visibility (the bar shows only when `selectionMode && selectionCount > 0`) and the default picker-sheet title. The page owns selection state; this prop is just the count.
+- `bulkActions?: BulkAction[]`. The actions rendered in the contextual bottom bar (§9.3.1).
 
 `ListPageProps` is an open interface that extends `Omit<HTMLAttributes<HTMLElement>, 'class'>`. Any attribute valid on `<section>` is accepted and spread onto the root `<section>` element (e.g. `data-*`, `aria-*`, `id`). The `class` prop is reserved and handled internally.
+
+### 9.3.1 `BulkAction` — declarative contextual bar
+
+Each bar entry is a `BulkAction`. The template owns the bar chrome (layout, icon-over-label buttons, destructive tint, disabled state) so every list page looks identical; pages supply only data + handlers. Icons are names from the shared `Icon` set (`BulkActionIcon = keyof typeof import('@lucide/svelte').icons`).
+
+```ts
+type BulkAction =
+  | {
+      kind?: 'button';            // default
+      id: string;                 // stable key
+      label: string;              // "Check", "Delete"
+      icon: BulkActionIcon;       // "CircleCheck", "Trash2"
+      variant?: 'default' | 'destructive';
+      disabled?: boolean;
+      testId?: string;            // data-testid override (else "list-page-bulk-action")
+      onSelect: () => void;
+    }
+  | {
+      kind: 'picker';             // opens a template-owned bottom Sheet of targets
+      id: string;
+      label: string;              // "Move"
+      icon: BulkActionIcon;       // "FolderInput"
+      disabled?: boolean;
+      testId?: string;
+      sheetTitle?: string;        // "Move 3 items to…" (defaults to label)
+      targets: { id: string; label: string }[];
+      optionTestId?: string;      // data-testid for each option (else "list-page-bulk-picker-option")
+      onPick: (targetId: string) => void;
+    };
+```
+
+Worked call-site (shopping):
+
+```svelte
+<ListPage
+  bind:selectionMode
+  selectionCount={selectedCount}
+  bulkActions={[
+    { id: 'check',   label: 'Check',   icon: 'CircleCheck', onSelect: handleBulkCheck },
+    { id: 'uncheck', label: 'Uncheck', icon: 'Circle',      onSelect: handleBulkUncheck },
+    { kind: 'picker', id: 'move', label: 'Move', icon: 'FolderInput',
+      disabled: otherLists.length === 0,
+      sheetTitle: `Move ${selectedCount} item${selectedCount === 1 ? '' : 's'} to…`,
+      targets: otherLists.map((l) => ({ id: l.id, label: l.name })),
+      onPick: handleMoveTo },
+    { id: 'delete', label: 'Delete', icon: 'Trash2', variant: 'destructive', onSelect: handleBulkDelete },
+  ]}
+>
+  {#snippet selectionBar()}<Checkbox … />{/snippet}
+  {#snippet children()}…rows…{/snippet}
+</ListPage>
+```
+
+### 9.3.2 Move / target picker
+
+A `kind: 'picker'` action renders, in the bottom bar, a button that opens a template-owned bottom `Sheet` listing `targets`. Selecting one fires `onPick(targetId)` and closes the sheet. The template owns the sheet entirely — pages do not render their own move sheet. Use a picker for "move into one of N containers" flows (shopping lists, folders); use a plain `button` action whose `onSelect` opens a bespoke `Dialog` for genuinely complex flows that the simple target list can't represent (e.g. aisle merge with per-item choices, or an aisle delete that must disclose affected items).
+
+### 9.3.3 Deferred bulk delete + Undo snackbar
+
+The canonical bulk-delete is **deferred-delete + Undo snackbar, with no confirm dialog and no soft-delete/tombstones** (true to Firestore-as-master): selected items hide immediately, and the real Firestore delete commits only once the Undo toast lapses. Pressing **Undo** cancels the commit, so nothing is ever deleted and no restore path is required.
+
+`ListPage` stays toast-free — the toast is app-level (§ Toast / `toastStore`), because `@salt/ui-components` must not depend on the app's toast store. The repeated hide → commit → undo orchestration lives in the shared web-pwa helper `createDeferredDelete()` (`apps/web-pwa/src/lib/deferredDelete.svelte.ts`):
+
+```ts
+const deferredDelete = createDeferredDelete();
+// hide pending-deleted rows from rendering:
+const visibleItems = $derived(deferredDelete.visible($items));
+
+function handleBulkDelete() {
+  const ids = [...selected];
+  selectionMode = false;
+  deferredDelete.request(ids, async (delIds) => {
+    const result = await removeItems(delIds);
+    if (result.kind !== 'ok') addToast('Failed to delete items.', 'destructive');
+  });
+}
+```
+
+A `Delete` `BulkAction` (`variant: 'destructive'`) simply calls the page's `handleBulkDelete` from `onSelect`; the template renders the button but owns none of the delete semantics. Pages with consequential structural deletes that need disclosure (aisle management) keep a `Dialog`, triggered from a bar action's `onSelect` instead.
 
 ### `titleSlot` — custom header title
 
@@ -524,6 +610,8 @@ Do **not** call `LIST_PAGE_CONTEXT.get()` in a consuming page's own `<script>` b
 ## 9.8 Forbidden
 
 - Do not re-implement the "Select"/"Done" toggle in consuming pages.
+- Do not render a bespoke bottom action bar or move/target `Sheet` in a consuming page — declare `bulkActions` (incl. `kind: 'picker'`) and let `ListPage` own the chrome. (Pre-`#115` pages each hand-rolled a `fixed bottom-0` bar; that is now superseded.)
+- Do not gate bulk **delete** behind a confirm dialog or implement soft-delete/tombstones — use the deferred-delete + Undo pattern via `createDeferredDelete()` (§9.3.3). The only exception is a consequential structural delete that must disclose side-effects (aisle management), which may keep a `Dialog` triggered from a bar action.
 - Do not call `LIST_PAGE_CONTEXT.get()` from a consuming page's `<script>` block — it is outside the context tree and will throw.
 
 ---
@@ -533,6 +621,8 @@ Do **not** call `LIST_PAGE_CONTEXT.get()` in a consuming page's own `<script>` b
 ## 10.1 Overview
 
 `SelectableList<T>` renders a vertical list of rows from an `items` array, each row produced by a caller-supplied `row` snippet, with an optional per-row select `Checkbox` driven by a bound `selected` Set. It is the row-rendering counterpart to `ListPage`'s Selection Mode (§9): a consuming page typically passes its own `selectionMode` down so the checkboxes appear only while selecting.
+
+> **Scope: rows only.** `SelectableList` renders rows + per-row checkboxes and tracks the `selected` Set; it does **not** own bulk actions. Bulk actions belong to `ListPage`'s contextual action bar via `bulkActions` (§9.3.1). `SelectableList` has no `bulkActions` prop — a page composes `SelectableList` inside `ListPage`'s `children` and declares `bulkActions` on the `ListPage`.
 
 ## 10.2 Props
 

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -198,7 +198,11 @@ export { default as FormPage } from './templates/FormPage/FormPage.svelte';
 export { default as DetailPage } from './templates/DetailPage/DetailPage.svelte';
 export { default as SelectableList } from './templates/SelectableList/SelectableList.svelte';
 
-export type { ListPageProps } from './templates/ListPage/ListPage.types';
+export type {
+  ListPageProps,
+  BulkAction,
+  BulkActionIcon,
+} from './templates/ListPage/ListPage.types';
 export { LIST_PAGE_CONTEXT } from './templates/ListPage/ListPage.context';
 export type { ListPageContext } from './templates/ListPage/ListPage.context';
 export type { FormPageProps } from './templates/FormPage/FormPage.types';

--- a/packages/ui-components/src/primitives/ErrorState/ErrorState.svelte
+++ b/packages/ui-components/src/primitives/ErrorState/ErrorState.svelte
@@ -23,7 +23,7 @@
   role="alert"
 >
   <div class="text-destructive">
-    <Icon name="AlertTriangle" size={28} ariaLabel="Error" />
+    <Icon name="TriangleAlert" size={28} ariaLabel="Error" />
   </div>
   <h3 class="text-base font-semibold text-foreground">{title}</h3>
   {#if description}

--- a/packages/ui-components/src/primitives/Toast/Toast.svelte
+++ b/packages/ui-components/src/primitives/Toast/Toast.svelte
@@ -74,6 +74,11 @@
   let dragging = false;
 
   function onpointerdown(e: PointerEvent) {
+    // Don't start a swipe (and don't capture the pointer) when the press lands
+    // on an interactive control like the Undo action or the close button.
+    // Capturing here retargets the resulting `click` to this container, so the
+    // button's own onclick would never fire.
+    if ((e.target as HTMLElement).closest('button')) return;
     pointerStartX = e.clientX;
     dragging = true;
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);

--- a/packages/ui-components/src/templates/ListPage/ListPage.svelte
+++ b/packages/ui-components/src/templates/ListPage/ListPage.svelte
@@ -5,6 +5,11 @@
   import EmptyState from '../../primitives/EmptyState/EmptyState.svelte';
   import ErrorState from '../../primitives/ErrorState/ErrorState.svelte';
   import Button from '../../primitives/Button/Button.svelte';
+  import Icon from '../../primitives/Icon/Icon.svelte';
+  import Sheet from '../../primitives/Sheet/Sheet.svelte';
+  import SheetContent from '../../primitives/Sheet/SheetContent.svelte';
+  import SheetHeader from '../../primitives/Sheet/SheetHeader.svelte';
+  import SheetTitle from '../../primitives/Sheet/SheetTitle.svelte';
   import { LIST_PAGE_CONTEXT } from './ListPage.context.js';
   import type { ListPageProps } from './ListPage.types';
 
@@ -15,6 +20,8 @@
     toolbar,
     selectionBar,
     selectionMode = $bindable(false),
+    bulkActions,
+    selectionCount = 0,
     actions,
     isLoading = false,
     isError = false,
@@ -35,9 +42,23 @@
       selectionMode = false;
     },
   });
+
+  // The contextual bottom action bar takes over the BottomNav area while the user
+  // is selecting. It appears only once there is at least one selected item.
+  const showActionBar = $derived(
+    selectionMode && selectionCount > 0 && !!bulkActions && bulkActions.length > 0,
+  );
+
+  // Which picker action's target sheet is open (by action id), or null.
+  let openPickerId = $state<string | null>(null);
 </script>
 
-<section class={cn('flex flex-col gap-4', className)} {...restProps}>
+<!--
+  pb-24 while the action bar is shown reserves space so the last rows aren't
+  hidden behind the fixed bar. cn (tailwind-merge) lets it override a caller's
+  pb-* / p-* on the bottom edge only.
+-->
+<section class={cn('flex flex-col gap-4', className, showActionBar && 'pb-24')} {...restProps}>
   <header class="flex flex-wrap items-start justify-between gap-3">
     <div class="flex flex-col gap-1 min-w-0">
       {#if titleSlot}
@@ -109,3 +130,77 @@
     {/if}
   </div>
 </section>
+
+<!--
+  Contextual bulk-action bar. While selecting, it occupies the bottom slot and
+  covers the app's BottomNav (z-30 over the nav's z-10) — Android-style
+  contextual action mode, replacing the nav rather than stacking above it.
+-->
+{#if showActionBar && bulkActions}
+  <div
+    class="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-card pb-[env(safe-area-inset-bottom)]"
+    role="toolbar"
+    aria-label="Bulk actions"
+    data-testid="list-page-bulk-bar"
+  >
+    <div class="mx-auto flex w-full max-w-lg items-stretch">
+      {#each bulkActions as action (action.id)}
+        <button
+          type="button"
+          class={cn(
+            'flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-xs transition-colors disabled:opacity-40',
+            action.kind !== 'picker' && action.variant === 'destructive'
+              ? 'text-destructive hover:bg-destructive/10'
+              : 'text-foreground hover:bg-accent',
+          )}
+          disabled={action.disabled}
+          onclick={() => {
+            if (action.kind === 'picker') openPickerId = action.id;
+            else action.onSelect();
+          }}
+          data-testid={action.testId ?? 'list-page-bulk-action'}
+          data-action-id={action.id}
+        >
+          <Icon name={action.icon} size={20} />
+          {action.label}
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <!-- Target-picker sheets (one per picker action, opened by id). -->
+  {#each bulkActions as action (action.id)}
+    {#if action.kind === 'picker'}
+      <Sheet
+        side="bottom"
+        open={openPickerId === action.id}
+        onOpenChange={(v) => {
+          if (!v && openPickerId === action.id) openPickerId = null;
+        }}
+      >
+        <SheetContent class="flex flex-col gap-2 p-4 pb-8">
+          <SheetHeader>
+            <SheetTitle>{action.sheetTitle ?? action.label}</SheetTitle>
+          </SheetHeader>
+          <div class="flex flex-col">
+            {#each action.targets as target (target.id)}
+              <button
+                type="button"
+                class="w-full rounded px-3 py-3 text-left text-sm transition-colors hover:bg-accent disabled:opacity-40"
+                disabled={action.disabled}
+                onclick={() => {
+                  openPickerId = null;
+                  action.onPick(target.id);
+                }}
+                data-testid={action.optionTestId ?? 'list-page-bulk-picker-option'}
+                data-target-id={target.id}
+              >
+                {target.label}
+              </button>
+            {/each}
+          </div>
+        </SheetContent>
+      </Sheet>
+    {/if}
+  {/each}
+{/if}

--- a/packages/ui-components/src/templates/ListPage/ListPage.types.ts
+++ b/packages/ui-components/src/templates/ListPage/ListPage.types.ts
@@ -1,6 +1,47 @@
 // spec: ui-spec-v04.md §9 v0.4
 import type { Snippet } from 'svelte';
 import type { HTMLAttributes } from 'svelte/elements';
+import type { icons } from '@lucide/svelte';
+
+/** Name of a Lucide icon, matching the {@link Icon} primitive's `name` prop. */
+export type BulkActionIcon = keyof typeof icons;
+
+/**
+ * A single entry in the contextual bottom action bar (selection mode).
+ *
+ * - `button` (default): fires `onSelect` directly — e.g. Check, Uncheck, Delete.
+ *   Use `variant: 'destructive'` to tint a delete action.
+ * - `picker`: opens a template-owned bottom `Sheet` listing `targets`; choosing
+ *   one fires `onPick(targetId)` — e.g. "Move to…".
+ */
+export type BulkAction =
+  | {
+      kind?: 'button';
+      /** Stable key for the `{#each}` over actions. */
+      id: string;
+      label: string;
+      icon: BulkActionIcon;
+      variant?: 'default' | 'destructive';
+      disabled?: boolean;
+      /** Optional `data-testid` for the bar button (falls back to `list-page-bulk-action`). */
+      testId?: string;
+      onSelect: () => void;
+    }
+  | {
+      kind: 'picker';
+      id: string;
+      label: string;
+      icon: BulkActionIcon;
+      disabled?: boolean;
+      /** Optional `data-testid` for the bar button (falls back to `list-page-bulk-action`). */
+      testId?: string;
+      /** Title shown at the top of the target-picker sheet, e.g. "Move 3 items to…". */
+      sheetTitle?: string;
+      targets: { id: string; label: string }[];
+      /** Optional `data-testid` for each target option (falls back to `list-page-bulk-picker-option`). */
+      optionTestId?: string;
+      onPick: (targetId: string) => void;
+    };
 
 export type ListPageProps = {
   title: string;
@@ -8,13 +49,28 @@ export type ListPageProps = {
   description?: string;
   toolbar?: Snippet;
   /**
-   * Rendered inside a grey bar between the header and content when items are selected.
-   * Convention: show selection count on the Checkbox label ("3 selected"), use
-   * variant="destructive" for delete actions, variant="outline" for non-destructive
-   * bulk actions (e.g. merge), variant="ghost" for Clear.
+   * Top **select-all** control, rendered in the bar between the header and content
+   * while in selection mode. Convention: a single select-all `Checkbox` whose label
+   * shows the count ("3 selected" / "Select all"). Bulk actions do **not** go here —
+   * they are declared via `bulkActions` and rendered in the contextual bottom bar
+   * (ui-spec-v04 §9.3.1). The old inline grey-bar buttons (Delete/Clear) are removed.
    */
   selectionBar?: Snippet;
   selectionMode?: boolean;
+  /**
+   * Bulk actions for the contextual bottom action bar. When `selectionMode` is on
+   * and `selectionCount > 0`, the template renders a fixed bottom bar (one button
+   * per action) that takes over the area occupied by the app's `BottomNav`
+   * (Android-style contextual action mode) and reserves matching content padding.
+   * A `kind: 'picker'` action opens a template-owned bottom `Sheet` of targets.
+   */
+  bulkActions?: BulkAction[];
+  /**
+   * Number of currently-selected items. Drives contextual-bar visibility (the bar
+   * shows only when `selectionMode && selectionCount > 0`) and the default
+   * picker-sheet title. The page owns selection state; this is just the count.
+   */
+  selectionCount?: number;
   /**
    * Header action buttons, rendered to the right of the built-in Select/Done toggle.
    * Convention: use size="sm" on every button here so they line up with the Select

--- a/packages/ui-components/src/templates/ListPage/index.ts
+++ b/packages/ui-components/src/templates/ListPage/index.ts
@@ -1,5 +1,5 @@
 // spec: SPEC.md §9.1 v0.4.0
 export { default as ListPage } from './ListPage.svelte';
-export type { ListPageProps } from './ListPage.types';
+export type { ListPageProps, BulkAction, BulkActionIcon } from './ListPage.types';
 export { LIST_PAGE_CONTEXT } from './ListPage.context.js';
 export type { ListPageContext } from './ListPage.context.js';


### PR DESCRIPTION
Closes #115.

Generalises the shopping page's validated **contextual action mode** multi‑select into the shared `@salt/ui-components` `ListPage` template, so every list page inherits it instead of re‑implementing a bespoke bottom bar — and updates the design docs that still described the old inline grey‑bar pattern.

The public API (Phase 1) was agreed up front; all three decisions were approved as recommended:
1. **Declarative `bulkActions` array** (template owns the bar chrome; `Move` is a `kind:'picker'` action).
2. **Fixed‑overlay `z-30`** nav takeover (the already‑validated shopping behaviour; no `AppShell` changes).
3. **Toast stays app‑level + reusable deferred‑delete helper** (`ListPage` stays toast‑free; layer map intact).

## What changed

### Template — `ListPage`
- New `bulkActions: BulkAction[]` + `selectionCount` props. Renders a fixed bottom action bar that **replaces** the `BottomNav` (z‑30 over z‑10, Android‑style) once `selectionMode && selectionCount > 0`, and auto‑reserves bottom content padding.
- `kind:'picker'` actions open a **template‑owned bottom `Sheet`** of targets (Move to…).
- Optional `testId` / `optionTestId` passthrough keeps stable e2e hooks while the bar markup stays generic.

### Deferred‑delete + Undo
- New reusable helper `createDeferredDelete()` (`apps/web-pwa/src/lib/deferredDelete.svelte.ts`): hide rows immediately, commit on undo‑toast lapse, cancel on Undo — **no confirm dialog, no soft‑delete / tombstones** (Firestore‑as‑master). The toast stays app‑level (`toastStore`); `ListPage` never imports it.

### Page migrations — no bespoke selection bars remain
- **shopping**: drop the hand‑rolled bottom bar + move sheet; use `bulkActions` + the helper.
- **equipment, canon**: confirm‑dialog delete → deferred‑delete + Undo via the bar.
- **aisle management**: relocate Delete/Merge triggers into the bar, but **keep** their disclosure / per‑item‑choice dialogs — these are consequential structural ops, not simple item deletes (per the issue's "don't change behaviour beyond what's needed to adopt").

### Docs (Phase 3)
- Rewrote `ui-spec-v04.md` §9 for the contextual action mode (bar, picker, deferred delete + the worked call‑site); fixed the stale `selectionBar` JSDoc; documented the undo‑able Toast (`action`/`onDismiss`) in `ui-spec-v03.md` §6.6; marked `SelectableList` as **rows‑only** (bulk actions belong to `ListPage`).

### e2e (Phase 5)
- Added `shopping-list-bulk-delete.spec.ts`: **Undo restores** the item (never deleted) and **lapse commits** (gone after reload). The existing move‑sheet spec keeps working via preserved testids. *(Not run here — the e2e suite is run interactively in this repo.)*

## Drive‑by fixes (flagged, not silent)
Two **latent svelte‑check‑only** bugs surfaced while working in these files. Neither is gated by CI (which runs `tsc` / lint / test, not `svelte-check`), which is why they sat undetected:
- `ErrorState` used the renamed lucide icon → `AlertTriangle` → `TriangleAlert` (regression from the `@lucide/svelte` migration #146).
- The kitchen‑sink `TemplatesSection` demo referenced a **never‑implemented** `SelectableList` `bulkActions`/`onAction` API; rewired it to the real `ListPage` contextual‑action API and showed `SelectableList` as the rows‑only helper it actually is.

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm format:check` ✅ · `pnpm boundary:test` ✅ (17/17, dependency‑cruiser clean)
- `pnpm test` ✅ — **1322 passed (101 files)**, incl. updated equipment unit tests for the new deferred‑delete/undo flow.
- `@salt/ui-components` `svelte-check` ✅ 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)