### PR TITLE
feat: gate incomplete recipe module behind admin + shopping/recipe UI polish

### DIFF
--- a/apps/web-pwa/e2e/recipe-crud.spec.ts
+++ b/apps/web-pwa/e2e/recipe-crud.spec.ts
@@ -15,7 +15,8 @@ test.describe('recipes — manual CRUD', () => {
   test('create with two groups + steps, reload, edit, delete', async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     const email = uniqueEmail(testInfo.testId);
-    await gotoAndSignIn(page, email);
+    // Recipes are gated to admins while the module is incomplete (#179).
+    await gotoAndSignIn(page, email, '/', { admin: true });
 
     // ── Create ─────────────────────────────────────────────────────────────
     await page.goto('/#/recipes/new');

--- a/apps/web-pwa/e2e/recipe-shopping-list.spec.ts
+++ b/apps/web-pwa/e2e/recipe-shopping-list.spec.ts
@@ -25,7 +25,8 @@ test.describe('recipe → shopping list extraction', () => {
   }, testInfo) => {
     test.setTimeout(90_000);
     const email = uniqueEmail(testInfo.testId);
-    await gotoAndSignIn(page, email);
+    // Recipes are gated to admins while the module is incomplete (#179).
+    await gotoAndSignIn(page, email, '/', { admin: true });
 
     // ── Bootstrap: create the shopping list ──────────────────────────────────
     await page.goto('/#/shopping');
@@ -109,7 +110,8 @@ test.describe('recipe → shopping list extraction', () => {
   }, testInfo) => {
     test.setTimeout(90_000);
     const email = uniqueEmail(testInfo.testId);
-    await gotoAndSignIn(page, email);
+    // Recipes are gated to admins while the module is incomplete (#179).
+    await gotoAndSignIn(page, email, '/', { admin: true });
 
     // Bootstrap shopping list.
     await page.goto('/#/shopping');

--- a/apps/web-pwa/src/App.svelte
+++ b/apps/web-pwa/src/App.svelte
@@ -12,7 +12,7 @@
   } from '@salt/ui-components';
   import AuthGate from './components/AuthGate.svelte';
   import { auth } from './lib/auth.svelte.js';
-  import { navItems, adminNavItem } from './lib/nav.js';
+  import { navItems, adminNavItem, recipesNavItem } from './lib/nav.js';
   import { routes } from './routes/index.js';
   import { toasts, dismissToast } from './lib/toastStore.js';
   import { canonItems, initCanonSync } from './lib/canonService.js';
@@ -54,6 +54,9 @@
   const needsApprovalCount = $derived($canonItems.filter((i) => i.needs_approval).length);
   const decoratedNavItems = $derived([
     ...navItems,
+    // Recipes is admin-only for now (incomplete module, #179) — same cosmetic
+    // gating as the operator entry below.
+    ...(isAdmin ? [recipesNavItem] : []),
     ...(isAdmin
       ? [needsApprovalCount > 0 ? { ...adminNavItem, badge: needsApprovalCount } : adminNavItem]
       : []),
@@ -69,7 +72,12 @@
       {/snippet}
       <Router {routes} />
     </AppShell>
-    <ToastViewport>
+    <!--
+      Lift toasts above the mobile BottomNav so they don't cover it. Mirrors the
+      nav reservation used by AppShell's <main> (h-14 = 3.5rem + safe-area).
+      lg:bottom-0: the BottomNav is hidden on desktop, so drop back to the edge.
+    -->
+    <ToastViewport class="bottom-[calc(3.5rem_+_env(safe-area-inset-bottom))] lg:bottom-0">
       {#each $toasts as toast (toast.id)}
         <Toast
           defaultOpen={true}

--- a/apps/web-pwa/src/lib/nav.ts
+++ b/apps/web-pwa/src/lib/nav.ts
@@ -13,10 +13,20 @@ export const navItems: NavItem[] = [
   { id: 'home', label: 'Home', icon: Home, href: '#/' },
   { id: 'shopping', label: 'Shop', icon: ShoppingCart, href: '#/shopping' },
   { id: 'mealplan', label: 'Meals', icon: CalendarDays, href: '#/mealplan' },
-  { id: 'recipes', label: 'Recipes', icon: BookOpen, href: '#/recipes' },
   { id: 'equipment', label: 'Kitchen', icon: Blender, href: '#/equipment' },
   { id: 'settings', label: 'Settings', icon: Settings, href: '#/settings' },
 ];
+
+// The recipe module is still incomplete (issue #179). Until it's ready for
+// everyone, keep it out of the default nav and surface it only to admins — the
+// same cosmetic gating used for the operator area. Route-level AdminGuard on the
+// recipe pages is the matching server-agnostic backstop against direct URLs.
+export const recipesNavItem: NavItem = {
+  id: 'recipes',
+  label: 'Recipes',
+  icon: BookOpen,
+  href: '#/recipes',
+};
 
 // Operator-area entry (issues #155, #157). Appended to the nav only for admins —
 // see App.svelte, which also hangs the canon needs-approval badge here now that

--- a/apps/web-pwa/src/routes/recipes/RecipeAddToListSheet.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeAddToListSheet.svelte
@@ -8,7 +8,6 @@
     SheetFooter,
     SheetHeader,
     SheetTitle,
-    Spinner,
   } from '@salt/ui-components';
   import { titleCase } from '../../lib/titleCase.js';
   import type { Recipe } from '@salt/domain';
@@ -62,6 +61,12 @@
     row.add = value;
     // Check implies Add — drop the verification flag when an item leaves the list.
     if (!value) row.check = false;
+  }
+
+  function setCheck(row: RecipeAddRow, value: boolean): void {
+    row.check = value;
+    // Check implies Add — selecting Check pulls the item onto the list.
+    if (value) row.add = true;
   }
 
   async function handleConfirm(): Promise<void> {
@@ -157,8 +162,7 @@
           <div class="flex w-12 justify-center">
             <Checkbox
               checked={row.check}
-              disabled={!row.add}
-              onCheckedChange={(v) => (row.check = v === true)}
+              onCheckedChange={(v) => setCheck(row, v === true)}
               aria-label="Check {rowLabel(row)}"
               data-testid="recipe-add-review-check"
             />
@@ -178,7 +182,6 @@
         disabled={busy}
         data-testid="recipe-add-to-list-confirm"
       >
-        {#if busy}<Spinner size={14} />{/if}
         Add {addCount} to list
       </Button>
     </SheetFooter>

--- a/apps/web-pwa/src/routes/recipes/RecipeEditPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeEditPage.svelte
@@ -22,6 +22,7 @@
   } from '../../lib/recipeService.js';
   import { canonItems } from '../../lib/canonService.js';
   import { addToast } from '../../lib/toastStore.js';
+  import AdminGuard from '../admin/AdminGuard.svelte';
 
   interface Props {
     // Present on /recipes/:id/edit; absent (undefined) on /recipes/new.
@@ -309,372 +310,385 @@
   const pageTitle = $derived(editingId === null ? 'New recipe' : 'Edit recipe');
 </script>
 
-<DetailPage title={pageTitle} onBack={handleCancel} backLabel="Recipes" class="p-4 sm:p-6">
-  {#snippet actions()}
-    <Button variant="outline" size="sm" onclick={handleCancel} disabled={saving}>Cancel</Button>
-    <Button
-      size="sm"
-      onclick={handleSave}
-      loading={saving}
-      disabled={!canSave || saving}
-      data-testid="recipe-save-btn"
-    >
-      Save
-    </Button>
-  {/snippet}
+<!-- Recipe module gated to admins while incomplete (#179). -->
+<AdminGuard>
+  <DetailPage title={pageTitle} onBack={handleCancel} backLabel="Recipes" class="p-4 sm:p-6">
+    {#snippet actions()}
+      <Button variant="outline" size="sm" onclick={handleCancel} disabled={saving}>Cancel</Button>
+      <Button
+        size="sm"
+        onclick={handleSave}
+        loading={saving}
+        disabled={!canSave || saving}
+        data-testid="recipe-save-btn"
+      >
+        Save
+      </Button>
+    {/snippet}
 
-  <div class="flex flex-col gap-8" data-testid="recipe-editor">
-    <!-- Basics -->
-    <section class="flex flex-col gap-3">
-      <TextField
-        label="Title"
-        placeholder="e.g. Spiced lentil dahl"
-        value={draft.title}
-        onValueChange={(v) => (draft = { ...draft, title: v })}
-        required
-        data-testid="recipe-title-input"
-      />
-      <TextArea
-        label="Description"
-        placeholder="A short description (optional)"
-        value={draft.description ?? ''}
-        onValueChange={(v) => (draft = { ...draft, description: v.trim() === '' ? null : v })}
-        rows={2}
-        data-testid="recipe-description-input"
-      />
-    </section>
+    <div class="flex flex-col gap-8" data-testid="recipe-editor">
+      <!-- Basics -->
+      <section class="flex flex-col gap-3">
+        <TextField
+          label="Title"
+          placeholder="e.g. Spiced lentil dahl"
+          value={draft.title}
+          onValueChange={(v) => (draft = { ...draft, title: v })}
+          required
+          data-testid="recipe-title-input"
+        />
+        <TextArea
+          label="Description"
+          placeholder="A short description (optional)"
+          value={draft.description ?? ''}
+          onValueChange={(v) => (draft = { ...draft, description: v.trim() === '' ? null : v })}
+          rows={2}
+          data-testid="recipe-description-input"
+        />
+      </section>
 
-    <!-- Ingredient groups -->
-    <section class="flex flex-col gap-3">
-      <div class="flex items-center justify-between">
-        <p class="text-sm font-medium">Ingredients</p>
-        <div class="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onclick={() => (showPasteArea = !showPasteArea)}
-            data-testid="recipe-parse-toggle-btn"
-          >
-            {#snippet leading()}<Icon name="Wand2" size={16} />{/snippet}
-            Parse from text
-          </Button>
-          <Button variant="outline" size="sm" onclick={addGroup} data-testid="recipe-add-group-btn">
-            {#snippet leading()}<Icon name="Plus" size={16} />{/snippet}
-            Add group
-          </Button>
-        </div>
-      </div>
-
-      {#if showPasteArea}
-        <div
-          class="flex flex-col gap-2 rounded border border-border bg-muted/50 p-3"
-          data-testid="recipe-parse-area"
-        >
-          <p class="text-sm text-muted-foreground">
-            Paste an ingredient list. The AI will detect groups and structure each ingredient while
-            preserving the original text.
-          </p>
-          <TextArea
-            label="Ingredient list"
-            placeholder="1 cup plain flour, sifted&#10;2 eggs&#10;&#10;For the sauce:&#10;2 cloves garlic, crushed"
-            value={pasteText}
-            onValueChange={(v) => (pasteText = v)}
-            rows={6}
-            data-testid="recipe-parse-text-input"
-          />
+      <!-- Ingredient groups -->
+      <section class="flex flex-col gap-3">
+        <div class="flex items-center justify-between">
+          <p class="text-sm font-medium">Ingredients</p>
           <div class="flex gap-2">
             <Button
+              variant="outline"
               size="sm"
-              onclick={handleParse}
-              loading={parsing}
-              disabled={pasteText.trim() === '' || parsing}
-              data-testid="recipe-parse-btn"
+              onclick={() => (showPasteArea = !showPasteArea)}
+              data-testid="recipe-parse-toggle-btn"
             >
-              Parse
+              {#snippet leading()}<Icon name="Wand2" size={16} />{/snippet}
+              Parse from text
             </Button>
             <Button
-              variant="ghost"
+              variant="outline"
               size="sm"
-              onclick={() => {
-                showPasteArea = false;
-                pasteText = '';
-              }}
+              onclick={addGroup}
+              data-testid="recipe-add-group-btn"
             >
-              Cancel
+              {#snippet leading()}<Icon name="Plus" size={16} />{/snippet}
+              Add group
             </Button>
           </div>
         </div>
-      {/if}
 
-      {#if draft.ingredients.length === 0}
-        <p class="text-sm text-muted-foreground">
-          No ingredient groups yet. Add a group to start entering ingredients.
-        </p>
-      {/if}
-
-      {#each draft.ingredients as group, gIdx (group.id)}
-        <div
-          class="flex flex-col gap-3 rounded border border-border bg-card p-3"
-          data-testid="recipe-group"
-          data-group-id={group.id}
-        >
-          <div class="flex items-end gap-2">
-            <TextField
-              label="Group name"
-              placeholder="e.g. For the sauce (leave blank for the main list)"
-              value={group.name ?? ''}
-              onValueChange={(v) => setGroupName(group.id, v)}
-              class="flex-1"
-              data-testid="recipe-group-name-input"
+        {#if showPasteArea}
+          <div
+            class="flex flex-col gap-2 rounded border border-border bg-muted/50 p-3"
+            data-testid="recipe-parse-area"
+          >
+            <p class="text-sm text-muted-foreground">
+              Paste an ingredient list. The AI will detect groups and structure each ingredient
+              while preserving the original text.
+            </p>
+            <TextArea
+              label="Ingredient list"
+              placeholder="1 cup plain flour, sifted&#10;2 eggs&#10;&#10;For the sauce:&#10;2 cloves garlic, crushed"
+              value={pasteText}
+              onValueChange={(v) => (pasteText = v)}
+              rows={6}
+              data-testid="recipe-parse-text-input"
             />
-            <Button
-              variant="ghost"
-              size="sm"
-              onclick={() => moveGroup(gIdx, -1)}
-              disabled={gIdx === 0}
-              aria-label="Move group up"
-            >
-              <Icon name="ChevronUp" size={16} />
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onclick={() => moveGroup(gIdx, 1)}
-              disabled={gIdx === draft.ingredients.length - 1}
-              aria-label="Move group down"
-            >
-              <Icon name="ChevronDown" size={16} />
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onclick={() => removeGroup(group.id)}
-              aria-label="Remove group"
-              data-testid="recipe-remove-group-btn"
-            >
-              <Icon name="Trash2" size={16} />
-            </Button>
-          </div>
-
-          {#each group.items as ingredient (ingredient.id)}
-            <div
-              class="flex items-center gap-2"
-              data-testid="recipe-ingredient"
-              data-ingredient-id={ingredient.id}
-            >
-              <TextField
-                label="Ingredient"
-                placeholder="e.g. 1 ½ cups plain flour, sifted"
-                value={ingredient.rawText}
-                onValueChange={(v) => setIngredientRawText(group, ingredient.id, v)}
-                class="flex-1"
-                data-testid="recipe-ingredient-input"
-              />
-              {#if ingredient.rawText.trim() !== '' && !hasLiveCanonMatch(ingredient, liveCanonIds)}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onclick={() => handleMatchIngredient(group, ingredient)}
-                  loading={matchingIds[ingredient.id] ?? false}
-                  disabled={matchingIds[ingredient.id] ?? false}
-                  aria-label="Not matched — tap to match this ingredient"
-                  title="Not matched — tap to match this ingredient"
-                  class="shrink-0 text-destructive"
-                  data-testid="recipe-ingredient-match-btn"
-                >
-                  <Icon name="CircleX" size={16} />
-                </Button>
-              {/if}
-              <Switch
-                label="Optional"
-                checked={ingredient.isOptional}
-                onCheckedChange={(c) => setIngredientOptional(group, ingredient.id, c)}
-              />
+            <div class="flex gap-2">
+              <Button
+                size="sm"
+                onclick={handleParse}
+                loading={parsing}
+                disabled={pasteText.trim() === '' || parsing}
+                data-testid="recipe-parse-btn"
+              >
+                Parse
+              </Button>
               <Button
                 variant="ghost"
                 size="sm"
-                onclick={() => removeIngredient(group, ingredient.id)}
-                aria-label="Remove ingredient"
+                onclick={() => {
+                  showPasteArea = false;
+                  pasteText = '';
+                }}
               >
-                <Icon name="X" size={16} />
+                Cancel
               </Button>
             </div>
-          {/each}
+          </div>
+        {/if}
 
-          <Button
-            variant="ghost"
-            size="sm"
-            onclick={() => addIngredient(group)}
-            class="self-start"
-            data-testid="recipe-add-ingredient-btn"
+        {#if draft.ingredients.length === 0}
+          <p class="text-sm text-muted-foreground">
+            No ingredient groups yet. Add a group to start entering ingredients.
+          </p>
+        {/if}
+
+        {#each draft.ingredients as group, gIdx (group.id)}
+          <div
+            class="flex flex-col gap-3 rounded border border-border bg-card p-3"
+            data-testid="recipe-group"
+            data-group-id={group.id}
           >
-            {#snippet leading()}<Icon name="Plus" size={16} />{/snippet}
-            Add ingredient
-          </Button>
-        </div>
-      {/each}
-    </section>
-
-    <!-- Steps -->
-    <section class="flex flex-col gap-3">
-      <div class="flex items-center justify-between">
-        <p class="text-sm font-medium">Method</p>
-        <Button variant="outline" size="sm" onclick={addStepRow} data-testid="recipe-add-step-btn">
-          {#snippet leading()}<Icon name="Plus" size={16} />{/snippet}
-          Add step
-        </Button>
-      </div>
-
-      {#if draft.steps.length === 0}
-        <p class="text-sm text-muted-foreground">No steps yet.</p>
-      {/if}
-
-      {#each draft.steps as step, sIdx (step.id)}
-        <div
-          class="flex flex-col gap-2 rounded border border-border bg-card p-3"
-          data-testid="recipe-step"
-          data-step-id={step.id}
-        >
-          <div class="flex items-start gap-2">
-            <span class="mt-2 text-sm font-medium text-muted-foreground">{sIdx + 1}.</span>
-            <TextArea
-              label="Step"
-              placeholder="Describe this step"
-              value={step.text}
-              onValueChange={(v) => setStepText(step.id, v)}
-              rows={2}
-              class="flex-1"
-              data-testid="recipe-step-input"
-            />
-            <div class="flex flex-col">
+            <div class="flex items-end gap-2">
+              <TextField
+                label="Group name"
+                placeholder="e.g. For the sauce (leave blank for the main list)"
+                value={group.name ?? ''}
+                onValueChange={(v) => setGroupName(group.id, v)}
+                class="flex-1"
+                data-testid="recipe-group-name-input"
+              />
               <Button
                 variant="ghost"
                 size="sm"
-                onclick={() => moveStep(sIdx, -1)}
-                disabled={sIdx === 0}
-                aria-label="Move step up"
+                onclick={() => moveGroup(gIdx, -1)}
+                disabled={gIdx === 0}
+                aria-label="Move group up"
               >
                 <Icon name="ChevronUp" size={16} />
               </Button>
               <Button
                 variant="ghost"
                 size="sm"
-                onclick={() => moveStep(sIdx, 1)}
-                disabled={sIdx === draft.steps.length - 1}
-                aria-label="Move step down"
+                onclick={() => moveGroup(gIdx, 1)}
+                disabled={gIdx === draft.ingredients.length - 1}
+                aria-label="Move group down"
               >
                 <Icon name="ChevronDown" size={16} />
               </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onclick={() => removeGroup(group.id)}
+                aria-label="Remove group"
+                data-testid="recipe-remove-group-btn"
+              >
+                <Icon name="Trash2" size={16} />
+              </Button>
             </div>
+
+            {#each group.items as ingredient (ingredient.id)}
+              <div
+                class="flex items-center gap-2"
+                data-testid="recipe-ingredient"
+                data-ingredient-id={ingredient.id}
+              >
+                <TextField
+                  label="Ingredient"
+                  placeholder="e.g. 1 ½ cups plain flour, sifted"
+                  value={ingredient.rawText}
+                  onValueChange={(v) => setIngredientRawText(group, ingredient.id, v)}
+                  class="flex-1"
+                  data-testid="recipe-ingredient-input"
+                />
+                {#if ingredient.rawText.trim() !== '' && !hasLiveCanonMatch(ingredient, liveCanonIds)}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onclick={() => handleMatchIngredient(group, ingredient)}
+                    loading={matchingIds[ingredient.id] ?? false}
+                    disabled={matchingIds[ingredient.id] ?? false}
+                    aria-label="Not matched — tap to match this ingredient"
+                    title="Not matched — tap to match this ingredient"
+                    class="shrink-0 text-destructive"
+                    data-testid="recipe-ingredient-match-btn"
+                  >
+                    <Icon name="CircleX" size={16} />
+                  </Button>
+                {/if}
+                <Switch
+                  label="Optional"
+                  checked={ingredient.isOptional}
+                  onCheckedChange={(c) => setIngredientOptional(group, ingredient.id, c)}
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onclick={() => removeIngredient(group, ingredient.id)}
+                  aria-label="Remove ingredient"
+                >
+                  <Icon name="X" size={16} />
+                </Button>
+              </div>
+            {/each}
+
             <Button
               variant="ghost"
               size="sm"
-              onclick={() => removeStep(step.id)}
-              aria-label="Remove step"
+              onclick={() => addIngredient(group)}
+              class="self-start"
+              data-testid="recipe-add-ingredient-btn"
             >
-              <Icon name="Trash2" size={16} />
+              {#snippet leading()}<Icon name="Plus" size={16} />{/snippet}
+              Add ingredient
             </Button>
           </div>
+        {/each}
+      </section>
 
-          <div class="flex items-center gap-3 pl-6">
-            <Switch
-              label="Timer"
-              checked={step.timer !== null}
-              onCheckedChange={(c) => toggleStepTimer(step.id, c)}
-            />
-            {#if step.timer}
-              <TextField
-                label="Minutes"
-                inputmode="numeric"
-                value={String(step.timer.durationMinutes)}
-                onValueChange={(v) => setStepTimerMinutes(step.id, v)}
-                class="w-28"
-                data-testid="recipe-step-timer-minutes"
-              />
-              <TextField
-                label="Timer label"
-                placeholder="e.g. until golden"
-                value={step.timer.description ?? ''}
-                onValueChange={(v) => setStepTimerDescription(step.id, v)}
-                class="flex-1"
-                data-testid="recipe-step-timer-description"
-              />
-            {/if}
-          </div>
-
-          <div class="pl-6">
-            <TextArea
-              label="Note (optional)"
-              placeholder="Any note for this step"
-              value={step.note ?? ''}
-              onValueChange={(v) => setStepNote(step.id, v)}
-              rows={2}
-              data-testid="recipe-step-note-input"
-            />
-          </div>
+      <!-- Steps -->
+      <section class="flex flex-col gap-3">
+        <div class="flex items-center justify-between">
+          <p class="text-sm font-medium">Method</p>
+          <Button
+            variant="outline"
+            size="sm"
+            onclick={addStepRow}
+            data-testid="recipe-add-step-btn"
+          >
+            {#snippet leading()}<Icon name="Plus" size={16} />{/snippet}
+            Add step
+          </Button>
         </div>
-      {/each}
-    </section>
 
-    <!-- Metadata -->
-    <section class="flex flex-col gap-3">
-      <p class="text-sm font-medium">Details</p>
-      <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <TextField
-          label="Servings"
-          inputmode="numeric"
-          value={draft.metadata.servings === null ? '' : String(draft.metadata.servings)}
-          onValueChange={(v) => setMetadata({ servings: parseNumberOrNull(v) })}
-          data-testid="recipe-servings-input"
-        />
-        <TextField
-          label="Prep (min)"
-          inputmode="numeric"
-          value={draft.metadata.prepTimeMinutes === null
-            ? ''
-            : String(draft.metadata.prepTimeMinutes)}
-          onValueChange={(v) => setMetadata({ prepTimeMinutes: parseNumberOrNull(v) })}
-          data-testid="recipe-prep-input"
-        />
-        <TextField
-          label="Cook (min)"
-          inputmode="numeric"
-          value={draft.metadata.cookTimeMinutes === null
-            ? ''
-            : String(draft.metadata.cookTimeMinutes)}
-          onValueChange={(v) => setMetadata({ cookTimeMinutes: parseNumberOrNull(v) })}
-          data-testid="recipe-cook-input"
-        />
-        <TextField
-          label="Total (min)"
-          inputmode="numeric"
-          value={draft.metadata.totalTimeMinutes === null
-            ? ''
-            : String(draft.metadata.totalTimeMinutes)}
-          onValueChange={(v) => setMetadata({ totalTimeMinutes: parseNumberOrNull(v) })}
-          data-testid="recipe-total-input"
-        />
-      </div>
-      <TextField
-        label="Tags"
-        description="Comma-separated, e.g. vegetarian, weeknight"
-        value={tagsText}
-        onValueChange={setTags}
-        data-testid="recipe-tags-input"
-      />
-    </section>
+        {#if draft.steps.length === 0}
+          <p class="text-sm text-muted-foreground">No steps yet.</p>
+        {/if}
 
-    <!-- Notes -->
-    <section class="flex flex-col gap-3">
-      <p class="text-sm font-medium">Notes</p>
-      <TextArea
-        label="Notes"
-        placeholder="Anything else worth remembering"
-        value={draft.notes ?? ''}
-        onValueChange={(v) => (draft = { ...draft, notes: v.trim() === '' ? null : v })}
-        rows={3}
-        data-testid="recipe-notes-input"
-      />
-    </section>
-  </div>
-</DetailPage>
+        {#each draft.steps as step, sIdx (step.id)}
+          <div
+            class="flex flex-col gap-2 rounded border border-border bg-card p-3"
+            data-testid="recipe-step"
+            data-step-id={step.id}
+          >
+            <div class="flex items-start gap-2">
+              <span class="mt-2 text-sm font-medium text-muted-foreground">{sIdx + 1}.</span>
+              <TextArea
+                label="Step"
+                placeholder="Describe this step"
+                value={step.text}
+                onValueChange={(v) => setStepText(step.id, v)}
+                rows={2}
+                class="flex-1"
+                data-testid="recipe-step-input"
+              />
+              <div class="flex flex-col">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onclick={() => moveStep(sIdx, -1)}
+                  disabled={sIdx === 0}
+                  aria-label="Move step up"
+                >
+                  <Icon name="ChevronUp" size={16} />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onclick={() => moveStep(sIdx, 1)}
+                  disabled={sIdx === draft.steps.length - 1}
+                  aria-label="Move step down"
+                >
+                  <Icon name="ChevronDown" size={16} />
+                </Button>
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onclick={() => removeStep(step.id)}
+                aria-label="Remove step"
+              >
+                <Icon name="Trash2" size={16} />
+              </Button>
+            </div>
+
+            <div class="flex items-center gap-3 pl-6">
+              <Switch
+                label="Timer"
+                checked={step.timer !== null}
+                onCheckedChange={(c) => toggleStepTimer(step.id, c)}
+              />
+              {#if step.timer}
+                <TextField
+                  label="Minutes"
+                  inputmode="numeric"
+                  value={String(step.timer.durationMinutes)}
+                  onValueChange={(v) => setStepTimerMinutes(step.id, v)}
+                  class="w-28"
+                  data-testid="recipe-step-timer-minutes"
+                />
+                <TextField
+                  label="Timer label"
+                  placeholder="e.g. until golden"
+                  value={step.timer.description ?? ''}
+                  onValueChange={(v) => setStepTimerDescription(step.id, v)}
+                  class="flex-1"
+                  data-testid="recipe-step-timer-description"
+                />
+              {/if}
+            </div>
+
+            <div class="pl-6">
+              <TextArea
+                label="Note (optional)"
+                placeholder="Any note for this step"
+                value={step.note ?? ''}
+                onValueChange={(v) => setStepNote(step.id, v)}
+                rows={2}
+                data-testid="recipe-step-note-input"
+              />
+            </div>
+          </div>
+        {/each}
+      </section>
+
+      <!-- Metadata -->
+      <section class="flex flex-col gap-3">
+        <p class="text-sm font-medium">Details</p>
+        <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <TextField
+            label="Servings"
+            inputmode="numeric"
+            value={draft.metadata.servings === null ? '' : String(draft.metadata.servings)}
+            onValueChange={(v) => setMetadata({ servings: parseNumberOrNull(v) })}
+            data-testid="recipe-servings-input"
+          />
+          <TextField
+            label="Prep (min)"
+            inputmode="numeric"
+            value={draft.metadata.prepTimeMinutes === null
+              ? ''
+              : String(draft.metadata.prepTimeMinutes)}
+            onValueChange={(v) => setMetadata({ prepTimeMinutes: parseNumberOrNull(v) })}
+            data-testid="recipe-prep-input"
+          />
+          <TextField
+            label="Cook (min)"
+            inputmode="numeric"
+            value={draft.metadata.cookTimeMinutes === null
+              ? ''
+              : String(draft.metadata.cookTimeMinutes)}
+            onValueChange={(v) => setMetadata({ cookTimeMinutes: parseNumberOrNull(v) })}
+            data-testid="recipe-cook-input"
+          />
+          <TextField
+            label="Total (min)"
+            inputmode="numeric"
+            value={draft.metadata.totalTimeMinutes === null
+              ? ''
+              : String(draft.metadata.totalTimeMinutes)}
+            onValueChange={(v) => setMetadata({ totalTimeMinutes: parseNumberOrNull(v) })}
+            data-testid="recipe-total-input"
+          />
+        </div>
+        <TextField
+          label="Tags"
+          description="Comma-separated, e.g. vegetarian, weeknight"
+          value={tagsText}
+          onValueChange={setTags}
+          data-testid="recipe-tags-input"
+        />
+      </section>
+
+      <!-- Notes -->
+      <section class="flex flex-col gap-3">
+        <p class="text-sm font-medium">Notes</p>
+        <TextArea
+          label="Notes"
+          placeholder="Anything else worth remembering"
+          value={draft.notes ?? ''}
+          onValueChange={(v) => (draft = { ...draft, notes: v.trim() === '' ? null : v })}
+          rows={3}
+          data-testid="recipe-notes-input"
+        />
+      </section>
+    </div>
+  </DetailPage>
+</AdminGuard>

--- a/apps/web-pwa/src/routes/recipes/RecipeListPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeListPage.svelte
@@ -2,6 +2,7 @@
   import { Button, ListPage } from '@salt/ui-components';
   import { push } from 'svelte-spa-router';
   import { recipes, isLoadingRecipes } from '../../lib/recipeService.js';
+  import AdminGuard from '../admin/AdminGuard.svelte';
 
   const sorted = $derived([...$recipes].sort((a, b) => a.title.localeCompare(b.title)));
 
@@ -10,43 +11,46 @@
   }
 </script>
 
-<ListPage
-  title="Recipes"
-  description="Your recipe collection."
-  isLoading={$isLoadingRecipes}
-  isEmpty={sorted.length === 0}
-  class="p-4 sm:p-6"
->
-  {#snippet actions()}
-    <Button size="sm" onclick={() => push('/recipes/new')} data-testid="recipe-new-btn">
-      New recipe
-    </Button>
-  {/snippet}
+<!-- Recipe module gated to admins while incomplete (#179). -->
+<AdminGuard>
+  <ListPage
+    title="Recipes"
+    description="Your recipe collection."
+    isLoading={$isLoadingRecipes}
+    isEmpty={sorted.length === 0}
+    class="p-4 sm:p-6"
+  >
+    {#snippet actions()}
+      <Button size="sm" onclick={() => push('/recipes/new')} data-testid="recipe-new-btn">
+        New recipe
+      </Button>
+    {/snippet}
 
-  {#snippet empty()}
-    <div class="flex flex-col items-center gap-3 py-12 text-center">
-      <p class="text-sm text-muted-foreground">No recipes yet.</p>
-      <Button size="sm" onclick={() => push('/recipes/new')}>Create your first recipe</Button>
-    </div>
-  {/snippet}
+    {#snippet empty()}
+      <div class="flex flex-col items-center gap-3 py-12 text-center">
+        <p class="text-sm text-muted-foreground">No recipes yet.</p>
+        <Button size="sm" onclick={() => push('/recipes/new')}>Create your first recipe</Button>
+      </div>
+    {/snippet}
 
-  {#snippet children()}
-    <ul class="flex flex-col gap-1" data-testid="recipe-list">
-      {#each sorted as recipe (recipe.id)}
-        <li>
-          <button
-            class="w-full rounded px-2 py-2 text-left text-sm font-medium hover:bg-muted"
-            onclick={() => push(`/recipes/${recipe.id}`)}
-            data-testid="recipe-list-item"
-            data-recipe-id={recipe.id}
-          >
-            {recipe.title}
-            <span class="ml-2 text-xs font-normal text-muted-foreground">
-              {ingredientCount(recipe)} ingredient{ingredientCount(recipe) === 1 ? '' : 's'}
-            </span>
-          </button>
-        </li>
-      {/each}
-    </ul>
-  {/snippet}
-</ListPage>
+    {#snippet children()}
+      <ul class="flex flex-col gap-1" data-testid="recipe-list">
+        {#each sorted as recipe (recipe.id)}
+          <li>
+            <button
+              class="w-full rounded px-2 py-2 text-left text-sm font-medium hover:bg-muted"
+              onclick={() => push(`/recipes/${recipe.id}`)}
+              data-testid="recipe-list-item"
+              data-recipe-id={recipe.id}
+            >
+              {recipe.title}
+              <span class="ml-2 text-xs font-normal text-muted-foreground">
+                {ingredientCount(recipe)} ingredient{ingredientCount(recipe) === 1 ? '' : 's'}
+              </span>
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {/snippet}
+  </ListPage>
+</AdminGuard>

--- a/apps/web-pwa/src/routes/recipes/RecipeViewPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeViewPage.svelte
@@ -27,6 +27,7 @@
   import { hasLiveCanonMatch, type IngredientGroup, type Ingredient } from '@salt/domain';
   import { defaultListId } from '../../lib/shoppingListService.svelte.js';
   import { addToast } from '../../lib/toastStore.js';
+  import AdminGuard from '../admin/AdminGuard.svelte';
 
   interface Props {
     params: { id: string };
@@ -137,211 +138,214 @@
   }
 </script>
 
-{#if recipe === null}
-  <div class="p-4 sm:p-6">
-    {#if $isLoadingRecipes}
-      <p class="text-sm text-muted-foreground">Loading…</p>
-    {:else}
-      <p class="text-sm text-muted-foreground">Recipe not found.</p>
-      <Button variant="outline" class="mt-4" onclick={() => push('/recipes')}
-        >Back to recipes</Button
-      >
-    {/if}
-  </div>
-{:else}
-  <DetailPage
-    title={recipe.title}
-    onBack={() => push('/recipes')}
-    backLabel="Recipes"
-    class="p-4 sm:p-6"
-  >
-    {#snippet actions()}
-      <Button
-        size="sm"
-        variant="outline"
-        onclick={openAddToList}
-        data-testid="recipe-add-to-list-button"
-      >
-        {#snippet leading()}<Icon name="ShoppingCart" size={16} />{/snippet}
-        Add to list
-      </Button>
-      <Button
-        size="sm"
-        onclick={() => push(`/recipes/${recipe.id}/edit`)}
-        data-testid="recipe-edit-button"
-      >
-        {#snippet leading()}<Icon name="Pencil" size={16} />{/snippet}
-        Edit
-      </Button>
-      <Button
-        variant="destructive"
-        size="sm"
-        onclick={() => (deleteOpen = true)}
-        data-testid="recipe-delete-button"
-      >
-        {#snippet leading()}<Icon name="Trash2" size={16} />{/snippet}
-        Delete
-      </Button>
-    {/snippet}
-
-    <div class="flex flex-col gap-8" data-testid="recipe-view">
-      {#if recipe.description}
-        <p class="text-sm text-muted-foreground">{recipe.description}</p>
-      {/if}
-
-      {#if timeParts().length > 0 || recipe.metadata.tags.length > 0}
-        <div class="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-          {#each timeParts() as part (part)}
-            <span class="rounded bg-muted px-2 py-1">{part}</span>
-          {/each}
-          {#each recipe.metadata.tags as tag (tag)}
-            <span class="rounded bg-muted px-2 py-1">#{tag}</span>
-          {/each}
-        </div>
-      {/if}
-
-      <!-- Ingredients -->
-      <section class="flex flex-col gap-3">
-        <div class="flex items-center justify-between">
-          <p class="text-sm font-medium">Ingredients</p>
-          {#if hasParsedPending}
-            <Button
-              size="sm"
-              variant="outline"
-              onclick={handleCanonicalise}
-              loading={canonalising}
-              disabled={canonalising}
-              data-testid="recipe-canonicalise-button"
-            >
-              {#snippet leading()}<Icon name="Link" size={14} />{/snippet}
-              Canonicalise
-            </Button>
-          {/if}
-        </div>
-        {#if recipe.ingredients.length === 0}
-          <p class="text-sm text-muted-foreground">No ingredients.</p>
-        {/if}
-        {#each recipe.ingredients as group (group.id)}
-          <div class="flex flex-col gap-1" data-testid="recipe-view-group">
-            {#if group.name}
-              <p class="text-sm font-medium" data-testid="recipe-view-group-name">{group.name}</p>
-            {/if}
-            <ul class="flex flex-col gap-1">
-              {#each group.items as ingredient (ingredient.id)}
-                <li class="text-sm" data-testid="recipe-view-ingredient">
-                  {ingredient.rawText}{#if ingredient.parsed?.convertedWeight}<span
-                      class="ml-1 text-xs text-muted-foreground"
-                      >({ingredient.parsed.convertedWeight.value}{ingredient.parsed.convertedWeight
-                        .unit})</span
-                    >{/if}{#if ingredient.isOptional}<span
-                      class="ml-1 text-xs text-muted-foreground">(optional)</span
-                    >{/if}{#if !hasLiveCanonMatch(ingredient, liveCanonIds)}<button
-                      type="button"
-                      class="ml-1 text-xs text-destructive hover:underline disabled:opacity-50"
-                      title="Not matched — tap to match"
-                      aria-label="Not matched — tap to match"
-                      onclick={() => handleRematch(group, ingredient)}
-                      disabled={matchingIds[ingredient.id] ?? false}
-                      data-testid="match-state-unmatched"
-                      >{(matchingIds[ingredient.id] ?? false) ? '…' : '✗'}</button
-                    >{/if}
-                </li>
-              {/each}
-            </ul>
-          </div>
-        {/each}
-      </section>
-
-      <!-- Method -->
-      <section class="flex flex-col gap-3">
-        <p class="text-sm font-medium">Method</p>
-        {#if recipe.steps.length === 0}
-          <p class="text-sm text-muted-foreground">No steps.</p>
-        {/if}
-        <ol class="flex flex-col gap-3">
-          {#each recipe.steps as step, idx (step.id)}
-            <li class="flex gap-3 text-sm" data-testid="recipe-view-step">
-              <span class="font-medium text-muted-foreground">{idx + 1}.</span>
-              <div class="flex flex-col gap-1 flex-1">
-                <div class="flex items-start gap-1">
-                  <span class="flex-1">{step.text}</span>
-                  {#if step.note}
-                    <Popover>
-                      <PopoverTrigger>
-                        <button
-                          class="shrink-0 text-muted-foreground hover:text-foreground"
-                          aria-label="View step note"
-                          data-testid="recipe-step-note-trigger"
-                        >
-                          <Icon name="StickyNote" size={14} />
-                        </button>
-                      </PopoverTrigger>
-                      <PopoverContent side="top" align="end" class="max-w-xs">
-                        <p
-                          class="text-sm whitespace-pre-wrap"
-                          data-testid="recipe-step-note-content"
-                        >
-                          {step.note}
-                        </p>
-                      </PopoverContent>
-                    </Popover>
-                  {/if}
-                </div>
-                {#if step.timer}
-                  <span class="text-xs text-muted-foreground">
-                    ⏱ {step.timer.durationMinutes} min{step.timer.description
-                      ? ` — ${step.timer.description}`
-                      : ''}
-                  </span>
-                {/if}
-              </div>
-            </li>
-          {/each}
-        </ol>
-      </section>
-
-      {#if recipe.notes}
-        <section class="flex flex-col gap-2">
-          <p class="text-sm font-medium">Notes</p>
-          <p class="whitespace-pre-wrap text-sm text-muted-foreground">{recipe.notes}</p>
-        </section>
+<!-- Recipe module gated to admins while incomplete (#179). -->
+<AdminGuard>
+  {#if recipe === null}
+    <div class="p-4 sm:p-6">
+      {#if $isLoadingRecipes}
+        <p class="text-sm text-muted-foreground">Loading…</p>
+      {:else}
+        <p class="text-sm text-muted-foreground">Recipe not found.</p>
+        <Button variant="outline" class="mt-4" onclick={() => push('/recipes')}
+          >Back to recipes</Button
+        >
       {/if}
     </div>
-  </DetailPage>
-{/if}
-
-<!-- Add to shopping list review sheet -->
-{#if recipe && $defaultListId}
-  <RecipeAddToListSheet {recipe} listId={$defaultListId} bind:open={addToListOpen} />
-{/if}
-
-<!-- Delete confirm dialog -->
-<Dialog
-  bind:open={deleteOpen}
-  onOpenChange={(v) => {
-    if (!v) deleteBusy = false;
-  }}
->
-  <DialogContent>
-    <div class="flex flex-col gap-4" data-testid="recipe-delete-dialog">
-      <DialogHeader>
-        <DialogTitle>Delete "{recipe?.title ?? ''}"?</DialogTitle>
-        <DialogDescription>This action cannot be undone.</DialogDescription>
-      </DialogHeader>
-      <DialogFooter>
-        <Button variant="outline" onclick={() => (deleteOpen = false)} disabled={deleteBusy}>
-          Cancel
+  {:else}
+    <DetailPage
+      title={recipe.title}
+      onBack={() => push('/recipes')}
+      backLabel="Recipes"
+      class="p-4 sm:p-6"
+    >
+      {#snippet actions()}
+        <Button
+          size="sm"
+          variant="outline"
+          onclick={openAddToList}
+          data-testid="recipe-add-to-list-button"
+        >
+          {#snippet leading()}<Icon name="ShoppingCart" size={16} />{/snippet}
+          Add to list
+        </Button>
+        <Button
+          size="sm"
+          onclick={() => push(`/recipes/${recipe.id}/edit`)}
+          data-testid="recipe-edit-button"
+        >
+          {#snippet leading()}<Icon name="Pencil" size={16} />{/snippet}
+          Edit
         </Button>
         <Button
           variant="destructive"
-          onclick={handleDelete}
-          loading={deleteBusy}
-          disabled={deleteBusy}
-          data-testid="recipe-delete-confirm"
+          size="sm"
+          onclick={() => (deleteOpen = true)}
+          data-testid="recipe-delete-button"
         >
+          {#snippet leading()}<Icon name="Trash2" size={16} />{/snippet}
           Delete
         </Button>
-      </DialogFooter>
-    </div>
-  </DialogContent>
-</Dialog>
+      {/snippet}
+
+      <div class="flex flex-col gap-8" data-testid="recipe-view">
+        {#if recipe.description}
+          <p class="text-sm text-muted-foreground">{recipe.description}</p>
+        {/if}
+
+        {#if timeParts().length > 0 || recipe.metadata.tags.length > 0}
+          <div class="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            {#each timeParts() as part (part)}
+              <span class="rounded bg-muted px-2 py-1">{part}</span>
+            {/each}
+            {#each recipe.metadata.tags as tag (tag)}
+              <span class="rounded bg-muted px-2 py-1">#{tag}</span>
+            {/each}
+          </div>
+        {/if}
+
+        <!-- Ingredients -->
+        <section class="flex flex-col gap-3">
+          <div class="flex items-center justify-between">
+            <p class="text-sm font-medium">Ingredients</p>
+            {#if hasParsedPending}
+              <Button
+                size="sm"
+                variant="outline"
+                onclick={handleCanonicalise}
+                loading={canonalising}
+                disabled={canonalising}
+                data-testid="recipe-canonicalise-button"
+              >
+                {#snippet leading()}<Icon name="Link" size={14} />{/snippet}
+                Canonicalise
+              </Button>
+            {/if}
+          </div>
+          {#if recipe.ingredients.length === 0}
+            <p class="text-sm text-muted-foreground">No ingredients.</p>
+          {/if}
+          {#each recipe.ingredients as group (group.id)}
+            <div class="flex flex-col gap-1" data-testid="recipe-view-group">
+              {#if group.name}
+                <p class="text-sm font-medium" data-testid="recipe-view-group-name">{group.name}</p>
+              {/if}
+              <ul class="flex flex-col gap-1">
+                {#each group.items as ingredient (ingredient.id)}
+                  <li class="text-sm" data-testid="recipe-view-ingredient">
+                    {ingredient.rawText}{#if ingredient.parsed?.convertedWeight}<span
+                        class="ml-1 text-xs text-muted-foreground"
+                        >({ingredient.parsed.convertedWeight.value}{ingredient.parsed
+                          .convertedWeight.unit})</span
+                      >{/if}{#if ingredient.isOptional}<span
+                        class="ml-1 text-xs text-muted-foreground">(optional)</span
+                      >{/if}{#if !hasLiveCanonMatch(ingredient, liveCanonIds)}<button
+                        type="button"
+                        class="ml-1 text-xs text-destructive hover:underline disabled:opacity-50"
+                        title="Not matched — tap to match"
+                        aria-label="Not matched — tap to match"
+                        onclick={() => handleRematch(group, ingredient)}
+                        disabled={matchingIds[ingredient.id] ?? false}
+                        data-testid="match-state-unmatched"
+                        >{(matchingIds[ingredient.id] ?? false) ? '…' : '✗'}</button
+                      >{/if}
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/each}
+        </section>
+
+        <!-- Method -->
+        <section class="flex flex-col gap-3">
+          <p class="text-sm font-medium">Method</p>
+          {#if recipe.steps.length === 0}
+            <p class="text-sm text-muted-foreground">No steps.</p>
+          {/if}
+          <ol class="flex flex-col gap-3">
+            {#each recipe.steps as step, idx (step.id)}
+              <li class="flex gap-3 text-sm" data-testid="recipe-view-step">
+                <span class="font-medium text-muted-foreground">{idx + 1}.</span>
+                <div class="flex flex-col gap-1 flex-1">
+                  <div class="flex items-start gap-1">
+                    <span class="flex-1">{step.text}</span>
+                    {#if step.note}
+                      <Popover>
+                        <PopoverTrigger>
+                          <button
+                            class="shrink-0 text-muted-foreground hover:text-foreground"
+                            aria-label="View step note"
+                            data-testid="recipe-step-note-trigger"
+                          >
+                            <Icon name="StickyNote" size={14} />
+                          </button>
+                        </PopoverTrigger>
+                        <PopoverContent side="top" align="end" class="max-w-xs">
+                          <p
+                            class="text-sm whitespace-pre-wrap"
+                            data-testid="recipe-step-note-content"
+                          >
+                            {step.note}
+                          </p>
+                        </PopoverContent>
+                      </Popover>
+                    {/if}
+                  </div>
+                  {#if step.timer}
+                    <span class="text-xs text-muted-foreground">
+                      ⏱ {step.timer.durationMinutes} min{step.timer.description
+                        ? ` — ${step.timer.description}`
+                        : ''}
+                    </span>
+                  {/if}
+                </div>
+              </li>
+            {/each}
+          </ol>
+        </section>
+
+        {#if recipe.notes}
+          <section class="flex flex-col gap-2">
+            <p class="text-sm font-medium">Notes</p>
+            <p class="whitespace-pre-wrap text-sm text-muted-foreground">{recipe.notes}</p>
+          </section>
+        {/if}
+      </div>
+    </DetailPage>
+  {/if}
+
+  <!-- Add to shopping list review sheet -->
+  {#if recipe && $defaultListId}
+    <RecipeAddToListSheet {recipe} listId={$defaultListId} bind:open={addToListOpen} />
+  {/if}
+
+  <!-- Delete confirm dialog -->
+  <Dialog
+    bind:open={deleteOpen}
+    onOpenChange={(v) => {
+      if (!v) deleteBusy = false;
+    }}
+  >
+    <DialogContent>
+      <div class="flex flex-col gap-4" data-testid="recipe-delete-dialog">
+        <DialogHeader>
+          <DialogTitle>Delete "{recipe?.title ?? ''}"?</DialogTitle>
+          <DialogDescription>This action cannot be undone.</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onclick={() => (deleteOpen = false)} disabled={deleteBusy}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onclick={handleDelete}
+            loading={deleteBusy}
+            disabled={deleteBusy}
+            data-testid="recipe-delete-confirm"
+          >
+            Delete
+          </Button>
+        </DialogFooter>
+      </div>
+    </DialogContent>
+  </Dialog>
+</AdminGuard>

--- a/apps/web-pwa/src/routes/shopping/ShoppingListPage.svelte
+++ b/apps/web-pwa/src/routes/shopping/ShoppingListPage.svelte
@@ -400,11 +400,11 @@
     return text.charAt(0).toUpperCase() + text.slice(1);
   }
 
-  // Label a row by its canon name when live-matched (title-cased, as canon names
-  // are shown elsewhere), falling back to its sentence-cased raw text otherwise.
+  // Label a row by its canon name when live-matched, falling back to its raw
+  // text otherwise — title-cased either way so every item reads consistently.
   function displayLabel(item: ShoppingListItem): string {
     const resolved = resolveItemDisplayName(item, canonMap, liveCanonIds);
-    return resolved.source === 'canon' ? titleCase(resolved.text) : toSentenceCase(resolved.text);
+    return titleCase(resolved.text);
   }
 
   function sourceLabel(item: ShoppingListItem): string {

--- a/apps/web-pwa/tests/RecipeEditPage.clearMatch.test.ts
+++ b/apps/web-pwa/tests/RecipeEditPage.clearMatch.test.ts
@@ -29,6 +29,21 @@ const { mockRecipes } = vi.hoisted(() => {
 
 vi.mock('svelte-spa-router', () => ({ push: vi.fn() }));
 vi.mock('../src/lib/toastStore.js', () => ({ addToast: vi.fn() }));
+// RecipeEditPage is wrapped in AdminGuard (#179); seed an admin context so the
+// guard renders the form under test.
+vi.mock('../src/lib/auth.svelte.js', () => ({ auth: { user: { email: 'admin@test' } } }));
+vi.mock('../src/lib/membersService.js', () => {
+  const readable = <T>(v: T) => ({
+    subscribe(fn: (x: T) => void) {
+      fn(v);
+      return () => {};
+    },
+  });
+  return {
+    members: readable([{ email: 'admin@test', admin: true }]),
+    isLoadingMembers: readable(false),
+  };
+});
 vi.mock('../src/lib/recipeService.js', () => ({
   recipes: mockRecipes,
   persistRecipe: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),

--- a/apps/web-pwa/tests/RecipeEditPage.matchRow.test.ts
+++ b/apps/web-pwa/tests/RecipeEditPage.matchRow.test.ts
@@ -32,6 +32,21 @@ const { mockRecipes, mockCanonItems } = vi.hoisted(() => {
 
 vi.mock('svelte-spa-router', () => ({ push: vi.fn() }));
 vi.mock('../src/lib/toastStore.js', () => ({ addToast: vi.fn() }));
+// RecipeEditPage is wrapped in AdminGuard (#179); seed an admin context so the
+// guard renders the form under test.
+vi.mock('../src/lib/auth.svelte.js', () => ({ auth: { user: { email: 'admin@test' } } }));
+vi.mock('../src/lib/membersService.js', () => {
+  const readable = <T>(v: T) => ({
+    subscribe(fn: (x: T) => void) {
+      fn(v);
+      return () => {};
+    },
+  });
+  return {
+    members: readable([{ email: 'admin@test', admin: true }]),
+    isLoadingMembers: readable(false),
+  };
+});
 vi.mock('../src/lib/recipeService.js', () => ({
   recipes: mockRecipes,
   persistRecipe: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),

--- a/packages/ui-components/src/layout/BottomNav/BottomNav.svelte
+++ b/packages/ui-components/src/layout/BottomNav/BottomNav.svelte
@@ -20,7 +20,7 @@
   )}
   aria-label="Main navigation"
 >
-  <ul class="mx-auto flex h-14 w-full max-w-lg items-center justify-around" role="list">
+  <ul class="mx-auto flex h-14 w-full max-w-lg items-stretch justify-around" role="list">
     {#each items as item (item.id)}
       {@const active = isActive(item.href, currentPath)}
       {@const Icon = item.icon}

--- a/packages/ui-components/src/primitives/Toast/ToastViewport.svelte
+++ b/packages/ui-components/src/primitives/Toast/ToastViewport.svelte
@@ -8,7 +8,10 @@
 
 <div
   class={cn(
-    'fixed bottom-0 right-0 z-[100] flex max-h-screen w-full flex-col-reverse gap-2 p-4 md:max-w-[420px]',
+    // pointer-events-none: the viewport spans a fixed, full-width strip at the
+    // bottom (above the BottomNav in z-order) even when empty — without this it
+    // swallows taps meant for the nav. Each Toast re-enables pointer-events-auto.
+    'pointer-events-none fixed bottom-0 right-0 z-[100] flex max-h-screen w-full flex-col-reverse gap-2 p-4 md:max-w-[420px]',
     className,
   )}
 >


### PR DESCRIPTION
A batch of pre-publish UI fixes plus hiding the still-incomplete recipe module so it can't be stumbled onto.

## Hide the recipe module behind admin (#179)
The recipe module isn't ready for everyone yet, so it's now gated the same cosmetic way as the operator area:
- Recipes dropped from the default nav; appended only for admins (alongside the Admin entry).
- The three recipe route pages (`RecipeListPage`, `RecipeEditPage`, `RecipeViewPage`) wrapped in `AdminGuard`, so direct URLs bounce non-admins too.
- Recipe e2e specs sign in as admin to reach the gated routes; the two `RecipeEditPage` unit tests seed an admin context so the guard renders the form under test.

> Note: this is **UX gating only** — the real boundary is server-side, and recipe data still lives in shared collections with the open write path. Fine for "don't surface it", not a hard lock. Shout if you want a Firestore-rules lock scoped as a follow-up.

## UI / UX fixes
- **Bottom nav taps:** the `<ul>` used `items-center`, so each tab `<a>` floated mid-row with dead strips above/below — switched to `items-stretch` for full-height tap targets.
- **Toast viewport eating taps:** the fixed, full-width, `z-[100]` toast viewport sat over the lower half of the BottomNav even when empty and swallowed taps — added `pointer-events-none` to the container (each Toast re-enables `pointer-events-auto`). This was the root cause of the "have to tap the top of the icon" bug.
- **Toast position:** lifted toasts above the mobile BottomNav (mirrors the `h-14 + safe-area` reservation); back to the bottom edge on `lg` where the nav is hidden.
- **Shopping list:** every item name now renders Title Case (previously only canon-matched items were; raw items were sentence-cased). Free-form notes stay sentence-cased.
- **Recipe → add-to-list sheet:** selecting **Check** now auto-selects **Add** (and Check is no longer disabled when Add is off); removed a duplicate confirm-button spinner.

## Notes for review
- The large line counts on the recipe pages are prettier **re-indenting** the markup wrapped in `AdminGuard` (whitespace), not logic changes — review with "hide whitespace".

## Testing
- `pnpm test` — 1514 passing (pre-push)
- lint / typecheck / dependency-cruiser green (pre-commit); `vite build` clean
- Recipe e2e (`recipe-crud`, `recipe-shopping-list`) updated for the admin gate — run interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)