### PR TITLE
fix(cloud-functions): bound icon-trigger memory + parent batch canon traces

### DIFF
--- a/apps/cloud-functions/src/flows/canonicaliseRecipeIngredients.ts
+++ b/apps/cloud-functions/src/flows/canonicaliseRecipeIngredients.ts
@@ -4,6 +4,7 @@ import type { MatchOrCreateInput } from '@salt/domain';
 import { CanonicaliseRecipeIngredientsInputSchema } from '@salt/domain/schemas';
 import {
   flushServerObservability,
+  startSpan,
   whenServerObservabilityReady,
 } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
@@ -38,9 +39,16 @@ export const canonicaliseRecipeIngredientsFlow = ai.defineFlow(
       ...(item.rawText !== undefined ? { rawText: item.rawText } : {}),
       ...(item.selectedAisleId !== undefined ? { selectedAisleId: item.selectedAisleId } : {}),
     }));
+    // One parent span for the whole batch so every per-item canon.stages span
+    // is parented under a single trace. Without this the batch passes no parent
+    // to buildMatchOrCreatePorts, so each item's match-log span roots its own
+    // trace — N near-identical traces in LaunchDarkly for one recipe.
+    const batchSpan = startSpan(`canon.canonicaliseRecipeBatch: ${inputs.length} items`);
     try {
-      return await matchOrCreateBatch(inputs, buildMatchOrCreatePorts());
+      batchSpan.setAttribute('canon.batchSize', inputs.length);
+      return await matchOrCreateBatch(inputs, buildMatchOrCreatePorts(batchSpan));
     } finally {
+      batchSpan.end();
       await flushServerObservability();
     }
   },

--- a/apps/cloud-functions/src/triggers/onCanonItemWritten.ts
+++ b/apps/cloud-functions/src/triggers/onCanonItemWritten.ts
@@ -111,7 +111,15 @@ export const onCanonItemWritten = onDocumentWritten(
     // Image generation (~5–8s+) plus sharp processing need more headroom than
     // the default text-only triggers.
     timeoutSeconds: 300,
-    memory: '512MiB',
+    // A batch of new canon items (e.g. a recipe creating 34) fires this trigger
+    // many times at once. Cloud Run packs concurrent invocations onto one
+    // instance, and each icon decode holds a libvips/sharp image buffer — a few
+    // in parallel blow past the memory cap and the instance is OOM-killed,
+    // losing every in-flight icon. concurrency:1 serialises icon work per
+    // instance (Cloud Run scales out instances instead), bounding memory
+    // regardless of batch size; 1GiB gives the single decode comfortable room.
+    concurrency: 1,
+    memory: '1GiB',
   },
   async (event) => {
     const after = event.data?.after;


### PR DESCRIPTION
Follow-up to #201. When a recipe created 34 canon items in staging, two issues surfaced.

## 1. Only 2 of 34 icons generated (OOM)

`onCanonItemWritten` runs Gemini image-gen + sharp/libvips decode per item. A batch fires the trigger many times at once; Cloud Run packs concurrent invocations onto a single instance and the decoded image buffers exceed the 512 MiB cap, so the instance is **OOM-killed** mid-request and every in-flight icon is lost. Logs show **40 OOM terminations**; only 2 icons survived.

**Fix:** `concurrency: 1` serialises icon work per instance (Cloud Run scales out instances instead), bounding memory regardless of batch size; `memory: 1GiB` gives the single decode comfortable headroom.

## 2. Many near-duplicate traces in LaunchDarkly

The batch flow called `buildMatchOrCreatePorts()` with **no parent span**, so each item's `canon.stages` match-log span rooted its own trace → N near-identical root traces for one recipe. The single-item `matchOrCreateCanon` path doesn't have this because it threads one parent span through.

**Fix:** open one `canon.canonicaliseRecipeBatch` span and pass it to `buildMatchOrCreatePorts`, so the per-item spans become children of a single trace.

## Notes
- Takes effect on next functions deploy to staging.
- **Backfill:** the ~32 canon items that already failed icon-gen still have `thumbnail: null`; the trigger only retries on a fresh write, so they need a nudge (touch the docs or regenerate via admin) — not handled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)