### PR TITLE
fix(firebase-sync): force long-polling on emulator transport to fix flaky Listen-stream timeouts (#122, #199)

### DIFF
--- a/apps/web-pwa/e2e/canon-sync.spec.ts
+++ b/apps/web-pwa/e2e/canon-sync.spec.ts
@@ -21,10 +21,13 @@ import { getAisles, getCanonItem, seedAisles, seedCanonItem } from './helpers/se
 const CONVERGENCE_TIMEOUT = 20_000;
 
 test.describe('canon sync — two-tab convergence', () => {
-  // STOPGAP (#199): the aisle convergence cases flake on emulator cold-start +
-  // manifest-tick timing (a propagation timeout, not a real break). Bounded
-  // retries keep CI green while the shared root cause is chased alongside #122
-  // (likely resolved by the test-stack dockerization). Remove once #199 lands.
+  // RESIDUAL FLAKE INSURANCE (#199): the root fix for the cross-client Listen
+  // flake — forcing long-polling on the emulator transport (#122, init.ts) —
+  // removed the bulk of these failures, but a fresh single-doc aisle listen
+  // still occasionally loses the convergence race on emulator cold paths (a
+  // propagation timeout, not a real break). Bounded retries absorb that
+  // residual; it self-recovers on the first retry. Do NOT remove without
+  // confirming the bare suite stays green across several CI runs.
   test.describe.configure({ retries: 2 });
 
   test('canon item created in tab A appears in tab B via manifest tick', async ({

--- a/packages/adapters/firebase-sync/src/init.ts
+++ b/packages/adapters/firebase-sync/src/init.ts
@@ -54,14 +54,32 @@ export function initFirebase(
   }
 
   if (isNew && usePersistentCache) {
-    initializeFirestore(app, { localCache: persistentLocalCache() });
+    // Under emulators, also force long-polling — the e2e/dev PWA hits the same
+    // gRPC Listen-stream corruption as the integration suite (#122/#199), which
+    // surfaces as flaky cross-tab convergence (canon-sync aisle specs). Real
+    // backends keep default gRPC streaming. (see the emulator branch below)
+    initializeFirestore(app, {
+      localCache: persistentLocalCache(),
+      ...(useEmulators ? { experimentalForceLongPolling: true } : {}),
+    });
   }
 
   if (useEmulators && !emulatorsConnected) {
     const _env = (import.meta as { env?: Record<string, string | undefined> }).env ?? {};
     const firestorePort = Number(_env['VITE_EMULATOR_FIRESTORE_PORT'] ?? 8080);
     const functionsPort = Number(_env['VITE_EMULATOR_FUNCTIONS_PORT'] ?? 5001);
-    connectFirestoreEmulator(getFirestore(app), '127.0.0.1', firestorePort);
+    // Force long-polling for the emulator transport. The default gRPC streaming
+    // Listen channel intermittently corrupts against the Firestore emulator —
+    // bogus "RESOURCE_EXHAUSTED: Received message larger than max" framing
+    // errors (a multi-GB phantom size) that poison the channel for the client's
+    // lifetime, after which realtime subscriptions never deliver and the
+    // integration suite times out. Long-polling sidesteps the streaming
+    // transport entirely. Emulator-only — production keeps default gRPC. (#122)
+    const db =
+      isNew && !usePersistentCache
+        ? initializeFirestore(app, { experimentalForceLongPolling: true })
+        : getFirestore(app);
+    connectFirestoreEmulator(db, '127.0.0.1', firestorePort);
     connectFunctionsEmulator(getFunctions(app, 'europe-west2'), '127.0.0.1', functionsPort);
     connectAuthEmulatorOnce(getAuth(app));
     emulatorsConnected = true;

--- a/packages/adapters/firebase-sync/tests/realtimeSubscriptions.emulator.test.ts
+++ b/packages/adapters/firebase-sync/tests/realtimeSubscriptions.emulator.test.ts
@@ -11,7 +11,7 @@
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { initializeApp, deleteApp, type FirebaseApp } from 'firebase/app';
-import { getFirestore, connectFirestoreEmulator, doc, setDoc } from 'firebase/firestore';
+import { initializeFirestore, connectFirestoreEmulator, doc, setDoc } from 'firebase/firestore';
 import type { Firestore } from 'firebase/firestore';
 import { getAuth, connectAuthEmulator, signInAnonymously } from 'firebase/auth';
 import { subscribeCanonItems, upsertCanonItem, deleteCanonItem } from '../src/canonSubscription.js';
@@ -84,7 +84,10 @@ beforeAll(async () => {
   await initFirebaseEmulator();
 
   writerApp = initializeApp({ projectId: PROJECT_ID, apiKey: 'demo-api-key' }, 'rt-writer');
-  writerDb = getFirestore(writerApp);
+  // Force long-polling for the same reason as the default app (see init.ts): the
+  // emulator's gRPC streaming transport intermittently corrupts the Listen
+  // channel and poisons the writer's connection. (#122)
+  writerDb = initializeFirestore(writerApp, { experimentalForceLongPolling: true });
   connectFirestoreEmulator(writerDb, '127.0.0.1', WRITER_FIRESTORE_PORT);
   const writerAuth = getAuth(writerApp);
   connectAuthEmulator(writerAuth, `http://127.0.0.1:${WRITER_AUTH_PORT}`, {

--- a/packages/adapters/firebase-sync/vitest.emulator.config.ts
+++ b/packages/adapters/firebase-sync/vitest.emulator.config.ts
@@ -30,12 +30,15 @@ export default defineConfig({
     // hit the emulator (init, anon sign-in, data clear).
     testTimeout: 20_000,
     hookTimeout: 30_000,
-    // Stopgap for the flaky Firestore realtime Listen stream (issue #122): on CI
-    // the gRPC Listen stream intermittently breaks with a bogus multi-GB
-    // RESOURCE_EXHAUSTED, after which the subscription delivers nothing and every
-    // waitFor times out. A longer timeout can't help (the stream is dead), but a
-    // retry re-runs on a fresh subscription and clears the transient. This masks
-    // the symptom; the root fix (emulator cold-start / teardown) stays in #122.
+    // Residual insurance for the flaky Firestore realtime Listen stream (#122).
+    // Root cause: the default gRPC streaming transport intermittently breaks the
+    // emulator Listen stream with a bogus multi-GB RESOURCE_EXHAUSTED, poisoning
+    // the channel for the client's lifetime — and since the clients live in
+    // beforeAll, retries reused the dead channel, so retry alone never cleared
+    // it. The landed root fix forces long-polling on the emulator transport
+    // (init.ts + the writer app here), which removes the streaming framing bug.
+    // retry:2 stays as cheap insurance; drop it once main stays green for a
+    // stretch without it.
     retry: 2,
   },
 });


### PR DESCRIPTION
## Problem

Both flaky CI suites share one root cause: the Firestore **emulator's default gRPC streaming `Listen` channel intermittently corrupts** with a bogus multi-GB `RESOURCE_EXHAUSTED: Received message larger than max (~2.5 GB vs 4 MB)` framing error. Once that fires, the channel is **poisoned for the client's lifetime** — realtime subscriptions stop delivering and every convergence assertion times out.

Because the integration test clients live in `beforeAll`, the existing `retry: 2` reused the **dead channel** and never cleared it (observed as `45144ms = 3 × 15s`, all attempts timing out). A longer timeout can't help a dead stream either.

## Fix

Force `experimentalForceLongPolling` on **every emulator client path**, which bypasses the streaming transport that produces the framing bug:

- `init.ts` — both the no-cache path (integration default app) and the persistent-cache path (web-pwa / e2e), gated on `useEmulators` only.
- `realtimeSubscriptions.emulator.test.ts` — the standalone "writer" app.

**Production is untouched** — real backends keep default gRPC; the setting is only spread in under `useEmulators`.

## Result

| Suite | Before | After |
|---|---|---|
| `Vitest integration (emulator)` (#122) | flakes regularly; retry can't clear the poisoned channel | green locally, 0 `RESOURCE_EXHAUSTED` |
| `E2E (Playwright)` canon-sync aisle (#199) | flakes regularly | 29 passed, 1 flaky → self-recovered on retry 1 |

Long-polling is the substantive root-cause fix. It does **not** zero the browser-side aisle convergence race (same `onSnapshot` plumbing as the canon-item path that doesn't flake — no aisle-specific bug exists), so the bounded `retries` stopgaps are **kept as residual insurance**, with comments re-labeled and the inaccurate "retry re-runs on a fresh subscription" note corrected.

## Follow-up

Once `main` stays green across several runs, revisit whether the integration `retry: 2` can be removed.

Closes #122
Relates #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)