### PR TITLE
feat(observability): human-readable names for CF flow spans

### DIFF
--- a/apps/cloud-functions/src/flows/arbitrateCanon.ts
+++ b/apps/cloud-functions/src/flows/arbitrateCanon.ts
@@ -1,6 +1,7 @@
 import { z } from 'genkit';
 import { googleAI } from '@genkit-ai/google-genai';
 import { ArbitrationRequestSchema, CanonArbitrationAIOutputSchema } from '@salt/domain/schemas';
+import { setActiveSpanName } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
 
 const GENERATION_MODEL = googleAI.model('gemini-flash-latest');
@@ -39,6 +40,7 @@ export const arbitrateCanonFlow = ai.defineFlow(
     outputSchema: ArbitrationResultSchema,
   },
   async (req) => {
+    setActiveSpanName(`arbitrateCanon: ${req.normalisedName}`);
     const builtPrompt = buildPrompt(req);
     const result = await ai.generate({
       model: GENERATION_MODEL,

--- a/apps/cloud-functions/src/flows/embedText.ts
+++ b/apps/cloud-functions/src/flows/embedText.ts
@@ -1,6 +1,7 @@
 import { z } from 'genkit';
 import { googleAI } from '@genkit-ai/google-genai';
 import { EmbedTextInputSchema } from '@salt/domain/schemas';
+import { setActiveSpanName } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
 
 const EMBEDDING_MODEL = 'gemini-embedding-001';
@@ -12,6 +13,7 @@ export const embedTextFlow = ai.defineFlow(
     outputSchema: z.object({ values: z.array(z.number()) }),
   },
   async ({ text }) => {
+    setActiveSpanName(`embedText: ${text}`);
     const embeddings = await ai.embed({
       embedder: googleAI.embedder(EMBEDDING_MODEL),
       content: text,

--- a/apps/cloud-functions/src/flows/generateCanonIcon.ts
+++ b/apps/cloud-functions/src/flows/generateCanonIcon.ts
@@ -1,5 +1,6 @@
 import { z } from 'genkit';
 import { googleAI } from '@genkit-ai/google-genai';
+import { setActiveSpanName } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
 import { withAiTimeout } from '../adapters/withAiTimeout.js';
 import { loadCanonIconSeed } from './assets/canonIconSeed.js';
@@ -63,6 +64,7 @@ export const generateCanonIconFlow = ai.defineFlow(
     outputSchema: GenerateCanonIconOutputSchema,
   },
   async ({ name, hint }) => {
+    setActiveSpanName(`generateCanonIcon: ${name}`);
     const seed = loadCanonIconSeed();
 
     const result = await withAiTimeout(

--- a/apps/cloud-functions/src/flows/identifyEquipment.ts
+++ b/apps/cloud-functions/src/flows/identifyEquipment.ts
@@ -3,6 +3,7 @@ import {
   IdentifyEquipmentAIOutputSchema,
   IdentifyEquipmentInputSchema,
 } from '@salt/domain/schemas';
+import { setActiveSpanName } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
 
 const GENERATION_MODEL = googleAI.model('gemini-flash-latest');
@@ -14,6 +15,7 @@ export const identifyEquipmentFlow = ai.defineFlow(
     outputSchema: IdentifyEquipmentAIOutputSchema,
   },
   async ({ rawName }) => {
+    setActiveSpanName(`identifyEquipment: ${rawName}`);
     const result = await ai.generate({
       model: GENERATION_MODEL,
       system: SYSTEM_INSTRUCTIONS,

--- a/apps/cloud-functions/src/flows/parseEntry.ts
+++ b/apps/cloud-functions/src/flows/parseEntry.ts
@@ -1,6 +1,7 @@
 import { z } from 'genkit';
 import { googleAI } from '@genkit-ai/google-genai';
 import { ParseEntryAIOutputSchema } from '@salt/domain/schemas';
+import { setActiveSpanName } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
 
 const GENERATION_MODEL = googleAI.model('gemini-flash-latest');
@@ -16,6 +17,7 @@ export const parseEntryFlow = ai.defineFlow(
     outputSchema: ParseEntryAIOutputSchema,
   },
   async ({ rawText }) => {
+    setActiveSpanName(`parseEntry: ${rawText}`);
     const prompt = buildPrompt(rawText);
     const result = await ai.generate({
       model: GENERATION_MODEL,

--- a/apps/cloud-functions/src/flows/populateEquipmentEntry.ts
+++ b/apps/cloud-functions/src/flows/populateEquipmentEntry.ts
@@ -3,6 +3,7 @@ import {
   PopulateEquipmentEntryAIOutputSchema,
   PopulateEquipmentEntryInputSchema,
 } from '@salt/domain/schemas';
+import { setActiveSpanName } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
 
 const GENERATION_MODEL = googleAI.model('gemini-flash-latest');
@@ -14,6 +15,7 @@ export const populateEquipmentEntryFlow = ai.defineFlow(
     outputSchema: PopulateEquipmentEntryAIOutputSchema,
   },
   async ({ confirmedName }) => {
+    setActiveSpanName(`populateEquipmentEntry: ${confirmedName}`);
     const result = await ai.generate({
       model: GENERATION_MODEL,
       system: SYSTEM_INSTRUCTIONS,

--- a/packages/adapters/ld-observability/src/server/index.ts
+++ b/packages/adapters/ld-observability/src/server/index.ts
@@ -5,6 +5,7 @@ export {
   whenServerObservabilityReady,
   flushServerObservability,
   startSpan,
+  setActiveSpanName,
   extractTraceHeaders,
   runWithExtractedTraceContext,
   addServerSpanProcessor,

--- a/packages/adapters/ld-observability/src/server/init.ts
+++ b/packages/adapters/ld-observability/src/server/init.ts
@@ -119,6 +119,19 @@ const NOOP_OTEL_SPAN: OtelSpan = {
   recordException: () => undefined,
 } as unknown as OtelSpan;
 
+// Rename the currently-active OTel span. Call this inside a Genkit flow body to
+// append a human-readable descriptor (e.g. the item name) to the otherwise
+// generic flow span name, so traces are scannable in the LD list. The flow span
+// is the active span inside the flow body. No-op when observability isn't
+// initialised or no span is active. Caps length so span names stay bounded even
+// when fed long raw input.
+const MAX_SPAN_NAME = 80;
+export function setActiveSpanName(name: string): void {
+  if (!provider) return;
+  const trimmed = name.length > MAX_SPAN_NAME ? `${name.slice(0, MAX_SPAN_NAME - 1)}…` : name;
+  trace.getActiveSpan()?.updateName(trimmed);
+}
+
 export function startSpan(name: string, opts?: StartSpanOptions): ObservabilitySpan {
   if (!provider) return wrap(NOOP_OTEL_SPAN);
 


### PR DESCRIPTION
## Context

Prod/staging Genkit traces are working and visible in the LaunchDarkly observability UI, but in the trace list most spans show only a generic operation name (`generateCanonIcon`, `arbitrateCanon`, `identifyEquipment`, `embedText`, …), so you can't tell at a glance *which item* a trace relates to. A few spans we create ourselves already do this well — e.g. `canon.stages: Cottage cheese`, `canon.matchOrCreateCanon: <name>`. This extends that readability to the flow-level spans.

## Change

- **`setActiveSpanName(name)`** added to `@salt/ld-observability/server` — renames the active OTel span (which inside a Genkit flow body *is* the flow span) via `updateName()`. Guarded on the provider (no-op when observability is off) and capped at 80 chars so long raw input can't bloat span names.
- One line at the top of each user-facing flow stamps the entity onto its span:

  | Flow | New span name |
  |---|---|
  | `generateCanonIcon` | `generateCanonIcon: Red Onion` |
  | `identifyEquipment` | `identifyEquipment: KitchenAid mixer` |
  | `populateEquipmentEntry` | `populateEquipmentEntry: <name>` |
  | `arbitrateCanon` | `arbitrateCanon: <normalisedName>` |
  | `embedText` | `embedText: <text>` |
  | `parseEntry` | `parseEntry: <rawText>` |

`matchOrCreateCanon` and the `onShoppingListItemWrite` trigger already create explicitly-named parent spans, so they're unchanged. Model spans (`generate`, `googleai/*`) and Firestore auto-instrumentation spans are emitted by Genkit/OTel internals — left untouched; they nest under the now-named flow span so the trace stays scannable by its anchor.

## Why this approach

Avoids converting `onCallGenkit` callables to manual `onCall` (which would mean re-wiring `authPolicy: isSignedIn()` and re-implementing Genkit's flow instrumentation). One helper + one line per flow, uniform across callables and trigger-invoked flows. No new deps, no layer-map changes, no schema changes.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` (incl. `eslint-plugin-boundaries`; the new `cloud-functions → ld-observability/server` import is on an allowed edge) ✅
- `@salt/ld-observability` tests: 13 passed ✅

**Still needs a runtime check:** the load-bearing assumption is that `trace.getActiveSpan()` inside a Genkit flow body resolves to the flow span LD exports. Run `pnpm dev:emulators`, trigger an icon-gen (add a canon item) and an equipment identify, and confirm the Genkit Admin UI shows e.g. `generateCanonIcon: <item>` and the trace list still renders. If good locally, it carries to staging/LD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)