### PR TITLE
fix(canon): regenerate icon when item has no existing icon

### DIFF
--- a/apps/cloud-functions/src/callables/regenerateCanonIcon.ts
+++ b/apps/cloud-functions/src/callables/regenerateCanonIcon.ts
@@ -2,8 +2,12 @@ import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { onCall, HttpsError } from 'firebase-functions/https';
 import { RegenerateCanonIconInputSchema } from '@salt/domain/schemas';
 
-// Manual regenerate / un-hide escape hatch (issue #148). Clearing `thumbnail`
-// (→ null) re-fires onCanonItemWritten, whose icon branch then regenerates.
+// Manual regenerate / un-hide escape hatch (issue #148). Setting `thumbnail`
+// (→ null) and stamping the `iconRequestedAt` nonce re-fires onCanonItemWritten,
+// whose icon branch then regenerates. The nonce is load-bearing: when the item
+// has no icon yet `thumbnail` is *already* null, so writing null again is a
+// no-op and Firestore emits no write event — the trigger never fires. A fresh
+// `iconRequestedAt` guarantees the update always mutates the doc.
 // Auth-gated: only signed-in callers may trigger (re)generation. "Hide"
 // (setting the "hidden" sentinel) is a client-side write — it needs no server
 // authority, so there is no hide callable.
@@ -26,11 +30,17 @@ export const regenerateCanonIcon = onCall(
     }
     const { canonId, hint } = parsed.data;
     // Clear the icon (→ trigger regenerates) and carry the one-shot steer, if any.
-    // No hint clears any stale hint so the regeneration is plain.
+    // No hint clears any stale hint so the regeneration is plain. iconRequestedAt
+    // forces the write to mutate the doc so the trigger fires even when the item
+    // had no icon (thumbnail already null) — see the header note.
     await getFirestore()
       .collection('canonItems')
       .doc(canonId)
-      .update({ thumbnail: null, iconHint: hint ? hint : FieldValue.delete() });
+      .update({
+        thumbnail: null,
+        iconHint: hint ? hint : FieldValue.delete(),
+        iconRequestedAt: Date.now(),
+      });
     return { ok: true } as const;
   },
 );

--- a/apps/cloud-functions/tests/callables/regenerateCanonIcon.test.ts
+++ b/apps/cloud-functions/tests/callables/regenerateCanonIcon.test.ts
@@ -25,8 +25,11 @@ vi.mock('firebase-functions/https', () => ({
 
 const { regenerateCanonIcon } = await import('../../src/callables/regenerateCanonIcon.js');
 
+const NOW = 1_700_000_000_000;
+
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.spyOn(Date, 'now').mockReturnValue(NOW);
 });
 
 describe('regenerateCanonIcon callable', () => {
@@ -52,7 +55,11 @@ describe('regenerateCanonIcon callable', () => {
 
     expect(mockCollection).toHaveBeenCalledWith('canonItems');
     expect(mockDoc).toHaveBeenCalledWith('canon-123');
-    expect(mockUpdate).toHaveBeenCalledWith({ thumbnail: null, iconHint: DELETE_SENTINEL });
+    expect(mockUpdate).toHaveBeenCalledWith({
+      thumbnail: null,
+      iconHint: DELETE_SENTINEL,
+      iconRequestedAt: NOW,
+    });
     expect(result).toEqual({ ok: true });
   });
 
@@ -62,6 +69,10 @@ describe('regenerateCanonIcon callable', () => {
       data: { canonId: 'canon-123', hint: 'show it as a tin' },
     });
 
-    expect(mockUpdate).toHaveBeenCalledWith({ thumbnail: null, iconHint: 'show it as a tin' });
+    expect(mockUpdate).toHaveBeenCalledWith({
+      thumbnail: null,
+      iconHint: 'show it as a tin',
+      iconRequestedAt: NOW,
+    });
   });
 });

--- a/packages/domain/src/canon/entities/CanonItem.ts
+++ b/packages/domain/src/canon/entities/CanonItem.ts
@@ -14,6 +14,10 @@ export interface CanonItem {
   // Transient one-shot steer for the next icon (re)generation (issue #148);
   // written on regenerate, consumed + cleared by the CF icon branch.
   readonly iconHint?: string;
+  // Regenerate nonce (epoch ms): stamped on every regenerate request so the
+  // write always mutates the doc (even when thumbnail is already null) and the
+  // onCanonItemWritten icon branch re-fires. See CanonItemSchema.
+  readonly iconRequestedAt?: number;
   readonly embedding: readonly number[] | null;
   readonly needs_approval: boolean;
   readonly shoppingBehavior: ShoppingBehavior;

--- a/packages/domain/src/schemas/canonItem.ts
+++ b/packages/domain/src/schemas/canonItem.ts
@@ -11,6 +11,12 @@ export const CanonItemSchema = z.object({
   // Written by the regenerateCanonIcon callable alongside thumbnail: null;
   // consumed and cleared by the onCanonItemWritten icon branch.
   iconHint: z.string().optional(),
+  // Regenerate nonce (epoch ms): the regenerateCanonIcon callable stamps this on
+  // every request so the write always mutates the doc — even when thumbnail is
+  // already null — which is what re-fires the onCanonItemWritten icon branch
+  // (Firestore emits no write event for a no-op update). Number, not a Firestore
+  // Timestamp, so both the trigger and the client subscription parse it cleanly.
+  iconRequestedAt: z.number().optional(),
   embedding: z.array(z.number()).nullable(),
   needs_approval: z.boolean(),
   shoppingBehavior: z.enum(['stocked', 'check', 'needed']),


### PR DESCRIPTION
## Problem

When a canon item has **no icon**, clicking **Regenerate** shows a "Regenerating icon…" success toast but nothing is generated.

### Root cause

The regenerate escape hatch is *fire-by-side-effect*: the `regenerateCanonIcon` callable writes `thumbnail: null` and relies on the `onCanonItemWritten` trigger to notice and regenerate (the trigger's icon branch runs only when `thumbnail === null`).

This works only when the icon transitions from something → null:

- **Has an icon (URL):** regenerate writes `URL → null` — a real change, trigger fires, regenerates. ✅
- **No icon (`thumbnail` already `null`):** regenerate writes `null → null`, and `iconHint` was already absent so `FieldValue.delete()` is also a no-op. The update **mutates nothing**, Firestore emits no write event, and the trigger never fires. The callable still returns `{ ok: true }`, so the UI shows a misleading success toast. ❌

(Regenerating *with* a typed hint, and **Unhide**, already worked — both produce a real field change.)

## Fix

Stamp an `iconRequestedAt` epoch-ms nonce on every regenerate request so the write **always** mutates the doc and the trigger always fires. The `thumbnail === null` guard in the trigger is unchanged.

- A **number** (not `serverTimestamp()` / Firestore `Timestamp`) is used deliberately: a `Timestamp` would fail the `z.number()`/`z.string()` `safeParse` in both the trigger and the client subscription, silently dropping docs.
- Field added to `CanonItemSchema` and the `CanonItem` entity (both reader paths cast through these).

## Tests

- Updated the callable unit test to pin `Date.now()` and assert the nonce is written — the regression guard proving every regenerate request now mutates the doc.
- Full suite green (1390 tests), typecheck + lint + dependency-cruiser clean via pre-commit.

> Note on verification: the no-op-write-doesn't-fire-the-trigger behavior can't be exercised in the unit/emulator harness (the emulator test invokes the trigger handler directly). Worth a manual check against staging on a known icon-less item after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
