### PR TITLE
feat(canon): add regenerate-icon to list batch actions

### DIFF
--- a/apps/web-pwa/src/routes/canon/CanonListPage.svelte
+++ b/apps/web-pwa/src/routes/canon/CanonListPage.svelte
@@ -16,6 +16,7 @@
     isLoadingAisles,
     deleteCanonItem,
     approveCanonItems,
+    regenerateCanonIcon,
   } from '../../lib/canonService.js';
   import { aisles } from '../../lib/aisleService.js';
   import { titleCase } from '../../lib/titleCase.js';
@@ -112,6 +113,18 @@
     selection.remove(selectedApprovalIds);
   }
 
+  async function handleBulkRegenerateIcon() {
+    if (selection.count === 0) return;
+    const ids = selection.ids;
+    selectionMode = false; // exiting selection mode clears the selection
+    const results = await Promise.all(ids.map((id) => regenerateCanonIcon(id)));
+    if (results.some((r) => r.kind !== 'ok')) {
+      addToast('Failed to regenerate some icons.', 'destructive');
+    } else {
+      addToast(`Regenerating ${ids.length} icon${ids.length === 1 ? '' : 's'}…`, 'success');
+    }
+  }
+
   function handleBulkDelete() {
     if (selection.count === 0) return;
     const ids = selection.ids;
@@ -138,6 +151,13 @@
           } satisfies BulkAction,
         ]
       : []),
+    {
+      id: 'regenerate-icon',
+      label: 'Regenerate icon',
+      icon: 'RefreshCw',
+      testId: 'canon-list-bulk-regenerate-icon',
+      onSelect: () => void handleBulkRegenerateIcon(),
+    },
     {
       id: 'delete',
       label: 'Delete',


### PR DESCRIPTION
## What

Adds a **Regenerate icon** action to the canon items list bulk-actions bar, sitting between **Approve** and **Delete**.

## How

- New `handleBulkRegenerateIcon()` calls `regenerateCanonIcon(id)` for each selected item in parallel, exits selection mode, and toasts `Regenerating N icons…` (or a destructive toast if any fail).
- New `regenerate-icon` entry in `bulkActions`, using the same `RefreshCw` icon as the single-item regenerate button on the detail page.
- No steer hint is passed (batch use), matching the detail page's plain regenerate path.
- Always available alongside Delete (not gated like Approve).

## Verification

- `pnpm typecheck` passes; pre-commit dependency-cruiser clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)