### PR TITLE
feat(meal-plan): weekly evening-meal planner with a standard template (#169)

### DIFF
--- a/apps/web-pwa/src/App.svelte
+++ b/apps/web-pwa/src/App.svelte
@@ -19,6 +19,7 @@
   import { initEquipmentSync } from './lib/equipmentService.js';
   import { initShoppingListSync } from './lib/shoppingListService.svelte.js';
   import { members, initMembersSync } from './lib/membersService.js';
+  import { initMealPlanSync } from './lib/mealPlanService.js';
   import { normaliseMemberEmail } from '@salt/domain';
   import SessionOverlay from './lib/dev/SessionOverlay.svelte';
 
@@ -29,11 +30,13 @@
     const unsubEquipment = initEquipmentSync();
     const unsubShopping = initShoppingListSync();
     const unsubMembers = initMembersSync();
+    const unsubMealPlan = initMealPlanSync();
     return () => {
       unsubCanon();
       unsubEquipment();
       unsubShopping();
       unsubMembers();
+      unsubMealPlan();
     };
   });
 

--- a/apps/web-pwa/src/lib/mealPlanService.ts
+++ b/apps/web-pwa/src/lib/mealPlanService.ts
@@ -13,6 +13,7 @@ import {
   instantiateWeek,
   setDayNote,
   setDayChefs,
+  setDayGuests,
   addAttendee,
   removeAttendee,
   setAttendeeHomeTime,
@@ -199,6 +200,9 @@ export function setWeekDayNote(dateKey: string, note: string) {
 export function setWeekDayChefs(dateKey: string, chefs: readonly string[]) {
   return persistWeek(setDayChefs(currentWeekObject(), dateKey, chefs));
 }
+export function setWeekDayGuests(dateKey: string, guests: number) {
+  return persistWeek(setDayGuests(currentWeekObject(), dateKey, guests));
+}
 export function addWeekAttendee(dateKey: string, attendee: Attendee) {
   return persistWeek(addAttendee(currentWeekObject(), dateKey, attendee));
 }
@@ -227,6 +231,9 @@ export function setTemplateDayNote(weekday: Weekday, note: string) {
 }
 export function setTemplateDayChefs(weekday: Weekday, chefs: readonly string[]) {
   return persistTemplate(setDayChefs(currentTemplateObject(), weekday, chefs));
+}
+export function setTemplateDayGuests(weekday: Weekday, guests: number) {
+  return persistTemplate(setDayGuests(currentTemplateObject(), weekday, guests));
 }
 export function addTemplateAttendee(weekday: Weekday, attendee: Attendee) {
   return persistTemplate(addAttendee(currentTemplateObject(), weekday, attendee));

--- a/apps/web-pwa/src/lib/mealPlanService.ts
+++ b/apps/web-pwa/src/lib/mealPlanService.ts
@@ -1,0 +1,285 @@
+import {
+  subscribeMealPlanConfig,
+  subscribeMealPlanTemplate,
+  subscribeMealPlanWeek,
+  saveMealPlanConfig,
+  saveMealPlanTemplate,
+  saveMealPlanWeek,
+} from '@salt/firebase-sync';
+import {
+  weekStartFor,
+  emptyWeek,
+  emptyTemplate,
+  instantiateWeek,
+  setDayNote,
+  setDayChefs,
+  addAttendee,
+  removeAttendee,
+  setAttendeeHomeTime,
+  setAttendeeNote,
+  type Attendee,
+  type MealPlanConfig,
+  type MealPlanTemplate,
+  type MealPlanWeek,
+  type Weekday,
+} from '@salt/domain';
+import type { DomainError, ReadResult } from '@salt/shared-types';
+import { writable, derived, get } from 'svelte/store';
+import type { Readable } from 'svelte/store';
+
+// Meal planning service (issue #169). Subscribes to the two singletons (config +
+// template) once and to the currently-selected week, re-subscribing as the user
+// navigates. Domain commands compute new documents; the adapter persists them.
+// See docs/meal-planning.md.
+
+const DEFAULT_FIRST_DAY: Weekday = 'mon';
+
+// ─── Local date helpers (date-only YYYY-MM-DD, UTC arithmetic) ────────────────
+
+function todayIso(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+    d.getDate(),
+  ).padStart(2, '0')}`;
+}
+
+function addDays(date: string, n: number): string {
+  const d = new Date(`${date}T00:00:00.000Z`);
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+// ─── Reactive stores ──────────────────────────────────────────────────────────
+
+const _config = writable<MealPlanConfig | null>(null);
+const _template = writable<MealPlanTemplate | null>(null);
+const _week = writable<MealPlanWeek | null>(null);
+// The anchor date the user is viewing; the displayed week is the one containing
+// it under the current firstDayOfWeek.
+const _anchorDate = writable<string>(todayIso());
+// Start date of the week currently subscribed/displayed.
+const _subscribedStart = writable<string>('');
+
+const _isLoadingConfig = writable(true);
+const _isLoadingTemplate = writable(true);
+const _isLoadingWeek = writable(true);
+
+export const mealPlanConfig: Readable<MealPlanConfig | null> = _config;
+export const mealPlanTemplate: Readable<MealPlanTemplate | null> = _template;
+export const selectedStartDate: Readable<string> = _subscribedStart;
+export const isLoadingMealPlanConfig: Readable<boolean> = _isLoadingConfig;
+export const isLoadingMealPlanTemplate: Readable<boolean> = _isLoadingTemplate;
+export const isLoadingMealPlanWeek: Readable<boolean> = _isLoadingWeek;
+
+// firstDayOfWeek with a 'mon' fallback until the config doc loads.
+export const firstDayOfWeek: Readable<Weekday> = derived(
+  _config,
+  ($c) => $c?.firstDayOfWeek ?? DEFAULT_FIRST_DAY,
+);
+
+// The displayed week — falls back to an unsaved empty week (only persisted on
+// first edit / load-template) so the editor always has seven days to render.
+export const currentWeek: Readable<MealPlanWeek> = derived(
+  [_week, _subscribedStart],
+  ([$w, $start]) => $w ?? emptyWeek($start || todayIso()),
+);
+
+// ─── Subscriptions / navigation ───────────────────────────────────────────────
+
+let configUnsub: (() => void) | null = null;
+let templateUnsub: (() => void) | null = null;
+let weekUnsub: (() => void) | null = null;
+
+function firstDay(): Weekday {
+  return get(_config)?.firstDayOfWeek ?? DEFAULT_FIRST_DAY;
+}
+
+// (Re)subscribe to the week containing the anchor date under the current
+// firstDayOfWeek. No-op when the start date is unchanged.
+function syncWeekSubscription(): void {
+  const start = weekStartFor(get(_anchorDate), firstDay());
+  if (start === get(_subscribedStart) && weekUnsub) return;
+  weekUnsub?.();
+  _subscribedStart.set(start);
+  _week.set(null);
+  _isLoadingWeek.set(true);
+  weekUnsub = subscribeMealPlanWeek(
+    start,
+    (w) => {
+      _week.set(w);
+      _isLoadingWeek.set(false);
+    },
+    () => _isLoadingWeek.set(false),
+  );
+}
+
+export function initMealPlanSync(): () => void {
+  _isLoadingConfig.set(true);
+  _isLoadingTemplate.set(true);
+  configUnsub = subscribeMealPlanConfig(
+    (c) => {
+      _config.set(c);
+      _isLoadingConfig.set(false);
+      // firstDayOfWeek may have changed which date this week starts on.
+      syncWeekSubscription();
+    },
+    () => _isLoadingConfig.set(false),
+  );
+  templateUnsub = subscribeMealPlanTemplate(
+    (t) => {
+      _template.set(t);
+      _isLoadingTemplate.set(false);
+    },
+    () => _isLoadingTemplate.set(false),
+  );
+  syncWeekSubscription();
+  return () => {
+    configUnsub?.();
+    templateUnsub?.();
+    weekUnsub?.();
+    configUnsub = templateUnsub = weekUnsub = null;
+  };
+}
+
+export function goToWeek(date: string): void {
+  _anchorDate.set(date);
+  syncWeekSubscription();
+}
+
+export function thisWeek(): void {
+  goToWeek(todayIso());
+}
+
+export function nextWeek(): void {
+  goToWeek(addDays(get(_subscribedStart) || todayIso(), 7));
+}
+
+export function prevWeek(): void {
+  goToWeek(addDays(get(_subscribedStart) || todayIso(), -7));
+}
+
+// ─── Mutations ────────────────────────────────────────────────────────────────
+
+function currentWeekObject(): MealPlanWeek {
+  return get(_week) ?? emptyWeek(get(_subscribedStart) || todayIso());
+}
+
+function currentTemplateObject(): MealPlanTemplate {
+  return get(_template) ?? emptyTemplate();
+}
+
+// Stamp updatedAt, update the store optimistically, then persist.
+async function persistWeek(week: MealPlanWeek): Promise<ReadResult<void, DomainError>> {
+  const stamped: MealPlanWeek = { ...week, updatedAt: new Date().toISOString() };
+  _week.set(stamped);
+  return saveMealPlanWeek(stamped);
+}
+
+async function persistTemplate(template: MealPlanTemplate): Promise<ReadResult<void, DomainError>> {
+  _template.set(template);
+  return saveMealPlanTemplate(template);
+}
+
+// Load the standard template into the current week (overwrites it back to the
+// standard, ready for exception-tweaking).
+export function loadTemplateIntoCurrentWeek(): Promise<ReadResult<void, DomainError>> {
+  const start = get(_subscribedStart) || todayIso();
+  const week = instantiateWeek(
+    start,
+    get(_config) ?? { firstDayOfWeek: firstDay(), schemaVersion: 1 },
+    currentTemplateObject(),
+  );
+  return persistWeek(week);
+}
+
+// — Week day/attendee mutators —
+export function setWeekDayNote(dateKey: string, note: string) {
+  return persistWeek(setDayNote(currentWeekObject(), dateKey, note));
+}
+export function setWeekDayChefs(dateKey: string, chefs: readonly string[]) {
+  return persistWeek(setDayChefs(currentWeekObject(), dateKey, chefs));
+}
+export function addWeekAttendee(dateKey: string, attendee: Attendee) {
+  return persistWeek(addAttendee(currentWeekObject(), dateKey, attendee));
+}
+export function removeWeekAttendee(dateKey: string, memberId: string) {
+  return persistWeek(removeAttendee(currentWeekObject(), dateKey, memberId));
+}
+export function setWeekAttendeeHomeTime(
+  dateKey: string,
+  memberId: string,
+  homeTime: string | null,
+) {
+  return persistWeek(setAttendeeHomeTime(currentWeekObject(), dateKey, memberId, homeTime));
+}
+export function setWeekAttendeeNote(dateKey: string, memberId: string, note: string) {
+  return persistWeek(setAttendeeNote(currentWeekObject(), dateKey, memberId, note));
+}
+
+// — Config —
+export function saveFirstDayOfWeek(day: Weekday): Promise<ReadResult<void, DomainError>> {
+  return saveMealPlanConfig({ firstDayOfWeek: day, schemaVersion: 1 });
+}
+
+// — Template day/attendee mutators (keyed by weekday) —
+export function setTemplateDayNote(weekday: Weekday, note: string) {
+  return persistTemplate(setDayNote(currentTemplateObject(), weekday, note));
+}
+export function setTemplateDayChefs(weekday: Weekday, chefs: readonly string[]) {
+  return persistTemplate(setDayChefs(currentTemplateObject(), weekday, chefs));
+}
+export function addTemplateAttendee(weekday: Weekday, attendee: Attendee) {
+  return persistTemplate(addAttendee(currentTemplateObject(), weekday, attendee));
+}
+export function removeTemplateAttendee(weekday: Weekday, memberId: string) {
+  return persistTemplate(removeAttendee(currentTemplateObject(), weekday, memberId));
+}
+export function setTemplateAttendeeHomeTime(
+  weekday: Weekday,
+  memberId: string,
+  homeTime: string | null,
+) {
+  return persistTemplate(setAttendeeHomeTime(currentTemplateObject(), weekday, memberId, homeTime));
+}
+export function setTemplateAttendeeNote(weekday: Weekday, memberId: string, note: string) {
+  return persistTemplate(setAttendeeNote(currentTemplateObject(), weekday, memberId, note));
+}
+
+// ─── Test / e2e helpers ───────────────────────────────────────────────────────
+
+export function __resetMealPlanServiceForTest(): void {
+  configUnsub?.();
+  templateUnsub?.();
+  weekUnsub?.();
+  configUnsub = templateUnsub = weekUnsub = null;
+  _config.set(null);
+  _template.set(null);
+  _week.set(null);
+  _anchorDate.set(todayIso());
+  _subscribedStart.set('');
+  _isLoadingConfig.set(true);
+  _isLoadingTemplate.set(true);
+  _isLoadingWeek.set(true);
+}
+
+export function seedMealPlanConfig(config: MealPlanConfig | null): void {
+  _config.set(config);
+  _isLoadingConfig.set(false);
+}
+
+export function seedMealPlanTemplate(template: MealPlanTemplate | null): void {
+  _template.set(template);
+  _isLoadingTemplate.set(false);
+}
+
+// Seed a concrete week as the displayed one (used by tests / e2e).
+export function seedMealPlanWeek(week: MealPlanWeek): void {
+  _anchorDate.set(week.startDate);
+  _subscribedStart.set(week.startDate);
+  _week.set(week);
+  _isLoadingWeek.set(false);
+}
+
+export function getMealPlanWeekSnapshot(): MealPlanWeek {
+  return currentWeekObject();
+}

--- a/apps/web-pwa/src/lib/mealPlanService.ts
+++ b/apps/web-pwa/src/lib/mealPlanService.ts
@@ -90,6 +90,10 @@ export const currentWeek: Readable<MealPlanWeek> = derived(
 let configUnsub: (() => void) | null = null;
 let templateUnsub: (() => void) | null = null;
 let weekUnsub: (() => void) | null = null;
+// Newest week `updatedAt` we've applied (from a local optimistic write or an
+// accepted snapshot). Guards against an in-flight stale snapshot echo landing
+// after a newer local edit and reverting it (e.g. select-then-deselect chef).
+let latestWeekUpdatedAt = '';
 
 function firstDay(): Weekday {
   return get(_config)?.firstDayOfWeek ?? DEFAULT_FIRST_DAY;
@@ -103,10 +107,17 @@ function syncWeekSubscription(): void {
   weekUnsub?.();
   _subscribedStart.set(start);
   _week.set(null);
+  latestWeekUpdatedAt = '';
   _isLoadingWeek.set(true);
   weekUnsub = subscribeMealPlanWeek(
     start,
     (w) => {
+      // Drop a stale snapshot that predates a newer local edit of this week.
+      if (w && w.updatedAt < latestWeekUpdatedAt) {
+        _isLoadingWeek.set(false);
+        return;
+      }
+      if (w) latestWeekUpdatedAt = w.updatedAt;
       _week.set(w);
       _isLoadingWeek.set(false);
     },
@@ -172,6 +183,7 @@ function currentTemplateObject(): MealPlanTemplate {
 // Stamp updatedAt, update the store optimistically, then persist.
 async function persistWeek(week: MealPlanWeek): Promise<ReadResult<void, DomainError>> {
   const stamped: MealPlanWeek = { ...week, updatedAt: new Date().toISOString() };
+  latestWeekUpdatedAt = stamped.updatedAt;
   _week.set(stamped);
   return saveMealPlanWeek(stamped);
 }
@@ -259,6 +271,7 @@ export function __resetMealPlanServiceForTest(): void {
   templateUnsub?.();
   weekUnsub?.();
   configUnsub = templateUnsub = weekUnsub = null;
+  latestWeekUpdatedAt = '';
   _config.set(null);
   _template.set(null);
   _week.set(null);
@@ -283,6 +296,7 @@ export function seedMealPlanTemplate(template: MealPlanTemplate | null): void {
 export function seedMealPlanWeek(week: MealPlanWeek): void {
   _anchorDate.set(week.startDate);
   _subscribedStart.set(week.startDate);
+  latestWeekUpdatedAt = week.updatedAt;
   _week.set(week);
   _isLoadingWeek.set(false);
 }

--- a/apps/web-pwa/src/lib/nav.ts
+++ b/apps/web-pwa/src/lib/nav.ts
@@ -1,9 +1,10 @@
-import { Blender, Home, Settings, Shield, ShoppingCart } from '@lucide/svelte';
+import { Blender, CalendarDays, Home, Settings, Shield, ShoppingCart } from '@lucide/svelte';
 import type { NavItem } from '@salt/ui-components';
 
 export const navItems: NavItem[] = [
   { id: 'home', label: 'Home', icon: Home, href: '#/' },
   { id: 'shopping', label: 'Shop', icon: ShoppingCart, href: '#/shopping' },
+  { id: 'mealplan', label: 'Meals', icon: CalendarDays, href: '#/mealplan' },
   { id: 'equipment', label: 'Kitchen', icon: Blender, href: '#/equipment' },
   { id: 'settings', label: 'Settings', icon: Settings, href: '#/settings' },
 ];

--- a/apps/web-pwa/src/routes/admin/AdminHomePage.svelte
+++ b/apps/web-pwa/src/routes/admin/AdminHomePage.svelte
@@ -19,6 +19,12 @@
       description: 'Review and curate the shared item catalog and aisles.',
       href: '/admin/canon',
     },
+    {
+      id: 'mealplan',
+      title: 'Meal plan',
+      description: 'Edit the standard weekly template and the big-shop day.',
+      href: '/admin/mealplan',
+    },
   ];
 </script>
 

--- a/apps/web-pwa/src/routes/admin/AdminMealPlanPage.svelte
+++ b/apps/web-pwa/src/routes/admin/AdminMealPlanPage.svelte
@@ -51,8 +51,8 @@
     if (attending) {
       void removeTemplateAttendee(weekday, memberId);
     } else {
-      // Default to the usual dinner time; clearable to blank afterwards.
-      const attendee: Attendee = { memberId, homeTime: '18:30', note: '' };
+      // Home time starts blank; the picker seeds 18:30 when first opened.
+      const attendee: Attendee = { memberId, homeTime: null, note: '' };
       void addTemplateAttendee(weekday, attendee);
     }
   }

--- a/apps/web-pwa/src/routes/admin/AdminMealPlanPage.svelte
+++ b/apps/web-pwa/src/routes/admin/AdminMealPlanPage.svelte
@@ -51,7 +51,8 @@
     if (attending) {
       void removeTemplateAttendee(weekday, memberId);
     } else {
-      const attendee: Attendee = { memberId, homeTime: null, note: '' };
+      // Default to the usual dinner time; clearable to blank afterwards.
+      const attendee: Attendee = { memberId, homeTime: '18:30', note: '' };
       void addTemplateAttendee(weekday, attendee);
     }
   }

--- a/apps/web-pwa/src/routes/admin/AdminMealPlanPage.svelte
+++ b/apps/web-pwa/src/routes/admin/AdminMealPlanPage.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import { Button, Select, SelectContent, SelectItem, SelectTrigger } from '@salt/ui-components';
+  import { push } from 'svelte-spa-router';
+  import { WEEKDAYS, emptyTemplate, type Attendee, type Weekday } from '@salt/domain';
+  import AdminGuard from './AdminGuard.svelte';
+  import MealDayEditor from '../mealplan/MealDayEditor.svelte';
+  import { members } from '../../lib/membersService.js';
+  import {
+    mealPlanTemplate,
+    firstDayOfWeek,
+    saveFirstDayOfWeek,
+    setTemplateDayNote,
+    setTemplateDayChefs,
+    addTemplateAttendee,
+    removeTemplateAttendee,
+    setTemplateAttendeeHomeTime,
+    setTemplateAttendeeNote,
+  } from '../../lib/mealPlanService.js';
+  import { addToast } from '../../lib/toastStore.js';
+
+  // The displayed template — falls back to an empty one until the doc loads (and
+  // for a greenfield project with no template yet).
+  const template = $derived($mealPlanTemplate ?? emptyTemplate());
+
+  const WEEKDAY_LABELS: Record<Weekday, string> = {
+    mon: 'Monday',
+    tue: 'Tuesday',
+    wed: 'Wednesday',
+    thu: 'Thursday',
+    fri: 'Friday',
+    sat: 'Saturday',
+    sun: 'Sunday',
+  };
+
+  async function onFirstDayChange(value: string): Promise<void> {
+    const result = await saveFirstDayOfWeek(value as Weekday);
+    if (result.kind !== 'ok') addToast('Failed to save the first day of the week.', 'error');
+  }
+
+  function toggleChef(weekday: Weekday, memberId: string): void {
+    const chefs = template.days[weekday]?.chefs ?? [];
+    const next = chefs.includes(memberId)
+      ? chefs.filter((c) => c !== memberId)
+      : [...chefs, memberId];
+    void setTemplateDayChefs(weekday, next);
+  }
+
+  function toggleAttendee(weekday: Weekday, memberId: string): void {
+    const attending = template.days[weekday]?.attendees.some((a) => a.memberId === memberId);
+    if (attending) {
+      void removeTemplateAttendee(weekday, memberId);
+    } else {
+      const attendee: Attendee = { memberId, homeTime: null, note: '' };
+      void addTemplateAttendee(weekday, attendee);
+    }
+  }
+</script>
+
+<AdminGuard>
+  <div class="flex flex-col gap-4 p-4 sm:p-6" data-testid="admin-mealplan">
+    <div class="flex items-start justify-between gap-3">
+      <div>
+        <h1 class="text-xl font-semibold">Meal plan settings</h1>
+        <p class="text-sm text-muted-foreground">
+          The standard week and the big-shop day. Loading the template into a week copies these days
+          in.
+        </p>
+      </div>
+      <Button size="sm" onclick={() => push('/admin')}>Back to admin</Button>
+    </div>
+
+    <!-- First day of the week (the big-shop day) -->
+    <div class="flex flex-col gap-1.5" data-testid="first-day-setting">
+      <span class="text-sm font-medium">First day of the week</span>
+      <p class="text-xs text-muted-foreground">
+        The "big shop" day each week starts on. Changing it only re-lays-out the week — it never
+        reshapes the template.
+      </p>
+      <Select value={$firstDayOfWeek} onValueChange={(v) => v && void onFirstDayChange(v)}>
+        <SelectTrigger class="w-48" data-testid="first-day-trigger">
+          {WEEKDAY_LABELS[$firstDayOfWeek]}
+        </SelectTrigger>
+        <SelectContent>
+          {#each WEEKDAYS as wd (wd)}
+            <SelectItem value={wd}>{WEEKDAY_LABELS[wd]}</SelectItem>
+          {/each}
+        </SelectContent>
+      </Select>
+    </div>
+
+    <!-- Standard template — seven weekday days -->
+    <div class="mt-2 flex flex-col gap-3">
+      {#each WEEKDAYS as wd (wd)}
+        {@const day = template.days[wd]}
+        {#if day}
+          <MealDayEditor
+            label={WEEKDAY_LABELS[wd]}
+            {day}
+            members={$members}
+            testid={`tmpl-${wd}`}
+            onNoteChange={(note) => void setTemplateDayNote(wd, note)}
+            onChefToggle={(id) => toggleChef(wd, id)}
+            onAttendeeToggle={(id) => toggleAttendee(wd, id)}
+            onAttendeeHomeTime={(id, t) => void setTemplateAttendeeHomeTime(wd, id, t)}
+            onAttendeeNote={(id, n) => void setTemplateAttendeeNote(wd, id, n)}
+          />
+        {/if}
+      {/each}
+    </div>
+  </div>
+</AdminGuard>

--- a/apps/web-pwa/src/routes/admin/AdminMealPlanPage.svelte
+++ b/apps/web-pwa/src/routes/admin/AdminMealPlanPage.svelte
@@ -11,6 +11,7 @@
     saveFirstDayOfWeek,
     setTemplateDayNote,
     setTemplateDayChefs,
+    setTemplateDayGuests,
     addTemplateAttendee,
     removeTemplateAttendee,
     setTemplateAttendeeHomeTime,
@@ -103,6 +104,7 @@
             onAttendeeToggle={(id) => toggleAttendee(wd, id)}
             onAttendeeHomeTime={(id, t) => void setTemplateAttendeeHomeTime(wd, id, t)}
             onAttendeeNote={(id, n) => void setTemplateAttendeeNote(wd, id, n)}
+            onGuestsChange={(g) => void setTemplateDayGuests(wd, g)}
           />
         {/if}
       {/each}

--- a/apps/web-pwa/src/routes/index.ts
+++ b/apps/web-pwa/src/routes/index.ts
@@ -11,9 +11,11 @@ import ShoppingListRedirectPage from './shopping/ShoppingListRedirectPage.svelte
 import ShoppingListCreatePage from './shopping/ShoppingListCreatePage.svelte';
 import ShoppingListsManagePage from './shopping/ShoppingListsManagePage.svelte';
 import ShoppingListPage from './shopping/ShoppingListPage.svelte';
+import MealPlanWeekPage from './mealplan/MealPlanWeekPage.svelte';
 import SettingsPage from './settings/SettingsPage.svelte';
 import AdminHomePage from './admin/AdminHomePage.svelte';
 import AdminMembersPage from './admin/AdminMembersPage.svelte';
+import AdminMealPlanPage from './admin/AdminMealPlanPage.svelte';
 import NotFound from './NotFound.svelte';
 
 // More-specific static routes must precede parameterised ones when using a Map.
@@ -26,6 +28,7 @@ export const routes: RouteDefinition = new Map([
   ['/shopping/new', ShoppingListCreatePage],
   ['/shopping/lists', ShoppingListsManagePage],
   ['/shopping/:listId', ShoppingListPage],
+  ['/mealplan', MealPlanWeekPage],
   ['/settings', SettingsPage],
   // Operator area (issues #155, #157). All routes are guarded client-side by
   // AdminGuard; the real boundary is server-side (rules + CF admin checks).
@@ -33,6 +36,7 @@ export const routes: RouteDefinition = new Map([
   // canon records is an operator activity — see #157.
   ['/admin', AdminHomePage],
   ['/admin/members', AdminMembersPage],
+  ['/admin/mealplan', AdminMealPlanPage],
   ['/admin/canon', CanonListPage],
   ['/admin/canon/aisles', AisleManagementPage],
   ['/admin/canon/new', CanonCreatePage],

--- a/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
+++ b/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+  import { TextField, Checkbox, Button } from '@salt/ui-components';
+  import { memberInitials, type Day, type Member } from '@salt/domain';
+
+  // Presentational editor for a single Day, shared by the weekly page (date-keyed)
+  // and the template editor (weekday-keyed). It knows nothing about day keys: the
+  // parent supplies handlers already bound to the correct date/weekday. Members
+  // are resolved live; a memberId with no matching member renders as unknown +
+  // removable. See docs/meal-planning.md.
+  interface Props {
+    label: string;
+    sublabel?: string;
+    day: Day;
+    members: Member[];
+    testid: string;
+    onNoteChange: (note: string) => void;
+    onChefToggle: (memberId: string) => void;
+    onAttendeeToggle: (memberId: string) => void;
+    onAttendeeHomeTime: (memberId: string, homeTime: string | null) => void;
+    onAttendeeNote: (memberId: string, note: string) => void;
+  }
+  let {
+    label,
+    sublabel,
+    day,
+    members,
+    testid,
+    onNoteChange,
+    onChefToggle,
+    onAttendeeToggle,
+    onAttendeeHomeTime,
+    onAttendeeNote,
+  }: Props = $props();
+
+  const memberName = (id: string): string | null => members.find((m) => m.id === id)?.name ?? null;
+  const isAttending = (id: string): boolean => day.attendees.some((a) => a.memberId === id);
+  const isChef = (id: string): boolean => day.chefs.includes(id);
+
+  // Attendees referencing someone no longer in the members roster — rendered so
+  // the document is never silently corrupted; removable, never blocking.
+  const unknownAttendees = $derived(
+    day.attendees.filter((a) => !members.some((m) => m.id === a.memberId)),
+  );
+</script>
+
+<div class="flex flex-col gap-3 rounded-lg border p-4" data-testid={testid} data-day={testid}>
+  <div class="flex items-baseline justify-between gap-2">
+    <h3 class="text-sm font-semibold text-foreground">{label}</h3>
+    {#if sublabel}
+      <span class="text-xs text-muted-foreground">{sublabel}</span>
+    {/if}
+  </div>
+
+  <TextField
+    label="Meal"
+    placeholder="What's for dinner?"
+    value={day.note}
+    onValueChange={(v) => onNoteChange(v)}
+    data-testid={`${testid}-note`}
+  />
+
+  <!-- Chefs: zero or more; a chef need not be an attendee. -->
+  <fieldset class="flex flex-col gap-1.5">
+    <legend class="text-xs font-medium text-muted-foreground">Chefs</legend>
+    <div class="flex flex-wrap gap-x-4 gap-y-1.5">
+      {#each members as m (m.id)}
+        <Checkbox
+          checked={isChef(m.id)}
+          label={m.name}
+          onCheckedChange={() => onChefToggle(m.id)}
+          data-testid={`${testid}-chef-${m.id}`}
+        />
+      {/each}
+    </div>
+  </fieldset>
+
+  <!-- Attendees: tick to attend, then set an optional home time + per-person note. -->
+  <fieldset class="flex flex-col gap-2">
+    <legend class="text-xs font-medium text-muted-foreground">Attendees</legend>
+    {#each members as m (m.id)}
+      <div class="flex flex-col gap-1.5" data-testid={`${testid}-attendee-${m.id}`}>
+        <Checkbox
+          checked={isAttending(m.id)}
+          label={m.name}
+          onCheckedChange={() => onAttendeeToggle(m.id)}
+          data-testid={`${testid}-attend-${m.id}`}
+        />
+        {#if isAttending(m.id)}
+          {@const a = day.attendees.find((x) => x.memberId === m.id)}
+          <div class="ml-6 flex flex-col gap-1.5 sm:flex-row sm:items-end">
+            <TextField
+              label="Home time"
+              type="time"
+              value={a?.homeTime ?? ''}
+              onValueChange={(v) => onAttendeeHomeTime(m.id, v === '' ? null : v)}
+              data-testid={`${testid}-time-${m.id}`}
+            />
+            <TextField
+              label="Note"
+              placeholder="e.g. make a portion for tomorrow"
+              value={a?.note ?? ''}
+              onValueChange={(v) => onAttendeeNote(m.id, v)}
+              class="flex-1"
+              data-testid={`${testid}-attnote-${m.id}`}
+            />
+          </div>
+        {/if}
+      </div>
+    {/each}
+
+    {#each unknownAttendees as a (a.memberId)}
+      <div
+        class="flex items-center justify-between gap-2 rounded border border-dashed px-2 py-1.5"
+        data-testid={`${testid}-unknown-${a.memberId}`}
+      >
+        <span class="flex items-center gap-2 text-sm text-muted-foreground">
+          <span
+            class="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-[10px] font-semibold"
+            aria-hidden="true">{memberInitials(memberName(a.memberId) ?? '?')}</span
+          >
+          Unknown member ({a.memberId})
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onclick={() => onAttendeeToggle(a.memberId)}
+          data-testid={`${testid}-unknown-remove-${a.memberId}`}
+        >
+          Remove
+        </Button>
+      </div>
+    {/each}
+  </fieldset>
+</div>

--- a/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
+++ b/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
@@ -203,19 +203,21 @@
                   data-testid={`${testid}-time-${m.id}`}
                 />
               {/if}
-              <!-- Chef is independent of attending: a chef need not eat. -->
-              <Button
-                variant="outline"
-                size="sm"
-                class={isChef(m.id)
-                  ? 'border-amber-500 bg-amber-500 text-white hover:bg-amber-600 hover:text-white'
-                  : ''}
+              <!-- Chef is independent of attending: a chef need not eat. Plain
+                   button (not the salt Button) so both states are fully Tailwind:
+                   selected = filled amber, unselected = clear neutral. -->
+              <button
+                type="button"
+                class="inline-flex h-8 items-center gap-1 rounded-md border px-2.5 text-sm font-medium transition-colors
+                  {isChef(m.id)
+                  ? 'border-amber-500 bg-amber-500 text-white hover:bg-amber-600'
+                  : 'border-input bg-background text-muted-foreground hover:bg-muted'}"
                 onclick={() => onChefToggle(m.id)}
                 aria-pressed={isChef(m.id)}
                 data-testid={`${testid}-chef-${m.id}`}
               >
-                <ChefHat class="mr-1 h-3.5 w-3.5" /> Chef
-              </Button>
+                <ChefHat class="h-3.5 w-3.5" strokeWidth={2.5} /> Chef
+              </button>
             </div>
             {#if isAttending(m.id)}
               <input

--- a/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
+++ b/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TextField, Checkbox, Button } from '@salt/ui-components';
+  import { Checkbox, Button } from '@salt/ui-components';
   import { ChevronDown, ChevronRight, ChefHat, StickyNote } from '@lucide/svelte';
   import { memberInitials, type Day, type Member } from '@salt/domain';
 
@@ -77,6 +77,17 @@
   );
   const attendingCount = $derived(day.attendees.length + day.guests);
   const hasNotes = $derived(day.attendees.some((a) => a.note.trim() !== ''));
+
+  // Auto-grow the multiline meal field to fit its content. Re-runs whenever the
+  // note changes (typing, or load-template swapping the value in).
+  let noteEl: HTMLTextAreaElement | undefined = $state();
+  $effect(() => {
+    const _note = day.note; // track
+    if (noteEl) {
+      noteEl.style.height = 'auto';
+      noteEl.style.height = `${noteEl.scrollHeight}px`;
+    }
+  });
 </script>
 
 <div class="overflow-hidden rounded-lg border" data-testid={testid}>
@@ -159,13 +170,19 @@
 
   {#if open}
     <div class="flex flex-col gap-3 border-t px-3 py-3" data-testid={`${testid}-detail`}>
-      <TextField
-        label="Meal"
-        placeholder="What's for dinner?"
-        value={day.note}
-        onValueChange={(v) => onNoteChange(v)}
-        data-testid={`${testid}-note`}
-      />
+      <div class="flex flex-col gap-1.5">
+        <label class="text-sm font-medium text-foreground" for={`${testid}-note`}>Meal</label>
+        <textarea
+          bind:this={noteEl}
+          id={`${testid}-note`}
+          rows="1"
+          class="w-full resize-none overflow-hidden rounded-md border bg-background px-3 py-2 text-sm"
+          placeholder="What's for dinner?"
+          value={day.note}
+          oninput={(e) => onNoteChange(e.currentTarget.value)}
+          data-testid={`${testid}-note`}
+        ></textarea>
+      </div>
 
       <div class="flex flex-col gap-2.5">
         <span class="text-xs font-medium text-muted-foreground">Who's eating</span>

--- a/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
+++ b/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
@@ -86,8 +86,8 @@
       {#if sublabel}<span class="text-[11px] text-muted-foreground">{sublabel}</span>{/if}
     </span>
 
-    <span class="min-w-0 flex-1">
-      <span class="flex items-center gap-1.5">
+    <span class="flex min-w-0 flex-1 flex-col gap-1.5 sm:flex-row sm:items-center sm:gap-6">
+      <span class="flex items-center gap-1.5 sm:flex-1">
         <span
           class="min-w-0 truncate text-sm {day.note ? 'text-foreground' : 'text-muted-foreground'}"
         >
@@ -102,7 +102,7 @@
           />
         {/if}
       </span>
-      <span class="mt-1.5 flex flex-wrap items-start gap-2.5">
+      <span class="flex flex-wrap items-start gap-2.5 sm:shrink-0 sm:justify-end">
         {#each members as m (m.id)}
           {@const a = attendeeOf(m.id)}
           <span class="flex flex-col items-center gap-0.5">

--- a/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
+++ b/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
@@ -39,6 +39,26 @@
 
   let open = $state(false);
 
+  // Home time stays blank by default; opening the picker on a blank field starts
+  // from the usual dinner time rather than 00:00 (DOM-only — not persisted until
+  // the user actually picks a value).
+  const EDIT_START_TIME = '18:30';
+
+  // Initial-chips grow to use the available width when there are few members and
+  // shrink as the roster grows (the household is small, ~5, with rare guests).
+  const chip = $derived(
+    members.length <= 4
+      ? { box: 'h-9 w-9 text-xs', time: 'text-[11px]', badge: 'h-4 w-4', hat: 'h-3 w-3' }
+      : members.length <= 6
+        ? {
+            box: 'h-8 w-8 text-[11px]',
+            time: 'text-[10px]',
+            badge: 'h-3.5 w-3.5',
+            hat: 'h-2.5 w-2.5',
+          }
+        : { box: 'h-7 w-7 text-[10px]', time: 'text-[9px]', badge: 'h-3 w-3', hat: 'h-2 w-2' },
+  );
+
   const isAttending = (id: string): boolean => day.attendees.some((a) => a.memberId === id);
   const isChef = (id: string): boolean => day.chefs.includes(id);
   const attendeeOf = (id: string) => day.attendees.find((a) => a.memberId === id);
@@ -75,18 +95,19 @@
         </span>
         {#if hasNotes}
           <StickyNote
-            class="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+            class="h-4 w-4 shrink-0 text-primary"
+            strokeWidth={2.5}
             aria-label="has notes"
             data-testid={`${testid}-note-indicator`}
           />
         {/if}
       </span>
-      <span class="mt-1 flex flex-wrap items-start gap-1.5">
+      <span class="mt-1.5 flex flex-wrap items-start gap-2.5">
         {#each members as m (m.id)}
           {@const a = attendeeOf(m.id)}
           <span class="flex flex-col items-center gap-0.5">
             <span
-              class="relative flex h-6 w-6 items-center justify-center rounded-full text-[10px] font-semibold
+              class="relative flex {chip.box} items-center justify-center rounded-full font-semibold
                 {isAttending(m.id)
                 ? 'bg-primary text-primary-foreground'
                 : 'bg-muted text-muted-foreground/50'}"
@@ -96,21 +117,21 @@
               {memberInitials(m.name)}
               {#if isChef(m.id)}
                 <span
-                  class="absolute -bottom-1 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-background"
+                  class="absolute -bottom-1 -right-1 flex {chip.badge} items-center justify-center rounded-full bg-amber-500 ring-2 ring-background"
                   aria-label="chef"
                 >
-                  <ChefHat class="h-2.5 w-2.5 text-primary" />
+                  <ChefHat class="{chip.hat} text-white" strokeWidth={2.5} />
                 </span>
               {/if}
             </span>
             {#if isAttending(m.id) && a?.homeTime}
-              <span class="text-[9px] tabular-nums text-muted-foreground">{a.homeTime}</span>
+              <span class="{chip.time} tabular-nums text-muted-foreground">{a.homeTime}</span>
             {/if}
           </span>
         {/each}
         {#if day.guests > 0}
           <span
-            class="rounded-full bg-secondary px-1.5 py-0.5 text-[10px] font-semibold text-secondary-foreground"
+            class="rounded-full bg-secondary px-2 py-0.5 text-xs font-semibold text-secondary-foreground"
             data-testid={`${testid}-guest-badge`}>+{day.guests}</span
           >
         {/if}
@@ -152,9 +173,18 @@
                   class="h-8 rounded-md border bg-background px-2 text-sm disabled:opacity-40"
                   value={a?.homeTime ?? ''}
                   disabled={!isAttending(m.id)}
+                  onfocus={(e) => {
+                    // Seed the picker from the usual dinner time when blank (DOM
+                    // only — nothing is saved until the user actually picks one).
+                    if (e.currentTarget.value === '') e.currentTarget.value = EDIT_START_TIME;
+                  }}
                   oninput={(e) => {
                     const v = e.currentTarget.value;
                     onAttendeeHomeTime(m.id, v === '' ? null : v);
+                  }}
+                  onblur={(e) => {
+                    // Re-sync to the committed value, discarding an unpicked seed.
+                    e.currentTarget.value = attendeeOf(m.id)?.homeTime ?? '';
                   }}
                   aria-label={`${m.name} home time`}
                   data-testid={`${testid}-time-${m.id}`}

--- a/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
+++ b/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import { TextField, Checkbox, Button } from '@salt/ui-components';
+  import { ChevronDown, ChevronRight, CookingPot } from '@lucide/svelte';
   import { memberInitials, type Day, type Member } from '@salt/domain';
 
-  // Presentational editor for a single Day, shared by the weekly page (date-keyed)
-  // and the template editor (weekday-keyed). It knows nothing about day keys: the
-  // parent supplies handlers already bound to the correct date/weekday. Members
-  // are resolved live; a memberId with no matching member renders as unknown +
-  // removable. See docs/meal-planning.md.
+  // Collapsible editor for a single Day, shared by the weekly page (date-keyed)
+  // and the template editor (weekday-keyed). Collapsed it shows a one-line
+  // summary — meal + who's in + chef + guests — so the whole week scans fast;
+  // expand one day to edit detail in a roomy panel. It knows nothing about day
+  // keys: the parent supplies handlers already bound to the right date/weekday.
+  // Members resolve live; an unknown memberId renders as removable, never
+  // blocking. See docs/meal-planning.md.
   interface Props {
     label: string;
     sublabel?: string;
@@ -18,6 +21,7 @@
     onAttendeeToggle: (memberId: string) => void;
     onAttendeeHomeTime: (memberId: string, homeTime: string | null) => void;
     onAttendeeNote: (memberId: string, note: string) => void;
+    onGuestsChange: (guests: number) => void;
   }
   let {
     label,
@@ -30,105 +34,189 @@
     onAttendeeToggle,
     onAttendeeHomeTime,
     onAttendeeNote,
+    onGuestsChange,
   }: Props = $props();
+
+  let open = $state(false);
 
   const memberName = (id: string): string | null => members.find((m) => m.id === id)?.name ?? null;
   const isAttending = (id: string): boolean => day.attendees.some((a) => a.memberId === id);
   const isChef = (id: string): boolean => day.chefs.includes(id);
+  const attendeeOf = (id: string) => day.attendees.find((a) => a.memberId === id);
 
-  // Attendees referencing someone no longer in the members roster — rendered so
-  // the document is never silently corrupted; removable, never blocking.
+  // Attendees referencing someone no longer in the roster — rendered removable so
+  // the document is never silently corrupted.
   const unknownAttendees = $derived(
     day.attendees.filter((a) => !members.some((m) => m.id === a.memberId)),
   );
+  const attendingCount = $derived(day.attendees.length + day.guests);
 </script>
 
-<div class="flex flex-col gap-3 rounded-lg border p-4" data-testid={testid} data-day={testid}>
-  <div class="flex items-baseline justify-between gap-2">
-    <h3 class="text-sm font-semibold text-foreground">{label}</h3>
-    {#if sublabel}
-      <span class="text-xs text-muted-foreground">{sublabel}</span>
-    {/if}
-  </div>
+<div class="overflow-hidden rounded-lg border" data-testid={testid}>
+  <!-- Collapsed summary: tap anywhere to expand. -->
+  <button
+    type="button"
+    class="flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-muted/40"
+    onclick={() => (open = !open)}
+    aria-expanded={open}
+    data-testid={`${testid}-summary`}
+  >
+    <span class="flex w-12 shrink-0 flex-col leading-tight">
+      <span class="text-sm font-semibold">{label}</span>
+      {#if sublabel}<span class="text-[11px] text-muted-foreground">{sublabel}</span>{/if}
+    </span>
 
-  <TextField
-    label="Meal"
-    placeholder="What's for dinner?"
-    value={day.note}
-    onValueChange={(v) => onNoteChange(v)}
-    data-testid={`${testid}-note`}
-  />
-
-  <!-- Chefs: zero or more; a chef need not be an attendee. -->
-  <fieldset class="flex flex-col gap-1.5">
-    <legend class="text-xs font-medium text-muted-foreground">Chefs</legend>
-    <div class="flex flex-wrap gap-x-4 gap-y-1.5">
-      {#each members as m (m.id)}
-        <Checkbox
-          checked={isChef(m.id)}
-          label={m.name}
-          onCheckedChange={() => onChefToggle(m.id)}
-          data-testid={`${testid}-chef-${m.id}`}
-        />
-      {/each}
-    </div>
-  </fieldset>
-
-  <!-- Attendees: tick to attend, then set an optional home time + per-person note. -->
-  <fieldset class="flex flex-col gap-2">
-    <legend class="text-xs font-medium text-muted-foreground">Attendees</legend>
-    {#each members as m (m.id)}
-      <div class="flex flex-col gap-1.5" data-testid={`${testid}-attendee-${m.id}`}>
-        <Checkbox
-          checked={isAttending(m.id)}
-          label={m.name}
-          onCheckedChange={() => onAttendeeToggle(m.id)}
-          data-testid={`${testid}-attend-${m.id}`}
-        />
-        {#if isAttending(m.id)}
-          {@const a = day.attendees.find((x) => x.memberId === m.id)}
-          <div class="ml-6 flex flex-col gap-1.5 sm:flex-row sm:items-end">
-            <TextField
-              label="Home time"
-              type="time"
-              value={a?.homeTime ?? ''}
-              onValueChange={(v) => onAttendeeHomeTime(m.id, v === '' ? null : v)}
-              data-testid={`${testid}-time-${m.id}`}
-            />
-            <TextField
-              label="Note"
-              placeholder="e.g. make a portion for tomorrow"
-              value={a?.note ?? ''}
-              onValueChange={(v) => onAttendeeNote(m.id, v)}
-              class="flex-1"
-              data-testid={`${testid}-attnote-${m.id}`}
-            />
-          </div>
-        {/if}
-      </div>
-    {/each}
-
-    {#each unknownAttendees as a (a.memberId)}
-      <div
-        class="flex items-center justify-between gap-2 rounded border border-dashed px-2 py-1.5"
-        data-testid={`${testid}-unknown-${a.memberId}`}
-      >
-        <span class="flex items-center gap-2 text-sm text-muted-foreground">
+    <span class="min-w-0 flex-1">
+      <span class="block truncate text-sm {day.note ? 'text-foreground' : 'text-muted-foreground'}">
+        {day.note || 'No meal set'}
+      </span>
+      <span class="mt-1 flex flex-wrap items-center gap-1">
+        {#each members as m (m.id)}
           <span
-            class="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-[10px] font-semibold"
-            aria-hidden="true">{memberInitials(memberName(a.memberId) ?? '?')}</span
+            class="relative flex h-6 w-6 items-center justify-center rounded-full text-[10px] font-semibold
+              {isAttending(m.id)
+              ? 'bg-primary text-primary-foreground'
+              : 'bg-muted text-muted-foreground/50'}"
+            title={m.name}
+            data-testid={`${testid}-chip-${m.id}`}
           >
-          Unknown member ({a.memberId})
-        </span>
-        <Button
-          variant="ghost"
-          size="sm"
-          onclick={() => onAttendeeToggle(a.memberId)}
-          data-testid={`${testid}-unknown-remove-${a.memberId}`}
-        >
-          Remove
-        </Button>
+            {memberInitials(m.name)}
+            {#if isChef(m.id)}
+              <span
+                class="absolute -bottom-1 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-background"
+                aria-label="chef"
+              >
+                <CookingPot class="h-2.5 w-2.5 text-primary" />
+              </span>
+            {/if}
+          </span>
+        {/each}
+        {#if day.guests > 0}
+          <span
+            class="rounded-full bg-secondary px-1.5 py-0.5 text-[10px] font-semibold text-secondary-foreground"
+            data-testid={`${testid}-guest-badge`}>+{day.guests}</span
+          >
+        {/if}
+      </span>
+    </span>
+
+    <span class="shrink-0 text-muted-foreground" aria-hidden="true">
+      {#if open}<ChevronDown class="h-4 w-4" />{:else}<ChevronRight class="h-4 w-4" />{/if}
+    </span>
+  </button>
+
+  {#if open}
+    <div class="flex flex-col gap-3 border-t px-3 py-3" data-testid={`${testid}-detail`}>
+      <TextField
+        label="Meal"
+        placeholder="What's for dinner?"
+        value={day.note}
+        onValueChange={(v) => onNoteChange(v)}
+        data-testid={`${testid}-note`}
+      />
+
+      <div class="flex flex-col gap-2">
+        <span class="text-xs font-medium text-muted-foreground">Who's eating</span>
+        {#each members as m (m.id)}
+          {@const a = attendeeOf(m.id)}
+          <div
+            class="flex flex-wrap items-center gap-x-3 gap-y-1.5"
+            data-testid={`${testid}-attendee-${m.id}`}
+          >
+            <div class="w-28 shrink-0">
+              <Checkbox
+                checked={isAttending(m.id)}
+                label={m.name}
+                onCheckedChange={() => onAttendeeToggle(m.id)}
+                data-testid={`${testid}-attend-${m.id}`}
+              />
+            </div>
+            {#if isAttending(m.id) || isChef(m.id)}
+              <input
+                type="time"
+                class="h-8 rounded-md border bg-background px-2 text-sm disabled:opacity-40"
+                value={a?.homeTime ?? ''}
+                disabled={!isAttending(m.id)}
+                oninput={(e) => {
+                  const v = e.currentTarget.value;
+                  onAttendeeHomeTime(m.id, v === '' ? null : v);
+                }}
+                aria-label={`${m.name} home time`}
+                data-testid={`${testid}-time-${m.id}`}
+              />
+              <Button
+                variant={isChef(m.id) ? 'default' : 'outline'}
+                size="sm"
+                onclick={() => onChefToggle(m.id)}
+                data-testid={`${testid}-chef-${m.id}`}
+              >
+                <CookingPot class="mr-1 h-3.5 w-3.5" /> Chef
+              </Button>
+              {#if isAttending(m.id)}
+                <input
+                  class="h-8 min-w-0 flex-1 rounded-md border bg-background px-2 text-sm"
+                  placeholder="note (e.g. portion for tomorrow)"
+                  value={a?.note ?? ''}
+                  oninput={(e) => onAttendeeNote(m.id, e.currentTarget.value)}
+                  aria-label={`${m.name} note`}
+                  data-testid={`${testid}-attnote-${m.id}`}
+                />
+              {/if}
+            {/if}
+          </div>
+        {/each}
+
+        {#each unknownAttendees as a (a.memberId)}
+          <div
+            class="flex items-center justify-between gap-2 rounded border border-dashed px-2 py-1.5"
+            data-testid={`${testid}-unknown-${a.memberId}`}
+          >
+            <span class="truncate text-sm text-muted-foreground">
+              Unknown member ({a.memberId})
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onclick={() => onAttendeeToggle(a.memberId)}
+              data-testid={`${testid}-unknown-remove-${a.memberId}`}
+            >
+              Remove
+            </Button>
+          </div>
+        {/each}
+
+        <!-- Occasional unnamed guests: a simple count. -->
+        <div class="flex items-center gap-2 pt-1" data-testid={`${testid}-guests`}>
+          <span class="w-28 shrink-0 text-sm">Guests</span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={day.guests <= 0}
+            onclick={() => onGuestsChange(day.guests - 1)}
+            aria-label="Fewer guests"
+            data-testid={`${testid}-guests-dec`}
+          >
+            −
+          </Button>
+          <span class="w-6 text-center text-sm tabular-nums" data-testid={`${testid}-guests-count`}>
+            {day.guests}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onclick={() => onGuestsChange(day.guests + 1)}
+            aria-label="More guests"
+            data-testid={`${testid}-guests-inc`}
+          >
+            +
+          </Button>
+        </div>
       </div>
-    {/each}
-  </fieldset>
+
+      <p class="text-[11px] text-muted-foreground">
+        {attendingCount}
+        {attendingCount === 1 ? 'person' : 'people'} eating
+      </p>
+    </div>
+  {/if}
 </div>

--- a/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
+++ b/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
@@ -181,12 +181,11 @@
                   data-testid={`${testid}-attend-${m.id}`}
                 />
               </div>
-              {#if isAttending(m.id) || isChef(m.id)}
+              {#if isAttending(m.id)}
                 <input
                   type="time"
-                  class="h-8 rounded-md border bg-background px-2 text-sm disabled:opacity-40"
+                  class="h-8 rounded-md border bg-background px-2 text-sm"
                   value={a?.homeTime ?? ''}
-                  disabled={!isAttending(m.id)}
                   onfocus={(e) => {
                     // Seed the picker from the usual dinner time when blank (DOM
                     // only — nothing is saved until the user actually picks one).
@@ -203,15 +202,20 @@
                   aria-label={`${m.name} home time`}
                   data-testid={`${testid}-time-${m.id}`}
                 />
-                <Button
-                  variant={isChef(m.id) ? 'default' : 'outline'}
-                  size="sm"
-                  onclick={() => onChefToggle(m.id)}
-                  data-testid={`${testid}-chef-${m.id}`}
-                >
-                  <ChefHat class="mr-1 h-3.5 w-3.5" /> Chef
-                </Button>
               {/if}
+              <!-- Chef is independent of attending: a chef need not eat. -->
+              <Button
+                variant="outline"
+                size="sm"
+                class={isChef(m.id)
+                  ? 'border-amber-500 bg-amber-500 text-white hover:bg-amber-600 hover:text-white'
+                  : ''}
+                onclick={() => onChefToggle(m.id)}
+                aria-pressed={isChef(m.id)}
+                data-testid={`${testid}-chef-${m.id}`}
+              >
+                <ChefHat class="mr-1 h-3.5 w-3.5" /> Chef
+              </Button>
             </div>
             {#if isAttending(m.id)}
               <input

--- a/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
+++ b/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
   import { TextField, Checkbox, Button } from '@salt/ui-components';
-  import { ChevronDown, ChevronRight, CookingPot } from '@lucide/svelte';
+  import { ChevronDown, ChevronRight, ChefHat, StickyNote } from '@lucide/svelte';
   import { memberInitials, type Day, type Member } from '@salt/domain';
 
   // Collapsible editor for a single Day, shared by the weekly page (date-keyed)
   // and the template editor (weekday-keyed). Collapsed it shows a one-line
-  // summary — meal + who's in + chef + guests — so the whole week scans fast;
-  // expand one day to edit detail in a roomy panel. It knows nothing about day
-  // keys: the parent supplies handlers already bound to the right date/weekday.
-  // Members resolve live; an unknown memberId renders as removable, never
-  // blocking. See docs/meal-planning.md.
+  // summary — meal + who's in (with home time) + chef + a note indicator + guest
+  // count — so the whole week scans fast; expand one day to edit detail in a
+  // roomy panel. It knows nothing about day keys: the parent supplies handlers
+  // already bound to the right date/weekday. Members resolve live; an unknown
+  // memberId renders as removable, never blocking. See docs/meal-planning.md.
   interface Props {
     label: string;
     sublabel?: string;
@@ -39,7 +39,6 @@
 
   let open = $state(false);
 
-  const memberName = (id: string): string | null => members.find((m) => m.id === id)?.name ?? null;
   const isAttending = (id: string): boolean => day.attendees.some((a) => a.memberId === id);
   const isChef = (id: string): boolean => day.chefs.includes(id);
   const attendeeOf = (id: string) => day.attendees.find((a) => a.memberId === id);
@@ -50,44 +49,62 @@
     day.attendees.filter((a) => !members.some((m) => m.id === a.memberId)),
   );
   const attendingCount = $derived(day.attendees.length + day.guests);
+  const hasNotes = $derived(day.attendees.some((a) => a.note.trim() !== ''));
 </script>
 
 <div class="overflow-hidden rounded-lg border" data-testid={testid}>
   <!-- Collapsed summary: tap anywhere to expand. -->
   <button
     type="button"
-    class="flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-muted/40"
+    class="flex w-full items-start gap-5 px-3 py-2.5 text-left hover:bg-muted/40"
     onclick={() => (open = !open)}
     aria-expanded={open}
     data-testid={`${testid}-summary`}
   >
-    <span class="flex w-12 shrink-0 flex-col leading-tight">
+    <span class="flex w-16 shrink-0 flex-col leading-tight">
       <span class="text-sm font-semibold">{label}</span>
       {#if sublabel}<span class="text-[11px] text-muted-foreground">{sublabel}</span>{/if}
     </span>
 
     <span class="min-w-0 flex-1">
-      <span class="block truncate text-sm {day.note ? 'text-foreground' : 'text-muted-foreground'}">
-        {day.note || 'No meal set'}
+      <span class="flex items-center gap-1.5">
+        <span
+          class="min-w-0 truncate text-sm {day.note ? 'text-foreground' : 'text-muted-foreground'}"
+        >
+          {day.note || 'No meal set'}
+        </span>
+        {#if hasNotes}
+          <StickyNote
+            class="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+            aria-label="has notes"
+            data-testid={`${testid}-note-indicator`}
+          />
+        {/if}
       </span>
-      <span class="mt-1 flex flex-wrap items-center gap-1">
+      <span class="mt-1 flex flex-wrap items-start gap-1.5">
         {#each members as m (m.id)}
-          <span
-            class="relative flex h-6 w-6 items-center justify-center rounded-full text-[10px] font-semibold
-              {isAttending(m.id)
-              ? 'bg-primary text-primary-foreground'
-              : 'bg-muted text-muted-foreground/50'}"
-            title={m.name}
-            data-testid={`${testid}-chip-${m.id}`}
-          >
-            {memberInitials(m.name)}
-            {#if isChef(m.id)}
-              <span
-                class="absolute -bottom-1 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-background"
-                aria-label="chef"
-              >
-                <CookingPot class="h-2.5 w-2.5 text-primary" />
-              </span>
+          {@const a = attendeeOf(m.id)}
+          <span class="flex flex-col items-center gap-0.5">
+            <span
+              class="relative flex h-6 w-6 items-center justify-center rounded-full text-[10px] font-semibold
+                {isAttending(m.id)
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground/50'}"
+              title={m.name}
+              data-testid={`${testid}-chip-${m.id}`}
+            >
+              {memberInitials(m.name)}
+              {#if isChef(m.id)}
+                <span
+                  class="absolute -bottom-1 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-background"
+                  aria-label="chef"
+                >
+                  <ChefHat class="h-2.5 w-2.5 text-primary" />
+                </span>
+              {/if}
+            </span>
+            {#if isAttending(m.id) && a?.homeTime}
+              <span class="text-[9px] tabular-nums text-muted-foreground">{a.homeTime}</span>
             {/if}
           </span>
         {/each}
@@ -100,7 +117,7 @@
       </span>
     </span>
 
-    <span class="shrink-0 text-muted-foreground" aria-hidden="true">
+    <span class="shrink-0 pt-0.5 text-muted-foreground" aria-hidden="true">
       {#if open}<ChevronDown class="h-4 w-4" />{:else}<ChevronRight class="h-4 w-4" />{/if}
     </span>
   </button>
@@ -115,53 +132,52 @@
         data-testid={`${testid}-note`}
       />
 
-      <div class="flex flex-col gap-2">
+      <div class="flex flex-col gap-2.5">
         <span class="text-xs font-medium text-muted-foreground">Who's eating</span>
         {#each members as m (m.id)}
           {@const a = attendeeOf(m.id)}
-          <div
-            class="flex flex-wrap items-center gap-x-3 gap-y-1.5"
-            data-testid={`${testid}-attendee-${m.id}`}
-          >
-            <div class="w-28 shrink-0">
-              <Checkbox
-                checked={isAttending(m.id)}
-                label={m.name}
-                onCheckedChange={() => onAttendeeToggle(m.id)}
-                data-testid={`${testid}-attend-${m.id}`}
-              />
-            </div>
-            {#if isAttending(m.id) || isChef(m.id)}
-              <input
-                type="time"
-                class="h-8 rounded-md border bg-background px-2 text-sm disabled:opacity-40"
-                value={a?.homeTime ?? ''}
-                disabled={!isAttending(m.id)}
-                oninput={(e) => {
-                  const v = e.currentTarget.value;
-                  onAttendeeHomeTime(m.id, v === '' ? null : v);
-                }}
-                aria-label={`${m.name} home time`}
-                data-testid={`${testid}-time-${m.id}`}
-              />
-              <Button
-                variant={isChef(m.id) ? 'default' : 'outline'}
-                size="sm"
-                onclick={() => onChefToggle(m.id)}
-                data-testid={`${testid}-chef-${m.id}`}
-              >
-                <CookingPot class="mr-1 h-3.5 w-3.5" /> Chef
-              </Button>
-              {#if isAttending(m.id)}
-                <input
-                  class="h-8 min-w-0 flex-1 rounded-md border bg-background px-2 text-sm"
-                  placeholder="note (e.g. portion for tomorrow)"
-                  value={a?.note ?? ''}
-                  oninput={(e) => onAttendeeNote(m.id, e.currentTarget.value)}
-                  aria-label={`${m.name} note`}
-                  data-testid={`${testid}-attnote-${m.id}`}
+          <div class="flex flex-col gap-1" data-testid={`${testid}-attendee-${m.id}`}>
+            <div class="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+              <div class="w-28 shrink-0">
+                <Checkbox
+                  checked={isAttending(m.id)}
+                  label={m.name}
+                  onCheckedChange={() => onAttendeeToggle(m.id)}
+                  data-testid={`${testid}-attend-${m.id}`}
                 />
+              </div>
+              {#if isAttending(m.id) || isChef(m.id)}
+                <input
+                  type="time"
+                  class="h-8 rounded-md border bg-background px-2 text-sm disabled:opacity-40"
+                  value={a?.homeTime ?? ''}
+                  disabled={!isAttending(m.id)}
+                  oninput={(e) => {
+                    const v = e.currentTarget.value;
+                    onAttendeeHomeTime(m.id, v === '' ? null : v);
+                  }}
+                  aria-label={`${m.name} home time`}
+                  data-testid={`${testid}-time-${m.id}`}
+                />
+                <Button
+                  variant={isChef(m.id) ? 'default' : 'outline'}
+                  size="sm"
+                  onclick={() => onChefToggle(m.id)}
+                  data-testid={`${testid}-chef-${m.id}`}
+                >
+                  <ChefHat class="mr-1 h-3.5 w-3.5" /> Chef
+                </Button>
               {/if}
+            </div>
+            {#if isAttending(m.id)}
+              <input
+                class="ml-1 h-8 w-full rounded-md border bg-background px-2 text-sm"
+                placeholder="Add a note (e.g. portion for tomorrow)"
+                value={a?.note ?? ''}
+                oninput={(e) => onAttendeeNote(m.id, e.currentTarget.value)}
+                aria-label={`${m.name} note`}
+                data-testid={`${testid}-attnote-${m.id}`}
+              />
             {/if}
           </div>
         {/each}

--- a/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
+++ b/apps/web-pwa/src/routes/mealplan/MealDayEditor.svelte
@@ -48,15 +48,22 @@
   // shrink as the roster grows (the household is small, ~5, with rare guests).
   const chip = $derived(
     members.length <= 4
-      ? { box: 'h-9 w-9 text-xs', time: 'text-[11px]', badge: 'h-4 w-4', hat: 'h-3 w-3' }
+      ? { box: 'h-9 w-9 text-xs', h: 'h-9', time: 'text-[11px]', badge: 'h-4 w-4', hat: 'h-3 w-3' }
       : members.length <= 6
         ? {
             box: 'h-8 w-8 text-[11px]',
+            h: 'h-8',
             time: 'text-[10px]',
             badge: 'h-3.5 w-3.5',
             hat: 'h-2.5 w-2.5',
           }
-        : { box: 'h-7 w-7 text-[10px]', time: 'text-[9px]', badge: 'h-3 w-3', hat: 'h-2 w-2' },
+        : {
+            box: 'h-7 w-7 text-[10px]',
+            h: 'h-7',
+            time: 'text-[9px]',
+            badge: 'h-3 w-3',
+            hat: 'h-2 w-2',
+          },
   );
 
   const isAttending = (id: string): boolean => day.attendees.some((a) => a.memberId === id);
@@ -102,39 +109,46 @@
           />
         {/if}
       </span>
-      <span class="flex flex-wrap items-start gap-2.5 sm:shrink-0 sm:justify-end">
-        {#each members as m (m.id)}
-          {@const a = attendeeOf(m.id)}
-          <span class="flex flex-col items-center gap-0.5">
-            <span
-              class="relative flex {chip.box} items-center justify-center rounded-full font-semibold
-                {isAttending(m.id)
-                ? 'bg-primary text-primary-foreground'
-                : 'bg-muted text-muted-foreground/50'}"
-              title={m.name}
-              data-testid={`${testid}-chip-${m.id}`}
-            >
-              {memberInitials(m.name)}
-              {#if isChef(m.id)}
-                <span
-                  class="absolute -bottom-1 -right-1 flex {chip.badge} items-center justify-center rounded-full bg-amber-500 ring-2 ring-background"
-                  aria-label="chef"
-                >
-                  <ChefHat class="{chip.hat} text-white" strokeWidth={2.5} />
-                </span>
+      <span class="flex items-start gap-3 sm:shrink-0">
+        <!-- Member chips: fixed roster → constant width, so they line up across
+             every row regardless of guests. Slightly more relaxed on wide screens. -->
+        <span class="flex items-start gap-2.5 lg:gap-4">
+          {#each members as m (m.id)}
+            {@const a = attendeeOf(m.id)}
+            <span class="flex flex-col items-center gap-0.5">
+              <span
+                class="relative flex {chip.box} items-center justify-center rounded-full font-semibold
+                  {isAttending(m.id)
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground/50'}"
+                title={m.name}
+                data-testid={`${testid}-chip-${m.id}`}
+              >
+                {memberInitials(m.name)}
+                {#if isChef(m.id)}
+                  <span
+                    class="absolute -bottom-1 -right-1 flex {chip.badge} items-center justify-center rounded-full bg-amber-500 ring-2 ring-background"
+                    aria-label="chef"
+                  >
+                    <ChefHat class="{chip.hat} text-white" strokeWidth={2.5} />
+                  </span>
+                {/if}
+              </span>
+              {#if isAttending(m.id) && a?.homeTime}
+                <span class="{chip.time} tabular-nums text-muted-foreground">{a.homeTime}</span>
               {/if}
             </span>
-            {#if isAttending(m.id) && a?.homeTime}
-              <span class="{chip.time} tabular-nums text-muted-foreground">{a.homeTime}</span>
-            {/if}
-          </span>
-        {/each}
-        {#if day.guests > 0}
-          <span
-            class="rounded-full bg-secondary px-2 py-0.5 text-xs font-semibold text-secondary-foreground"
-            data-testid={`${testid}-guest-badge`}>+{day.guests}</span
-          >
-        {/if}
+          {/each}
+        </span>
+        <!-- Guests: their own reserved column so the member chips never shift. -->
+        <span class="flex {chip.h} w-8 shrink-0 items-center justify-start">
+          {#if day.guests > 0}
+            <span
+              class="rounded-full bg-secondary px-2 py-0.5 text-xs font-semibold text-secondary-foreground"
+              data-testid={`${testid}-guest-badge`}>+{day.guests}</span
+            >
+          {/if}
+        </span>
       </span>
     </span>
 

--- a/apps/web-pwa/src/routes/mealplan/MealPlanWeekPage.svelte
+++ b/apps/web-pwa/src/routes/mealplan/MealPlanWeekPage.svelte
@@ -23,6 +23,7 @@
     loadTemplateIntoCurrentWeek,
     setWeekDayNote,
     setWeekDayChefs,
+    setWeekDayGuests,
     addWeekAttendee,
     removeWeekAttendee,
     setWeekAttendeeHomeTime,
@@ -128,6 +129,7 @@
             onAttendeeToggle={(id) => toggleAttendee(date, id)}
             onAttendeeHomeTime={(id, t) => void setWeekAttendeeHomeTime(date, id, t)}
             onAttendeeNote={(id, n) => void setWeekAttendeeNote(date, id, n)}
+            onGuestsChange={(g) => void setWeekDayGuests(date, g)}
           />
         {/if}
       {/each}

--- a/apps/web-pwa/src/routes/mealplan/MealPlanWeekPage.svelte
+++ b/apps/web-pwa/src/routes/mealplan/MealPlanWeekPage.svelte
@@ -31,6 +31,8 @@
   } from '../../lib/mealPlanService.js';
   import { addToast } from '../../lib/toastStore.js';
 
+  const DEFAULT_HOME_TIME = '18:30';
+
   const dates = $derived(weekDates($selectedStartDate));
 
   // Friendly labels for the week range and each day, formatted from the UTC date.
@@ -81,7 +83,8 @@
     if (attending) {
       void removeWeekAttendee(date, memberId);
     } else {
-      const attendee: Attendee = { memberId, homeTime: null, note: '' };
+      // Default to the usual dinner time; clearable to blank afterwards.
+      const attendee: Attendee = { memberId, homeTime: DEFAULT_HOME_TIME, note: '' };
       void addWeekAttendee(date, attendee);
     }
   }

--- a/apps/web-pwa/src/routes/mealplan/MealPlanWeekPage.svelte
+++ b/apps/web-pwa/src/routes/mealplan/MealPlanWeekPage.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  import {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    ListPage,
+  } from '@salt/ui-components';
+  import { ChevronLeft, ChevronRight } from '@lucide/svelte';
+  import { weekDates, type Attendee } from '@salt/domain';
+  import MealDayEditor from './MealDayEditor.svelte';
+  import { members } from '../../lib/membersService.js';
+  import {
+    currentWeek,
+    selectedStartDate,
+    isLoadingMealPlanWeek,
+    nextWeek,
+    prevWeek,
+    thisWeek,
+    loadTemplateIntoCurrentWeek,
+    setWeekDayNote,
+    setWeekDayChefs,
+    addWeekAttendee,
+    removeWeekAttendee,
+    setWeekAttendeeHomeTime,
+    setWeekAttendeeNote,
+  } from '../../lib/mealPlanService.js';
+  import { addToast } from '../../lib/toastStore.js';
+
+  const dates = $derived(weekDates($selectedStartDate));
+
+  // Friendly labels for the week range and each day, formatted from the UTC date.
+  function fmt(date: string, opts: Intl.DateTimeFormatOptions): string {
+    return new Intl.DateTimeFormat('en-GB', { ...opts, timeZone: 'UTC' }).format(
+      new Date(`${date}T00:00:00.000Z`),
+    );
+  }
+  const rangeLabel = $derived(
+    dates.length === 7
+      ? `${fmt(dates[0]!, { day: 'numeric', month: 'short' })} – ${fmt(dates[6]!, {
+          day: 'numeric',
+          month: 'short',
+          year: 'numeric',
+        })}`
+      : '',
+  );
+
+  // ─── Load-template confirmation ───────────────────────────────────────────
+  let showLoadConfirm = $state(false);
+
+  function requestLoadTemplate(): void {
+    // Only confirm when the week has already been edited (persisted).
+    if ($currentWeek.updatedAt !== '') {
+      showLoadConfirm = true;
+    } else {
+      void doLoadTemplate();
+    }
+  }
+
+  async function doLoadTemplate(): Promise<void> {
+    showLoadConfirm = false;
+    const result = await loadTemplateIntoCurrentWeek();
+    if (result.kind !== 'ok') addToast('Failed to load the template.', 'error');
+  }
+
+  // ─── Day-editor handlers (bound to a concrete date) ───────────────────────
+  function toggleChef(date: string, memberId: string): void {
+    const chefs = $currentWeek.days[date]?.chefs ?? [];
+    const next = chefs.includes(memberId)
+      ? chefs.filter((c) => c !== memberId)
+      : [...chefs, memberId];
+    void setWeekDayChefs(date, next);
+  }
+
+  function toggleAttendee(date: string, memberId: string): void {
+    const attending = $currentWeek.days[date]?.attendees.some((a) => a.memberId === memberId);
+    if (attending) {
+      void removeWeekAttendee(date, memberId);
+    } else {
+      const attendee: Attendee = { memberId, homeTime: null, note: '' };
+      void addWeekAttendee(date, attendee);
+    }
+  }
+</script>
+
+<ListPage title="Meal plan" isLoading={$isLoadingMealPlanWeek} class="p-4 sm:p-6">
+  {#snippet actions()}
+    <Button size="sm" onclick={requestLoadTemplate} data-testid="load-template">
+      Load template
+    </Button>
+  {/snippet}
+
+  {#snippet children()}
+    <div class="flex items-center justify-between gap-2" data-testid="week-nav">
+      <Button variant="outline" size="sm" onclick={prevWeek} aria-label="Previous week">
+        <ChevronLeft class="h-4 w-4" />
+      </Button>
+      <div class="flex flex-col items-center">
+        <span class="text-sm font-medium" data-testid="week-range">{rangeLabel}</span>
+        <button
+          class="text-xs text-muted-foreground underline-offset-2 hover:underline"
+          onclick={thisWeek}
+          data-testid="this-week"
+        >
+          This week
+        </button>
+      </div>
+      <Button variant="outline" size="sm" onclick={nextWeek} aria-label="Next week">
+        <ChevronRight class="h-4 w-4" />
+      </Button>
+    </div>
+
+    <div class="mt-4 flex flex-col gap-3">
+      {#each dates as date (date)}
+        {@const day = $currentWeek.days[date]}
+        {#if day}
+          <MealDayEditor
+            label={fmt(date, { weekday: 'long' })}
+            sublabel={fmt(date, { day: 'numeric', month: 'short' })}
+            {day}
+            members={$members}
+            testid={`day-${date}`}
+            onNoteChange={(note) => void setWeekDayNote(date, note)}
+            onChefToggle={(id) => toggleChef(date, id)}
+            onAttendeeToggle={(id) => toggleAttendee(date, id)}
+            onAttendeeHomeTime={(id, t) => void setWeekAttendeeHomeTime(date, id, t)}
+            onAttendeeNote={(id, n) => void setWeekAttendeeNote(date, id, n)}
+          />
+        {/if}
+      {/each}
+    </div>
+  {/snippet}
+</ListPage>
+
+<Dialog open={showLoadConfirm} onOpenChange={(v) => (showLoadConfirm = v)}>
+  <DialogContent>
+    <div class="flex flex-col gap-4" data-testid="load-template-confirm">
+      <DialogHeader>
+        <DialogTitle>Load the standard template?</DialogTitle>
+        <DialogDescription>
+          This overwrites this week's days back to the standard template. Any edits you've made to
+          this week will be lost.
+        </DialogDescription>
+      </DialogHeader>
+      <DialogFooter>
+        <Button variant="outline" onclick={() => (showLoadConfirm = false)}>Cancel</Button>
+        <Button onclick={doLoadTemplate} data-testid="load-template-confirm-btn">
+          Load template
+        </Button>
+      </DialogFooter>
+    </div>
+  </DialogContent>
+</Dialog>

--- a/apps/web-pwa/src/routes/mealplan/MealPlanWeekPage.svelte
+++ b/apps/web-pwa/src/routes/mealplan/MealPlanWeekPage.svelte
@@ -31,8 +31,6 @@
   } from '../../lib/mealPlanService.js';
   import { addToast } from '../../lib/toastStore.js';
 
-  const DEFAULT_HOME_TIME = '18:30';
-
   const dates = $derived(weekDates($selectedStartDate));
 
   // Friendly labels for the week range and each day, formatted from the UTC date.
@@ -83,8 +81,8 @@
     if (attending) {
       void removeWeekAttendee(date, memberId);
     } else {
-      // Default to the usual dinner time; clearable to blank afterwards.
-      const attendee: Attendee = { memberId, homeTime: DEFAULT_HOME_TIME, note: '' };
+      // Home time starts blank; the picker seeds 18:30 when first opened.
+      const attendee: Attendee = { memberId, homeTime: null, note: '' };
       void addWeekAttendee(date, attendee);
     }
   }

--- a/apps/web-pwa/tests/AdminMealPlanPage.test.ts
+++ b/apps/web-pwa/tests/AdminMealPlanPage.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { emptyTemplate, setDayNote, type MealPlanTemplate, type Member } from '@salt/domain';
+
+const { mockMembers, mockIsLoadingMembers, mockTemplate, mockFirstDay, mockAuth } = vi.hoisted(
+  () => {
+    function makeStore<T>(initial: T) {
+      let value = initial;
+      const subs = new Set<(v: T) => void>();
+      return {
+        subscribe(fn: (v: T) => void) {
+          subs.add(fn);
+          fn(value);
+          return () => {
+            subs.delete(fn);
+          };
+        },
+        _set(v: T) {
+          value = v;
+          subs.forEach((fn) => fn(v));
+        },
+      };
+    }
+    return {
+      mockMembers: makeStore<Member[]>([]),
+      mockIsLoadingMembers: makeStore<boolean>(false),
+      mockTemplate: makeStore<MealPlanTemplate | null>(null),
+      mockFirstDay: makeStore<string>('mon'),
+      mockAuth: { user: { email: 'admin@e.org' } as { email: string } | null },
+    };
+  },
+);
+
+vi.mock('svelte-spa-router', () => ({ push: vi.fn() }));
+vi.mock('../src/lib/toastStore.js', () => ({ addToast: vi.fn() }));
+vi.mock('../src/lib/auth.svelte.js', () => ({ auth: mockAuth }));
+vi.mock('../src/lib/membersService.js', () => ({
+  members: mockMembers,
+  isLoadingMembers: mockIsLoadingMembers,
+}));
+vi.mock('../src/lib/mealPlanService.js', () => ({
+  mealPlanTemplate: mockTemplate,
+  firstDayOfWeek: mockFirstDay,
+  saveFirstDayOfWeek: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  setTemplateDayNote: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  setTemplateDayChefs: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  addTemplateAttendee: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  removeTemplateAttendee: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  setTemplateAttendeeHomeTime: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  setTemplateAttendeeNote: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+}));
+
+import AdminMealPlanPage from '../src/routes/admin/AdminMealPlanPage.svelte';
+import { saveFirstDayOfWeek, setTemplateDayNote } from '../src/lib/mealPlanService.js';
+
+function member(id: string, name: string, admin = false): Member {
+  return {
+    id,
+    schemaVersion: 1,
+    name,
+    email: id,
+    admin,
+    sortOrder: 0,
+    icon: null,
+    updatedAt: '2026-06-07T00:00:00.000Z',
+  };
+}
+
+const ADMIN = member('admin@e.org', 'Ada Admin', true);
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.user = { email: 'admin@e.org' };
+  mockIsLoadingMembers._set(false);
+  mockMembers._set([ADMIN]);
+  mockFirstDay._set('mon');
+  mockTemplate._set(emptyTemplate());
+});
+
+describe('AdminMealPlanPage', () => {
+  it('renders the first-day setting and seven weekday editors', () => {
+    render(AdminMealPlanPage);
+    expect(screen.getByTestId('first-day-setting')).toBeInTheDocument();
+    expect(screen.getByTestId('tmpl-mon')).toBeInTheDocument();
+    expect(screen.getByTestId('tmpl-sun')).toBeInTheDocument();
+  });
+
+  it('edits a weekday template note through the service', async () => {
+    render(AdminMealPlanPage);
+    await userEvent.type(screen.getByTestId('tmpl-fri-note'), 'Pizza');
+    await waitFor(() => expect(vi.mocked(setTemplateDayNote)).toHaveBeenCalled());
+    expect(vi.mocked(setTemplateDayNote).mock.calls[0]![0]).toBe('fri');
+  });
+
+  it('reflects an existing template note', () => {
+    mockTemplate._set(setDayNote(emptyTemplate(), 'mon', 'Roast'));
+    render(AdminMealPlanPage);
+    expect((screen.getByTestId('tmpl-mon-note') as HTMLInputElement).value).toBe('Roast');
+  });
+
+  it('saves a new first-day-of-week selection', async () => {
+    render(AdminMealPlanPage);
+    // Open the select and choose Saturday (options render with role="option").
+    await userEvent.click(screen.getByTestId('first-day-trigger'));
+    await waitFor(() => screen.getByRole('option', { name: 'Saturday' }));
+    await userEvent.click(screen.getByRole('option', { name: 'Saturday' }));
+    await waitFor(() => expect(vi.mocked(saveFirstDayOfWeek)).toHaveBeenCalledWith('sat'));
+  });
+
+  it('denies a non-admin', async () => {
+    mockAuth.user = { email: 'kid@e.org' };
+    mockMembers._set([ADMIN, member('kid@e.org', 'Kid')]);
+    render(AdminMealPlanPage);
+    await waitFor(() => expect(screen.queryByTestId('admin-mealplan')).not.toBeInTheDocument());
+  });
+});

--- a/apps/web-pwa/tests/AdminMealPlanPage.test.ts
+++ b/apps/web-pwa/tests/AdminMealPlanPage.test.ts
@@ -45,6 +45,7 @@ vi.mock('../src/lib/mealPlanService.js', () => ({
   saveFirstDayOfWeek: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   setTemplateDayNote: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   setTemplateDayChefs: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  setTemplateDayGuests: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   addTemplateAttendee: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   removeTemplateAttendee: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   setTemplateAttendeeHomeTime: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
@@ -84,23 +85,25 @@ beforeEach(() => {
 });
 
 describe('AdminMealPlanPage', () => {
-  it('renders the first-day setting and seven weekday editors', () => {
+  it('renders the first-day setting and seven weekday rows', () => {
     render(AdminMealPlanPage);
     expect(screen.getByTestId('first-day-setting')).toBeInTheDocument();
     expect(screen.getByTestId('tmpl-mon')).toBeInTheDocument();
     expect(screen.getByTestId('tmpl-sun')).toBeInTheDocument();
   });
 
-  it('edits a weekday template note through the service', async () => {
+  it('edits a weekday template note through the service after expanding the day', async () => {
     render(AdminMealPlanPage);
+    await userEvent.click(screen.getByTestId('tmpl-fri-summary'));
     await userEvent.type(screen.getByTestId('tmpl-fri-note'), 'Pizza');
     await waitFor(() => expect(vi.mocked(setTemplateDayNote)).toHaveBeenCalled());
     expect(vi.mocked(setTemplateDayNote).mock.calls[0]![0]).toBe('fri');
   });
 
-  it('reflects an existing template note', () => {
+  it('reflects an existing template note when expanded', async () => {
     mockTemplate._set(setDayNote(emptyTemplate(), 'mon', 'Roast'));
     render(AdminMealPlanPage);
+    await userEvent.click(screen.getByTestId('tmpl-mon-summary'));
     expect((screen.getByTestId('tmpl-mon-note') as HTMLInputElement).value).toBe('Roast');
   });
 

--- a/apps/web-pwa/tests/MealPlanWeekPage.test.ts
+++ b/apps/web-pwa/tests/MealPlanWeekPage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen, cleanup, waitFor, within } from '@testing-library/svelte';
+import { render, screen, cleanup, waitFor, within, fireEvent } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { emptyWeek, setDayNote, type MealPlanWeek, type Member } from '@salt/domain';
 
@@ -133,7 +133,7 @@ describe('MealPlanWeekPage', () => {
     await userEvent.click(within(attendWrap).getByRole('checkbox'));
     expect(vi.mocked(addWeekAttendee)).toHaveBeenCalledWith(
       '2026-06-08',
-      expect.objectContaining({ memberId: 'alice@e.org', homeTime: '18:30' }),
+      expect.objectContaining({ memberId: 'alice@e.org', homeTime: null }),
     );
 
     // With Alice attending, the home-time input appears; leaving it blank saves null.
@@ -245,6 +245,35 @@ describe('MealPlanWeekPage', () => {
     });
     render(MealPlanWeekPage);
     expect(screen.queryByTestId('day-2026-06-08-note-indicator')).not.toBeInTheDocument();
+  });
+
+  it('seeds the time picker from 18:30 when blank, without persisting on cancel', async () => {
+    mockWeek._set({
+      ...emptyWeek('2026-06-08'),
+      days: {
+        ...emptyWeek('2026-06-08').days,
+        '2026-06-08': {
+          note: '',
+          recipeIds: [],
+          chefs: [],
+          attendees: [{ memberId: 'alice@e.org', homeTime: null, note: '' }],
+          guests: 0,
+        },
+      },
+    });
+    render(MealPlanWeekPage);
+    await expandDay('2026-06-08');
+    const timeInput = screen.getByTestId('day-2026-06-08-time-alice@e.org') as HTMLInputElement;
+    expect(timeInput.value).toBe('');
+
+    await fireEvent.focus(timeInput);
+    expect(timeInput.value).toBe('18:30');
+    // Focus alone does not persist anything.
+    expect(vi.mocked(setWeekAttendeeHomeTime)).not.toHaveBeenCalled();
+
+    // Blurring without picking re-syncs back to the committed blank value.
+    await fireEvent.blur(timeInput);
+    expect(timeInput.value).toBe('');
   });
 
   it('adjusts the guest count through the service', async () => {

--- a/apps/web-pwa/tests/MealPlanWeekPage.test.ts
+++ b/apps/web-pwa/tests/MealPlanWeekPage.test.ts
@@ -48,6 +48,7 @@ vi.mock('../src/lib/mealPlanService.js', () => ({
   loadTemplateIntoCurrentWeek: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   setWeekDayNote: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   setWeekDayChefs: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  setWeekDayGuests: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   addWeekAttendee: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   removeWeekAttendee: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   setWeekAttendeeHomeTime: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
@@ -60,9 +61,14 @@ import {
   prevWeek,
   loadTemplateIntoCurrentWeek,
   setWeekDayNote,
+  setWeekDayGuests,
   addWeekAttendee,
   setWeekAttendeeHomeTime,
 } from '../src/lib/mealPlanService.js';
+
+async function expandDay(date: string): Promise<void> {
+  await userEvent.click(screen.getByTestId(`day-${date}-summary`));
+}
 
 function member(id: string, name: string): Member {
   return {
@@ -94,11 +100,13 @@ beforeEach(() => {
 });
 
 describe('MealPlanWeekPage', () => {
-  it('renders seven day editors and the week range', () => {
+  it('renders seven collapsed day rows and the week range', () => {
     render(MealPlanWeekPage);
     expect(screen.getByTestId('day-2026-06-08')).toBeInTheDocument();
     expect(screen.getByTestId('day-2026-06-14')).toBeInTheDocument();
     expect(screen.getByTestId('week-range').textContent).toContain('Jun');
+    // Detail is hidden until a day is expanded.
+    expect(screen.queryByTestId('day-2026-06-08-detail')).not.toBeInTheDocument();
   });
 
   it('navigates with prev/next', async () => {
@@ -109,8 +117,9 @@ describe('MealPlanWeekPage', () => {
     expect(vi.mocked(prevWeek)).toHaveBeenCalled();
   });
 
-  it('edits a meal note through the service', async () => {
+  it('edits a meal note through the service after expanding the day', async () => {
     render(MealPlanWeekPage);
+    await expandDay('2026-06-08');
     const noteInput = screen.getByTestId('day-2026-06-08-note');
     await userEvent.type(noteInput, 'Pasta');
     await waitFor(() => expect(vi.mocked(setWeekDayNote)).toHaveBeenCalled());
@@ -119,6 +128,7 @@ describe('MealPlanWeekPage', () => {
 
   it('toggles an attendee and reveals a savable blank home-time', async () => {
     render(MealPlanWeekPage);
+    await expandDay('2026-06-08');
     const attendWrap = screen.getByTestId('day-2026-06-08-attend-alice@e.org');
     await userEvent.click(within(attendWrap).getByRole('checkbox'));
     expect(vi.mocked(addWeekAttendee)).toHaveBeenCalledWith(
@@ -136,6 +146,7 @@ describe('MealPlanWeekPage', () => {
           recipeIds: [],
           chefs: [],
           attendees: [{ memberId: 'alice@e.org', homeTime: '18:00', note: '' }],
+          guests: 0,
         },
       },
     });
@@ -174,7 +185,7 @@ describe('MealPlanWeekPage', () => {
     expect(vi.mocked(loadTemplateIntoCurrentWeek)).toHaveBeenCalled();
   });
 
-  it('renders an unknown attendee as removable', async () => {
+  it('renders an unknown attendee as removable in the detail panel', async () => {
     mockWeek._set({
       ...emptyWeek('2026-06-08'),
       days: {
@@ -184,17 +195,26 @@ describe('MealPlanWeekPage', () => {
           recipeIds: [],
           chefs: [],
           attendees: [{ memberId: 'gone@e.org', homeTime: null, note: '' }],
+          guests: 0,
         },
       },
     });
     render(MealPlanWeekPage);
+    await expandDay('2026-06-08');
     expect(screen.getByTestId('day-2026-06-08-unknown-gone@e.org')).toBeInTheDocument();
+  });
+
+  it('adjusts the guest count through the service', async () => {
+    render(MealPlanWeekPage);
+    await expandDay('2026-06-08');
+    await userEvent.click(screen.getByTestId('day-2026-06-08-guests-inc'));
+    expect(vi.mocked(setWeekDayGuests)).toHaveBeenCalledWith('2026-06-08', 1);
   });
 
   it('shows a spinner while the week is loading', () => {
     mockLoading._set(true);
     render(MealPlanWeekPage);
-    // ListPage renders its loading state; the day editors are absent.
+    // ListPage renders its loading state; the day rows are absent.
     expect(screen.queryByTestId('day-2026-06-08')).not.toBeInTheDocument();
   });
 });

--- a/apps/web-pwa/tests/MealPlanWeekPage.test.ts
+++ b/apps/web-pwa/tests/MealPlanWeekPage.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, waitFor, within } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { emptyWeek, setDayNote, type MealPlanWeek, type Member } from '@salt/domain';
+
+// ─── Hoisted reactive stubs ────────────────────────────────────────────────
+const { mockMembers, mockWeek, mockStart, mockLoading } = vi.hoisted(() => {
+  function makeStore<T>(initial: T) {
+    let value = initial;
+    const subs = new Set<(v: T) => void>();
+    return {
+      subscribe(fn: (v: T) => void) {
+        subs.add(fn);
+        fn(value);
+        return () => {
+          subs.delete(fn);
+        };
+      },
+      _set(v: T) {
+        value = v;
+        subs.forEach((fn) => fn(v));
+      },
+    };
+  }
+  return {
+    mockMembers: makeStore<Member[]>([]),
+    mockWeek: makeStore<MealPlanWeek>({
+      id: '',
+      schemaVersion: 1,
+      startDate: '',
+      days: {},
+      updatedAt: '',
+    }),
+    mockStart: makeStore<string>('2026-06-08'),
+    mockLoading: makeStore<boolean>(false),
+  };
+});
+
+vi.mock('../src/lib/toastStore.js', () => ({ addToast: vi.fn() }));
+vi.mock('../src/lib/membersService.js', () => ({ members: mockMembers }));
+vi.mock('../src/lib/mealPlanService.js', () => ({
+  currentWeek: mockWeek,
+  selectedStartDate: mockStart,
+  isLoadingMealPlanWeek: mockLoading,
+  nextWeek: vi.fn(),
+  prevWeek: vi.fn(),
+  thisWeek: vi.fn(),
+  loadTemplateIntoCurrentWeek: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  setWeekDayNote: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  setWeekDayChefs: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  addWeekAttendee: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  removeWeekAttendee: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  setWeekAttendeeHomeTime: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  setWeekAttendeeNote: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+}));
+
+import MealPlanWeekPage from '../src/routes/mealplan/MealPlanWeekPage.svelte';
+import {
+  nextWeek,
+  prevWeek,
+  loadTemplateIntoCurrentWeek,
+  setWeekDayNote,
+  addWeekAttendee,
+  setWeekAttendeeHomeTime,
+} from '../src/lib/mealPlanService.js';
+
+function member(id: string, name: string): Member {
+  return {
+    id,
+    schemaVersion: 1,
+    name,
+    email: id,
+    admin: false,
+    sortOrder: 0,
+    icon: null,
+    updatedAt: '2026-06-07T00:00:00.000Z',
+  };
+}
+
+const ALICE = member('alice@e.org', 'Alice');
+const BOB = member('bob@e.org', 'Bob');
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMembers._set([ALICE, BOB]);
+  mockStart._set('2026-06-08');
+  mockLoading._set(false);
+  mockWeek._set(emptyWeek('2026-06-08'));
+});
+
+describe('MealPlanWeekPage', () => {
+  it('renders seven day editors and the week range', () => {
+    render(MealPlanWeekPage);
+    expect(screen.getByTestId('day-2026-06-08')).toBeInTheDocument();
+    expect(screen.getByTestId('day-2026-06-14')).toBeInTheDocument();
+    expect(screen.getByTestId('week-range').textContent).toContain('Jun');
+  });
+
+  it('navigates with prev/next', async () => {
+    render(MealPlanWeekPage);
+    await userEvent.click(screen.getByLabelText('Next week'));
+    expect(vi.mocked(nextWeek)).toHaveBeenCalled();
+    await userEvent.click(screen.getByLabelText('Previous week'));
+    expect(vi.mocked(prevWeek)).toHaveBeenCalled();
+  });
+
+  it('edits a meal note through the service', async () => {
+    render(MealPlanWeekPage);
+    const noteInput = screen.getByTestId('day-2026-06-08-note');
+    await userEvent.type(noteInput, 'Pasta');
+    await waitFor(() => expect(vi.mocked(setWeekDayNote)).toHaveBeenCalled());
+    expect(vi.mocked(setWeekDayNote).mock.calls[0]![0]).toBe('2026-06-08');
+  });
+
+  it('toggles an attendee and reveals a savable blank home-time', async () => {
+    render(MealPlanWeekPage);
+    const attendWrap = screen.getByTestId('day-2026-06-08-attend-alice@e.org');
+    await userEvent.click(within(attendWrap).getByRole('checkbox'));
+    expect(vi.mocked(addWeekAttendee)).toHaveBeenCalledWith(
+      '2026-06-08',
+      expect.objectContaining({ memberId: 'alice@e.org', homeTime: null }),
+    );
+
+    // With Alice attending, the home-time input appears; leaving it blank saves null.
+    mockWeek._set({
+      ...emptyWeek('2026-06-08'),
+      days: {
+        ...emptyWeek('2026-06-08').days,
+        '2026-06-08': {
+          note: '',
+          recipeIds: [],
+          chefs: [],
+          attendees: [{ memberId: 'alice@e.org', homeTime: '18:00', note: '' }],
+        },
+      },
+    });
+    const timeInput = (await screen.findByTestId(
+      'day-2026-06-08-time-alice@e.org',
+    )) as HTMLInputElement;
+    await userEvent.clear(timeInput);
+    await waitFor(() =>
+      expect(vi.mocked(setWeekAttendeeHomeTime)).toHaveBeenCalledWith(
+        '2026-06-08',
+        'alice@e.org',
+        null,
+      ),
+    );
+  });
+
+  it('loads the template directly for an unedited week (no confirm)', async () => {
+    render(MealPlanWeekPage);
+    await userEvent.click(screen.getByTestId('load-template'));
+    expect(vi.mocked(loadTemplateIntoCurrentWeek)).toHaveBeenCalled();
+  });
+
+  it('confirms before overwriting an already-edited week', async () => {
+    mockWeek._set(
+      setDayNote(
+        { ...emptyWeek('2026-06-08'), updatedAt: '2026-06-08T00:00:00.000Z' },
+        '2026-06-08',
+        'edited',
+      ),
+    );
+    render(MealPlanWeekPage);
+    await userEvent.click(screen.getByTestId('load-template'));
+    await waitFor(() => screen.getByTestId('load-template-confirm'));
+    expect(vi.mocked(loadTemplateIntoCurrentWeek)).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByTestId('load-template-confirm-btn'));
+    expect(vi.mocked(loadTemplateIntoCurrentWeek)).toHaveBeenCalled();
+  });
+
+  it('renders an unknown attendee as removable', async () => {
+    mockWeek._set({
+      ...emptyWeek('2026-06-08'),
+      days: {
+        ...emptyWeek('2026-06-08').days,
+        '2026-06-08': {
+          note: '',
+          recipeIds: [],
+          chefs: [],
+          attendees: [{ memberId: 'gone@e.org', homeTime: null, note: '' }],
+        },
+      },
+    });
+    render(MealPlanWeekPage);
+    expect(screen.getByTestId('day-2026-06-08-unknown-gone@e.org')).toBeInTheDocument();
+  });
+
+  it('shows a spinner while the week is loading', () => {
+    mockLoading._set(true);
+    render(MealPlanWeekPage);
+    // ListPage renders its loading state; the day editors are absent.
+    expect(screen.queryByTestId('day-2026-06-08')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web-pwa/tests/MealPlanWeekPage.test.ts
+++ b/apps/web-pwa/tests/MealPlanWeekPage.test.ts
@@ -285,6 +285,25 @@ describe('MealPlanWeekPage', () => {
     expect(vi.mocked(setWeekDayChefs)).toHaveBeenCalledWith('2026-06-08', ['alice@e.org']);
   });
 
+  it('chef toggle styling reacts to selection state', async () => {
+    const chefDay = (chefs: string[]) => ({
+      ...emptyWeek('2026-06-08'),
+      days: {
+        ...emptyWeek('2026-06-08').days,
+        '2026-06-08': { note: '', recipeIds: [], chefs, attendees: [], guests: 0 },
+      },
+    });
+    mockWeek._set(chefDay(['alice@e.org']));
+    render(MealPlanWeekPage);
+    await expandDay('2026-06-08');
+    const btn = screen.getByTestId('day-2026-06-08-chef-alice@e.org');
+    expect(btn.className).toContain('bg-amber-500');
+
+    // Deselecting (chefs back to empty) must drop the selected colour.
+    mockWeek._set(chefDay([]));
+    await waitFor(() => expect(btn.className).not.toContain('bg-amber-500'));
+  });
+
   it('adjusts the guest count through the service', async () => {
     render(MealPlanWeekPage);
     await expandDay('2026-06-08');

--- a/apps/web-pwa/tests/MealPlanWeekPage.test.ts
+++ b/apps/web-pwa/tests/MealPlanWeekPage.test.ts
@@ -133,7 +133,7 @@ describe('MealPlanWeekPage', () => {
     await userEvent.click(within(attendWrap).getByRole('checkbox'));
     expect(vi.mocked(addWeekAttendee)).toHaveBeenCalledWith(
       '2026-06-08',
-      expect.objectContaining({ memberId: 'alice@e.org', homeTime: null }),
+      expect.objectContaining({ memberId: 'alice@e.org', homeTime: '18:30' }),
     );
 
     // With Alice attending, the home-time input appears; leaving it blank saves null.
@@ -202,6 +202,49 @@ describe('MealPlanWeekPage', () => {
     render(MealPlanWeekPage);
     await expandDay('2026-06-08');
     expect(screen.getByTestId('day-2026-06-08-unknown-gone@e.org')).toBeInTheDocument();
+  });
+
+  it('shows home time and a note indicator on the collapsed row', () => {
+    mockWeek._set({
+      ...emptyWeek('2026-06-08'),
+      days: {
+        ...emptyWeek('2026-06-08').days,
+        '2026-06-08': {
+          note: 'Roast',
+          recipeIds: [],
+          chefs: [],
+          attendees: [
+            { memberId: 'alice@e.org', homeTime: '18:00', note: 'late' },
+            { memberId: 'bob@e.org', homeTime: null, note: '' },
+          ],
+          guests: 0,
+        },
+      },
+    });
+    render(MealPlanWeekPage);
+    const summary = screen.getByTestId('day-2026-06-08-summary');
+    // Alice's time shows; Bob's blank time shows nothing.
+    expect(summary.textContent).toContain('18:00');
+    // A note exists, so the indicator is present.
+    expect(screen.getByTestId('day-2026-06-08-note-indicator')).toBeInTheDocument();
+  });
+
+  it('omits the note indicator when no attendee has a note', () => {
+    mockWeek._set({
+      ...emptyWeek('2026-06-08'),
+      days: {
+        ...emptyWeek('2026-06-08').days,
+        '2026-06-08': {
+          note: 'Roast',
+          recipeIds: [],
+          chefs: [],
+          attendees: [{ memberId: 'alice@e.org', homeTime: '18:00', note: '' }],
+          guests: 0,
+        },
+      },
+    });
+    render(MealPlanWeekPage);
+    expect(screen.queryByTestId('day-2026-06-08-note-indicator')).not.toBeInTheDocument();
   });
 
   it('adjusts the guest count through the service', async () => {

--- a/apps/web-pwa/tests/MealPlanWeekPage.test.ts
+++ b/apps/web-pwa/tests/MealPlanWeekPage.test.ts
@@ -62,6 +62,7 @@ import {
   loadTemplateIntoCurrentWeek,
   setWeekDayNote,
   setWeekDayGuests,
+  setWeekDayChefs,
   addWeekAttendee,
   setWeekAttendeeHomeTime,
 } from '../src/lib/mealPlanService.js';
@@ -274,6 +275,14 @@ describe('MealPlanWeekPage', () => {
     // Blurring without picking re-syncs back to the committed blank value.
     await fireEvent.blur(timeInput);
     expect(timeInput.value).toBe('');
+  });
+
+  it('lets a non-attending member be set as chef', async () => {
+    render(MealPlanWeekPage);
+    await expandDay('2026-06-08');
+    // Alice is not attending; the Chef toggle is still present and works.
+    await userEvent.click(screen.getByTestId('day-2026-06-08-chef-alice@e.org'));
+    expect(vi.mocked(setWeekDayChefs)).toHaveBeenCalledWith('2026-06-08', ['alice@e.org']);
   });
 
   it('adjusts the guest count through the service', async () => {

--- a/apps/web-pwa/tests/mealPlanService.sync.test.ts
+++ b/apps/web-pwa/tests/mealPlanService.sync.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, vi, type Mocked } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  emptyTemplate,
+  emptyWeek,
+  setDayNote,
+  weekStartFor,
+  type MealPlanConfig,
+  type MealPlanTemplate,
+  type MealPlanWeek,
+} from '@salt/domain';
+
+vi.mock('@salt/firebase-sync', () => ({
+  subscribeMealPlanConfig: vi.fn(),
+  subscribeMealPlanTemplate: vi.fn(),
+  subscribeMealPlanWeek: vi.fn(),
+  saveMealPlanConfig: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  saveMealPlanTemplate: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  saveMealPlanWeek: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+}));
+
+import * as firebaseSync from '@salt/firebase-sync';
+import {
+  currentWeek,
+  selectedStartDate,
+  firstDayOfWeek,
+  mealPlanTemplate,
+  initMealPlanSync,
+  goToWeek,
+  nextWeek,
+  prevWeek,
+  loadTemplateIntoCurrentWeek,
+  setWeekDayNote,
+  saveFirstDayOfWeek,
+  setTemplateDayNote,
+  seedMealPlanConfig,
+  seedMealPlanTemplate,
+  seedMealPlanWeek,
+  getMealPlanWeekSnapshot,
+  __resetMealPlanServiceForTest,
+} from '../src/lib/mealPlanService.js';
+
+const fs = firebaseSync as Mocked<typeof firebaseSync>;
+
+type WeekCb = (w: MealPlanWeek | null) => void;
+type ConfigCb = (c: MealPlanConfig | null) => void;
+type TemplateCb = (t: MealPlanTemplate | null) => void;
+
+const CONFIG: MealPlanConfig = { firstDayOfWeek: 'mon', schemaVersion: 1 };
+
+function wireSubscriptions() {
+  let weekCb: WeekCb | null = null;
+  let configCb: ConfigCb | null = null;
+  let templateCb: TemplateCb | null = null;
+  const weekUnsub = vi.fn();
+  fs.subscribeMealPlanConfig.mockImplementation((on) => {
+    configCb = on as ConfigCb;
+    return vi.fn();
+  });
+  fs.subscribeMealPlanTemplate.mockImplementation((on) => {
+    templateCb = on as TemplateCb;
+    return vi.fn();
+  });
+  fs.subscribeMealPlanWeek.mockImplementation((_start, on) => {
+    weekCb = on as WeekCb;
+    return weekUnsub;
+  });
+  return {
+    emitConfig: (c: MealPlanConfig | null) => configCb!(c),
+    emitTemplate: (t: MealPlanTemplate | null) => templateCb!(t),
+    emitWeek: (w: MealPlanWeek | null) => weekCb!(w),
+    weekUnsub,
+  };
+}
+
+beforeEach(() => {
+  __resetMealPlanServiceForTest();
+  vi.clearAllMocks();
+  fs.saveMealPlanConfig.mockResolvedValue({ kind: 'ok', value: undefined });
+  fs.saveMealPlanTemplate.mockResolvedValue({ kind: 'ok', value: undefined });
+  fs.saveMealPlanWeek.mockResolvedValue({ kind: 'ok', value: undefined });
+});
+
+describe('mealPlanService — subscriptions', () => {
+  it('subscribes to config, template and the current week on init', () => {
+    wireSubscriptions();
+    initMealPlanSync();
+    expect(fs.subscribeMealPlanConfig).toHaveBeenCalledTimes(1);
+    expect(fs.subscribeMealPlanTemplate).toHaveBeenCalledTimes(1);
+    expect(fs.subscribeMealPlanWeek).toHaveBeenCalled();
+  });
+
+  it('presents an empty week when the week doc does not exist', () => {
+    const { emitWeek } = wireSubscriptions();
+    initMealPlanSync();
+    emitWeek(null);
+    const week = get(currentWeek);
+    expect(Object.keys(week.days)).toHaveLength(7);
+    expect(week.updatedAt).toBe('');
+  });
+
+  it('re-subscribes when firstDayOfWeek changes which date the week starts on', () => {
+    const { emitConfig } = wireSubscriptions();
+    initMealPlanSync();
+    goToWeek('2026-06-10'); // Wednesday
+    const monStart = get(selectedStartDate);
+    expect(monStart).toBe('2026-06-08'); // default mon
+
+    emitConfig({ firstDayOfWeek: 'wed', schemaVersion: 1 });
+    expect(get(firstDayOfWeek)).toBe('wed');
+    expect(get(selectedStartDate)).toBe('2026-06-10'); // week now starts Wed
+  });
+});
+
+describe('mealPlanService — navigation', () => {
+  beforeEach(() => {
+    wireSubscriptions();
+    initMealPlanSync();
+    seedMealPlanConfig(CONFIG);
+  });
+
+  it('goToWeek computes the Monday start of the anchor date', () => {
+    goToWeek('2026-06-10');
+    expect(get(selectedStartDate)).toBe('2026-06-08');
+  });
+
+  it('nextWeek and prevWeek step a whole week', () => {
+    goToWeek('2026-06-10');
+    nextWeek();
+    expect(get(selectedStartDate)).toBe('2026-06-15');
+    prevWeek();
+    prevWeek();
+    expect(get(selectedStartDate)).toBe('2026-06-01');
+  });
+});
+
+describe('mealPlanService — mutations', () => {
+  beforeEach(() => {
+    wireSubscriptions();
+    initMealPlanSync();
+    seedMealPlanConfig(CONFIG);
+  });
+
+  it('loadTemplateIntoCurrentWeek instantiates the week from the template and saves', async () => {
+    const template = setDayNote(emptyTemplate(), 'mon', 'roast');
+    seedMealPlanTemplate(template);
+    goToWeek('2026-06-08'); // Monday start
+
+    await loadTemplateIntoCurrentWeek();
+
+    const saved = fs.saveMealPlanWeek.mock.calls[0]![0]!;
+    expect(saved.days['2026-06-08']!.note).toBe('roast');
+    expect(saved.updatedAt).not.toBe('');
+    expect(get(currentWeek).days['2026-06-08']!.note).toBe('roast');
+  });
+
+  it('setWeekDayNote persists the edited day and stamps updatedAt', async () => {
+    const week = emptyWeek('2026-06-08');
+    seedMealPlanWeek(week);
+
+    await setWeekDayNote('2026-06-09', 'pasta');
+
+    const saved = fs.saveMealPlanWeek.mock.calls[0]![0]!;
+    expect(saved.days['2026-06-09']!.note).toBe('pasta');
+    expect(saved.updatedAt).not.toBe('');
+    expect(getMealPlanWeekSnapshot().days['2026-06-09']!.note).toBe('pasta');
+  });
+
+  it('saveFirstDayOfWeek writes the config singleton', async () => {
+    await saveFirstDayOfWeek('sat');
+    expect(fs.saveMealPlanConfig).toHaveBeenCalledWith({
+      firstDayOfWeek: 'sat',
+      schemaVersion: 1,
+    });
+  });
+
+  it('setTemplateDayNote persists the template keyed by weekday', async () => {
+    seedMealPlanTemplate(emptyTemplate());
+    await setTemplateDayNote('fri', 'pizza');
+    const saved = fs.saveMealPlanTemplate.mock.calls[0]![0]!;
+    expect(saved.days.fri.note).toBe('pizza');
+    expect(get(mealPlanTemplate)!.days.fri.note).toBe('pizza');
+  });
+});
+
+describe('mealPlanService — week-start helper parity', () => {
+  it('uses weekStartFor consistently with the domain', () => {
+    expect(weekStartFor('2026-06-10', 'mon')).toBe('2026-06-08');
+  });
+});

--- a/apps/web-pwa/tests/mealPlanService.sync.test.ts
+++ b/apps/web-pwa/tests/mealPlanService.sync.test.ts
@@ -31,6 +31,7 @@ import {
   prevWeek,
   loadTemplateIntoCurrentWeek,
   setWeekDayNote,
+  setWeekDayChefs,
   saveFirstDayOfWeek,
   setTemplateDayNote,
   seedMealPlanConfig,
@@ -97,6 +98,34 @@ describe('mealPlanService — subscriptions', () => {
     const week = get(currentWeek);
     expect(Object.keys(week.days)).toHaveLength(7);
     expect(week.updatedAt).toBe('');
+  });
+
+  it('ignores a stale week snapshot that predates a newer local edit', () => {
+    const { emitWeek } = wireSubscriptions();
+    initMealPlanSync();
+    seedMealPlanConfig(CONFIG);
+    goToWeek('2026-06-08');
+    const start = '2026-06-08';
+    const chefWeek = (chefs: string[], updatedAt: string): MealPlanWeek => ({
+      ...emptyWeek(start),
+      days: {
+        ...emptyWeek(start).days,
+        [start]: { note: '', recipeIds: [], chefs, attendees: [], guests: 0 },
+      },
+      updatedAt,
+    });
+
+    // Initial doc has alice as chef (older timestamp).
+    emitWeek(chefWeek(['alice@e.org'], '2026-06-08T10:00:00.000Z'));
+    expect(getMealPlanWeekSnapshot().days[start]!.chefs).toEqual(['alice@e.org']);
+
+    // Local deselect → optimistic update stamps a newer updatedAt.
+    void setWeekDayChefs(start, []);
+    expect(getMealPlanWeekSnapshot().days[start]!.chefs).toEqual([]);
+
+    // A stale in-flight snapshot echo of the OLD chef state must be ignored.
+    emitWeek(chefWeek(['alice@e.org'], '2026-06-08T10:00:00.000Z'));
+    expect(getMealPlanWeekSnapshot().days[start]!.chefs).toEqual([]);
   });
 
   it('re-subscribes when firstDayOfWeek changes which date the week starts on', () => {

--- a/docs/meal-planning.md
+++ b/docs/meal-planning.md
@@ -1,0 +1,105 @@
+# Meal Planning module
+
+Plan a week's worth of **evening meals**. Each week is one document; a single
+**standard template** (the typical week) can be loaded into any week and then
+tweaked. The whole point is fast weekly turnaround: load the template, adjust
+the exceptions, done.
+
+All data is family-shared (no per-user scoping). Member references are by
+`memberId` (= normalised email, the members-module key from #155).
+
+## Documents
+
+| Doc | Firestore path | Cardinality | Purpose |
+| --- | --- | --- | --- |
+| `MealPlanConfig` | `mealPlanConfig/{document}` (singleton) | 1 | `firstDayOfWeek` — the "big shop" day that starts each week |
+| `MealPlanTemplate` | `mealPlanTemplate/{document}` (singleton) | 1 | The standard week, keyed by weekday (`mon`…`sun`) |
+| `MealPlanWeek` | `mealPlans/{YYYY-MM-DD}` | many | One concrete week, keyed by the date of its start day |
+
+Config and template are **separate singletons** so editing one never
+last-write-wins-clobbers the other.
+
+## Day shape (shared by template and week)
+
+Both the template's seven weekday entries and a week's seven dated entries use
+the same shape:
+
+```
+Day {
+  note: string                       // free-text meal description (v1)
+  recipeIds: string[]                // RESERVED seam for recipes (#17); empty until then
+  chefs: memberId[]                  // zero or more; a chef need NOT be an attendee
+  attendees: Attendee[]
+}
+
+Attendee {
+  memberId: string
+  homeTime: string | null            // "HH:mm" 24h local time; null = attending, time unknown (a valid saved state)
+  note: string                       // per-person note, e.g. "make a portion for another day"
+}
+```
+
+- **Template** keys its seven `Day`s by weekday name. It carries the *usual*
+  attendees, chefs, home-times (which may be blank), per-person notes, and an
+  optional recurring meal `note` (e.g. Friday = pizza).
+- **Week** keys its seven `Day`s by concrete `YYYY-MM-DD` date.
+
+## First-day-of-week & week identity
+
+`firstDayOfWeek` (a global setting, the big-shop day) controls only **layout and
+which date a week starts on** — it never reshapes the template. The template is
+always keyed mon–sun, so changing the big-shop day re-maps the standard week
+onto the new day order without data migration.
+
+A week's document key is the ISO date (`YYYY-MM-DD`) of its start day. A pure
+domain function `weekStartFor(date, config)` computes the start date of the week
+containing any given date.
+
+## The core mechanic: load template
+
+`instantiateWeek(startDate, config, template)` is a pure function: for each of
+the seven dates from `startDate`, it looks up that date's weekday in the
+template and copies the weekday `Day` into the dated `Day`. This is the
+"load template" action. Re-loading overwrites the week back to the standard,
+ready for exception-tweaking. This is the heart of the quick-weekly-update goal.
+
+## Conflict model
+
+One Firestore document per week, **whole-document last-write-wins** (consistent
+with Firestore-as-master, no tombstones). The only clobber window is two people
+editing the *same* week simultaneously — acceptable for a single small
+household. Per-day documents were rejected as over-engineering for the
+concurrency profile.
+
+## Member references
+
+Store `memberId` only. Names, initials, and avatars are resolved at **display
+time** from the live members store — never denormalised into the plan. A member
+who has left the family renders as removable/unknown rather than corrupting the
+document. Tolerate-and-render, never block on a missing member.
+
+## Access & admin
+
+Firestore rules keep **writes open to any authenticated user** (an
+authenticated user is already an allowlisted member via `beforeMemberCreated`),
+matching the shared-data / canon-write-path-open principle. The **template
+editor and first-day setting live in the admin settings area**, but that
+`AdminGuard` is **cosmetic** (accidental-damage protection) — it is never
+enforced in rules. The weekly plan editor is open to all members.
+
+## Architecture placement
+
+New modules sit inside existing packages — **no new package, no new dependency,
+no layer-map change, no Cloud Function, no AI** (recipes/AI arrive later via #17):
+
+- `packages/domain/src/mealPlan/` — entities, pure commands/queries
+- `packages/domain/src/schemas/mealPlan*.ts` — zod schemas (validated on read in firebase-sync)
+- `packages/adapters/firebase-sync/src/mealPlan*.ts` — subscriptions + writes for the three docs
+- `apps/web-pwa/src/lib/mealPlanService.ts` + routes — store, navigation, editors
+
+## Future seam: recipes (#17)
+
+`Day.recipeIds` ships now as an always-empty array. When the recipe module
+lands, the weekly/template UI gains a recipe multi-select that populates it; the
+free-text `note` remains for ad-hoc meals. No schema-shape break required
+(pre-launch greenfield; adding use of an existing field is free).

--- a/firestore.rules
+++ b/firestore.rules
@@ -51,6 +51,18 @@ service cloud.firestore {
     match /shoppingListsConfig/{document} {
       allow read, write: if request.auth != null;
     }
+    // Meal planning (issue #169) — all shared, family-wide; any authenticated
+    // user can read and write. The template/first-day AdminGuard is cosmetic UI
+    // only and is deliberately NOT enforced here (docs/meal-planning.md).
+    match /mealPlanConfig/{document} {
+      allow read, write: if request.auth != null;
+    }
+    match /mealPlanTemplate/{document} {
+      allow read, write: if request.auth != null;
+    }
+    match /mealPlans/{startDate} {
+      allow read, write: if request.auth != null;
+    }
     match /{document=**} {
       allow read, write: if false;
     }

--- a/packages/adapters/firebase-sync/src/index.ts
+++ b/packages/adapters/firebase-sync/src/index.ts
@@ -31,6 +31,14 @@ export {
   saveShoppingListsConfig,
 } from './shoppingListsConfigSubscription.js';
 export { subscribeMembers, upsertMember, deleteMember } from './membersSubscription.js';
+export {
+  subscribeMealPlanConfig,
+  subscribeMealPlanTemplate,
+  subscribeMealPlanWeek,
+  saveMealPlanConfig,
+  saveMealPlanTemplate,
+  saveMealPlanWeek,
+} from './mealPlanSync.js';
 export type {
   IdentifyEquipmentCandidate,
   IdentifyEquipmentResult,

--- a/packages/adapters/firebase-sync/src/mealPlanSync.ts
+++ b/packages/adapters/firebase-sync/src/mealPlanSync.ts
@@ -1,0 +1,126 @@
+import { getFirestore, doc, setDoc, onSnapshot } from 'firebase/firestore';
+import { getApp } from 'firebase/app';
+import type { MealPlanConfig, MealPlanTemplate, MealPlanWeek } from '@salt/domain';
+import type { DomainError, ReadResult } from '@salt/shared-types';
+import { success, failure } from '@salt/shared-types';
+import {
+  MealPlanConfigSchema,
+  MealPlanTemplateSchema,
+  MealPlanWeekSchema,
+} from '@salt/domain/schemas';
+import { classifyFirestoreError } from './firestoreErrors.js';
+
+// Meal planning sync (issue #169). Three Firestore docs, all single-document
+// reads: config + template are singletons, a week is one dated doc. A corrupt
+// doc surfaces a Failure via onError (single-doc read contract) rather than
+// throwing. See docs/meal-planning.md.
+
+const CONFIG_COLLECTION = 'mealPlanConfig';
+const TEMPLATE_COLLECTION = 'mealPlanTemplate';
+const WEEKS_COLLECTION = 'mealPlans';
+const SINGLETON_DOC_ID = 'singleton';
+
+export function subscribeMealPlanConfig(
+  onConfig: (config: MealPlanConfig | null) => void,
+  onError: (err: DomainError) => void,
+): () => void {
+  const db = getFirestore(getApp());
+  return onSnapshot(
+    doc(db, CONFIG_COLLECTION, SINGLETON_DOC_ID),
+    (snap) => {
+      if (!snap.exists()) {
+        onConfig(null);
+        return;
+      }
+      const result = MealPlanConfigSchema.safeParse(snap.data());
+      if (!result.success) {
+        onError({ kind: 'StorageError', reason: 'corruption' });
+        return;
+      }
+      onConfig(result.data as MealPlanConfig);
+    },
+    (err) => onError(classifyFirestoreError(err)),
+  );
+}
+
+export function subscribeMealPlanTemplate(
+  onTemplate: (template: MealPlanTemplate | null) => void,
+  onError: (err: DomainError) => void,
+): () => void {
+  const db = getFirestore(getApp());
+  return onSnapshot(
+    doc(db, TEMPLATE_COLLECTION, SINGLETON_DOC_ID),
+    (snap) => {
+      if (!snap.exists()) {
+        onTemplate(null);
+        return;
+      }
+      const result = MealPlanTemplateSchema.safeParse(snap.data());
+      if (!result.success) {
+        onError({ kind: 'StorageError', reason: 'corruption' });
+        return;
+      }
+      onTemplate(result.data as MealPlanTemplate);
+    },
+    (err) => onError(classifyFirestoreError(err)),
+  );
+}
+
+export function subscribeMealPlanWeek(
+  startDate: string,
+  onWeek: (week: MealPlanWeek | null) => void,
+  onError: (err: DomainError) => void,
+): () => void {
+  const db = getFirestore(getApp());
+  return onSnapshot(
+    doc(db, WEEKS_COLLECTION, startDate),
+    (snap) => {
+      if (!snap.exists()) {
+        onWeek(null);
+        return;
+      }
+      const result = MealPlanWeekSchema.safeParse(snap.data());
+      if (!result.success) {
+        onError({ kind: 'StorageError', reason: 'corruption' });
+        return;
+      }
+      onWeek(result.data as MealPlanWeek);
+    },
+    (err) => onError(classifyFirestoreError(err)),
+  );
+}
+
+export async function saveMealPlanConfig(
+  config: MealPlanConfig,
+): Promise<ReadResult<void, DomainError>> {
+  try {
+    const db = getFirestore(getApp());
+    await setDoc(doc(db, CONFIG_COLLECTION, SINGLETON_DOC_ID), { ...config });
+    return success(undefined);
+  } catch (err) {
+    return failure(classifyFirestoreError(err));
+  }
+}
+
+export async function saveMealPlanTemplate(
+  template: MealPlanTemplate,
+): Promise<ReadResult<void, DomainError>> {
+  try {
+    const db = getFirestore(getApp());
+    await setDoc(doc(db, TEMPLATE_COLLECTION, SINGLETON_DOC_ID), { ...template });
+    return success(undefined);
+  } catch (err) {
+    return failure(classifyFirestoreError(err));
+  }
+}
+
+// Keyed by week.id (= startDate). Whole-document last-write-wins.
+export async function saveMealPlanWeek(week: MealPlanWeek): Promise<ReadResult<void, DomainError>> {
+  try {
+    const db = getFirestore(getApp());
+    await setDoc(doc(db, WEEKS_COLLECTION, week.id), { ...week });
+    return success(undefined);
+  } catch (err) {
+    return failure(classifyFirestoreError(err));
+  }
+}

--- a/packages/adapters/firebase-sync/tests/firestoreRules.emulator.test.ts
+++ b/packages/adapters/firebase-sync/tests/firestoreRules.emulator.test.ts
@@ -144,3 +144,69 @@ describe.skipIf(!reachable)('firestore.rules — members allowlist', () => {
     await assertFails(setDoc(doc(db, 'members', 'x@e.org'), memberDoc('x@e.org', false)));
   });
 });
+
+describe.skipIf(!reachable)('firestore.rules — meal planning (issue #169)', () => {
+  let testEnv: RulesTestEnvironment;
+
+  beforeAll(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId: PROJECT_ID,
+      firestore: {
+        host: HOST,
+        port: PORT,
+        rules: readFileSync(RULES_PATH, 'utf8'),
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await testEnv?.cleanup();
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+  });
+
+  function userCtx() {
+    // Any signed-in user is already an allowlisted member; no member doc needed
+    // because meal-plan rules never call get(/members/...) (writes are open).
+    return testEnv.authenticatedContext('uid-user', { email: 'user@e.org' }).firestore();
+  }
+
+  it('lets any signed-in user read and write the config singleton', async () => {
+    const db = userCtx();
+    await assertSucceeds(
+      setDoc(doc(db, 'mealPlanConfig', 'singleton'), { firstDayOfWeek: 'mon', schemaVersion: 1 }),
+    );
+    await assertSucceeds(getDoc(doc(db, 'mealPlanConfig', 'singleton')));
+  });
+
+  it('lets any signed-in user read and write the template singleton', async () => {
+    const db = userCtx();
+    await assertSucceeds(
+      setDoc(doc(db, 'mealPlanTemplate', 'singleton'), { schemaVersion: 1, days: {} }),
+    );
+    await assertSucceeds(getDoc(doc(db, 'mealPlanTemplate', 'singleton')));
+  });
+
+  it('lets any signed-in user read and write a week doc', async () => {
+    const db = userCtx();
+    await assertSucceeds(
+      setDoc(doc(db, 'mealPlans', '2026-06-08'), {
+        id: '2026-06-08',
+        schemaVersion: 1,
+        startDate: '2026-06-08',
+        days: {},
+        updatedAt: '2026-06-08T00:00:00.000Z',
+      }),
+    );
+    await assertSucceeds(getDoc(doc(db, 'mealPlans', '2026-06-08')));
+  });
+
+  it('denies an unauthenticated caller on every meal-plan doc', async () => {
+    const db = testEnv.unauthenticatedContext().firestore();
+    await assertFails(getDoc(doc(db, 'mealPlanConfig', 'singleton')));
+    await assertFails(getDoc(doc(db, 'mealPlanTemplate', 'singleton')));
+    await assertFails(getDoc(doc(db, 'mealPlans', '2026-06-08')));
+  });
+});

--- a/packages/adapters/firebase-sync/tests/mealPlanSync.test.ts
+++ b/packages/adapters/firebase-sync/tests/mealPlanSync.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockUnsubscribe, mockOnSnapshot, mockSetDoc, mockDoc, mockGetFirestore } = vi.hoisted(
+  () => ({
+    mockUnsubscribe: vi.fn(),
+    mockOnSnapshot: vi.fn(),
+    mockSetDoc: vi.fn(),
+    mockDoc: vi.fn(() => 'mock-doc-ref'),
+    mockGetFirestore: vi.fn(() => 'mock-db'),
+  }),
+);
+
+vi.mock('firebase/app', () => ({
+  getApp: vi.fn(() => ({})),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  getFirestore: mockGetFirestore,
+  doc: mockDoc,
+  onSnapshot: mockOnSnapshot,
+  setDoc: mockSetDoc,
+}));
+
+import {
+  subscribeMealPlanConfig,
+  subscribeMealPlanTemplate,
+  subscribeMealPlanWeek,
+  saveMealPlanConfig,
+  saveMealPlanTemplate,
+  saveMealPlanWeek,
+} from '../src/mealPlanSync.js';
+import type { MealPlanConfig, MealPlanTemplate, MealPlanWeek } from '@salt/domain';
+import { emptyDay, emptyTemplate, emptyWeek } from '@salt/domain';
+
+type SnapCallback = (snap: { exists: () => boolean; data: () => unknown }) => void;
+type ErrorCallback = (err: Error & { code?: string }) => void;
+
+const CONFIG: MealPlanConfig = { firstDayOfWeek: 'mon', schemaVersion: 1 };
+const TEMPLATE: MealPlanTemplate = emptyTemplate();
+const WEEK: MealPlanWeek = { ...emptyWeek('2026-06-08'), updatedAt: '2026-06-08T00:00:00.000Z' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockOnSnapshot.mockReturnValue(mockUnsubscribe);
+  mockSetDoc.mockResolvedValue(undefined);
+  vi.stubGlobal('navigator', { onLine: true });
+});
+
+describe('subscribeMealPlanConfig', () => {
+  it('targets mealPlanConfig/singleton and returns the unsubscribe', () => {
+    const unsub = subscribeMealPlanConfig(
+      () => {},
+      () => {},
+    );
+    expect(mockDoc).toHaveBeenCalledWith('mock-db', 'mealPlanConfig', 'singleton');
+    expect(unsub).toBe(mockUnsubscribe);
+  });
+
+  it('calls onConfig(null) when the doc does not exist', () => {
+    const onConfig = vi.fn();
+    subscribeMealPlanConfig(onConfig, () => {});
+    (mockOnSnapshot.mock.calls[0][1] as SnapCallback)({
+      exists: () => false,
+      data: () => undefined,
+    });
+    expect(onConfig).toHaveBeenCalledWith(null);
+  });
+
+  it('maps a valid config doc', () => {
+    const onConfig = vi.fn();
+    subscribeMealPlanConfig(onConfig, () => {});
+    (mockOnSnapshot.mock.calls[0][1] as SnapCallback)({
+      exists: () => true,
+      data: () => ({ firstDayOfWeek: 'mon', schemaVersion: 1 }),
+    });
+    expect(onConfig).toHaveBeenCalledWith(CONFIG);
+  });
+
+  it('surfaces corruption on an invalid config doc (single-doc read)', () => {
+    const onError = vi.fn();
+    subscribeMealPlanConfig(() => {}, onError);
+    (mockOnSnapshot.mock.calls[0][1] as SnapCallback)({
+      exists: () => true,
+      data: () => ({ firstDayOfWeek: 'notaday', schemaVersion: 1 }),
+    });
+    expect(onError).toHaveBeenCalledWith({ kind: 'StorageError', reason: 'corruption' });
+  });
+
+  it('classifies stream-level errors', () => {
+    const onError = vi.fn();
+    subscribeMealPlanConfig(() => {}, onError);
+    (mockOnSnapshot.mock.calls[0][2] as ErrorCallback)(
+      Object.assign(new Error('e'), { code: 'permission-denied' }),
+    );
+    expect(onError).toHaveBeenCalledWith({ kind: 'AuthError', reason: 'forbidden' });
+  });
+});
+
+describe('subscribeMealPlanTemplate', () => {
+  it('targets mealPlanTemplate/singleton', () => {
+    subscribeMealPlanTemplate(
+      () => {},
+      () => {},
+    );
+    expect(mockDoc).toHaveBeenCalledWith('mock-db', 'mealPlanTemplate', 'singleton');
+  });
+
+  it('maps a valid template doc', () => {
+    const onTemplate = vi.fn();
+    subscribeMealPlanTemplate(onTemplate, () => {});
+    (mockOnSnapshot.mock.calls[0][1] as SnapCallback)({
+      exists: () => true,
+      data: () => ({ schemaVersion: 1, days: TEMPLATE.days }),
+    });
+    expect(onTemplate).toHaveBeenCalledWith(TEMPLATE);
+  });
+
+  it('surfaces corruption on an invalid template doc', () => {
+    const onError = vi.fn();
+    subscribeMealPlanTemplate(() => {}, onError);
+    (mockOnSnapshot.mock.calls[0][1] as SnapCallback)({
+      exists: () => true,
+      data: () => ({ schemaVersion: 2, days: {} }),
+    });
+    expect(onError).toHaveBeenCalledWith({ kind: 'StorageError', reason: 'corruption' });
+  });
+});
+
+describe('subscribeMealPlanWeek', () => {
+  it('targets mealPlans/{startDate}', () => {
+    subscribeMealPlanWeek(
+      '2026-06-08',
+      () => {},
+      () => {},
+    );
+    expect(mockDoc).toHaveBeenCalledWith('mock-db', 'mealPlans', '2026-06-08');
+  });
+
+  it('calls onWeek(null) when the week does not exist yet', () => {
+    const onWeek = vi.fn();
+    subscribeMealPlanWeek('2026-06-08', onWeek, () => {});
+    (mockOnSnapshot.mock.calls[0][1] as SnapCallback)({
+      exists: () => false,
+      data: () => undefined,
+    });
+    expect(onWeek).toHaveBeenCalledWith(null);
+  });
+
+  it('maps a valid week doc (round-trips a null home-time attendee)', () => {
+    const onWeek = vi.fn();
+    const week: MealPlanWeek = {
+      ...WEEK,
+      days: {
+        ...WEEK.days,
+        '2026-06-08': {
+          ...emptyDay(),
+          attendees: [{ memberId: 'a@x.org', homeTime: null, note: '' }],
+        },
+      },
+    };
+    subscribeMealPlanWeek('2026-06-08', onWeek, () => {});
+    (mockOnSnapshot.mock.calls[0][1] as SnapCallback)({
+      exists: () => true,
+      data: () => week,
+    });
+    const [received] = onWeek.mock.calls[0] as [MealPlanWeek];
+    expect(received.days['2026-06-08']!.attendees[0]!.homeTime).toBeNull();
+  });
+
+  it('surfaces corruption on an invalid week doc', () => {
+    const onError = vi.fn();
+    subscribeMealPlanWeek('2026-06-08', () => {}, onError);
+    (mockOnSnapshot.mock.calls[0][1] as SnapCallback)({
+      exists: () => true,
+      data: () => ({ id: '2026-06-08', schemaVersion: 1 }),
+    });
+    expect(onError).toHaveBeenCalledWith({ kind: 'StorageError', reason: 'corruption' });
+  });
+});
+
+describe('save*', () => {
+  it('saveMealPlanConfig writes to the singleton', async () => {
+    const result = await saveMealPlanConfig(CONFIG);
+    expect(mockDoc).toHaveBeenCalledWith('mock-db', 'mealPlanConfig', 'singleton');
+    expect(mockSetDoc).toHaveBeenCalledWith('mock-doc-ref', { ...CONFIG });
+    expect(result).toEqual({ kind: 'ok', value: undefined });
+  });
+
+  it('saveMealPlanTemplate writes to the singleton', async () => {
+    const result = await saveMealPlanTemplate(TEMPLATE);
+    expect(mockDoc).toHaveBeenCalledWith('mock-db', 'mealPlanTemplate', 'singleton');
+    expect(result).toEqual({ kind: 'ok', value: undefined });
+  });
+
+  it('saveMealPlanWeek is keyed by week.id', async () => {
+    const result = await saveMealPlanWeek(WEEK);
+    expect(mockDoc).toHaveBeenCalledWith('mock-db', 'mealPlans', '2026-06-08');
+    expect(mockSetDoc).toHaveBeenCalledWith('mock-doc-ref', { ...WEEK });
+    expect(result).toEqual({ kind: 'ok', value: undefined });
+  });
+
+  it('returns failure (never throws) on a Firestore error', async () => {
+    mockSetDoc.mockRejectedValue(Object.assign(new Error('e'), { code: 'permission-denied' }));
+    const result = await saveMealPlanWeek(WEEK);
+    expect(result).toEqual({ kind: 'err', error: { kind: 'AuthError', reason: 'forbidden' } });
+  });
+});

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -168,5 +168,32 @@ export {
   sortMembers,
 } from './members/index.js';
 
+// Meal planning module — published surface (issue #169).
+export type {
+  Weekday,
+  Attendee,
+  Day,
+  MealPlanConfig,
+  MealPlanTemplate,
+  MealPlanWeek,
+} from './mealPlan/index.js';
+export {
+  WEEKDAYS,
+  WEEKDAY_INDEX,
+  weekStartFor,
+  weekDates,
+  weekdayOf,
+  emptyDay,
+  emptyWeek,
+  emptyTemplate,
+  instantiateWeek,
+  setDayNote,
+  setDayChefs,
+  addAttendee,
+  removeAttendee,
+  setAttendeeHomeTime,
+  setAttendeeNote,
+} from './mealPlan/index.js';
+
 // Cross-cutting ports.
 export type { ErrorReportingPort } from './ErrorReportingPort.js';

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -189,6 +189,7 @@ export {
   instantiateWeek,
   setDayNote,
   setDayChefs,
+  setDayGuests,
   addAttendee,
   removeAttendee,
   setAttendeeHomeTime,

--- a/packages/domain/src/mealPlan/commands/dayMutators.ts
+++ b/packages/domain/src/mealPlan/commands/dayMutators.ts
@@ -1,0 +1,86 @@
+import type { Attendee, Day } from '../entities/Day.js';
+
+// Day mutators operate on a "day container" — either a MealPlanWeek (date-keyed)
+// or a MealPlanTemplate (weekday-keyed). They are generic over the key type so a
+// week is mutated with a "YYYY-MM-DD" key and a template with a weekday key,
+// while sharing one implementation. All return a new container and never mutate
+// the input (pure, time-free — the service stamps `updatedAt` on save).
+
+type DayContainer<K extends string> = { readonly days: Readonly<Record<K, Day>> };
+
+function withDay<K extends string, T extends DayContainer<K>>(
+  container: T,
+  dayKey: K,
+  update: (day: Day) => Day,
+): T {
+  const next = update(container.days[dayKey]);
+  return { ...container, days: { ...container.days, [dayKey]: next } } as T;
+}
+
+function withAttendee(day: Day, memberId: string, update: (a: Attendee) => Attendee): Day {
+  return {
+    ...day,
+    attendees: day.attendees.map((a) => (a.memberId === memberId ? update(a) : a)),
+  };
+}
+
+export function setDayNote<K extends string, T extends DayContainer<K>>(
+  container: T,
+  dayKey: K,
+  note: string,
+): T {
+  return withDay(container, dayKey, (day) => ({ ...day, note }));
+}
+
+export function setDayChefs<K extends string, T extends DayContainer<K>>(
+  container: T,
+  dayKey: K,
+  chefs: readonly string[],
+): T {
+  return withDay(container, dayKey, (day) => ({ ...day, chefs: [...chefs] }));
+}
+
+// Add an attendee. Idempotent on memberId: an existing entry for the same member
+// is replaced, so a member can never appear twice.
+export function addAttendee<K extends string, T extends DayContainer<K>>(
+  container: T,
+  dayKey: K,
+  attendee: Attendee,
+): T {
+  return withDay(container, dayKey, (day) => ({
+    ...day,
+    attendees: [...day.attendees.filter((a) => a.memberId !== attendee.memberId), { ...attendee }],
+  }));
+}
+
+export function removeAttendee<K extends string, T extends DayContainer<K>>(
+  container: T,
+  dayKey: K,
+  memberId: string,
+): T {
+  return withDay(container, dayKey, (day) => ({
+    ...day,
+    attendees: day.attendees.filter((a) => a.memberId !== memberId),
+  }));
+}
+
+// Set an attendee's home time. `null` (blank) is a valid saved state.
+export function setAttendeeHomeTime<K extends string, T extends DayContainer<K>>(
+  container: T,
+  dayKey: K,
+  memberId: string,
+  homeTime: string | null,
+): T {
+  return withDay(container, dayKey, (day) =>
+    withAttendee(day, memberId, (a) => ({ ...a, homeTime })),
+  );
+}
+
+export function setAttendeeNote<K extends string, T extends DayContainer<K>>(
+  container: T,
+  dayKey: K,
+  memberId: string,
+  note: string,
+): T {
+  return withDay(container, dayKey, (day) => withAttendee(day, memberId, (a) => ({ ...a, note })));
+}

--- a/packages/domain/src/mealPlan/commands/dayMutators.ts
+++ b/packages/domain/src/mealPlan/commands/dayMutators.ts
@@ -40,6 +40,15 @@ export function setDayChefs<K extends string, T extends DayContainer<K>>(
   return withDay(container, dayKey, (day) => ({ ...day, chefs: [...chefs] }));
 }
 
+// Set the count of extra unnamed guests. Negative inputs are clamped to 0.
+export function setDayGuests<K extends string, T extends DayContainer<K>>(
+  container: T,
+  dayKey: K,
+  guests: number,
+): T {
+  return withDay(container, dayKey, (day) => ({ ...day, guests: Math.max(0, Math.trunc(guests)) }));
+}
+
 // Add an attendee. Idempotent on memberId: an existing entry for the same member
 // is replaced, so a member can never appear twice.
 export function addAttendee<K extends string, T extends DayContainer<K>>(

--- a/packages/domain/src/mealPlan/commands/emptyDay.ts
+++ b/packages/domain/src/mealPlan/commands/emptyDay.ts
@@ -1,0 +1,29 @@
+import type { Day } from '../entities/Day.js';
+import type { MealPlanTemplate } from '../entities/MealPlanTemplate.js';
+import type { MealPlanWeek } from '../entities/MealPlanWeek.js';
+import { WEEKDAYS } from '../entities/Weekday.js';
+import { weekDates } from '../queries/weekdays.js';
+
+// A blank day: no meal note, no recipes, no chefs, no attendees.
+export function emptyDay(): Day {
+  return { note: '', recipeIds: [], chefs: [], attendees: [] };
+}
+
+// A blank template with all seven weekdays empty.
+export function emptyTemplate(): MealPlanTemplate {
+  const days = Object.fromEntries(WEEKDAYS.map((wd) => [wd, emptyDay()]));
+  return { schemaVersion: 1, days: days as MealPlanTemplate['days'] };
+}
+
+// A blank week for `startDate` (its seven dates empty). `updatedAt` is left blank
+// until the service stamps and persists it on first edit / load-template.
+export function emptyWeek(startDate: string): MealPlanWeek {
+  const days = Object.fromEntries(weekDates(startDate).map((d) => [d, emptyDay()]));
+  return {
+    id: startDate,
+    schemaVersion: 1,
+    startDate,
+    days: days as MealPlanWeek['days'],
+    updatedAt: '',
+  };
+}

--- a/packages/domain/src/mealPlan/commands/emptyDay.ts
+++ b/packages/domain/src/mealPlan/commands/emptyDay.ts
@@ -4,9 +4,9 @@ import type { MealPlanWeek } from '../entities/MealPlanWeek.js';
 import { WEEKDAYS } from '../entities/Weekday.js';
 import { weekDates } from '../queries/weekdays.js';
 
-// A blank day: no meal note, no recipes, no chefs, no attendees.
+// A blank day: no meal note, no recipes, no chefs, no attendees, no guests.
 export function emptyDay(): Day {
-  return { note: '', recipeIds: [], chefs: [], attendees: [] };
+  return { note: '', recipeIds: [], chefs: [], attendees: [], guests: 0 };
 }
 
 // A blank template with all seven weekdays empty.

--- a/packages/domain/src/mealPlan/commands/instantiateWeek.ts
+++ b/packages/domain/src/mealPlan/commands/instantiateWeek.ts
@@ -12,6 +12,7 @@ function cloneDay(day: Day): Day {
     recipeIds: [...day.recipeIds],
     chefs: [...day.chefs],
     attendees: day.attendees.map((a) => ({ ...a })),
+    guests: day.guests,
   };
 }
 

--- a/packages/domain/src/mealPlan/commands/instantiateWeek.ts
+++ b/packages/domain/src/mealPlan/commands/instantiateWeek.ts
@@ -1,0 +1,39 @@
+import type { Day } from '../entities/Day.js';
+import type { MealPlanConfig } from '../entities/MealPlanConfig.js';
+import type { MealPlanTemplate } from '../entities/MealPlanTemplate.js';
+import type { MealPlanWeek } from '../entities/MealPlanWeek.js';
+import { weekDates, weekdayOf, weekStartFor } from '../queries/weekdays.js';
+
+// Deep-copy a day so the produced week never shares mutable arrays with the
+// template it was instantiated from.
+function cloneDay(day: Day): Day {
+  return {
+    note: day.note,
+    recipeIds: [...day.recipeIds],
+    chefs: [...day.chefs],
+    attendees: day.attendees.map((a) => ({ ...a })),
+  };
+}
+
+// The "load template" mechanic: build a concrete week by copying, for each of
+// its seven dates, the template's day for that date's weekday. `startDate` is
+// normalised to the true week start under `config` first, so passing any date
+// in the target week is safe. Pure — returns a fresh week, `updatedAt` blank for
+// the service to stamp on save.
+export function instantiateWeek(
+  startDate: string,
+  config: MealPlanConfig,
+  template: MealPlanTemplate,
+): MealPlanWeek {
+  const start = weekStartFor(startDate, config.firstDayOfWeek);
+  const days = Object.fromEntries(
+    weekDates(start).map((date) => [date, cloneDay(template.days[weekdayOf(date)])]),
+  );
+  return {
+    id: start,
+    schemaVersion: 1,
+    startDate: start,
+    days: days as MealPlanWeek['days'],
+    updatedAt: '',
+  };
+}

--- a/packages/domain/src/mealPlan/entities/Day.ts
+++ b/packages/domain/src/mealPlan/entities/Day.ts
@@ -18,4 +18,6 @@ export interface Day {
   // Zero or more chefs; a chef need NOT be an attendee. Member refs only.
   readonly chefs: readonly string[];
   readonly attendees: readonly Attendee[];
+  // Count of extra, unnamed diners (occasional guests with no member record).
+  readonly guests: number;
 }

--- a/packages/domain/src/mealPlan/entities/Day.ts
+++ b/packages/domain/src/mealPlan/entities/Day.ts
@@ -1,0 +1,21 @@
+// The shared day shape used by both the template (weekday-keyed) and a concrete
+// week (date-keyed). See docs/meal-planning.md.
+
+export interface Attendee {
+  readonly memberId: string;
+  // "HH:mm" 24h local time, or null = attending but time unknown (a valid saved
+  // state, not "missing").
+  readonly homeTime: string | null;
+  // Per-person free-text note, e.g. "make a portion for another day".
+  readonly note: string;
+}
+
+export interface Day {
+  // Free-text meal description (v1). Recipe refs arrive via recipeIds (#17).
+  readonly note: string;
+  // RESERVED seam for recipes (#17); always empty until that module lands.
+  readonly recipeIds: readonly string[];
+  // Zero or more chefs; a chef need NOT be an attendee. Member refs only.
+  readonly chefs: readonly string[];
+  readonly attendees: readonly Attendee[];
+}

--- a/packages/domain/src/mealPlan/entities/MealPlanConfig.ts
+++ b/packages/domain/src/mealPlan/entities/MealPlanConfig.ts
@@ -1,0 +1,8 @@
+import type { Weekday } from './Weekday.js';
+
+// Singleton config. `firstDayOfWeek` is the "big shop" day that starts each
+// week — a global layout setting kept separate from the template.
+export interface MealPlanConfig {
+  readonly firstDayOfWeek: Weekday;
+  readonly schemaVersion: 1;
+}

--- a/packages/domain/src/mealPlan/entities/MealPlanTemplate.ts
+++ b/packages/domain/src/mealPlan/entities/MealPlanTemplate.ts
@@ -1,0 +1,9 @@
+import type { Weekday } from './Weekday.js';
+import type { Day } from './Day.js';
+
+// The standard week, keyed by weekday. Loaded into any concrete week via
+// instantiateWeek and then tweaked.
+export interface MealPlanTemplate {
+  readonly schemaVersion: 1;
+  readonly days: Readonly<Record<Weekday, Day>>;
+}

--- a/packages/domain/src/mealPlan/entities/MealPlanWeek.ts
+++ b/packages/domain/src/mealPlan/entities/MealPlanWeek.ts
@@ -1,0 +1,12 @@
+import type { Day } from './Day.js';
+
+// One concrete week. `id` equals `startDate` (the YYYY-MM-DD of the week's start
+// day) and doubles as the Firestore document key. `days` is keyed by the seven
+// concrete YYYY-MM-DD dates. Whole-document last-write-wins.
+export interface MealPlanWeek {
+  readonly id: string;
+  readonly schemaVersion: 1;
+  readonly startDate: string;
+  readonly days: Readonly<Record<string, Day>>;
+  readonly updatedAt: string; // ISO-8601; stamped by the service on save
+}

--- a/packages/domain/src/mealPlan/entities/Weekday.ts
+++ b/packages/domain/src/mealPlan/entities/Weekday.ts
@@ -1,0 +1,7 @@
+// The seven weekday keys used by the template and by weekday-indexing of dates.
+// Monday-first is the canonical internal order. `firstDayOfWeek` (in
+// MealPlanConfig) only changes how a week is laid out for the user — it never
+// reshapes this enum, so changing the big-shop day needs no data migration.
+export type Weekday = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
+
+export const WEEKDAYS: readonly Weekday[] = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];

--- a/packages/domain/src/mealPlan/index.ts
+++ b/packages/domain/src/mealPlan/index.ts
@@ -16,6 +16,7 @@ export { instantiateWeek } from './commands/instantiateWeek.js';
 export {
   setDayNote,
   setDayChefs,
+  setDayGuests,
   addAttendee,
   removeAttendee,
   setAttendeeHomeTime,

--- a/packages/domain/src/mealPlan/index.ts
+++ b/packages/domain/src/mealPlan/index.ts
@@ -1,0 +1,23 @@
+// Meal planning module — published surface (issue #169).
+// This file is the ONLY thing other domain modules and adapters import from
+// mealPlan. Anything not re-exported here is private. See docs/meal-planning.md.
+
+export type { Weekday } from './entities/Weekday.js';
+export { WEEKDAYS } from './entities/Weekday.js';
+export type { Attendee, Day } from './entities/Day.js';
+export type { MealPlanConfig } from './entities/MealPlanConfig.js';
+export type { MealPlanTemplate } from './entities/MealPlanTemplate.js';
+export type { MealPlanWeek } from './entities/MealPlanWeek.js';
+
+export { weekStartFor, weekDates, weekdayOf, WEEKDAY_INDEX } from './queries/weekdays.js';
+
+export { emptyDay, emptyWeek, emptyTemplate } from './commands/emptyDay.js';
+export { instantiateWeek } from './commands/instantiateWeek.js';
+export {
+  setDayNote,
+  setDayChefs,
+  addAttendee,
+  removeAttendee,
+  setAttendeeHomeTime,
+  setAttendeeNote,
+} from './commands/dayMutators.js';

--- a/packages/domain/src/mealPlan/queries/weekdays.ts
+++ b/packages/domain/src/mealPlan/queries/weekdays.ts
@@ -1,0 +1,58 @@
+import type { Weekday } from '../entities/Weekday.js';
+import { WEEKDAYS } from '../entities/Weekday.js';
+
+// Monday-first index of each weekday (mon = 0 … sun = 6).
+export const WEEKDAY_INDEX: Readonly<Record<Weekday, number>> = {
+  mon: 0,
+  tue: 1,
+  wed: 2,
+  thu: 3,
+  fri: 4,
+  sat: 5,
+  sun: 6,
+};
+
+// Parse a date-only "YYYY-MM-DD" string as a UTC instant. All week arithmetic is
+// done in UTC so it never drifts across DST or the local timezone.
+function toUtcDate(date: string): Date {
+  return new Date(`${date}T00:00:00.000Z`);
+}
+
+// Format a Date back to its UTC "YYYY-MM-DD" calendar day.
+function formatUtc(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+// Monday-first index (0–6) of any UTC Date.
+function mondayFirstIndex(d: Date): number {
+  // getUTCDay: 0 = Sun … 6 = Sat. Shift so Monday = 0.
+  return (d.getUTCDay() + 6) % 7;
+}
+
+// The weekday name of a "YYYY-MM-DD" date.
+export function weekdayOf(date: string): Weekday {
+  return WEEKDAYS[mondayFirstIndex(toUtcDate(date))]!;
+}
+
+// The "YYYY-MM-DD" start date of the week containing `date`, where weeks start
+// on `firstDayOfWeek`. Accepts a Date (its local calendar day is used) or a
+// "YYYY-MM-DD" string.
+export function weekStartFor(date: Date | string, firstDayOfWeek: Weekday): string {
+  const d =
+    typeof date === 'string'
+      ? toUtcDate(date)
+      : new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const diff = (mondayFirstIndex(d) - WEEKDAY_INDEX[firstDayOfWeek] + 7) % 7;
+  d.setUTCDate(d.getUTCDate() - diff);
+  return formatUtc(d);
+}
+
+// The seven consecutive "YYYY-MM-DD" date keys of a week starting at `startDate`.
+export function weekDates(startDate: string): string[] {
+  const start = toUtcDate(startDate);
+  return Array.from({ length: 7 }, (_unused, i) => {
+    const d = new Date(start);
+    d.setUTCDate(d.getUTCDate() + i);
+    return formatUtc(d);
+  });
+}

--- a/packages/domain/src/schemas/index.ts
+++ b/packages/domain/src/schemas/index.ts
@@ -59,3 +59,15 @@ export type { ShoppingListsConfigDoc } from './shoppingListsConfig.js';
 
 export { MemberSchema } from './member.js';
 export type { MemberDoc } from './member.js';
+
+export { WeekdayEnum, AttendeeSchema, MealPlanDaySchema } from './mealPlanDay.js';
+export type { WeekdayDoc, AttendeeDoc, MealPlanDayDoc } from './mealPlanDay.js';
+
+export { MealPlanConfigSchema } from './mealPlanConfig.js';
+export type { MealPlanConfigDoc } from './mealPlanConfig.js';
+
+export { MealPlanTemplateSchema } from './mealPlanTemplate.js';
+export type { MealPlanTemplateDoc } from './mealPlanTemplate.js';
+
+export { MealPlanWeekSchema } from './mealPlanWeek.js';
+export type { MealPlanWeekDoc } from './mealPlanWeek.js';

--- a/packages/domain/src/schemas/mealPlanConfig.ts
+++ b/packages/domain/src/schemas/mealPlanConfig.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+import { WeekdayEnum } from './mealPlanDay.js';
+
+// Singleton `mealPlanConfig/{document}`. `firstDayOfWeek` is the "big shop" day
+// that starts each week — a global layout setting, separate from the template
+// so editing one never clobbers the other (docs/meal-planning.md).
+export const MealPlanConfigSchema = z.object({
+  firstDayOfWeek: WeekdayEnum,
+  schemaVersion: z.literal(1),
+});
+
+export type MealPlanConfigDoc = z.infer<typeof MealPlanConfigSchema>;

--- a/packages/domain/src/schemas/mealPlanDay.ts
+++ b/packages/domain/src/schemas/mealPlanDay.ts
@@ -16,12 +16,14 @@ export const AttendeeSchema = z.object({
 
 // The shared day shape used by both the template (weekday-keyed) and a concrete
 // week (date-keyed). `recipeIds` is a reserved seam for recipes (#17); it ships
-// as an always-empty array until that module lands.
+// as an always-empty array until that module lands. `guests` is a simple count
+// of extra, unnamed diners (occasional guests with no member record).
 export const MealPlanDaySchema = z.object({
   note: z.string().default(''),
   recipeIds: z.array(z.string()).default([]),
   chefs: z.array(z.string()).default([]),
   attendees: z.array(AttendeeSchema).default([]),
+  guests: z.number().int().nonnegative().default(0),
 });
 
 export type WeekdayDoc = z.infer<typeof WeekdayEnum>;

--- a/packages/domain/src/schemas/mealPlanDay.ts
+++ b/packages/domain/src/schemas/mealPlanDay.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+// Weekday key used by the template (and weekday-indexing of dates). Monday-first
+// ordering is the canonical internal order; `firstDayOfWeek` only changes how a
+// week is laid out, never this enum (see docs/meal-planning.md).
+export const WeekdayEnum = z.enum(['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']);
+
+// One attendee of a meal. `homeTime` is a "HH:mm" 24h local time, or null when
+// the person is attending but their time is unknown — null is a valid saved
+// state, not "missing". `note` is a per-person free-text note.
+export const AttendeeSchema = z.object({
+  memberId: z.string(),
+  homeTime: z.string().nullable(),
+  note: z.string().default(''),
+});
+
+// The shared day shape used by both the template (weekday-keyed) and a concrete
+// week (date-keyed). `recipeIds` is a reserved seam for recipes (#17); it ships
+// as an always-empty array until that module lands.
+export const MealPlanDaySchema = z.object({
+  note: z.string().default(''),
+  recipeIds: z.array(z.string()).default([]),
+  chefs: z.array(z.string()).default([]),
+  attendees: z.array(AttendeeSchema).default([]),
+});
+
+export type WeekdayDoc = z.infer<typeof WeekdayEnum>;
+export type AttendeeDoc = z.infer<typeof AttendeeSchema>;
+export type MealPlanDayDoc = z.infer<typeof MealPlanDaySchema>;

--- a/packages/domain/src/schemas/mealPlanTemplate.ts
+++ b/packages/domain/src/schemas/mealPlanTemplate.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { WeekdayEnum, MealPlanDaySchema } from './mealPlanDay.js';
+
+// Singleton `mealPlanTemplate/{document}` — the standard week, keyed by weekday.
+// Loaded into any concrete week via instantiateWeek and then tweaked.
+export const MealPlanTemplateSchema = z.object({
+  schemaVersion: z.literal(1),
+  days: z.record(WeekdayEnum, MealPlanDaySchema),
+});
+
+export type MealPlanTemplateDoc = z.infer<typeof MealPlanTemplateSchema>;

--- a/packages/domain/src/schemas/mealPlanWeek.ts
+++ b/packages/domain/src/schemas/mealPlanWeek.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { MealPlanDaySchema } from './mealPlanDay.js';
+
+// `mealPlans/{YYYY-MM-DD}` — one concrete week, keyed (and `id`/`startDate`-
+// stamped) by the date of its start day. Whole-document last-write-wins; the
+// seven days are keyed by their concrete YYYY-MM-DD dates.
+export const MealPlanWeekSchema = z.object({
+  id: z.string(),
+  schemaVersion: z.literal(1),
+  startDate: z.string(),
+  days: z.record(z.string(), MealPlanDaySchema),
+  updatedAt: z.string(),
+});
+
+export type MealPlanWeekDoc = z.infer<typeof MealPlanWeekSchema>;

--- a/packages/domain/tests/mealPlan/mealPlan.test.ts
+++ b/packages/domain/tests/mealPlan/mealPlan.test.ts
@@ -10,6 +10,7 @@ import {
   instantiateWeek,
   setDayNote,
   setDayChefs,
+  setDayGuests,
   addAttendee,
   removeAttendee,
   setAttendeeHomeTime,
@@ -83,7 +84,7 @@ describe('weekDates', () => {
 
 describe('emptyDay / emptyWeek / emptyTemplate', () => {
   it('emptyDay is fully blank', () => {
-    expect(emptyDay()).toEqual({ note: '', recipeIds: [], chefs: [], attendees: [] });
+    expect(emptyDay()).toEqual({ note: '', recipeIds: [], chefs: [], attendees: [], guests: 0 });
   });
 
   it('emptyTemplate has all seven weekdays blank', () => {
@@ -152,6 +153,13 @@ describe('day mutators (immutability + correctness)', () => {
     const next = setDayChefs(base, key, ['a@x.org', 'b@x.org']);
     expect(next.days[key]!.chefs).toEqual(['a@x.org', 'b@x.org']);
     expect(base.days[key]!.chefs).toEqual([]);
+  });
+
+  it('setDayGuests sets a non-negative integer count and clamps junk to 0', () => {
+    expect(setDayGuests(base, key, 3).days[key]!.guests).toBe(3);
+    expect(setDayGuests(base, key, -2).days[key]!.guests).toBe(0);
+    expect(setDayGuests(base, key, 2.9).days[key]!.guests).toBe(2);
+    expect(base.days[key]!.guests).toBe(0);
   });
 
   it('addAttendee appends and is idempotent on memberId', () => {

--- a/packages/domain/tests/mealPlan/mealPlan.test.ts
+++ b/packages/domain/tests/mealPlan/mealPlan.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import {
+  WEEKDAYS,
+  weekStartFor,
+  weekDates,
+  weekdayOf,
+  emptyDay,
+  emptyWeek,
+  emptyTemplate,
+  instantiateWeek,
+  setDayNote,
+  setDayChefs,
+  addAttendee,
+  removeAttendee,
+  setAttendeeHomeTime,
+  setAttendeeNote,
+  type Attendee,
+  type MealPlanConfig,
+  type MealPlanTemplate,
+  type Weekday,
+} from '@salt/domain';
+
+const config = (firstDayOfWeek: Weekday): MealPlanConfig => ({
+  firstDayOfWeek,
+  schemaVersion: 1,
+});
+
+describe('weekdayOf', () => {
+  it('maps known dates to their weekday', () => {
+    // 2026-06-08 is a Monday; the following six days walk the week.
+    expect(weekdayOf('2026-06-08')).toBe('mon');
+    expect(weekdayOf('2026-06-09')).toBe('tue');
+    expect(weekdayOf('2026-06-13')).toBe('sat');
+    expect(weekdayOf('2026-06-14')).toBe('sun');
+  });
+});
+
+describe('weekStartFor', () => {
+  // 2026-06-10 is a Wednesday.
+  it('finds the Monday-start of a midweek date', () => {
+    expect(weekStartFor('2026-06-10', 'mon')).toBe('2026-06-08');
+  });
+
+  it('returns the date itself when it is already the start day', () => {
+    expect(weekStartFor('2026-06-08', 'mon')).toBe('2026-06-08');
+  });
+
+  it('handles every firstDayOfWeek for the same Wednesday', () => {
+    // Wed 2026-06-10. The start is the most recent occurrence of firstDayOfWeek.
+    expect(weekStartFor('2026-06-10', 'mon')).toBe('2026-06-08');
+    expect(weekStartFor('2026-06-10', 'tue')).toBe('2026-06-09');
+    expect(weekStartFor('2026-06-10', 'wed')).toBe('2026-06-10');
+    expect(weekStartFor('2026-06-10', 'thu')).toBe('2026-06-04');
+    expect(weekStartFor('2026-06-10', 'fri')).toBe('2026-06-05');
+    expect(weekStartFor('2026-06-10', 'sat')).toBe('2026-06-06');
+    expect(weekStartFor('2026-06-10', 'sun')).toBe('2026-06-07');
+  });
+
+  it('crosses a month boundary correctly', () => {
+    // Wed 2026-07-01 with a Friday start day → previous Friday is 2026-06-26.
+    expect(weekStartFor('2026-07-01', 'fri')).toBe('2026-06-26');
+  });
+
+  it('accepts a Date and uses its local calendar day', () => {
+    const d = new Date(2026, 5, 10); // local Wed 2026-06-10
+    expect(weekStartFor(d, 'mon')).toBe('2026-06-08');
+  });
+});
+
+describe('weekDates', () => {
+  it('returns seven consecutive dates from the start', () => {
+    expect(weekDates('2026-06-08')).toEqual([
+      '2026-06-08',
+      '2026-06-09',
+      '2026-06-10',
+      '2026-06-11',
+      '2026-06-12',
+      '2026-06-13',
+      '2026-06-14',
+    ]);
+  });
+});
+
+describe('emptyDay / emptyWeek / emptyTemplate', () => {
+  it('emptyDay is fully blank', () => {
+    expect(emptyDay()).toEqual({ note: '', recipeIds: [], chefs: [], attendees: [] });
+  });
+
+  it('emptyTemplate has all seven weekdays blank', () => {
+    const t = emptyTemplate();
+    expect(Object.keys(t.days).sort()).toEqual([...WEEKDAYS].sort());
+    for (const wd of WEEKDAYS) expect(t.days[wd]).toEqual(emptyDay());
+  });
+
+  it('emptyWeek is keyed by its seven dates with a blank updatedAt', () => {
+    const w = emptyWeek('2026-06-08');
+    expect(w.id).toBe('2026-06-08');
+    expect(w.startDate).toBe('2026-06-08');
+    expect(w.updatedAt).toBe('');
+    expect(Object.keys(w.days)).toEqual(weekDates('2026-06-08'));
+  });
+});
+
+describe('instantiateWeek', () => {
+  function templateWithLabels(): MealPlanTemplate {
+    const days = Object.fromEntries(
+      WEEKDAYS.map((wd) => [wd, { ...emptyDay(), note: `usual-${wd}` }]),
+    );
+    return { schemaVersion: 1, days: days as MealPlanTemplate['days'] };
+  }
+
+  it('copies each weekday template day onto the matching dated day (Monday start)', () => {
+    const week = instantiateWeek('2026-06-08', config('mon'), templateWithLabels());
+    expect(week.days['2026-06-08']!.note).toBe('usual-mon');
+    expect(week.days['2026-06-14']!.note).toBe('usual-sun');
+  });
+
+  it('maps weekdays correctly when firstDayOfWeek is not Monday', () => {
+    // Friday start: 2026-06-12 is a Friday.
+    const week = instantiateWeek('2026-06-12', config('fri'), templateWithLabels());
+    expect(week.startDate).toBe('2026-06-12');
+    expect(week.days['2026-06-12']!.note).toBe('usual-fri');
+    expect(week.days['2026-06-13']!.note).toBe('usual-sat');
+    expect(week.days['2026-06-18']!.note).toBe('usual-thu');
+  });
+
+  it('normalises a midweek startDate to the true week start', () => {
+    const week = instantiateWeek('2026-06-10', config('mon'), templateWithLabels());
+    expect(week.id).toBe('2026-06-08');
+    expect(week.startDate).toBe('2026-06-08');
+  });
+
+  it('deep-copies template days (no shared array references)', () => {
+    const template = emptyTemplate();
+    const week = instantiateWeek('2026-06-08', config('mon'), template);
+    expect(week.days['2026-06-08']!.chefs).not.toBe(template.days.mon.chefs);
+  });
+});
+
+describe('day mutators (immutability + correctness)', () => {
+  const base = emptyWeek('2026-06-08');
+  const key = '2026-06-08';
+  const attendee: Attendee = { memberId: 'a@x.org', homeTime: '18:00', note: '' };
+
+  it('setDayNote sets the note and does not mutate the input', () => {
+    const next = setDayNote(base, key, 'pasta');
+    expect(next.days[key]!.note).toBe('pasta');
+    expect(base.days[key]!.note).toBe('');
+  });
+
+  it('setDayChefs replaces chefs with a fresh array', () => {
+    const next = setDayChefs(base, key, ['a@x.org', 'b@x.org']);
+    expect(next.days[key]!.chefs).toEqual(['a@x.org', 'b@x.org']);
+    expect(base.days[key]!.chefs).toEqual([]);
+  });
+
+  it('addAttendee appends and is idempotent on memberId', () => {
+    const once = addAttendee(base, key, attendee);
+    const twice = addAttendee(once, key, { ...attendee, homeTime: '19:30' });
+    expect(twice.days[key]!.attendees).toHaveLength(1);
+    expect(twice.days[key]!.attendees[0]!.homeTime).toBe('19:30');
+    expect(base.days[key]!.attendees).toHaveLength(0);
+  });
+
+  it('removeAttendee drops the matching member', () => {
+    const withA = addAttendee(base, key, attendee);
+    const without = removeAttendee(withA, key, 'a@x.org');
+    expect(without.days[key]!.attendees).toHaveLength(0);
+  });
+
+  it('setAttendeeHomeTime round-trips a blank time as null', () => {
+    const withA = addAttendee(base, key, attendee);
+    const blanked = setAttendeeHomeTime(withA, key, 'a@x.org', null);
+    expect(blanked.days[key]!.attendees[0]!.homeTime).toBeNull();
+    // input untouched
+    expect(withA.days[key]!.attendees[0]!.homeTime).toBe('18:00');
+  });
+
+  it('setAttendeeNote updates only the per-person note', () => {
+    const withA = addAttendee(base, key, attendee);
+    const noted = setAttendeeNote(withA, key, 'a@x.org', 'portion for tomorrow');
+    expect(noted.days[key]!.attendees[0]!.note).toBe('portion for tomorrow');
+    expect(noted.days[key]!.attendees[0]!.homeTime).toBe('18:00');
+  });
+
+  it('mutators also operate on a template keyed by weekday', () => {
+    const template = emptyTemplate();
+    const next = setDayNote(template, 'fri', 'pizza');
+    expect(next.days.fri.note).toBe('pizza');
+    expect(template.days.fri.note).toBe('');
+  });
+});


### PR DESCRIPTION
Implements the Meal Planning module (#169). New code lives entirely inside existing packages — no new package, dependency, layer-map change, Cloud Function, or AI. Design contract: [`docs/meal-planning.md`](../blob/main/docs/meal-planning.md).

## What

Plan a week of evening meals. One document per week, keyed by the configurable big-shop start day. A single standard template can be loaded into any week and then tweaked. Per day: free-text meal note, zero-or-more chefs, and attendees each with an optional (blank-allowed) home time and a per-person note. Member references are `memberId` only, resolved to names at display time.

## Phases (each met its DoD)

- **Phase 1 — domain core.** Zod schemas (`MealPlanConfig`/`Day`/`Attendee`/`Template`/`Week`) under `@salt/domain/schemas`; entities; pure queries (`weekStartFor`, `weekDates`, `weekdayOf`, UTC/DST-safe); pure commands (`instantiateWeek` load-template, `emptyWeek`/`emptyTemplate`, generic day/attendee mutators shared by week + template). Full unit tests.
- **Phase 2 — firebase-sync.** `mealPlanSync.ts`: single-doc subscriptions (`safeParse` → `Failure` via `onError`) + `setDoc` writes returning `ReadResult`, never throwing. `firestore.rules` opens the three collections to any authenticated user (AdminGuard stays cosmetic). Mock unit tests + emulator rules block.
- **Phase 3 — web-pwa service.** Svelte-store service over the adapter: subscribes config + template once and the selected week (re-subscribing on navigation), presents an unsaved `emptyWeek` until first edit/load-template, `goTo/this/next/prevWeek`, `loadTemplateIntoCurrentWeek`, and per-day/attendee mutators stamping `updatedAt`. Wired into `App.svelte`.
- **Phase 4 — weekly editor** (`/mealplan`): seven-day week, prev/next/this-week nav, week-range header, Load-template with confirm-on-overwrite; shared `MealDayEditor` (note, chef multi-select, attendee toggle with blank-savable home time + per-person note); unknown members render removable.
- **Phase 5 — admin template + first-day** (`/admin/mealplan`, cosmetic AdminGuard): edits the weekday-keyed standard template (reusing `MealDayEditor`) and `firstDayOfWeek`.

## Out of scope (per issue)

`Day.recipeIds` ships as an always-empty reserved array for recipes (#17); multiple templates / multiple meals per day / analytics deferred.

## Verification

`pnpm lint && pnpm typecheck && pnpm boundary:test` green; full `pnpm test` (1382 tests) green; `pnpm --filter @salt/web-pwa build` succeeds. Emulator adapter/rules suites added in the style of the existing ones (run by the integration CI job).

Closes #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)