### PR TITLE
refactor(ui): consolidate list selection onto one shared controller (#106)

### DIFF
--- a/apps/web-pwa/src/routes/canon/AisleManagementPage.svelte
+++ b/apps/web-pwa/src/routes/canon/AisleManagementPage.svelte
@@ -3,7 +3,6 @@
   import AdminGuard from '../admin/AdminGuard.svelte';
   import {
     Button,
-    Checkbox,
     Dialog,
     DialogContent,
     DialogDescription,
@@ -14,12 +13,15 @@
     ListPage,
     RadioGroup,
     RadioGroupItem,
+    RowSelectCheckbox,
     Select,
+    SelectAllCheckbox,
     SelectContent,
     SelectItem,
     SelectTrigger,
     SortableList,
     TextArea,
+    createListSelection,
     type BulkAction,
   } from '@salt/ui-components';
   import {
@@ -55,12 +57,6 @@
   let editingName = $state('');
   let editInputEl = $state<HTMLInputElement | undefined>();
 
-  // Selection
-  let selected = $state(new Set<string>());
-  $effect(() => {
-    if (!selectionMode) selected = new Set();
-  });
-
   // Delete modal
   let deleteOpen = $state(false);
   let deleteBusy = $state(false);
@@ -84,25 +80,10 @@
     }),
   );
 
-  let selectedCount = $derived(filteredAisles.filter((a) => selected.has(a.id)).length);
-  let allSelected = $derived(
-    filteredAisles.length > 0 && filteredAisles.every((a) => selected.has(a.id)),
-  );
-  let someSelected = $derived(selectedCount > 0 && !allSelected);
-
-  function toggleSelect(id: string) {
-    const s = new Set(selected);
-    if (s.has(id)) s.delete(id);
-    else s.add(id);
-    selected = s;
-  }
-
-  function toggleSelectAll() {
-    const s = new Set(selected);
-    if (allSelected) filteredAisles.forEach((a) => s.delete(a.id));
-    else filteredAisles.forEach((a) => s.add(a.id));
-    selected = s;
-  }
+  const selection = createListSelection({
+    getAllIds: () => filteredAisles.map((a) => a.id),
+    isSelectionMode: () => selectionMode,
+  });
 
   // Add
   async function handleAdd() {
@@ -168,11 +149,11 @@
 
   // Derived: canon items affected by a bulk delete of all selected aisles
   let deleteAffectedItems = $derived(
-    $canonItems.filter((item) => item.aisleId !== null && selected.has(item.aisleId)),
+    $canonItems.filter((item) => item.aisleId !== null && selection.isSelected(item.aisleId)),
   );
 
   // Derived: source aisle ids for the merge (all selected except the target)
-  let mergeSourceIds = $derived([...selected].filter((id) => id !== mergeTargetId));
+  let mergeSourceIds = $derived([...selection.selected].filter((id) => id !== mergeTargetId));
 
   // Derived: canon items that will be affected by the merge (belong to a source aisle)
   let mergeAffectedItems = $derived(
@@ -189,7 +170,7 @@
   });
 
   function openMerge() {
-    mergeTargetId = [...selected][0] ?? '';
+    mergeTargetId = [...selection.selected][0] ?? '';
     mergeOpen = true;
   }
 
@@ -200,7 +181,7 @@
       id: 'merge',
       label: 'Merge',
       icon: 'Merge',
-      disabled: selectedCount < 2,
+      disabled: selection.count < 2,
       testId: 'bulk-merge-button',
       onSelect: openMerge,
     },
