### PR TITLE
feat(canon): reference integrity — clear on edit, display-time derivation on deletion (#188)

### DIFF
--- a/apps/web-pwa/src/lib/recipeService.ts
+++ b/apps/web-pwa/src/lib/recipeService.ts
@@ -9,7 +9,9 @@ import {
 import { createLDErrorReportingAdapter } from '@salt/ld-observability';
 import { addItem } from '@salt/domain';
 import type { Recipe, Ingredient, IngredientGroup, Quantity, SourceRef } from '@salt/domain';
+import { hasLiveCanonMatch } from '@salt/domain';
 import { success, type DomainError, type ReadResult } from '@salt/shared-types';
+import { getCanonItemsSnapshot } from './canonService.js';
 import { writable, get } from 'svelte/store';
 import type { Readable } from 'svelte/store';
 
@@ -107,11 +109,13 @@ export async function parseIngredients(
 export async function canonicaliseIngredients(
   recipe: Recipe,
 ): Promise<ReadResult<void, DomainError>> {
-  // Collect ingredients that need canonicalisation: parsed and not yet matched.
+  // Collect ingredients that need canonicalisation: parsed and without a live match
+  // (pending, failed, or matched-but-canon-item-deleted).
+  const canonIds = new Set(getCanonItemsSnapshot().map((c) => c.id));
   const toProcess: Array<{ ingredientId: string; rawName: string; rawText: string }> = [];
   for (const group of recipe.ingredients) {
     for (const ing of group.items) {
-      if (ing.parsed !== null && (ing.matchState === 'pending' || ing.matchState === 'failed')) {
+      if (ing.parsed !== null && !hasLiveCanonMatch(ing, canonIds)) {
         toProcess.push({ ingredientId: ing.id, rawName: ing.parsed.item, rawText: ing.rawText });
       }
     }
@@ -223,10 +227,11 @@ export async function addRecipeToShoppingList(
   };
 
   const saves: Promise<ReadResult<void, DomainError>>[] = [];
+  const liveCanonIds = new Set(getCanonItemsSnapshot().map((c) => c.id));
 
   for (const group of recipe.ingredients) {
     for (const ing of group.items) {
-      const isMatched = ing.matchState === 'matched' && ing.canonId !== null;
+      const isMatched = hasLiveCanonMatch(ing, liveCanonIds);
 
       let amount: number | undefined;
       let unit: string | undefined;

--- a/apps/web-pwa/src/lib/recipeService.ts
+++ b/apps/web-pwa/src/lib/recipeService.ts
@@ -8,7 +8,7 @@ import {
 } from '@salt/firebase-sync';
 import { createLDErrorReportingAdapter } from '@salt/ld-observability';
 import { addItem } from '@salt/domain';
-import type { Recipe, IngredientGroup, Quantity, SourceRef } from '@salt/domain';
+import type { Recipe, Ingredient, IngredientGroup, Quantity, SourceRef } from '@salt/domain';
 import { success, type DomainError, type ReadResult } from '@salt/shared-types';
 import { writable, get } from 'svelte/store';
 import type { Readable } from 'svelte/store';
@@ -150,6 +150,38 @@ export async function canonicaliseIngredients(
   }));
 
   return persistRecipe({ ...recipe, ingredients: updatedGroups });
+}
+
+// Parse and canon-match a single ingredient line. Chains callParseRecipeIngredients
+// → callCanonicaliseRecipeIngredients (batch-of-one) and folds the result into the
+// ingredient. Operates on the in-memory draft; the caller must persist the result.
+export async function matchIngredient(
+  ing: Ingredient,
+): Promise<ReadResult<Ingredient, DomainError>> {
+  const parseResult = await callParseRecipeIngredients(ing.rawText);
+  if (parseResult.kind === 'err') return parseResult;
+
+  const firstItem = parseResult.value[0]?.items[0];
+  if (!firstItem?.parsed) {
+    return success({ ...ing, parsed: null, canonId: null, matchState: 'failed' as const });
+  }
+  const parsed = firstItem.parsed;
+
+  const canonResult = await callCanonicaliseRecipeIngredients({
+    items: [{ rawName: parsed.item, rawText: ing.rawText }],
+  });
+  if (canonResult.kind === 'err') return canonResult;
+
+  const slot = canonResult.value[0]!;
+  if (slot.kind === 'err') {
+    return success({ ...ing, parsed, canonId: null, matchState: 'failed' as const });
+  }
+  return success({
+    ...ing,
+    parsed,
+    canonId: slot.value.item.id,
+    matchState: 'matched' as const,
+  });
 }
 
 export async function removeRecipe(id: string): Promise<ReadResult<void, DomainError>> {

--- a/apps/web-pwa/src/routes/recipes/RecipeEditPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeEditPage.svelte
@@ -13,7 +13,12 @@
     type Step,
     type RecipeMetadata,
   } from '@salt/domain';
-  import { recipes, persistRecipe, parseIngredients } from '../../lib/recipeService.js';
+  import {
+    recipes,
+    persistRecipe,
+    parseIngredients,
+    matchIngredient,
+  } from '../../lib/recipeService.js';
   import { addToast } from '../../lib/toastStore.js';
 
   interface Props {
@@ -215,6 +220,29 @@
       draft.steps.map((s) =>
         s.id === stepId ? { ...s, note: trimmed === '' ? null : trimmed } : s,
       ),
+    );
+  }
+
+  // ─── Per-row match ───────────────────────────────────────────────────────────
+  let matchingIds = $state<Record<string, boolean>>({});
+
+  async function handleMatchIngredient(group: IngredientGroup, ing: Ingredient): Promise<void> {
+    if (matchingIds[ing.id]) return;
+    matchingIds = { ...matchingIds, [ing.id]: true };
+    const result = await matchIngredient(ing);
+    matchingIds = { ...matchingIds, [ing.id]: false };
+    if (result.kind !== 'ok') {
+      addToast('Failed to match ingredient.', 'destructive');
+      return;
+    }
+    // Discard stale result if text was edited while the match was in flight.
+    const currentGroup = draft.ingredients.find((g) => g.id === group.id);
+    if (!currentGroup) return;
+    const currentIng = currentGroup.items.find((i) => i.id === ing.id);
+    if (!currentIng || currentIng.rawText !== ing.rawText) return;
+    updateGroupItems(
+      group.id,
+      currentGroup.items.map((i) => (i.id === ing.id ? result.value : i)),
     );
   }
 
@@ -435,6 +463,26 @@
                 class="flex-1"
                 data-testid="recipe-ingredient-input"
               />
+              {#if ingredient.matchState === 'matched'}
+                <span data-testid="recipe-ingredient-match-ok" class="shrink-0 text-green-600">
+                  <Icon name="Check" size={16} />
+                </span>
+              {:else if ingredient.matchState === 'failed'}
+                <span data-testid="recipe-ingredient-match-err" class="shrink-0 text-destructive">
+                  <Icon name="CircleX" size={16} />
+                </span>
+              {/if}
+              <Button
+                variant="ghost"
+                size="sm"
+                onclick={() => handleMatchIngredient(group, ingredient)}
+                loading={matchingIds[ingredient.id] ?? false}
+                disabled={ingredient.rawText.trim() === '' || (matchingIds[ingredient.id] ?? false)}
+                aria-label="Match ingredient"
+                data-testid="recipe-ingredient-match-btn"
+              >
+                <Icon name="Wand2" size={16} />
+              </Button>
               <Switch
                 label="Optional"
                 checked={ingredient.isOptional}

--- a/apps/web-pwa/src/routes/recipes/RecipeEditPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeEditPage.svelte
@@ -6,6 +6,7 @@
     emptyIngredientGroup,
     newIngredient,
     newStep,
+    clearIngredientMatch,
     type Recipe,
     type IngredientGroup,
     type Ingredient,
@@ -133,7 +134,11 @@
   ): void {
     updateGroupItems(
       group.id,
-      group.items.map((i) => (i.id === ingredientId ? { ...i, rawText } : i)),
+      group.items.map((i) => {
+        if (i.id !== ingredientId) return i;
+        if (i.rawText === rawText) return i;
+        return { ...clearIngredientMatch(i), rawText };
+      }),
     );
   }
 

--- a/apps/web-pwa/src/routes/recipes/RecipeViewPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeViewPage.svelte
@@ -21,6 +21,8 @@
     canonicaliseIngredients,
     addRecipeToShoppingList,
   } from '../../lib/recipeService.js';
+  import { canonItems } from '../../lib/canonService.js';
+  import { hasLiveCanonMatch } from '@salt/domain';
   import { defaultListId } from '../../lib/shoppingListService.svelte.js';
   import { addToast } from '../../lib/toastStore.js';
 
@@ -42,16 +44,16 @@
     return parts;
   }
 
+  // ─── Canon live-id set (for dangling-match derivation) ───────────────────────
+  const liveCanonIds = $derived(new Set($canonItems.map((c) => c.id)));
+
   // ─── Canonicalise ────────────────────────────────────────────────────────────
   let canonalising = $state(false);
 
   const hasParsedPending = $derived(
     recipe !== null &&
       recipe.ingredients.some((g) =>
-        g.items.some(
-          (ing) =>
-            ing.parsed !== null && (ing.matchState === 'pending' || ing.matchState === 'failed'),
-        ),
+        g.items.some((ing) => ing.parsed !== null && !hasLiveCanonMatch(ing, liveCanonIds)),
       ),
   );
 
@@ -215,7 +217,7 @@
                         .unit})</span
                     >{/if}{#if ingredient.isOptional}<span
                       class="ml-1 text-xs text-muted-foreground">(optional)</span
-                    >{/if}{#if ingredient.matchState === 'matched'}<span
+                    >{/if}{#if hasLiveCanonMatch(ingredient, liveCanonIds)}<span
                       class="ml-1 text-xs text-green-600"
                       title="Matched"
                       data-testid="match-state-matched">✓</span

--- a/apps/web-pwa/tests/RecipeEditPage.clearMatch.test.ts
+++ b/apps/web-pwa/tests/RecipeEditPage.clearMatch.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { newIngredient, emptyIngredientGroup } from '@salt/domain';
+import type { Recipe, Ingredient } from '@salt/domain';
+
+// ─── Mock stores and services ──────────────────────────────────────────────────
+
+const { mockRecipes } = vi.hoisted(() => {
+  function makeStore<T>(initial: T) {
+    let value = initial;
+    const subs = new Set<(v: T) => void>();
+    return {
+      subscribe(fn: (v: T) => void) {
+        subs.add(fn);
+        fn(value);
+        return () => {
+          subs.delete(fn);
+        };
+      },
+      _set(v: T) {
+        value = v;
+        subs.forEach((fn) => fn(v));
+      },
+    };
+  }
+  return { mockRecipes: makeStore<readonly Recipe[]>([]) };
+});
+
+vi.mock('svelte-spa-router', () => ({ push: vi.fn() }));
+vi.mock('../src/lib/toastStore.js', () => ({ addToast: vi.fn() }));
+vi.mock('../src/lib/recipeService.js', () => ({
+  recipes: mockRecipes,
+  persistRecipe: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  parseIngredients: vi.fn(),
+}));
+
+import RecipeEditPage from '../src/routes/recipes/RecipeEditPage.svelte';
+import { persistRecipe } from '../src/lib/recipeService.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeMatchedIngredient(): Ingredient {
+  return {
+    ...newIngredient('ing-1', 'garlic'),
+    canonId: 'canon-abc',
+    matchState: 'matched',
+    parsed: {
+      quantity: null,
+      unit: null,
+      item: 'garlic',
+      preparation: [],
+      notes: null,
+      convertedWeight: null,
+    },
+  };
+}
+
+function makeRecipe(ing: Ingredient): Recipe {
+  return {
+    id: 'recipe-1',
+    schemaVersion: 1,
+    title: 'Test Recipe',
+    description: null,
+    ingredients: [{ ...emptyIngredientGroup('group-1'), items: [ing] }],
+    steps: [],
+    metadata: {
+      servings: null,
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      totalTimeMinutes: null,
+      tags: [],
+    },
+    source: null,
+    notes: null,
+    image: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('RecipeEditPage — clearIngredientMatch on edit', () => {
+  it('clears canonId and sets matchState pending when ingredient text changes', async () => {
+    mockRecipes._set([makeRecipe(makeMatchedIngredient())]);
+    render(RecipeEditPage, { props: { params: { id: 'recipe-1' } } });
+
+    const input = screen.getByTestId('recipe-ingredient-input');
+    await userEvent.type(input, ' minced');
+
+    await userEvent.click(screen.getByTestId('recipe-save-btn'));
+
+    await waitFor(() => {
+      expect(vi.mocked(persistRecipe)).toHaveBeenCalledTimes(1);
+    });
+
+    const saved = vi.mocked(persistRecipe).mock.calls[0]![0] as Recipe;
+    const ingredient = saved.ingredients[0]!.items[0]!;
+    expect(ingredient.matchState).toBe('pending');
+    expect(ingredient.canonId).toBeNull();
+  });
+
+  it('preserves existing match when ingredient text is not changed', async () => {
+    mockRecipes._set([makeRecipe(makeMatchedIngredient())]);
+    render(RecipeEditPage, { props: { params: { id: 'recipe-1' } } });
+
+    await userEvent.click(screen.getByTestId('recipe-save-btn'));
+
+    await waitFor(() => {
+      expect(vi.mocked(persistRecipe)).toHaveBeenCalledTimes(1);
+    });
+
+    const saved = vi.mocked(persistRecipe).mock.calls[0]![0] as Recipe;
+    const ingredient = saved.ingredients[0]!.items[0]!;
+    expect(ingredient.matchState).toBe('matched');
+    expect(ingredient.canonId).toBe('canon-abc');
+  });
+});

--- a/apps/web-pwa/tests/RecipeEditPage.matchRow.test.ts
+++ b/apps/web-pwa/tests/RecipeEditPage.matchRow.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { newIngredient, emptyIngredientGroup } from '@salt/domain';
+import type { Recipe, Ingredient } from '@salt/domain';
+
+// ─── Mock stores and services ──────────────────────────────────────────────────
+
+const { mockRecipes } = vi.hoisted(() => {
+  function makeStore<T>(initial: T) {
+    let value = initial;
+    const subs = new Set<(v: T) => void>();
+    return {
+      subscribe(fn: (v: T) => void) {
+        subs.add(fn);
+        fn(value);
+        return () => {
+          subs.delete(fn);
+        };
+      },
+      _set(v: T) {
+        value = v;
+        subs.forEach((fn) => fn(v));
+      },
+    };
+  }
+  return { mockRecipes: makeStore<readonly Recipe[]>([]) };
+});
+
+vi.mock('svelte-spa-router', () => ({ push: vi.fn() }));
+vi.mock('../src/lib/toastStore.js', () => ({ addToast: vi.fn() }));
+vi.mock('../src/lib/recipeService.js', () => ({
+  recipes: mockRecipes,
+  persistRecipe: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  parseIngredients: vi.fn(),
+  matchIngredient: vi.fn(),
+}));
+
+import RecipeEditPage from '../src/routes/recipes/RecipeEditPage.svelte';
+import { persistRecipe, matchIngredient } from '../src/lib/recipeService.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makePendingIngredient(): Ingredient {
+  return {
+    ...newIngredient('ing-1', '2 cups flour'),
+    parsed: null,
+    canonId: null,
+    matchState: 'pending',
+  };
+}
+
+function makeRecipe(ing: Ingredient): Recipe {
+  return {
+    id: 'recipe-1',
+    schemaVersion: 1,
+    title: 'Test Recipe',
+    description: null,
+    ingredients: [{ ...emptyIngredientGroup('group-1'), items: [ing] }],
+    steps: [],
+    metadata: {
+      servings: null,
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      totalTimeMinutes: null,
+      tags: [],
+    },
+    source: null,
+    notes: null,
+    image: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+const matchedIngredient: Ingredient = {
+  id: 'ing-1',
+  rawText: '2 cups flour',
+  parsed: {
+    quantity: { type: 'single', value: 2 },
+    unit: 'cups',
+    item: 'flour',
+    preparation: [],
+    notes: null,
+    convertedWeight: null,
+  },
+  canonId: 'canon-flour',
+  matchState: 'matched',
+  isOptional: false,
+  firstUsedInStepId: null,
+};
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('RecipeEditPage — per-row Match button', () => {
+  it('shows the matched indicator after clicking Match on a pending ingredient', async () => {
+    vi.mocked(matchIngredient).mockResolvedValue({ kind: 'ok', value: matchedIngredient });
+    mockRecipes._set([makeRecipe(makePendingIngredient())]);
+    render(RecipeEditPage, { props: { params: { id: 'recipe-1' } } });
+
+    await userEvent.click(screen.getByTestId('recipe-ingredient-match-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('recipe-ingredient-match-ok')).toBeInTheDocument();
+    });
+  });
+
+  it('persists the matched ingredient (canonId + matchState) on save', async () => {
+    vi.mocked(matchIngredient).mockResolvedValue({ kind: 'ok', value: matchedIngredient });
+    mockRecipes._set([makeRecipe(makePendingIngredient())]);
+    render(RecipeEditPage, { props: { params: { id: 'recipe-1' } } });
+
+    await userEvent.click(screen.getByTestId('recipe-ingredient-match-btn'));
+    await waitFor(() => {
+      expect(screen.getByTestId('recipe-ingredient-match-ok')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByTestId('recipe-save-btn'));
+    await waitFor(() => {
+      expect(vi.mocked(persistRecipe)).toHaveBeenCalledTimes(1);
+    });
+
+    const saved = vi.mocked(persistRecipe).mock.calls[0]![0] as Recipe;
+    const ing = saved.ingredients[0]!.items[0]!;
+    expect(ing.matchState).toBe('matched');
+    expect(ing.canonId).toBe('canon-flour');
+  });
+
+  it('shows the error indicator when matchIngredient returns failed', async () => {
+    const failedIngredient: Ingredient = {
+      ...makePendingIngredient(),
+      matchState: 'failed',
+    };
+    vi.mocked(matchIngredient).mockResolvedValue({ kind: 'ok', value: failedIngredient });
+    mockRecipes._set([makeRecipe(makePendingIngredient())]);
+    render(RecipeEditPage, { props: { params: { id: 'recipe-1' } } });
+
+    await userEvent.click(screen.getByTestId('recipe-ingredient-match-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('recipe-ingredient-match-err')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web-pwa/tests/ShoppingListPage.danglingCanon.test.ts
+++ b/apps/web-pwa/tests/ShoppingListPage.danglingCanon.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, within } from '@testing-library/svelte';
+import type { CanonItem, ShoppingList, ShoppingListItem } from '@salt/domain';
+
+// ─── Mock stores (hoisted so vi.mock factories can reference them) ─────────────
+
+const { mockCanonItems, mockAisles, mockLists, mockItems, mockDefaultListId, mockLoading } =
+  vi.hoisted(() => {
+    function makeStore<T>(initial: T) {
+      let value = initial;
+      const subs = new Set<(v: T) => void>();
+      return {
+        subscribe(fn: (v: T) => void) {
+          subs.add(fn);
+          fn(value);
+          return () => {
+            subs.delete(fn);
+          };
+        },
+        _set(v: T) {
+          value = v;
+          subs.forEach((fn) => fn(v));
+        },
+      };
+    }
+    return {
+      mockCanonItems: makeStore<CanonItem[]>([]),
+      mockAisles: makeStore<{ id: string; name: string; order: number }[]>([]),
+      mockLists: makeStore<ShoppingList[]>([]),
+      mockItems: makeStore<ShoppingListItem[]>([]),
+      mockDefaultListId: makeStore<string | null>('list-1'),
+      mockLoading: makeStore<boolean>(false),
+    };
+  });
+
+vi.mock('svelte-spa-router', () => ({ push: vi.fn() }));
+vi.mock('../src/lib/toastStore.js', () => ({ addToast: vi.fn() }));
+vi.mock('../src/lib/canonService.js', () => ({
+  canonItems: mockCanonItems,
+  aisles: mockAisles,
+}));
+vi.mock('../src/lib/shoppingListService.svelte.js', () => ({
+  lists: mockLists,
+  defaultListId: mockDefaultListId,
+  itemsForActiveList: mockItems,
+  isLoadingShoppingList: mockLoading,
+  setActiveListId: vi.fn(),
+  addItemToList: vi.fn(),
+  updateItemRawText: vi.fn(),
+  updateItemAmountUnit: vi.fn(),
+  updateItemNotes: vi.fn(),
+  toggleItemChecked: vi.fn(),
+  checkItems: vi.fn(),
+  uncheckItems: vi.fn(),
+  removeItem: vi.fn(),
+  removeItems: vi.fn(),
+  clearChecked: vi.fn(),
+  moveSelectedItems: vi.fn(),
+}));
+
+import ShoppingListPage from '../src/routes/shopping/ShoppingListPage.svelte';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function canonItem(overrides: Partial<CanonItem> & { id: string; name: string }): CanonItem {
+  return {
+    schemaVersion: 5,
+    synonyms: [],
+    aisleId: null,
+    thumbnail: null,
+    embedding: null,
+    needs_approval: false,
+    shoppingBehavior: 'needed',
+    updatedAt: '',
+    ...overrides,
+  };
+}
+
+function item(overrides: Partial<ShoppingListItem> & { id: string }): ShoppingListItem {
+  return {
+    rawText: 'thing',
+    notes: '',
+    sources: [],
+    canonId: null,
+    matchState: 'pending',
+    checked: false,
+    schemaVersion: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockLists._set([{ id: 'list-1', name: 'Groceries' } as ShoppingList]);
+  mockDefaultListId._set('list-1');
+  mockLoading._set(false);
+  mockAisles._set([{ id: 'aisle-1', name: 'Produce', order: 0 }]);
+  mockCanonItems._set([]);
+  mockItems._set([]);
+});
+
+describe('ShoppingListPage — dangling canon reference', () => {
+  it('routes a matched item with a deleted canon (absent from live store) to the Other section', async () => {
+    // Item claims to be matched to a canon that no longer exists in the live store.
+    mockCanonItems._set([]);
+    mockItems._set([
+      item({ id: 'i1', rawText: 'milk', canonId: 'deleted-canon', matchState: 'matched' }),
+    ]);
+
+    const { findByTestId, queryByTestId } = render(ShoppingListPage, {
+      props: { params: { listId: 'list-1' } },
+    });
+
+    const other = await findByTestId('shopping-other');
+    expect(within(other).getByText('milk', { exact: false })).toBeTruthy();
+    expect(queryByTestId('shopping-aisle-group')).toBeNull();
+  });
+
+  it('routes a matched item with a present canon (with aisle) to the aisle group', async () => {
+    mockAisles._set([{ id: 'aisle-1', name: 'Produce', order: 0 }]);
+    mockCanonItems._set([canonItem({ id: 'c-milk', name: 'milk', aisleId: 'aisle-1' })]);
+    mockItems._set([item({ id: 'i1', rawText: 'milk', canonId: 'c-milk', matchState: 'matched' })]);
+
+    const { findByTestId, queryByTestId } = render(ShoppingListPage, {
+      props: { params: { listId: 'list-1' } },
+    });
+
+    await findByTestId('shopping-aisle-group');
+    expect(queryByTestId('shopping-other')).toBeNull();
+  });
+});

--- a/apps/web-pwa/tests/recipeService.addToList.test.ts
+++ b/apps/web-pwa/tests/recipeService.addToList.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi, type Mocked } from 'vitest';
+import type { Recipe, CanonItem, IngredientGroup } from '@salt/domain';
+
+// ─── Mock firebase-sync ──────────────────────────────────────────────────────
+vi.mock('@salt/firebase-sync', () => ({
+  subscribeRecipes: vi.fn(() => vi.fn()),
+  saveRecipe: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  deleteRecipe: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  callParseRecipeIngredients: vi.fn(),
+  callCanonicaliseRecipeIngredients: vi.fn(),
+  saveShoppingListItem: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+}));
+
+vi.mock('@salt/ld-observability', () => ({
+  createLDErrorReportingAdapter: vi.fn(() => ({ report: vi.fn() })),
+}));
+
+// ─── Mock canonService ───────────────────────────────────────────────────────
+const { mockGetCanonItemsSnapshot } = vi.hoisted(() => ({
+  mockGetCanonItemsSnapshot: vi.fn(() => [] as CanonItem[]),
+}));
+
+vi.mock('../src/lib/canonService.js', () => ({
+  getCanonItemsSnapshot: mockGetCanonItemsSnapshot,
+}));
+
+import * as firebaseSync from '@salt/firebase-sync';
+import { addRecipeToShoppingList } from '../src/lib/recipeService.js';
+
+const fs = firebaseSync as Mocked<typeof firebaseSync>;
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeCanonItem(id: string): CanonItem {
+  return {
+    id,
+    schemaVersion: 2,
+    name: id,
+    synonyms: [],
+    aisleId: null,
+    thumbnail: null,
+    embedding: null,
+    needs_approval: false,
+    updatedAt: '',
+  };
+}
+
+function makeGroup(items: IngredientGroup['items']): IngredientGroup {
+  return { id: 'g1', name: null, items };
+}
+
+function makeRecipe(groups: IngredientGroup[]): Recipe {
+  return {
+    id: 'recipe-1',
+    schemaVersion: 1,
+    title: 'Test Recipe',
+    description: null,
+    ingredients: groups,
+    steps: [],
+    metadata: {
+      servings: 2,
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      totalTimeMinutes: null,
+      tags: [],
+    },
+    source: null,
+    notes: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+const parsedIngredient = {
+  quantity: { type: 'single' as const, value: 2 },
+  unit: 'cups',
+  item: 'flour',
+  preparation: [],
+  notes: null,
+  convertedWeight: null,
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fs.saveShoppingListItem.mockResolvedValue({ kind: 'ok', value: undefined });
+  mockGetCanonItemsSnapshot.mockReturnValue([]);
+});
+
+describe('addRecipeToShoppingList', () => {
+  it('adds a matched ingredient with canonId when the canon item is live', async () => {
+    mockGetCanonItemsSnapshot.mockReturnValue([makeCanonItem('canon-flour')]);
+
+    const recipe = makeRecipe([
+      makeGroup([
+        {
+          id: 'i1',
+          rawText: '2 cups flour',
+          parsed: parsedIngredient,
+          canonId: 'canon-flour',
+          matchState: 'matched',
+          isOptional: false,
+          firstUsedInStepId: null,
+        },
+      ]),
+    ]);
+
+    const result = await addRecipeToShoppingList(recipe, 'list-1', 2);
+
+    expect(result).toEqual({ kind: 'ok', value: undefined });
+    expect(fs.saveShoppingListItem).toHaveBeenCalledOnce();
+    const savedItem = (fs.saveShoppingListItem as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(savedItem.canonId).toBe('canon-flour');
+    expect(savedItem.matchState).toBe('matched');
+  });
+
+  it('adds a dangling-matched ingredient as raw text when the canon item is absent from the store', async () => {
+    // canon store is empty — 'canon-flour' was deleted
+    mockGetCanonItemsSnapshot.mockReturnValue([]);
+
+    const recipe = makeRecipe([
+      makeGroup([
+        {
+          id: 'i1',
+          rawText: '2 cups flour',
+          parsed: parsedIngredient,
+          canonId: 'canon-flour',
+          matchState: 'matched',
+          isOptional: false,
+          firstUsedInStepId: null,
+        },
+      ]),
+    ]);
+
+    const result = await addRecipeToShoppingList(recipe, 'list-1', 2);
+
+    expect(result).toEqual({ kind: 'ok', value: undefined });
+    expect(fs.saveShoppingListItem).toHaveBeenCalledOnce();
+    const savedItem = (fs.saveShoppingListItem as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    // Dangling ingredient: falls back to raw text (no live canon match).
+    expect(savedItem.canonId).toBeNull();
+    expect(savedItem.matchState).toBe('pending');
+    expect(savedItem.rawText).toBe('2 cups flour');
+  });
+
+  it('adds an unmatched ingredient as raw text', async () => {
+    const recipe = makeRecipe([
+      makeGroup([
+        {
+          id: 'i1',
+          rawText: 'some unknown thing',
+          parsed: null,
+          canonId: null,
+          matchState: 'pending',
+          isOptional: false,
+          firstUsedInStepId: null,
+        },
+      ]),
+    ]);
+
+    await addRecipeToShoppingList(recipe, 'list-1', 2);
+
+    const savedItem = (fs.saveShoppingListItem as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(savedItem.canonId).toBeNull();
+    expect(savedItem.matchState).toBe('pending');
+    expect(savedItem.rawText).toBe('some unknown thing');
+  });
+});

--- a/apps/web-pwa/tests/recipeService.canonicalise.test.ts
+++ b/apps/web-pwa/tests/recipeService.canonicalise.test.ts
@@ -14,6 +14,15 @@ vi.mock('@salt/ld-observability', () => ({
   createLDErrorReportingAdapter: vi.fn(() => ({ report: vi.fn() })),
 }));
 
+// ─── Mock canonService ───────────────────────────────────────────────────────
+const { mockGetCanonItemsSnapshot } = vi.hoisted(() => ({
+  mockGetCanonItemsSnapshot: vi.fn(() => [] as import('@salt/domain').CanonItem[]),
+}));
+
+vi.mock('../src/lib/canonService.js', () => ({
+  getCanonItemsSnapshot: mockGetCanonItemsSnapshot,
+}));
+
 import * as firebaseSync from '@salt/firebase-sync';
 import { canonicaliseIngredients } from '../src/lib/recipeService.js';
 
@@ -75,6 +84,8 @@ const parsedIngredient = {
 beforeEach(() => {
   vi.clearAllMocks();
   fs.saveRecipe.mockResolvedValue({ kind: 'ok', value: undefined });
+  // Default: empty canon store (no live matches).
+  mockGetCanonItemsSnapshot.mockReturnValue([]);
 });
 
 describe('canonicaliseIngredients', () => {
@@ -214,7 +225,9 @@ describe('canonicaliseIngredients', () => {
     expect(saved.ingredients[0].items[0].matchState).toBe('matched');
   });
 
-  it('skips already-matched ingredients', async () => {
+  it('skips ingredients whose canonId is live in the canon store', async () => {
+    mockGetCanonItemsSnapshot.mockReturnValue([makeCanonItem('canon-flour')]);
+
     const recipe = makeRecipe([
       makeGroup([
         {
@@ -234,6 +247,38 @@ describe('canonicaliseIngredients', () => {
     expect(result).toEqual({ kind: 'ok', value: undefined });
     expect(fs.callCanonicaliseRecipeIngredients).not.toHaveBeenCalled();
     expect(fs.saveRecipe).not.toHaveBeenCalled();
+  });
+
+  it('re-canonicalises a matched ingredient whose canon item was deleted (dangling)', async () => {
+    // canon store is empty — 'canon-flour' no longer exists.
+    mockGetCanonItemsSnapshot.mockReturnValue([]);
+
+    const canon = makeCanonItem('canon-flour-new');
+    fs.callCanonicaliseRecipeIngredients.mockResolvedValue({
+      kind: 'ok',
+      value: [{ kind: 'ok', value: { decision: 'matched', item: canon } }],
+    });
+
+    const recipe = makeRecipe([
+      makeGroup([
+        {
+          id: 'i1',
+          rawText: 'flour',
+          parsed: parsedIngredient,
+          canonId: 'canon-flour',
+          matchState: 'matched',
+          isOptional: false,
+          firstUsedInStepId: null,
+        },
+      ]),
+    ]);
+
+    await canonicaliseIngredients(recipe);
+
+    expect(fs.callCanonicaliseRecipeIngredients).toHaveBeenCalledOnce();
+    const saved = (fs.saveRecipe as ReturnType<typeof vi.fn>).mock.calls[0][0] as Recipe;
+    expect(saved.ingredients[0].items[0].canonId).toBe('canon-flour-new');
+    expect(saved.ingredients[0].items[0].matchState).toBe('matched');
   });
 
   it('calls the batch CF with rawName from parsed.item and rawText from ingredient', async () => {

--- a/apps/web-pwa/tests/recipeService.matchIngredient.test.ts
+++ b/apps/web-pwa/tests/recipeService.matchIngredient.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi, type Mocked } from 'vitest';
+import type { Ingredient, IngredientGroup } from '@salt/domain';
+
+// ─── Mock firebase-sync ──────────────────────────────────────────────────────
+vi.mock('@salt/firebase-sync', () => ({
+  subscribeRecipes: vi.fn(() => vi.fn()),
+  saveRecipe: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  deleteRecipe: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  callParseRecipeIngredients: vi.fn(),
+  callCanonicaliseRecipeIngredients: vi.fn(),
+  saveShoppingListItem: vi.fn(),
+}));
+
+vi.mock('@salt/ld-observability', () => ({
+  createLDErrorReportingAdapter: vi.fn(() => ({ report: vi.fn() })),
+}));
+
+import * as firebaseSync from '@salt/firebase-sync';
+import { matchIngredient } from '../src/lib/recipeService.js';
+
+const fs = firebaseSync as Mocked<typeof firebaseSync>;
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makePendingIngredient(): Ingredient {
+  return {
+    id: 'ing-1',
+    rawText: '2 cups flour',
+    parsed: null,
+    canonId: null,
+    matchState: 'pending',
+    isOptional: false,
+    firstUsedInStepId: null,
+  };
+}
+
+const parsedFlour = {
+  quantity: { type: 'single' as const, value: 2 },
+  unit: 'cups',
+  item: 'flour',
+  preparation: [],
+  notes: null,
+  convertedWeight: null,
+};
+
+const parseGroup: IngredientGroup = {
+  id: 'g1',
+  name: null,
+  items: [{ ...makePendingIngredient(), parsed: parsedFlour }],
+};
+
+function makeCanonItem(id: string) {
+  return {
+    id,
+    schemaVersion: 2 as const,
+    name: id,
+    synonyms: [],
+    aisleId: null,
+    thumbnail: null,
+    embedding: null,
+    needs_approval: false,
+    updatedAt: '',
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('matchIngredient', () => {
+  it('returns matched ingredient with canonId and parsed when both CFs succeed', async () => {
+    fs.callParseRecipeIngredients.mockResolvedValue({ kind: 'ok', value: [parseGroup] });
+    fs.callCanonicaliseRecipeIngredients.mockResolvedValue({
+      kind: 'ok',
+      value: [{ kind: 'ok', value: { decision: 'matched', item: makeCanonItem('canon-flour') } }],
+    });
+
+    const result = await matchIngredient(makePendingIngredient());
+
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.value.matchState).toBe('matched');
+    expect(result.value.canonId).toBe('canon-flour');
+    expect(result.value.parsed).toEqual(parsedFlour);
+    expect(result.value.id).toBe('ing-1');
+    expect(result.value.rawText).toBe('2 cups flour');
+  });
+
+  it('returns failed + null canonId when canonise slot returns an error', async () => {
+    fs.callParseRecipeIngredients.mockResolvedValue({ kind: 'ok', value: [parseGroup] });
+    fs.callCanonicaliseRecipeIngredients.mockResolvedValue({
+      kind: 'ok',
+      value: [{ kind: 'err', error: { kind: 'NetworkError', reason: 'transient' } }],
+    });
+
+    const result = await matchIngredient(makePendingIngredient());
+
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.value.matchState).toBe('failed');
+    expect(result.value.canonId).toBeNull();
+    expect(result.value.parsed).toEqual(parsedFlour);
+  });
+
+  it('returns failed + null parsed when parse returns no structured item', async () => {
+    fs.callParseRecipeIngredients.mockResolvedValue({ kind: 'ok', value: [] });
+
+    const result = await matchIngredient(makePendingIngredient());
+
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.value.matchState).toBe('failed');
+    expect(result.value.canonId).toBeNull();
+    expect(result.value.parsed).toBeNull();
+    expect(fs.callCanonicaliseRecipeIngredients).not.toHaveBeenCalled();
+  });
+
+  it('bubbles up transport error from callParseRecipeIngredients', async () => {
+    fs.callParseRecipeIngredients.mockResolvedValue({
+      kind: 'err',
+      error: { kind: 'NetworkError', reason: 'transient' },
+    });
+
+    const result = await matchIngredient(makePendingIngredient());
+
+    expect(result.kind).toBe('err');
+    expect(fs.callCanonicaliseRecipeIngredients).not.toHaveBeenCalled();
+  });
+
+  it('bubbles up transport error from callCanonicaliseRecipeIngredients', async () => {
+    fs.callParseRecipeIngredients.mockResolvedValue({ kind: 'ok', value: [parseGroup] });
+    fs.callCanonicaliseRecipeIngredients.mockResolvedValue({
+      kind: 'err',
+      error: { kind: 'NetworkError', reason: 'transient' },
+    });
+
+    const result = await matchIngredient(makePendingIngredient());
+
+    expect(result.kind).toBe('err');
+  });
+
+  it('calls canonicalise with rawName from parsed.item and rawText from ingredient', async () => {
+    fs.callParseRecipeIngredients.mockResolvedValue({ kind: 'ok', value: [parseGroup] });
+    fs.callCanonicaliseRecipeIngredients.mockResolvedValue({
+      kind: 'ok',
+      value: [{ kind: 'ok', value: { decision: 'matched', item: makeCanonItem('canon-flour') } }],
+    });
+
+    await matchIngredient(makePendingIngredient());
+
+    expect(fs.callCanonicaliseRecipeIngredients).toHaveBeenCalledWith({
+      items: [{ rawName: 'flour', rawText: '2 cups flour' }],
+    });
+  });
+});

--- a/packages/domain/src/canon/index.ts
+++ b/packages/domain/src/canon/index.ts
@@ -76,3 +76,4 @@ export { summarizeMatchLog } from './queries/summarizeMatchLog.js';
 export type { MatchLogSummary } from './queries/summarizeMatchLog.js';
 export { listAisles } from './queries/listAisles.js';
 export { getAisleUsage } from './queries/getAisleUsage.js';
+export { hasLiveCanonMatch } from './queries/hasLiveCanonMatch.js';

--- a/packages/domain/src/canon/queries/hasLiveCanonMatch.ts
+++ b/packages/domain/src/canon/queries/hasLiveCanonMatch.ts
@@ -1,0 +1,10 @@
+export function hasLiveCanonMatch(
+  ref: { matchState: string; canonId: string | null },
+  canonIds: ReadonlySet<string>,
+): boolean {
+  return (
+    (ref.matchState === 'matched' || ref.matchState === 'needs_approval') &&
+    ref.canonId !== null &&
+    canonIds.has(ref.canonId)
+  );
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -57,6 +57,7 @@ export {
   getAisleUsage,
   CANON_ICON_HIDDEN,
   isCanonIconRenderable,
+  hasLiveCanonMatch,
 } from './canon/index.js';
 export type {
   ConflictStrategy,

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -218,6 +218,7 @@ export {
   emptyIngredientGroup,
   newIngredient,
   newStep,
+  clearIngredientMatch,
   flattenIngredients,
 } from './recipe/index.js';
 

--- a/packages/domain/src/recipe/commands/clearIngredientMatch.ts
+++ b/packages/domain/src/recipe/commands/clearIngredientMatch.ts
@@ -1,0 +1,7 @@
+import type { Ingredient } from '../entities/Ingredient.js';
+
+// Resets the canon match on an ingredient whose rawText has been edited.
+// Mirrors editItemRawText's behaviour for shopping-list items.
+export function clearIngredientMatch(ing: Ingredient): Ingredient {
+  return { ...ing, parsed: null, canonId: null, matchState: 'pending' };
+}

--- a/packages/domain/src/recipe/index.ts
+++ b/packages/domain/src/recipe/index.ts
@@ -18,4 +18,5 @@ export type { Step, StepTimer } from './entities/Step.js';
 export type { Recipe, RecipeImage, RecipeMetadata, RecipeSource } from './entities/Recipe.js';
 
 export { emptyRecipe, emptyIngredientGroup, newIngredient, newStep } from './commands/builders.js';
+export { clearIngredientMatch } from './commands/clearIngredientMatch.js';
 export { flattenIngredients } from './queries/ingredients.js';

--- a/packages/domain/src/shoppingList/queries/groupItemsByAisle.ts
+++ b/packages/domain/src/shoppingList/queries/groupItemsByAisle.ts
@@ -1,4 +1,5 @@
 import type { ShoppingListItem } from '../entities/ShoppingListItem.js';
+import { hasLiveCanonMatch } from '../../canon/index.js';
 
 export interface CanonInfo {
   readonly id: string;
@@ -47,6 +48,7 @@ export function groupItemsByAisle(
   const otherContributors: OtherContributor[] = [];
   const checkedItems: ShoppingListItem[] = [];
   const aisleMap = new Map<string, ShoppingListItem[]>();
+  const liveCanonIds = new Set(canonMap.keys());
 
   for (const item of items) {
     if (item.checked) {
@@ -55,10 +57,7 @@ export function groupItemsByAisle(
     }
 
     const isMatchedToAisle =
-      (item.matchState === 'matched' || item.matchState === 'needs_approval') &&
-      item.canonId !== null &&
-      canonMap.has(item.canonId) &&
-      canonMap.get(item.canonId)!.aisleId !== null;
+      hasLiveCanonMatch(item, liveCanonIds) && canonMap.get(item.canonId!)!.aisleId !== null;
 
     if (!isMatchedToAisle) {
       otherContributors.push({

--- a/packages/domain/tests/canon/hasLiveCanonMatch.test.ts
+++ b/packages/domain/tests/canon/hasLiveCanonMatch.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { hasLiveCanonMatch } from '@salt/domain';
+
+describe('hasLiveCanonMatch', () => {
+  it('returns true when matched and canonId is in the set', () => {
+    expect(hasLiveCanonMatch({ matchState: 'matched', canonId: 'id1' }, new Set(['id1']))).toBe(
+      true,
+    );
+  });
+
+  it('returns false when matched but canonId is absent from the set', () => {
+    expect(hasLiveCanonMatch({ matchState: 'matched', canonId: 'id1' }, new Set())).toBe(false);
+  });
+
+  it('returns false when matched but canonId is null', () => {
+    expect(hasLiveCanonMatch({ matchState: 'matched', canonId: null }, new Set(['id1']))).toBe(
+      false,
+    );
+  });
+
+  it('returns false when pending regardless of canonId', () => {
+    expect(hasLiveCanonMatch({ matchState: 'pending', canonId: null }, new Set())).toBe(false);
+    expect(hasLiveCanonMatch({ matchState: 'pending', canonId: 'id1' }, new Set(['id1']))).toBe(
+      false,
+    );
+  });
+
+  it('returns false when failed', () => {
+    expect(hasLiveCanonMatch({ matchState: 'failed', canonId: null }, new Set())).toBe(false);
+  });
+
+  it('returns true when needs_approval and canonId is in the set', () => {
+    expect(
+      hasLiveCanonMatch({ matchState: 'needs_approval', canonId: 'id1' }, new Set(['id1'])),
+    ).toBe(true);
+  });
+
+  it('returns false when needs_approval but canonId is absent from the set', () => {
+    expect(
+      hasLiveCanonMatch({ matchState: 'needs_approval', canonId: 'id1' }, new Set(['other'])),
+    ).toBe(false);
+  });
+
+  it('returns false when needs_approval but canonId is null', () => {
+    expect(hasLiveCanonMatch({ matchState: 'needs_approval', canonId: null }, new Set())).toBe(
+      false,
+    );
+  });
+});

--- a/packages/domain/tests/recipe/clearIngredientMatch.test.ts
+++ b/packages/domain/tests/recipe/clearIngredientMatch.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { clearIngredientMatch, newIngredient } from '@salt/domain';
+import type { Ingredient } from '@salt/domain';
+
+function matchedIngredient(overrides: Partial<Ingredient> = {}): Ingredient {
+  return {
+    ...newIngredient('id-1', '2 cloves garlic'),
+    parsed: {
+      quantity: { type: 'single', value: 2 },
+      unit: null,
+      item: 'garlic',
+      preparation: ['minced'],
+      notes: null,
+      convertedWeight: null,
+    },
+    canonId: 'canon-abc',
+    matchState: 'matched',
+    ...overrides,
+  };
+}
+
+describe('clearIngredientMatch', () => {
+  it('sets parsed to null', () => {
+    expect(clearIngredientMatch(matchedIngredient()).parsed).toBeNull();
+  });
+
+  it('sets canonId to null', () => {
+    expect(clearIngredientMatch(matchedIngredient()).canonId).toBeNull();
+  });
+
+  it('sets matchState to pending', () => {
+    expect(clearIngredientMatch(matchedIngredient()).matchState).toBe('pending');
+  });
+
+  it('also clears a failed ingredient', () => {
+    const ing = matchedIngredient({ matchState: 'failed', canonId: null });
+    const result = clearIngredientMatch(ing);
+    expect(result.matchState).toBe('pending');
+    expect(result.canonId).toBeNull();
+  });
+
+  it('preserves rawText', () => {
+    expect(clearIngredientMatch(matchedIngredient()).rawText).toBe('2 cloves garlic');
+  });
+
+  it('preserves id', () => {
+    expect(clearIngredientMatch(matchedIngredient()).id).toBe('id-1');
+  });
+
+  it('preserves isOptional', () => {
+    const ing = matchedIngredient({ isOptional: true });
+    expect(clearIngredientMatch(ing).isOptional).toBe(true);
+  });
+
+  it('preserves firstUsedInStepId', () => {
+    const ing = matchedIngredient({ firstUsedInStepId: 'step-99' });
+    expect(clearIngredientMatch(ing).firstUsedInStepId).toBe('step-99');
+  });
+});


### PR DESCRIPTION
## Summary

- **Phase 1** — `clearIngredientMatch` domain helper; wired into `RecipeEditPage` so editing an ingredient's text resets `canonId`/`matchState` to `pending`
- **Phase 2** — per-row Match button in the recipe editor; chains `parseRecipeIngredients` → `canonicaliseRecipeIngredients` (batch-of-one) on the draft; stale-result guard if text changed mid-flight
- **Phase 3** — `hasLiveCanonMatch` pure domain predicate; `RecipeViewPage` and `recipeService` route the matched badge, Canonicalise eligibility filter, and `addRecipeToShoppingList` through it — dangling canon refs render unmatched and are re-offerable without write-back
- **Phase 4** — shopping-list parity audit; `groupItemsByAisle` refactored to call `hasLiveCanonMatch` instead of its inline check; `ShoppingListPage` already safe (no exposed matched badge); 2 new behaviour tests

## Test plan

- [ ] All unit/component tests pass (`pnpm test`)
- [ ] Recipe editor: edit a matched ingredient → match badge clears; per-row Match button re-matches single row
- [ ] Recipe view: delete a canon item → previously-matched ingredient loses ✓ badge and appears in Canonicalise count
- [ ] Shopping list: item whose canon is deleted → moves from aisle group to Other section

🤖 Generated with [Claude Code](https://claude.com/claude-code)