@@ -217,10 +198,10 @@
   async function handleBulkDelete() {
     deleteBusy = true;
     deleteError = '';
-    const result = await deleteAisles([...selected]);
+    const result = await deleteAisles([...selection.selected]);
     deleteBusy = false;
     if (result.kind === 'ok') {
-      selected = new Set();
+      selection.clear();
       deleteOpen = false;
     } else {
       deleteError = 'Failed to delete aisles. Try again.';
@@ -240,7 +221,7 @@
     });
     mergeBusy = false;
     if (result.kind === 'ok') {
-      selected = new Set();
+      selection.clear();
       mergeOpen = false;
     } else {
       mergeError = 'Failed to merge aisles. Try again.';
@@ -256,7 +237,7 @@
       isLoading={$isLoadingAisles}
       isEmpty={$aisles.length === 0 && !$isLoadingAisles}
       bind:selectionMode
-      selectionCount={selectedCount}
+      selectionCount={selection.count}
       {bulkActions}
     >
       {#snippet actions()}
@@ -269,11 +250,7 @@
         >
       {/snippet}
       {#snippet selectionBar()}
-        <Checkbox
-          checked={allSelected ? true : someSelected ? 'indeterminate' : false}
-          onCheckedChange={toggleSelectAll}
-          label={selectedCount > 0 ? `${selectedCount} selected` : 'Select all'}
-        />
+        <SelectAllCheckbox {selection} />
       {/snippet}
 
       {#snippet children()}
@@ -310,9 +287,9 @@
             <div data-testid={`aisle-row-${aisle.id}`} class="flex items-center gap-2 px-3 py-2">
               {#if selectionMode}
                 <span data-testid={`aisle-row-checkbox-${aisle.id}`}>
-                  <Checkbox
-                    checked={selected.has(aisle.id)}
-                    onCheckedChange={() => toggleSelect(aisle.id)}
+                  <RowSelectCheckbox
+                    {selection}
+                    id={aisle.id}
                     labelledBy={`aisle-name-${aisle.id}`}
                   />
                 </span>
@@ -466,7 +443,7 @@
               : 'Pick target aisle…'}
           </SelectTrigger>
           <SelectContent>
-            {#each [...selected] as id (id)}
+            {#each [...selection.selected] as id (id)}
               {@const a = $aisles.find((a) => a.id === id)}
               {#if a}
                 <SelectItem value={a.id}>{titleCase(a.name)}</SelectItem>

--- a/apps/web-pwa/src/routes/canon/CanonListPage.svelte
+++ b/apps/web-pwa/src/routes/canon/CanonListPage.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import {
     Button,
-    Checkbox,
     Icon,
     ListPage,
     Select,
+    SelectAllCheckbox,
     SelectContent,
     SelectItem,
     SelectTrigger,
+    createListSelection,
     type BulkAction,
   } from '@salt/ui-components';
   import { push } from 'svelte-spa-router';
@@ -30,12 +31,6 @@
 
   // Selection mode
   let selectionMode = $state(false);
-
-  // Selection
-  let selected = $state(new Set<string>());
-  $effect(() => {
-    if (!selectionMode) selected = new Set();
-  });
 
   // Deferred bulk delete (hide immediately, commit on undo-lapse — no confirm dialog).
   const deferredDelete = createDeferredDelete();
@@ -100,42 +95,28 @@
 
   // Derived: selection state
   const allVisibleIds = $derived(filteredItems.map((i) => i.id));
-  const allSelected = $derived(
-    allVisibleIds.length > 0 && allVisibleIds.every((id) => selected.has(id)),
-  );
-  const someSelected = $derived(allVisibleIds.some((id) => selected.has(id)) && !allSelected);
-  const selectedCount = $derived(allVisibleIds.filter((id) => selected.has(id)).length);
+  const selection = createListSelection({
+    getAllIds: () => allVisibleIds,
+    isSelectionMode: () => selectionMode,
+  });
 
   const selectedApprovalIds = $derived(
-    [...selected].filter((id) => filteredItems.find((i) => i.id === id)?.needs_approval),
+    [...selection.selected].filter((id) => filteredItems.find((i) => i.id === id)?.needs_approval),
   );
 
-  function toggleItem(id: string) {
-    const s = new Set(selected);
-    if (s.has(id)) s.delete(id);
-    else s.add(id);
-    selected = s;
-  }
-
-  function toggleAll() {
-    selected = allSelected ? new Set() : new Set(allVisibleIds);
-  }
-
   function selectPending() {
-    const s = new Set(selected);
-    filteredItems.filter((i) => i.needs_approval).forEach((i) => s.add(i.id));
-    selected = s;
+    selection.add(filteredItems.filter((i) => i.needs_approval).map((i) => i.id));
   }
 
   async function handleBulkApprove() {
     await approveCanonItems(selectedApprovalIds);
-    selected = new Set([...selected].filter((id) => !selectedApprovalIds.includes(id)));
+    selection.remove(selectedApprovalIds);
   }
 
   function handleBulkDelete() {
-    if (selectedCount === 0) return;
-    const ids = [...selected].filter((id) => allVisibleIds.includes(id));
-    selectionMode = false; // the $effect on selectionMode clears `selected`
+    if (selection.count === 0) return;
+    const ids = selection.ids;
+    selectionMode = false; // exiting selection mode clears the selection
     deferredDelete.request(ids, async (delIds) => {
       const results = await Promise.all(delIds.map((id) => deleteCanonItem(id)));
       if (results.some((r) => r.kind !== 'ok')) {
@@ -177,7 +158,7 @@
     isEmpty={$canonItems.length === 0}
     class="p-4 sm:p-6"
     bind:selectionMode
-    selectionCount={selectedCount}
+    selectionCount={selection.count}
     {bulkActions}
   >
     {#snippet actions()}
@@ -194,11 +175,7 @@
     {/snippet}
 
     {#snippet selectionBar()}
-      <Checkbox
-        checked={allSelected ? true : someSelected ? 'indeterminate' : false}
-        onCheckedChange={toggleAll}
-        label={selectedCount > 0 ? `${selectedCount} selected` : 'Select all'}
-      />
+      <SelectAllCheckbox {selection} />
     {/snippet}
 
     {#snippet children()}
@@ -249,8 +226,8 @@
               <CanonListRow
                 {item}
                 aisles={$aisles}
-                selected={selected.has(item.id)}
-                onToggleSelect={selectionMode ? () => toggleItem(item.id) : undefined}
+                selected={selection.isSelected(item.id)}
+                onToggleSelect={selectionMode ? () => selection.toggle(item.id) : undefined}
               />
             {/each}
           </ul>
@@ -270,8 +247,8 @@
                   <CanonListRow
                     {item}
                     aisles={$aisles}
-                    selected={selected.has(item.id)}
-                    onToggleSelect={selectionMode ? () => toggleItem(item.id) : undefined}
+                    selected={selection.isSelected(item.id)}
+                    onToggleSelect={selectionMode ? () => selection.toggle(item.id) : undefined}
                   />
                 {/each}
               </ul>

--- a/apps/web-pwa/src/routes/equipment/EquipmentListPage.svelte
+++ b/apps/web-pwa/src/routes/equipment/EquipmentListPage.svelte
@@ -73,7 +73,11 @@
 
   {#snippet children()}
     <div data-testid="equipment-list">
-      <SelectableList items={visibleItems} {selection}>
+      <SelectableList
+        items={visibleItems}
+        {selection}
+        getRowCheckboxLabel={(item) => `Select ${item.name}`}
+      >
         {#snippet row(item)}
           <button
             class="w-full text-left text-sm font-medium hover:underline"

--- a/apps/web-pwa/src/routes/equipment/EquipmentListPage.svelte
+++ b/apps/web-pwa/src/routes/equipment/EquipmentListPage.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import {
     Button,
-    Checkbox,
     ListPage,
     SelectableList,
+    SelectAllCheckbox,
     Spinner,
+    createListSelection,
     type BulkAction,
   } from '@salt/ui-components';
   import { push } from 'svelte-spa-router';
@@ -17,11 +18,6 @@
   import { createDeferredDelete } from '../../lib/deferredDelete.svelte.js';
 
   let selectionMode = $state(false);
-  let selected = $state(new Set<string>());
-
-  $effect(() => {
-    if (!selectionMode) selected = new Set();
-  });
 
   const deferredDelete = createDeferredDelete();
 
@@ -30,18 +26,15 @@
   const visibleItems = $derived(deferredDelete.visible(sorted));
 
   const allIds = $derived(visibleItems.map((i) => i.id));
-  const allSelected = $derived(allIds.length > 0 && allIds.every((id) => selected.has(id)));
-  const someSelected = $derived(allIds.some((id) => selected.has(id)) && !allSelected);
-  const selectedCount = $derived(allIds.filter((id) => selected.has(id)).length);
-
-  function toggleAll() {
-    selected = allSelected ? new Set() : new Set(allIds);
-  }
+  const selection = createListSelection({
+    getAllIds: () => allIds,
+    isSelectionMode: () => selectionMode,
+  });
 
   function handleBulkDelete(): void {
-    if (selectedCount === 0) return;
-    const ids = [...selected].filter((id) => allIds.includes(id));
-    selectionMode = false; // the $effect on selectionMode clears `selected`
+    if (selection.count === 0) return;
+    const ids = selection.ids;
+    selectionMode = false; // exiting selection mode clears the selection
     deferredDelete.request(ids, async (delIds) => {
       const result = await removeEquipmentItems([...delIds]);
       if (result.kind !== 'ok') addToast('Failed to delete items.', 'destructive');
@@ -67,7 +60,7 @@
   isEmpty={visibleItems.length === 0}
   class="p-4 sm:p-6"
   bind:selectionMode
-  selectionCount={selectedCount}
+  selectionCount={selection.count}
   {bulkActions}
 >
   {#snippet actions()}
@@ -75,16 +68,12 @@
   {/snippet}
 
   {#snippet selectionBar()}
-    <Checkbox
-      checked={allSelected ? true : someSelected ? 'indeterminate' : false}
-      onCheckedChange={toggleAll}
-      label={selectedCount > 0 ? `${selectedCount} selected` : 'Select all'}
-    />
+    <SelectAllCheckbox {selection} />
   {/snippet}
 
   {#snippet children()}
     <div data-testid="equipment-list">
-      <SelectableList items={visibleItems} bind:selected {selectionMode}>
+      <SelectableList items={visibleItems} {selection}>
         {#snippet row(item)}
           <button
             class="w-full text-left text-sm font-medium hover:underline"

--- a/apps/web-pwa/src/routes/shopping/ShoppingListPage.svelte
+++ b/apps/web-pwa/src/routes/shopping/ShoppingListPage.svelte
@@ -2,7 +2,6 @@
   import {
     Button,
     CanonIcon,
-    Checkbox,
     Combobox,
     ComboboxContent,
     ComboboxCreate,
@@ -12,6 +11,8 @@
     ComboboxItem,
     Icon,
     ListPage,
+    RowSelectCheckbox,
+    SelectAllCheckbox,
     Popover,
     PopoverContent,
     PopoverTrigger,
@@ -24,6 +25,7 @@
     TextArea,
     TextField,
     EmptyState,
+    createListSelection,
   } from '@salt/ui-components';
   import { titleCase } from '../../lib/titleCase.js';
   import { tick } from 'svelte';
@@ -130,26 +132,10 @@
 
   let selectionMode = $state(false);
 
-  let selected = $state(new Set<string>());
-
-  $effect(() => {
-    if (!selectionMode) selected = new Set();
+  const selection = createListSelection({
+    getAllIds: () => allItemIds,
+    isSelectionMode: () => selectionMode,
   });
-
-  const selectedCount = $derived(allItemIds.filter((id) => selected.has(id)).length);
-  const allSelected = $derived(allItemIds.length > 0 && allItemIds.every((id) => selected.has(id)));
-  const someSelected = $derived(allItemIds.some((id) => selected.has(id)) && !allSelected);
-
-  function toggleSelection(id: string): void {
-    const next = new Set(selected);
-    if (next.has(id)) next.delete(id);
-    else next.add(id);
-    selected = next;
-  }
-
-  function toggleAll(): void {
-    selected = allSelected ? new Set() : new Set(allItemIds);
-  }
 
   // ─── Item capture ─────────────────────────────────────────────────────────────
 
@@ -281,10 +267,10 @@
   let bulkBusy = $state(false);
 
   function handleBulkDelete(): void {
-    if (selectedCount === 0) return;
-    const ids = [...selected].filter((id) => allItemIds.includes(id));
+    if (selection.count === 0) return;
+    const ids = selection.ids;
     // Hide immediately and leave selection mode; commit (or undo) when the toast resolves.
-    selectionMode = false; // the $effect on selectionMode clears `selected`
+    selectionMode = false; // exiting selection mode clears the selection
     deferredDelete.request(ids, async (delIds) => {
       const result = await removeItems(params.listId, delIds);
       if (result.kind !== 'ok') addToast('Failed to delete items.', 'destructive');
@@ -292,25 +278,25 @@
   }
 
   async function handleBulkCheck(): Promise<void> {
-    if (selectedCount === 0) return;
+    if (selection.count === 0) return;
     bulkBusy = true;
-    await checkItems(params.listId, [...selected]);
+    await checkItems(params.listId, [...selection.selected]);
     bulkBusy = false;
-    selected = new Set();
+    selection.clear();
   }
 
   async function handleBulkUncheck(): Promise<void> {
-    if (selectedCount === 0) return;
+    if (selection.count === 0) return;
     bulkBusy = true;
-    await uncheckItems(params.listId, [...selected]);
+    await uncheckItems(params.listId, [...selection.selected]);
     bulkBusy = false;
-    selected = new Set();
+    selection.clear();
   }
 
   async function handleMoveTo(targetListId: string): Promise<void> {
-    if (selectedCount === 0) return;
+    if (selection.count === 0) return;
     bulkBusy = true;
-    const ids = [...selected];
+    const ids = [...selection.selected];
     const result = await moveSelectedItems(params.listId, targetListId, ids);
     bulkBusy = false;
     if (result.kind !== 'ok') {
@@ -351,7 +337,7 @@
       icon: 'FolderInput',
       disabled: bulkBusy || otherLists.length === 0,
       testId: 'shopping-bulk-move-select',
-      sheetTitle: `Move ${selectedCount} item${selectedCount === 1 ? '' : 's'} to…`,
+      sheetTitle: `Move ${selection.count} item${selection.count === 1 ? '' : 's'} to…`,
       targets: otherLists.map((l) => ({ id: l.id, label: l.name })),
       optionTestId: 'shopping-bulk-move-option',
       onPick: (id) => void handleMoveTo(id),
@@ -405,7 +391,7 @@
     isLoading={$isLoadingShoppingList}
     {isEmpty}
     bind:selectionMode
-    selectionCount={selectedCount}
+    selectionCount={selection.count}
     {bulkActions}
     class="p-4 sm:p-6"
     data-testid="shopping-list-page"
@@ -513,11 +499,7 @@
     {/snippet}
 
     {#snippet selectionBar()}
-      <Checkbox
-        checked={allSelected ? true : someSelected ? 'indeterminate' : false}
-        onCheckedChange={toggleAll}
-        label={selectedCount > 0 ? `${selectedCount} selected` : 'Select all'}
-      />
+      <SelectAllCheckbox {selection} />
     {/snippet}
 
     {#snippet empty()}
@@ -551,7 +533,7 @@
 
             {#if !aisleCollapsed}
               {#each aisleGroup.items as item (item.id)}
-                {@const isSelected = selected.has(item.id)}
+                {@const isSelected = selection.isSelected(item.id)}
                 {@const amountStr = formatAmount(item.amount, item.unit)}
                 <div
                   class="flex items-center gap-3 rounded border px-3 py-2 text-sm {isSelected
@@ -561,9 +543,9 @@
                   data-item-id={item.id}
                 >
                   {#if selectionMode}
-                    <Checkbox
-                      checked={isSelected}
-                      onCheckedChange={() => toggleSelection(item.id)}
+                    <RowSelectCheckbox
+                      {selection}
+                      id={item.id}
                       label=""
                       aria-label="Select {item.rawText}"
                     />
@@ -625,7 +607,7 @@
               {/if}
             </div>
             {#each grouped.other.contributors as { item, isPending } (item.id)}
-              {@const isSelected = selected.has(item.id)}
+              {@const isSelected = selection.isSelected(item.id)}
               {@const amountStr = formatAmount(item.amount, item.unit)}
               <div
                 class="flex items-center gap-3 rounded border px-3 py-2 text-sm {isSelected
@@ -635,9 +617,9 @@
                 data-item-id={item.id}
               >
                 {#if selectionMode}
-                  <Checkbox
-                    checked={isSelected}
-                    onCheckedChange={() => toggleSelection(item.id)}
+                  <RowSelectCheckbox
+                    {selection}
+                    id={item.id}
                     label=""
                     aria-label="Select {item.rawText}"
                   />
@@ -714,7 +696,7 @@
             </div>
             {#if !checkedCollapsed}
               {#each grouped.checked.contributors as item (item.id)}
-                {@const isSelected = selected.has(item.id)}
+                {@const isSelected = selection.isSelected(item.id)}
                 {@const amountStr = formatAmount(item.amount, item.unit)}
                 <div
                   class="flex items-center gap-3 rounded border px-3 py-2 text-sm {isSelected
@@ -724,9 +706,9 @@
                   data-item-id={item.id}
                 >
                   {#if selectionMode}
-                    <Checkbox
-                      checked={isSelected}
-                      onCheckedChange={() => toggleSelection(item.id)}
+                    <RowSelectCheckbox
+                      {selection}
+                      id={item.id}
                       label=""
                       aria-label="Select {item.rawText}"
                     />

--- a/docs/design/ui-spec-v04.md
+++ b/docs/design/ui-spec-v04.md
@@ -1,7 +1,7 @@
 # Salt 2.0 — UI Primitives Specification (v0.4)
 
 **Status:** Planning  
-**Scope:** `@salt/ui-components` — Combobox (incl. `ComboboxField`); ListPage Selection Mode (incl. `titleSlot`); SelectableList; EditableRow  
+**Scope:** `@salt/ui-components` — Combobox (incl. `ComboboxField`); ListPage Selection Mode (incl. `titleSlot`); list selection (`createListSelection` + `SelectableList` / `SelectAllCheckbox` / `RowSelectCheckbox`); EditableRow  
 **Audience:** AI code-generation agents + human contributors
 
 > Rule: If anything is missing or ambiguous → STOP → extend this spec → regenerate.  
@@ -18,7 +18,7 @@ v0.4 introduces:
 
 - **Combobox** — text input + popup listbox + filtering + optional custom values, with the optional `ComboboxField` joined-input frame (§3.4)
 - **ListPage Selection Mode** — app-wide hide-by-default multi-select with a **contextual bottom action bar** (`bulkActions`, incl. a move/target-picker sheet) that replaces the `BottomNav`, plus deferred-delete + Undo and the `titleSlot` header override (§9)
-- **SelectableList** — list template with `selectionMode`-gated per-row checkboxes (§10)
+- **List selection** — one shared `createListSelection` controller behind `SelectableList`, `SelectAllCheckbox`, and `RowSelectCheckbox`, so every list page shares the same selection logic instead of hand-rolling it (§10)
 - **EditableRow** — single-row primitive with an `onToggleSelect`-gated checkbox (§11)
 
 APG pattern: **Autocomplete (Listbox)**.
@@ -616,44 +616,81 @@ Do **not** call `LIST_PAGE_CONTEXT.get()` in a consuming page's own `<script>` b
 
 ---
 
-# 10. SelectableList (template)
+# 10. List selection (`createListSelection` + `SelectableList` / `SelectAllCheckbox` / `RowSelectCheckbox`)
 
 ## 10.1 Overview
 
-`SelectableList<T>` renders a vertical list of rows from an `items` array, each row produced by a caller-supplied `row` snippet, with an optional per-row select `Checkbox` driven by a bound `selected` Set. It is the row-rendering counterpart to `ListPage`'s Selection Mode (§9): a consuming page typically passes its own `selectionMode` down so the checkboxes appear only while selecting.
+Multi-selection across the app's list pages is owned by **one** shared controller, `createListSelection`, plus three thin presentational components that read from it. Before, every list page (shopping, canon, aisle, equipment) hand-rolled the same `selected` Set, the `allSelected` / `someSelected` / `count` deriveds, the `toggle` / `toggleAll` helpers, the auto-clear `$effect`, and its own select-all / per-row checkboxes. That logic now lives once, in the controller.
 
-> **Scope: rows only.** `SelectableList` renders rows + per-row checkboxes and tracks the `selected` Set; it does **not** own bulk actions. Bulk actions belong to `ListPage`'s contextual action bar via `bulkActions` (§9.3.1). `SelectableList` has no `bulkActions` prop — a page composes `SelectableList` inside `ListPage`'s `children` and declares `bulkActions` on the `ListPage`.
+The pieces:
 
-## 10.2 Props
+- **`createListSelection(options)`** — the selection "brain". Owns the `selected` Set and derives `allSelected` / `someSelected` / `count` from a scope (`getAllIds`). Sources selection mode from the page (`isSelectionMode`) and **auto-clears the selection when mode turns off**, replacing the per-page `$effect`.
+- **`SelectableList<T>`** — renders a flat `<ul>` of rows from `items`, each produced by a caller `row` snippet, with the per-row select checkbox gated on `selection.selectionMode`. Used for simple flat lists (equipment).
+- **`SelectAllCheckbox`** — the header/`selectionBar` select-all control (tri-state + "N selected" label), wired entirely from the controller.
+- **`RowSelectCheckbox`** — a single per-row select checkbox wired to the controller by `id`, for pages whose row layout is bespoke (shopping's trolley rows, aisle's drag-drop `SortableList` rows) and so cannot use `SelectableList`'s flat container.
 
-| Name            | Type                                                       | Default          | Notes                                                       |
-| --------------- | ---------------------------------------------------------- | ---------------- | ----------------------------------------------------------- |
-| `items`         | `T[]` where `T extends { id: string }`                     | —                | Rows to render; keyed by `item.id`                          |
-| `selected`      | `Set<string>` (bindable)                                   | `new Set()`      | IDs currently selected                                      |
-| `selectionMode` | `boolean`                                                  | `false`          | When `false`, the per-row `Checkbox` is **not rendered**    |
-| `row`           | `Snippet<[T, { selected: boolean; toggle: () => void }]>`  | —                | Renders each row's content; receives the item + row helpers |
-| `class`         | `string \| undefined`                                      | —                | Merged onto the `<ul>`                                      |
+> **Why a controller, not one mega-component.** The four lists are structurally divergent — flat (equipment), grouped + sectioned (canon, shopping), collapsible (shopping), and drag-drop sortable (aisle). Forcing them all through a single list container would couple selection to grouping/sorting. Instead the *selection logic* is unified in the controller; each page keeps its own structure and composes the shared checkboxes. Canon reuses `EditableRow`'s built-in checkbox (driven by the controller via `selected` / `onToggleSelect`).
 
-## 10.3 Behaviour
+> **Scope: selection only.** None of these own bulk actions. Bulk actions belong to `ListPage`'s contextual action bar via `bulkActions` (§9.3.1). A page composes the list/checkboxes inside `ListPage`'s `children` / `selectionBar` and declares `bulkActions` on the `ListPage`, passing `selectionCount={selection.count}`.
 
-- **`selectionMode` gates the checkbox.** When `selectionMode` is `false` (the default), no `Checkbox` is rendered and the list reads as a plain, clean list. When `true`, each row renders a leading `Checkbox` bound to membership in `selected`.
-- Toggling a row's checkbox (or calling the `toggle` helper passed into the `row` snippet) adds/removes that `item.id` from `selected` immutably (a new `Set` is assigned so bindings react).
-- Selected rows get a `ring-2 ring-ring border-ring` treatment on the row container.
-- Rows use the base `rounded` (4px) surface radius (ui-spec-v02 §2.3).
+## 10.2 `createListSelection(options)`
 
-> **Default-off is a deliberate, behaviour-breaking contract.** A caller that does not pass `selectionMode` gets **no** checkboxes. This matches the app-wide hide-by-default selection pattern (§9.2); it is not a regression.
+**Options**
 
-## 10.4 Accessibility
+| Name              | Type               | Notes                                                                 |
+| ----------------- | ------------------ | --------------------------------------------------------------------- |
+| `getAllIds`       | `() => string[]`   | All currently-selectable ids in scope; drives `all`/`some`/`count` + `toggleAll` |
+| `isSelectionMode` | `() => boolean`    | Page's selection mode (bound to `ListPage`); selection clears on exit |
 
-- The list root is a `<ul>`; each row is an `<li>`.
-- When rendered, the `Checkbox` carries the selection state for assistive tech; the `row` snippet is responsible for the row's own accessible label/content.
+**Returns `ListSelection`**
 
-## 10.5 Testing requirements
+| Member         | Type                       | Notes                                                          |
+| -------------- | -------------------------- | -------------------------------------------------------------- |
+| `selectionMode`| `boolean` (readonly)       | Mirror of `isSelectionMode()`                                  |
+| `selected`     | `Set<string>` (readonly)   | Live selected ids (reactive)                                   |
+| `ids`          | `string[]` (readonly)      | Selected ids still in scope (`getAllIds`)                      |
+| `count`        | `number` (readonly)        | `ids.length`                                                   |
+| `allSelected`  | `boolean` (readonly)       | Every in-scope id selected                                     |
+| `someSelected` | `boolean` (readonly)       | Some, but not all, in-scope ids selected                       |
+| `isSelected(id)`| `(id) => boolean`         | Membership test                                                |
+| `toggle(id)`   | `(id) => void`             | Add/remove one id (immutable Set swap)                         |
+| `toggleAll()`  | `() => void`               | Select all in-scope, or clear when all already selected        |
+| `add(ids)`     | `(ids) => void`            | Add a subset (e.g. "select all pending")                       |
+| `remove(ids)`  | `(ids) => void`            | Remove a subset (e.g. after a partial bulk action)             |
+| `clear()`      | `() => void`               | Clear the whole selection                                      |
 
-- Checkbox is **absent** when `selectionMode={false}` (default) and **present** when `selectionMode={true}`.
-- Toggling a checkbox updates the bound `selected` Set (add and remove).
-- Selected rows reflect the selected styling.
-- `row` snippet receives the correct `selected` flag and a working `toggle`.
+## 10.3 Component props
+
+**`SelectableList<T>`**
+
+| Name        | Type                                                      | Default | Notes                                          |
+| ----------- | -------------------------------------------------------- | ------- | ---------------------------------------------- |
+| `items`     | `T[]` where `T extends { id: string }`                   | —       | Rows to render; keyed by `item.id`             |
+| `selection` | `ListSelection`                                          | —       | Shared controller; gates + drives the checkbox |
+| `row`       | `Snippet<[T, { selected: boolean; toggle: () => void }]>`| —       | Renders each row's content                     |
+| `class`     | `string \| undefined`                                    | —       | Merged onto the `<ul>`                         |
+
+**`SelectAllCheckbox`** — `{ selection: ListSelection }` (extra attrs forwarded to `Checkbox`).
+**`RowSelectCheckbox`** — `{ selection: ListSelection; id: string }` (extra attrs — `aria-label`, `labelledBy`, `data-testid`… — forwarded to `Checkbox`).
+
+## 10.4 Behaviour
+
+- **`selection.selectionMode` gates the per-row checkbox.** When mode is off, `SelectableList` renders no checkbox and reads as a plain list; bespoke pages gate their `RowSelectCheckbox` behind their own `{#if selectionMode}`.
+- `toggle` / `toggleAll` / `add` / `remove` mutate the selection immutably (a new `Set` is assigned so deriveds and bindings react).
+- Leaving selection mode (`isSelectionMode()` → `false`) clears the selection automatically.
+- Selected rows in `SelectableList` get a `ring-2 ring-ring border-ring` treatment; rows use the base `rounded` (4px) surface radius (ui-spec-v02 §2.3).
+
+## 10.5 Accessibility
+
+- `SelectableList`'s root is a `<ul>`; each row is an `<li>`.
+- The select checkboxes carry selection state for assistive tech; the `row` snippet (or bespoke row) is responsible for the row's own accessible label/content. `SelectAllCheckbox` exposes a "Select all" / "N selected" label.
+
+## 10.6 Testing requirements
+
+- Per-row checkbox is **absent** when `selection.selectionMode` is `false` and **present** when `true`.
+- Toggling a checkbox updates the controller's selection (add and remove); `toggleAll` selects/clears the in-scope set.
+- Leaving selection mode clears the selection.
+- Selected rows reflect the selected styling; the `row` snippet receives the correct `selected` flag and a working `toggle`.
 
 ---
 

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -197,6 +197,9 @@ export { default as ListPage } from './templates/ListPage/ListPage.svelte';
 export { default as FormPage } from './templates/FormPage/FormPage.svelte';
 export { default as DetailPage } from './templates/DetailPage/DetailPage.svelte';
 export { default as SelectableList } from './templates/SelectableList/SelectableList.svelte';
+export { default as SelectAllCheckbox } from './templates/SelectableList/SelectAllCheckbox.svelte';
+export { default as RowSelectCheckbox } from './templates/SelectableList/RowSelectCheckbox.svelte';
+export { createListSelection } from './templates/SelectableList/listSelection.svelte.js';
 
 export type {
   ListPageProps,
@@ -211,3 +214,7 @@ export type {
   SelectableListProps,
   SelectableListItem,
 } from './templates/SelectableList/SelectableList.types';
+export type {
+  ListSelection,
+  CreateListSelectionOptions,
+} from './templates/SelectableList/listSelection.svelte.js';

--- a/packages/ui-components/src/templates/SelectableList/RowSelectCheckbox.svelte
+++ b/packages/ui-components/src/templates/SelectableList/RowSelectCheckbox.svelte
@@ -1,0 +1,24 @@
+<!-- spec: ui-spec-v04.md §10 v0.4 -->
+<!--
+  Shared per-row selection checkbox, wired to a `ListSelection` controller by id.
+  Pages with bespoke row layouts (shopping, aisle) render this inside their own
+  `{#if selectionMode}` gate instead of hand-rolling a `<Checkbox>` bound to a
+  local `selected` Set. Extra attributes (aria-label, labelledBy, data-testid…)
+  are forwarded to the underlying Checkbox.
+-->
+<script lang="ts">
+  import Checkbox from '../../primitives/Checkbox/Checkbox.svelte';
+  import type { ListSelection } from './listSelection.svelte.js';
+
+  let {
+    selection,
+    id,
+    ...rest
+  }: { selection: ListSelection; id: string } & Record<string, unknown> = $props();
+</script>
+
+<Checkbox
+  checked={selection.isSelected(id)}
+  onCheckedChange={() => selection.toggle(id)}
+  {...rest}
+/>

--- a/packages/ui-components/src/templates/SelectableList/SelectAllCheckbox.svelte
+++ b/packages/ui-components/src/templates/SelectableList/SelectAllCheckbox.svelte
@@ -1,0 +1,19 @@
+<!-- spec: ui-spec-v04.md §10 v0.4 -->
+<!--
+  Shared select-all control for a list's `selectionBar`. Reads everything it needs
+  from the `ListSelection` controller so no page hand-rolls the
+  allSelected/someSelected/toggleAll + count-label boilerplate.
+-->
+<script lang="ts">
+  import Checkbox from '../../primitives/Checkbox/Checkbox.svelte';
+  import type { ListSelection } from './listSelection.svelte.js';
+
+  let { selection, ...rest }: { selection: ListSelection } & Record<string, unknown> = $props();
+</script>
+
+<Checkbox
+  checked={selection.allSelected ? true : selection.someSelected ? 'indeterminate' : false}
+  onCheckedChange={() => selection.toggleAll()}
+  label={selection.count > 0 ? `${selection.count} selected` : 'Select all'}
+  {...rest}
+/>

--- a/packages/ui-components/src/templates/SelectableList/SelectableList.svelte
+++ b/packages/ui-components/src/templates/SelectableList/SelectableList.svelte
@@ -4,7 +4,13 @@
   import RowSelectCheckbox from './RowSelectCheckbox.svelte';
   import type { SelectableListItem, SelectableListProps } from './SelectableList.types';
 
-  let { items, selection, row, class: className }: SelectableListProps<T> = $props();
+  let {
+    items,
+    selection,
+    getRowCheckboxLabel = (item: T) => `Select ${item.id}`,
+    row,
+    class: className,
+  }: SelectableListProps<T> = $props();
 </script>
 
 <ul class={cn('flex flex-col gap-1', className)}>
@@ -17,7 +23,11 @@
       )}
     >
       {#if selection.selectionMode}
-        <RowSelectCheckbox {selection} id={item.id} />
+        <RowSelectCheckbox
+          {selection}
+          id={item.id}
+          aria-label={getRowCheckboxLabel(item)}
+        />
       {/if}
       <div class="flex-1 min-w-0">
         {@render row(item, { selected: isSelected, toggle: () => selection.toggle(item.id) })}

--- a/packages/ui-components/src/templates/SelectableList/SelectableList.svelte
+++ b/packages/ui-components/src/templates/SelectableList/SelectableList.svelte
@@ -1,39 +1,26 @@
 <!-- spec: ui-spec-v04.md §10 v0.4 -->
 <script lang="ts" generics="T extends SelectableListItem">
   import { cn } from '../../lib/cn';
-  import Checkbox from '../../primitives/Checkbox/Checkbox.svelte';
+  import RowSelectCheckbox from './RowSelectCheckbox.svelte';
   import type { SelectableListItem, SelectableListProps } from './SelectableList.types';
 
-  let {
-    items,
-    selected = $bindable(new Set<string>()),
-    selectionMode = false,
-    row,
-    class: className,
-  }: SelectableListProps<T> = $props();
-
-  function toggle(id: string) {
-    const next = new Set(selected);
-    if (next.has(id)) next.delete(id);
-    else next.add(id);
-    selected = next;
-  }
+  let { items, selection, row, class: className }: SelectableListProps<T> = $props();
 </script>
 
 <ul class={cn('flex flex-col gap-1', className)}>
   {#each items as item (item.id)}
-    {@const isSelected = selected.has(item.id)}
+    {@const isSelected = selection.isSelected(item.id)}
     <li
       class={cn(
         'flex items-center gap-3 px-3 py-2 rounded border border-border bg-card',
         isSelected && 'ring-2 ring-ring border-ring',
       )}
     >
-      {#if selectionMode}
-        <Checkbox checked={isSelected} onCheckedChange={() => toggle(item.id)} />
+      {#if selection.selectionMode}
+        <RowSelectCheckbox {selection} id={item.id} />
       {/if}
       <div class="flex-1 min-w-0">
-        {@render row(item, { selected: isSelected, toggle: () => toggle(item.id) })}
+        {@render row(item, { selected: isSelected, toggle: () => selection.toggle(item.id) })}
       </div>
     </li>
   {/each}

--- a/packages/ui-components/src/templates/SelectableList/SelectableList.svelte
+++ b/packages/ui-components/src/templates/SelectableList/SelectableList.svelte
@@ -23,11 +23,7 @@
       )}
     >
       {#if selection.selectionMode}
-        <RowSelectCheckbox
-          {selection}
-          id={item.id}
-          aria-label={getRowCheckboxLabel(item)}
-        />
+        <RowSelectCheckbox {selection} id={item.id} aria-label={getRowCheckboxLabel(item)} />
       {/if}
       <div class="flex-1 min-w-0">
         {@render row(item, { selected: isSelected, toggle: () => selection.toggle(item.id) })}

--- a/packages/ui-components/src/templates/SelectableList/SelectableList.types.ts
+++ b/packages/ui-components/src/templates/SelectableList/SelectableList.types.ts
@@ -8,6 +8,8 @@ export type SelectableListProps<T extends SelectableListItem = SelectableListIte
   items: T[];
   /** Shared selection controller (see `createListSelection`). */
   selection: ListSelection;
+  /** Accessible label for each row checkbox. Defaults to `Select ${item.id}`. */
+  getRowCheckboxLabel?: (item: T) => string;
   row: Snippet<[T, { selected: boolean; toggle: () => void }]>;
   class?: string;
 };

--- a/packages/ui-components/src/templates/SelectableList/SelectableList.types.ts
+++ b/packages/ui-components/src/templates/SelectableList/SelectableList.types.ts
@@ -1,12 +1,13 @@
 // spec: ui-spec-v04.md §10 v0.4
 import type { Snippet } from 'svelte';
+import type { ListSelection } from './listSelection.svelte.js';
 
 export type SelectableListItem = { id: string };
 
 export type SelectableListProps<T extends SelectableListItem = SelectableListItem> = {
   items: T[];
-  selected?: Set<string>;
-  selectionMode?: boolean;
+  /** Shared selection controller (see `createListSelection`). */
+  selection: ListSelection;
   row: Snippet<[T, { selected: boolean; toggle: () => void }]>;
   class?: string;
 };

--- a/packages/ui-components/src/templates/SelectableList/index.ts
+++ b/packages/ui-components/src/templates/SelectableList/index.ts
@@ -1,3 +1,7 @@
-// spec: SPEC.md §9.4 v0.2.3
+// spec: ui-spec-v04.md §10 v0.4
 export { default as SelectableList } from './SelectableList.svelte';
+export { default as SelectAllCheckbox } from './SelectAllCheckbox.svelte';
+export { default as RowSelectCheckbox } from './RowSelectCheckbox.svelte';
+export { createListSelection } from './listSelection.svelte.js';
+export type { ListSelection, CreateListSelectionOptions } from './listSelection.svelte.js';
 export type { SelectableListProps, SelectableListItem } from './SelectableList.types';

--- a/packages/ui-components/src/templates/SelectableList/listSelection.svelte.ts
+++ b/packages/ui-components/src/templates/SelectableList/listSelection.svelte.ts
@@ -1,0 +1,99 @@
+// spec: ui-spec-v04.md §10 v0.4
+//
+// The single source of truth for list multi-selection. Every list page used to
+// hand-roll the same `selected` Set plus `allSelected` / `someSelected` /
+// `selectedCount` deriveds and `toggle` / `toggleAll` helpers. This factory owns
+// that logic once so the four list pages (shopping, canon, aisle, equipment) and
+// the shared `SelectableList` / `SelectAllCheckbox` / `RowSelectCheckbox`
+// components all read from the same controller.
+//
+// Selection mode is *sourced from* the page (whose `selectionMode` is bound to
+// `ListPage`) rather than re-implemented here — exiting selection mode clears the
+// selection automatically, replacing the per-page `$effect`.
+
+export type ListSelection = {
+  /** Whether the host list is currently in selection mode. */
+  readonly selectionMode: boolean;
+  /** Live set of selected ids (reactive). */
+  readonly selected: Set<string>;
+  /** Selected ids still present in the current scope (`getAllIds`). */
+  readonly ids: string[];
+  /** Count of selected ids in scope. */
+  readonly count: number;
+  /** True when every in-scope id is selected. */
+  readonly allSelected: boolean;
+  /** True when some, but not all, in-scope ids are selected. */
+  readonly someSelected: boolean;
+  isSelected(id: string): boolean;
+  toggle(id: string): void;
+  /** Select all in-scope ids, or clear them when all are already selected. */
+  toggleAll(): void;
+  /** Add a subset to the selection (e.g. "select all pending"). */
+  add(ids: string[]): void;
+  /** Remove a subset from the selection (e.g. after a partial bulk action). */
+  remove(ids: string[]): void;
+  /** Clear the entire selection. */
+  clear(): void;
+};
+
+export type CreateListSelectionOptions = {
+  /** All currently-selectable ids in scope; drives all/some/count + toggleAll. */
+  getAllIds: () => string[];
+  /** Whether the host `ListPage` is in selection mode; selection clears on exit. */
+  isSelectionMode: () => boolean;
+};
+
+export function createListSelection(options: CreateListSelectionOptions): ListSelection {
+  let selected = $state(new Set<string>());
+
+  const allIds = $derived(options.getAllIds());
+  const inScope = $derived(allIds.filter((id) => selected.has(id)));
+  const allSelected = $derived(allIds.length > 0 && allIds.every((id) => selected.has(id)));
+  const someSelected = $derived(inScope.length > 0 && !allSelected);
+
+  // Exiting selection mode clears the selection (replaces the per-page $effect).
+  $effect(() => {
+    if (!options.isSelectionMode() && selected.size > 0) selected = new Set();
+  });
+
+  function mutate(fn: (next: Set<string>) => void): void {
+    const next = new Set(selected);
+    fn(next);
+    selected = next;
+  }
+
+  return {
+    get selectionMode() {
+      return options.isSelectionMode();
+    },
+    get selected() {
+      return selected;
+    },
+    get ids() {
+      return inScope;
+    },
+    get count() {
+      return inScope.length;
+    },
+    get allSelected() {
+      return allSelected;
+    },
+    get someSelected() {
+      return someSelected;
+    },
+    isSelected: (id) => selected.has(id),
+    toggle: (id) =>
+      mutate((next) => {
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+      }),
+    toggleAll() {
+      selected = allSelected ? new Set() : new Set(allIds);
+    },
+    add: (ids) => mutate((next) => ids.forEach((id) => next.add(id))),
+    remove: (ids) => mutate((next) => ids.forEach((id) => next.delete(id))),
+    clear() {
+      selected = new Set();
+    },
+  };
+}


### PR DESCRIPTION
Closes #106. Follow-on to #105 (selection mode in `ListPage`) and #115 (contextual action bar).

## What & why

All four list pages (shopping, canon, aisle, equipment) hand-rolled the same multi-select boilerplate: a `selected` Set, the auto-clear `$effect`, the `allSelected`/`someSelected`/`count` deriveds, `toggle`/`toggleAll`, and their own select-all + per-row checkboxes. This collapses that duplication onto **one shared selection controller** in `@salt/ui-components`, so the selection logic lives in exactly one place.

Per the architecture discussion on the issue, the four lists are too structurally divergent (flat / grouped+sectioned / collapsible / drag-drop sortable) to force through a single literal `SelectableList` container without turning it into a multi-mode god-component. Instead the **logic** is unified in a controller and each page keeps its own structure, composing shared checkboxes.

## Changes

**New in `@salt/ui-components` (`templates/SelectableList/`)**
- `createListSelection()` — the selection "brain": owns the `selected` Set, derives `all`/`some`/`count` from a `getAllIds` scope, sources mode via `isSelectionMode`, and auto-clears the selection when selection mode exits (replaces each page's `$effect`).
- `SelectAllCheckbox` — header tri-state "Select all / N selected" control.
- `RowSelectCheckbox` — per-row checkbox wired to the controller by `id`, for bespoke row layouts.
- `SelectableList` refactored to consume the controller (`selection` prop) instead of `bind:selected` + a `selectionMode` prop.

**Pages migrated** (no bulk-action behaviour change)
- **Equipment** → `SelectableList` + `SelectAllCheckbox`.
- **Canon** → controller drives `EditableRow`'s checkbox; `selectPending`/approve kept via `selection.add`/`.remove`.
- **Aisle** → `RowSelectCheckbox` in the `SortableList` row (testid + `labelledBy` preserved); merge/delete dialogs unchanged.
- **Shopping** → `RowSelectCheckbox` in all three sections; check/uncheck/move/delete identical.

**Docs** — rewrote ui-spec-v04 §10 for the controller + three-component model.

## Design note

Selection mode flows **through the controller** (`isSelectionMode` → `selection.selectionMode`) rather than `SelectableList` reading `LIST_PAGE_CONTEXT` directly as the issue text literally suggested. Same origin (the page's `selectionMode`, bound to `ListPage`), but it keeps `SelectableList` decoupled from `ListPage`.

## Verification

- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm boundary:test` ✓ (17/17) · dependency-cruiser ✓
- ui-components svelte-check ✓ (0 errors) · provenance ✓
- web-pwa tests **116/116** ✓ · ui-components tests **544/544** ✓
- e2e (shopping bulk-delete, aisles) not run here — run interactively; every `data-testid` / `aria-label` / `labelledBy` they rely on was preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)