### PR TITLE
feat(chat): AI Kitchen Assistant — phases 1–5 (#206)

### DIFF
--- a/apps/cloud-functions/src/flows/authorRecipe.ts
+++ b/apps/cloud-functions/src/flows/authorRecipe.ts
@@ -1,0 +1,149 @@
+import { z } from 'genkit';
+import { googleAI } from '@genkit-ai/google-genai';
+import { AuthorRecipeInputSchema, LibrarianOutputSchema } from '@salt/domain/schemas';
+import type { LibrarianOutput } from '@salt/domain/schemas';
+import type { RecipeDoc, IngredientGroupDoc } from '@salt/domain/schemas';
+import { withAiTimeout } from '../adapters/withAiTimeout.js';
+import { ai } from '../genkit.js';
+import { canonicaliseRecipeIngredientsFlow } from './canonicaliseRecipeIngredients.js';
+
+// Flash + temperature:0 for the librarian — accuracy over creativity (issue #206).
+const LIBRARIAN_MODEL = googleAI.model('gemini-flash-latest');
+
+const OutputSchema = z.custom<RecipeDoc>();
+
+export const authorRecipeFlow = ai.defineFlow(
+  {
+    name: 'authorRecipe',
+    inputSchema: AuthorRecipeInputSchema,
+    outputSchema: OutputSchema,
+  },
+  async (input) => {
+    const conversationText = input.messages
+      .map((m) => `${m.role === 'user' ? 'User' : 'Chef'}: ${m.text}`)
+      .join('\n\n');
+
+    const result = await withAiTimeout(
+      'authorRecipe',
+      () =>
+        ai.generate({
+          model: LIBRARIAN_MODEL,
+          system: LIBRARIAN_SYSTEM,
+          prompt: conversationText,
+          output: { schema: LibrarianOutputSchema },
+          config: { temperature: 0 },
+        }),
+      { timeoutMs: 55_000, retries: 0 },
+    );
+
+    const parsed = LibrarianOutputSchema.safeParse(result.output);
+    if (!parsed.success) {
+      throw new Error(`Librarian returned invalid recipe structure: ${parsed.error.message}`);
+    }
+
+    return assembleDraft(parsed.data);
+  },
+);
+
+async function assembleDraft(raw: LibrarianOutput): Promise<RecipeDoc> {
+  const now = new Date().toISOString();
+
+  // Assign stable IDs to steps first so we can resolve step ordinals → IDs.
+  const steps = raw.steps.map((s) => ({
+    id: crypto.randomUUID(),
+    text: s.text,
+    timer: s.timerMinutes !== null ? { durationMinutes: s.timerMinutes, description: null } : null,
+    note: s.note,
+  }));
+
+  // Flatten all ingredients for batch canonicalisation.
+  type IngMeta = { groupIdx: number; itemIdx: number; rawText: string };
+  const allIngredients: IngMeta[] = [];
+  for (let gi = 0; gi < raw.ingredientGroups.length; gi++) {
+    const group = raw.ingredientGroups[gi]!;
+    for (let ii = 0; ii < group.ingredients.length; ii++) {
+      allIngredients.push({ groupIdx: gi, itemIdx: ii, rawText: group.ingredients[ii]!.rawText });
+    }
+  }
+
+  // Batch canonicalise all ingredient raw texts.
+  let canonResults: Awaited<ReturnType<typeof canonicaliseRecipeIngredientsFlow>> = [];
+  if (allIngredients.length > 0) {
+    try {
+      canonResults = await canonicaliseRecipeIngredientsFlow({
+        items: allIngredients.map((i) => ({ rawName: i.rawText, rawText: i.rawText })),
+      });
+    } catch {
+      // Canon failure is non-fatal — ingredients land as pending.
+    }
+  }
+
+  // Assemble ingredient groups with IDs, canon results, and firstUsedInStepId.
+  const ingredientGroups: IngredientGroupDoc[] = raw.ingredientGroups.map((group, gi) => ({
+    id: crypto.randomUUID(),
+    name: group.name,
+    items: group.ingredients.map((ing, ii) => {
+      const flatIdx = allIngredients.findIndex((m) => m.groupIdx === gi && m.itemIdx === ii);
+      const canon = flatIdx >= 0 ? canonResults[flatIdx] : undefined;
+
+      const canonId = canon && canon.kind === 'ok' ? (canon.value.item as { id: string }).id : null;
+      const matchState: 'matched' | 'pending' | 'failed' =
+        canon && canon.kind === 'ok' ? 'matched' : canon ? 'failed' : 'pending';
+
+      // Resolve step ordinal → step ID.
+      const ord = ing.firstUsedInStepOrdinal;
+      const firstUsedInStepId =
+        ord !== null && ord >= 0 && ord < steps.length ? steps[ord]!.id : null;
+
+      return {
+        id: crypto.randomUUID(),
+        rawText: ing.rawText,
+        parsed: null,
+        canonId,
+        matchState,
+        isOptional: ing.isOptional,
+        firstUsedInStepId,
+      };
+    }),
+  }));
+
+  return {
+    id: crypto.randomUUID(),
+    schemaVersion: 1,
+    title: raw.title,
+    description: raw.description,
+    ingredients: ingredientGroups,
+    steps,
+    metadata: {
+      servings: raw.servings,
+      totalTimeMinutes: raw.totalTimeMinutes,
+      prepTimeMinutes: raw.prepTimeMinutes,
+      cookTimeMinutes: raw.cookTimeMinutes,
+      tags: raw.tags,
+    },
+    source: { type: 'manual' },
+    notes: raw.notes,
+    image: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+const LIBRARIAN_SYSTEM = `You are a precise recipe extraction assistant. \
+Given a cooking conversation between a user and a chef, extract and structure a complete recipe. \
+
+## Rules
+- title: clear, concise recipe name.
+- description: 1–2 sentence summary, or null.
+- servings: integer portions, or null if not stated.
+- totalTimeMinutes/prepTimeMinutes/cookTimeMinutes: integers in minutes, or null.
+- tags: short lowercase keywords (e.g. ["vegetarian","quick","pasta"]). Empty array if none.
+- ingredientGroups: group ingredients by course/stage (null name = default group).
+  Each ingredient: rawText (verbatim as stated), isOptional (true only if explicitly optional),
+  firstUsedInStepOrdinal (0-based index into the steps array for the first step that uses this
+  ingredient; null if the ingredient has no obvious first step).
+- steps: numbered method steps. Each step: text (clear instruction), timerMinutes (integer or null),
+  note (clarification or null).
+- notes: chef's overall notes or tips, or null.
+
+Extract only what is present in the conversation. Do not invent ingredients or steps not discussed.`;

--- a/apps/cloud-functions/src/flows/chefChat.ts
+++ b/apps/cloud-functions/src/flows/chefChat.ts
@@ -3,18 +3,24 @@ import { getFirestore } from 'firebase-admin/firestore';
 import { googleAI } from '@genkit-ai/google-genai';
 import { logger } from 'firebase-functions';
 import { ChefChatInputSchema } from '@salt/domain/schemas';
-import { EquipmentManifestSchema, RecipeSchema } from '@salt/domain/schemas';
+import {
+  EquipmentManifestSchema,
+  RecipeSchema,
+  EQUIPMENT_MANIFEST_COLLECTION,
+  EQUIPMENT_MANIFEST_DOC_ID,
+} from '@salt/domain/schemas';
 import { withAiTimeout } from '../adapters/withAiTimeout.js';
 import { ai } from '../genkit.js';
 
 // Pro-tier model for conversational quality (design principle #3, issue #206).
 const CHEF_MODEL = googleAI.model('gemini-pro-latest');
 
-const EQUIPMENT_DOC_PATH = 'equipmentManifest/manifest';
-
 async function readEquipmentContext(db: ReturnType<typeof getFirestore>): Promise<string> {
   try {
-    const snap = await db.doc(EQUIPMENT_DOC_PATH).get();
+    const snap = await db
+      .collection(EQUIPMENT_MANIFEST_COLLECTION)
+      .doc(EQUIPMENT_MANIFEST_DOC_ID)
+      .get();
     if (!snap.exists) return '';
     const result = EquipmentManifestSchema.safeParse(snap.data());
     if (!result.success) {
@@ -107,9 +113,13 @@ export const chefChatFlow = ai.defineFlow(
 
     const systemPrompt = buildSystemPrompt(equipmentContext, recipeContext);
 
-    // Convert Message[] history to Genkit MessageData format.
+    // Convert Message[] history to Genkit MessageData format. Our domain role is
+    // 'user' | 'assistant'; Genkit/Gemini uses 'user' | 'model', so the assistant
+    // turns must be remapped (a bare cast leaves 'assistant' at runtime, which
+    // Genkit rejects with "messages.N.role: must be equal to one of the allowed
+    // values").
     const history = input.messages.map((m) => ({
-      role: m.role as 'user' | 'model',
+      role: (m.role === 'assistant' ? 'model' : 'user') as 'user' | 'model',
       content: [{ text: m.text }],
     }));
 

--- a/apps/cloud-functions/src/flows/chefChat.ts
+++ b/apps/cloud-functions/src/flows/chefChat.ts
@@ -1,0 +1,143 @@
+import { z } from 'genkit';
+import { getFirestore } from 'firebase-admin/firestore';
+import { googleAI } from '@genkit-ai/google-genai';
+import { logger } from 'firebase-functions';
+import { ChefChatInputSchema } from '@salt/domain/schemas';
+import { EquipmentManifestSchema, RecipeSchema } from '@salt/domain/schemas';
+import { withAiTimeout } from '../adapters/withAiTimeout.js';
+import { ai } from '../genkit.js';
+
+// Pro-tier model for conversational quality (design principle #3, issue #206).
+const CHEF_MODEL = googleAI.model('gemini-pro-latest');
+
+const EQUIPMENT_DOC_PATH = 'equipmentManifest/manifest';
+
+async function readEquipmentContext(db: ReturnType<typeof getFirestore>): Promise<string> {
+  try {
+    const snap = await db.doc(EQUIPMENT_DOC_PATH).get();
+    if (!snap.exists) return '';
+    const result = EquipmentManifestSchema.safeParse(snap.data());
+    if (!result.success) {
+      logger.warn('chefChat: equipmentManifest failed validation, proceeding without kit context');
+      return '';
+    }
+    const { items } = result.data;
+    if (items.length === 0) return '';
+    const lines = items.map((item) => {
+      const parts = [`- ${item.name}`];
+      const ownedAccessories = item.accessories.filter((a) => a.owned);
+      if (ownedAccessories.length > 0) {
+        parts.push(`  accessories: ${ownedAccessories.map((a) => a.name).join(', ')}`);
+      }
+      if (item.rules.length > 0) {
+        parts.push(`  notes: ${item.rules.join('; ')}`);
+      }
+      return parts.join('\n');
+    });
+    return lines.join('\n');
+  } catch (err) {
+    logger.warn('chefChat: failed to read equipmentManifest', { err });
+    return '';
+  }
+}
+
+async function readRecipeContext(
+  db: ReturnType<typeof getFirestore>,
+  recipeId: string,
+): Promise<string> {
+  try {
+    const snap = await db.collection('recipes').doc(recipeId).get();
+    if (!snap.exists) return '';
+    const result = RecipeSchema.safeParse(snap.data());
+    if (!result.success) {
+      logger.warn('chefChat: recipe failed validation', { recipeId });
+      return '';
+    }
+    const r = result.data;
+    const ingredientLines: string[] = [];
+    for (const group of r.ingredients) {
+      if (group.name) ingredientLines.push(`${group.name}:`);
+      for (const ing of group.items) {
+        ingredientLines.push(`  - ${ing.rawText}${ing.isOptional ? ' (optional)' : ''}`);
+      }
+    }
+    const stepLines = r.steps.map((s, i) => `  ${i + 1}. ${s.text}`);
+    const parts = [`Recipe: ${r.title}`];
+    if (r.description) parts.push(`Description: ${r.description}`);
+    if (ingredientLines.length > 0) parts.push(`Ingredients:\n${ingredientLines.join('\n')}`);
+    if (stepLines.length > 0) parts.push(`Method:\n${stepLines.join('\n')}`);
+    return parts.join('\n\n');
+  } catch (err) {
+    logger.warn('chefChat: failed to read recipe', { recipeId, err });
+    return '';
+  }
+}
+
+function buildSystemPrompt(equipmentContext: string, recipeContext: string): string {
+  const sections: string[] = [CHEF_SYSTEM_BASE];
+
+  if (equipmentContext) {
+    sections.push(
+      `## Your equipment\nThe following kitchen equipment is available. Draw on it when it genuinely helps the conversation, but never feel obliged to mention or use it.\n\n${equipmentContext}`,
+    );
+  }
+
+  if (recipeContext) {
+    sections.push(
+      `## Current recipe\nThe user is asking about this recipe. Use it as context for the conversation.\n\n${recipeContext}`,
+    );
+  }
+
+  return sections.join('\n\n');
+}
+
+export const chefChatFlow = ai.defineFlow(
+  {
+    name: 'chefChat',
+    inputSchema: ChefChatInputSchema,
+    outputSchema: z.string(),
+    streamSchema: z.string(),
+  },
+  async (input, streamingCallback) => {
+    const db = getFirestore();
+    const [equipmentContext, recipeContext] = await Promise.all([
+      readEquipmentContext(db),
+      input.recipeId ? readRecipeContext(db, input.recipeId) : Promise.resolve(''),
+    ]);
+
+    const systemPrompt = buildSystemPrompt(equipmentContext, recipeContext);
+
+    // Convert Message[] history to Genkit MessageData format.
+    const history = input.messages.map((m) => ({
+      role: m.role as 'user' | 'model',
+      content: [{ text: m.text }],
+    }));
+
+    const { stream, response } = ai.generateStream({
+      model: CHEF_MODEL,
+      system: systemPrompt,
+      messages: history,
+      prompt: input.newMessage,
+    });
+
+    for await (const chunk of stream) {
+      const text = chunk.text;
+      if (text) streamingCallback(text);
+    }
+
+    const finalResponse = await withAiTimeout('chefChat', () => response, {
+      timeoutMs: 55_000,
+      retries: 0,
+    });
+
+    return finalResponse.text;
+  },
+);
+
+const CHEF_SYSTEM_BASE = `You are a skilled, knowledgeable kitchen assistant and conversational chef. \
+Your goal is to have genuinely helpful, creative, and practical cooking conversations. \
+You can discuss recipes, techniques, flavour pairings, substitutions, dietary adaptations, \
+and anything else related to cooking and food. \
+Speak naturally and warmly — like a knowledgeable friend in the kitchen, not a recipe generator. \
+When you suggest a recipe or technique, feel free to riff, improvise, and add your own perspective. \
+You are not bound to any particular list of ingredients or equipment.`;

--- a/apps/cloud-functions/src/index.ts
+++ b/apps/cloud-functions/src/index.ts
@@ -18,6 +18,7 @@ import { canonicaliseRecipeIngredientsFlow } from './flows/canonicaliseRecipeIng
 import { identifyEquipmentFlow } from './flows/identifyEquipment.js';
 import { populateEquipmentEntryFlow } from './flows/populateEquipmentEntry.js';
 import { parseRecipeIngredientsFlow } from './flows/parseRecipeIngredients.js';
+import { chefChatFlow } from './flows/chefChat.js';
 import { onShoppingListItemWrite } from './triggers/onShoppingListItemWrite.js';
 import { onCanonItemWritten } from './triggers/onCanonItemWritten.js';
 
@@ -158,6 +159,16 @@ export const parseRecipeIngredients = onCallGenkit(
     timeoutSeconds: 90,
   },
   parseRecipeIngredientsFlow,
+);
+
+export const chefChat = onCallGenkit(
+  {
+    ...APP_CHECK_ENFORCEMENT,
+    secrets: [geminiApiKey],
+    authPolicy: isSignedIn(),
+    timeoutSeconds: 120,
+  },
+  chefChatFlow,
 );
 
 export { onShoppingListItemWrite };

--- a/apps/cloud-functions/src/index.ts
+++ b/apps/cloud-functions/src/index.ts
@@ -5,6 +5,7 @@ import { onCall, onCallGenkit, isSignedIn, HttpsError } from 'firebase-functions
 import {
   MatchOrCreateCanonInputSchema,
   CanonicaliseRecipeIngredientsInputSchema,
+  AuthorRecipeInputSchema,
 } from '@salt/domain/schemas';
 import {
   initServerObservability,
@@ -19,6 +20,7 @@ import { identifyEquipmentFlow } from './flows/identifyEquipment.js';
 import { populateEquipmentEntryFlow } from './flows/populateEquipmentEntry.js';
 import { parseRecipeIngredientsFlow } from './flows/parseRecipeIngredients.js';
 import { chefChatFlow } from './flows/chefChat.js';
+import { authorRecipeFlow } from './flows/authorRecipe.js';
 import { onShoppingListItemWrite } from './triggers/onShoppingListItemWrite.js';
 import { onCanonItemWritten } from './triggers/onCanonItemWritten.js';
 
@@ -159,6 +161,29 @@ export const parseRecipeIngredients = onCallGenkit(
     timeoutSeconds: 90,
   },
   parseRecipeIngredientsFlow,
+);
+
+// Librarian: conversation → recipe draft with canon-matched ingredients.
+// Uses onCall (not onCallGenkit) so we can bump memory for the batch
+// canonicalisation, mirroring canonicaliseRecipeIngredients.
+export const authorRecipe = onCall(
+  {
+    ...APP_CHECK_ENFORCEMENT,
+    secrets: [geminiApiKey, ldSdkKey],
+    timeoutSeconds: 120,
+    memory: '512MiB',
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Sign in required.');
+    }
+    const parsed = AuthorRecipeInputSchema.safeParse(request.data);
+    if (!parsed.success) {
+      throw new HttpsError('invalid-argument', 'Invalid request payload.');
+    }
+    await whenServerObservabilityReady();
+    return authorRecipeFlow(parsed.data);
+  },
 );
 
 export const chefChat = onCallGenkit(

--- a/apps/web-pwa/src/App.svelte
+++ b/apps/web-pwa/src/App.svelte
@@ -21,6 +21,7 @@
   import { members, initMembersSync } from './lib/membersService.js';
   import { initMealPlanSync } from './lib/mealPlanService.js';
   import { initRecipeSync } from './lib/recipeService.js';
+  import { initChatSync } from './lib/chatService.js';
   import { normaliseMemberEmail } from '@salt/domain';
   import SessionOverlay from './lib/dev/SessionOverlay.svelte';
 
@@ -33,6 +34,7 @@
     const unsubMembers = initMembersSync();
     const unsubMealPlan = initMealPlanSync();
     const unsubRecipes = initRecipeSync();
+    const unsubChat = initChatSync(auth.user.uid);
     return () => {
       unsubCanon();
       unsubEquipment();
@@ -40,6 +42,7 @@
       unsubMembers();
       unsubMealPlan();
       unsubRecipes();
+      unsubChat();
     };
   });
 

--- a/apps/web-pwa/src/lib/chatService.ts
+++ b/apps/web-pwa/src/lib/chatService.ts
@@ -1,0 +1,168 @@
+import {
+  subscribeChatSessions,
+  saveChatSession,
+  deleteChatSession,
+  streamChefChat,
+} from '@salt/firebase-sync';
+import { createLDErrorReportingAdapter } from '@salt/ld-observability';
+import type { ChatSessionDoc } from '@salt/domain/schemas';
+import type { DomainError, ReadResult } from '@salt/shared-types';
+import { success } from '@salt/shared-types';
+import { writable, get } from 'svelte/store';
+import type { Readable } from 'svelte/store';
+
+// Chat service (issue #206, Phase 3). Optimistic store over the per-user
+// firebase-sync adapter. Follows the recipeService.ts pattern exactly.
+
+const _sessions = writable<readonly ChatSessionDoc[]>([]);
+export const sessions: Readable<readonly ChatSessionDoc[]> = _sessions;
+
+const _isLoadingSessions = writable(true);
+export const isLoadingSessions: Readable<boolean> = _isLoadingSessions;
+
+let _errorReporter: ReturnType<typeof createLDErrorReportingAdapter> | null = null;
+function getErrorReporter() {
+  if (!_errorReporter) _errorReporter = createLDErrorReportingAdapter();
+  return _errorReporter;
+}
+
+// Optimistic snapshot guard — same pattern as recipeService.ts.
+const latestLocalEdit = new Map<string, string>();
+
+function applySnapshot(incoming: ChatSessionDoc[]): void {
+  const currentById = new Map(get(_sessions).map((s) => [s.id, s]));
+  const result: ChatSessionDoc[] = [];
+  const seen = new Set<string>();
+  for (const s of incoming) {
+    seen.add(s.id);
+    const local = latestLocalEdit.get(s.id);
+    if (local !== undefined && s.updatedAt < local) {
+      const ours = currentById.get(s.id);
+      if (ours) result.push(ours);
+      continue;
+    }
+    if (s.updatedAt) latestLocalEdit.set(s.id, s.updatedAt);
+    result.push(s);
+  }
+  for (const [id, s] of currentById) {
+    if (!seen.has(id) && latestLocalEdit.has(id)) result.push(s);
+  }
+  _sessions.set(result);
+}
+
+export function initChatSync(ownerUid: string): () => void {
+  _isLoadingSessions.set(true);
+  const errors = getErrorReporter();
+  const unsub = subscribeChatSessions(
+    ownerUid,
+    (incoming) => {
+      applySnapshot(incoming);
+      _isLoadingSessions.set(false);
+    },
+    (err) => {
+      errors.report(err);
+      _isLoadingSessions.set(false);
+    },
+  );
+  return unsub;
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function newSession(ownerUid: string, recipeId: string | null): ChatSessionDoc {
+  const ts = now();
+  return {
+    id: crypto.randomUUID(),
+    schemaVersion: 1,
+    ownerUid,
+    recipeId,
+    title: recipeId ? 'Recipe chat' : 'New chat',
+    messages: [],
+    createdAt: ts,
+    updatedAt: ts,
+    expiresAt: ts, // saveChatSession will overwrite with now + 14 days
+  };
+}
+
+export async function createChatSession(
+  ownerUid: string,
+  recipeId: string | null = null,
+): Promise<ReadResult<ChatSessionDoc, DomainError>> {
+  const session = newSession(ownerUid, recipeId);
+  const stamped = { ...session, updatedAt: now() };
+  latestLocalEdit.set(stamped.id, stamped.updatedAt);
+  _sessions.set([...get(_sessions), stamped]);
+  const result = await saveChatSession(stamped);
+  if (result.kind === 'err') return result;
+  return success(stamped);
+}
+
+export async function persistSession(
+  session: ChatSessionDoc,
+): Promise<ReadResult<void, DomainError>> {
+  const stamped = { ...session, updatedAt: now() };
+  latestLocalEdit.set(stamped.id, stamped.updatedAt);
+  const others = get(_sessions).filter((s) => s.id !== stamped.id);
+  _sessions.set([...others, stamped]);
+  return saveChatSession(stamped);
+}
+
+export async function removeSession(id: string): Promise<ReadResult<void, DomainError>> {
+  latestLocalEdit.set(id, now());
+  _sessions.set(get(_sessions).filter((s) => s.id !== id));
+  return deleteChatSession(id);
+}
+
+// Send a user message: appends the user turn, streams the assistant reply,
+// then appends the final assistant turn and persists the session once.
+// onChunk is called for each streaming text fragment so the UI can render
+// the partial reply live; the full reply is committed to the session on finish.
+export async function sendMessage(
+  session: ChatSessionDoc,
+  text: string,
+  onChunk: (chunk: string) => void,
+): Promise<ReadResult<ChatSessionDoc, DomainError>> {
+  const userMsg: ChatSessionDoc['messages'][number] = {
+    id: crypto.randomUUID(),
+    role: 'user',
+    text,
+    createdAt: now(),
+  };
+
+  const sessionWithUser: ChatSessionDoc = {
+    ...session,
+    messages: [...session.messages, userMsg],
+    title: session.messages.length === 0 ? text.slice(0, 60) : session.title,
+  };
+
+  // Optimistically update with user message.
+  const stampedUser = { ...sessionWithUser, updatedAt: now() };
+  latestLocalEdit.set(stampedUser.id, stampedUser.updatedAt);
+  const others = get(_sessions).filter((s) => s.id !== stampedUser.id);
+  _sessions.set([...others, stampedUser]);
+
+  const streamResult = await streamChefChat(
+    { messages: session.messages, newMessage: text, recipeId: session.recipeId },
+    onChunk,
+  );
+
+  if (streamResult.kind === 'err') return streamResult;
+
+  const assistantMsg: ChatSessionDoc['messages'][number] = {
+    id: crypto.randomUUID(),
+    role: 'assistant',
+    text: streamResult.value,
+    createdAt: now(),
+  };
+
+  const finalSession: ChatSessionDoc = {
+    ...stampedUser,
+    messages: [...stampedUser.messages, assistantMsg],
+  };
+
+  const saveResult = await persistSession(finalSession);
+  if (saveResult.kind === 'err') return saveResult;
+  return success(finalSession);
+}

--- a/apps/web-pwa/src/lib/chatService.ts
+++ b/apps/web-pwa/src/lib/chatService.ts
@@ -137,10 +137,13 @@ export async function sendMessage(
     title: session.messages.length === 0 ? text.slice(0, 60) : session.title,
   };
 
-  // Optimistically update with user message.
+  // Optimistically update with user message. Snapshot the prior store state so a
+  // failed send can be rolled back — the turn is only persisted on success, so a
+  // left-behind optimistic turn would otherwise accumulate as a ghost on retry.
+  const prevSessions = get(_sessions);
   const stampedUser = { ...sessionWithUser, updatedAt: now() };
   latestLocalEdit.set(stampedUser.id, stampedUser.updatedAt);
-  const others = get(_sessions).filter((s) => s.id !== stampedUser.id);
+  const others = prevSessions.filter((s) => s.id !== stampedUser.id);
   _sessions.set([...others, stampedUser]);
 
   const streamResult = await streamChefChat(
@@ -148,7 +151,10 @@ export async function sendMessage(
     onChunk,
   );
 
-  if (streamResult.kind === 'err') return streamResult;
+  if (streamResult.kind === 'err') {
+    _sessions.set(prevSessions);
+    return streamResult;
+  }
 
   const assistantMsg: ChatSessionDoc['messages'][number] = {
     id: crypto.randomUUID(),

--- a/apps/web-pwa/src/lib/nav.ts
+++ b/apps/web-pwa/src/lib/nav.ts
@@ -2,6 +2,7 @@ import {
   Blender,
   BookOpen,
   CalendarDays,
+  ChefHat,
   Home,
   Settings,
   Shield,
@@ -14,6 +15,8 @@ export const navItems: NavItem[] = [
   { id: 'shopping', label: 'Shop', icon: ShoppingCart, href: '#/shopping' },
   { id: 'mealplan', label: 'Meals', icon: CalendarDays, href: '#/mealplan' },
   { id: 'equipment', label: 'Kitchen', icon: Blender, href: '#/equipment' },
+  // AI Kitchen Assistant (issue #206) — available to all members.
+  { id: 'chat', label: 'Chef', icon: ChefHat, href: '#/chat' },
   { id: 'settings', label: 'Settings', icon: Settings, href: '#/settings' },
 ];
 

--- a/apps/web-pwa/src/routes/chat/ChatListPage.svelte
+++ b/apps/web-pwa/src/routes/chat/ChatListPage.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import {
+    Button,
+    Icon,
+    ListPage,
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+    DialogFooter,
+  } from '@salt/ui-components';
+  import { push } from 'svelte-spa-router';
+  import { auth } from '../../lib/auth.svelte.js';
+  import {
+    sessions,
+    isLoadingSessions,
+    createChatSession,
+    removeSession,
+  } from '../../lib/chatService.js';
+  import { addToast } from '../../lib/toastStore.js';
+
+  const sorted = $derived([...$sessions].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)));
+
+  let creating = $state(false);
+
+  async function handleNew(): Promise<void> {
+    const uid = auth.user?.uid;
+    if (!uid) return;
+    creating = true;
+    const result = await createChatSession(uid, null);
+    creating = false;
+    if (result.kind !== 'ok') {
+      addToast('Failed to create chat.', 'destructive');
+      return;
+    }
+    push(`/chat/${result.value.id}`);
+  }
+
+  let deleteId = $state<string | null>(null);
+  let deleteBusy = $state(false);
+
+  async function handleDelete(): Promise<void> {
+    if (!deleteId) return;
+    deleteBusy = true;
+    const result = await removeSession(deleteId);
+    deleteBusy = false;
+    deleteId = null;
+    if (result.kind !== 'ok') {
+      addToast('Failed to delete chat.', 'destructive');
+    }
+  }
+
+  function formatDate(iso: string): string {
+    return new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(new Date(iso));
+  }
+</script>
+
+<ListPage
+  title="Chef"
+  description="Ask your kitchen assistant anything."
+  isLoading={$isLoadingSessions}
+  isEmpty={sorted.length === 0}
+  class="p-4 sm:p-6"
+>
+  {#snippet actions()}
+    <Button
+      size="sm"
+      onclick={handleNew}
+      loading={creating}
+      disabled={creating}
+      data-testid="chat-new-btn"
+    >
+      New chat
+    </Button>
+  {/snippet}
+
+  {#snippet empty()}
+    <div class="flex flex-col items-center gap-3 py-12 text-center">
+      <p class="text-sm text-muted-foreground">No chats yet.</p>
+      <Button size="sm" onclick={handleNew} loading={creating} disabled={creating}>
+        Start your first chat
+      </Button>
+    </div>
+  {/snippet}
+
+  {#snippet children()}
+    <ul class="flex flex-col gap-1" data-testid="chat-session-list">
+      {#each sorted as session (session.id)}
+        <li class="flex items-center gap-2">
+          <button
+            class="flex-1 rounded px-2 py-2 text-left text-sm font-medium hover:bg-muted"
+            onclick={() => push(`/chat/${session.id}`)}
+            data-testid="chat-session-item"
+          >
+            <span class="block truncate">{session.title}</span>
+            <span class="block text-xs font-normal text-muted-foreground">
+              {formatDate(session.updatedAt)}
+              {#if session.recipeId}<span class="ml-1 text-xs text-muted-foreground">· recipe</span
+                >{/if}
+            </span>
+          </button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onclick={() => (deleteId = session.id)}
+            aria-label="Delete chat"
+          >
+            <Icon name="Trash2" size={14} />
+          </Button>
+        </li>
+      {/each}
+    </ul>
+  {/snippet}
+</ListPage>
+
+<Dialog
+  open={deleteId !== null}
+  onOpenChange={(v) => {
+    if (!v) deleteId = null;
+  }}
+>
+  <DialogContent>
+    <div class="flex flex-col gap-4">
+      <DialogHeader>
+        <DialogTitle>Delete chat?</DialogTitle>
+        <DialogDescription>This action cannot be undone.</DialogDescription>
+      </DialogHeader>
+      <DialogFooter>
+        <Button variant="outline" onclick={() => (deleteId = null)} disabled={deleteBusy}
+          >Cancel</Button
+        >
+        <Button
+          variant="destructive"
+          onclick={handleDelete}
+          loading={deleteBusy}
+          disabled={deleteBusy}
+          data-testid="chat-delete-confirm"
+        >
+          Delete
+        </Button>
+      </DialogFooter>
+    </div>
+  </DialogContent>
+</Dialog>

--- a/apps/web-pwa/src/routes/chat/ChatSessionPage.svelte
+++ b/apps/web-pwa/src/routes/chat/ChatSessionPage.svelte
@@ -3,8 +3,8 @@
   import { push } from 'svelte-spa-router';
   import { sessions, isLoadingSessions, sendMessage } from '../../lib/chatService.js';
   import { addToast } from '../../lib/toastStore.js';
-  import { callAuthorRecipe } from '@salt/firebase-sync';
-  import { saveRecipe as saveRecipeDoc } from '@salt/firebase-sync';
+  import { callAuthorRecipe, saveRecipe as saveRecipeDoc } from '@salt/firebase-sync';
+  import { recipes } from '../../lib/recipeService.js';
   import type { ChatSessionDoc } from '@salt/domain/schemas';
 
   interface Props {
@@ -75,6 +75,43 @@
     push(`/recipes/${stamped.id}`);
   }
 
+  // Apply changes — re-runs the librarian against the conversation and updates
+  // the attached recipe in place (same id, original createdAt, new updatedAt).
+  let isApplying = $state(false);
+
+  async function handleApplyChanges(): Promise<void> {
+    if (!session?.recipeId || isApplying) return;
+    const existing = $recipes.find((r) => r.id === session!.recipeId);
+    if (!existing) {
+      addToast('Recipe not found.', 'destructive');
+      return;
+    }
+    isApplying = true;
+    const result = await callAuthorRecipe({ messages: session.messages });
+    if (result.kind !== 'ok') {
+      isApplying = false;
+      addToast('Failed to generate recipe update.', 'destructive');
+      return;
+    }
+    const draft = result.value;
+    const now = new Date().toISOString();
+    // Preserve the existing recipe's id and createdAt; bump updatedAt.
+    const updated = {
+      ...draft,
+      id: existing.id,
+      createdAt: existing.createdAt,
+      updatedAt: now,
+    };
+    const saveResult = await saveRecipeDoc(updated);
+    isApplying = false;
+    if (saveResult.kind !== 'ok') {
+      addToast('Failed to save recipe update.', 'destructive');
+      return;
+    }
+    addToast('Recipe updated!', 'success');
+    push(`/recipes/${existing.id}`);
+  }
+
   function handleKeydown(e: KeyboardEvent): void {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -114,6 +151,27 @@
         >
           {#snippet leading()}<Icon name="BookOpen" size={16} />{/snippet}
           Save as recipe
+        </Button>
+      {/if}
+      {#if session.recipeId && session.messages.some((m) => m.role === 'assistant')}
+        <Button
+          size="sm"
+          variant="outline"
+          onclick={() => push(`/recipes/${session!.recipeId}`)}
+          data-testid="chat-view-recipe-btn"
+        >
+          {#snippet leading()}<Icon name="BookOpen" size={16} />{/snippet}
+          View recipe
+        </Button>
+        <Button
+          size="sm"
+          onclick={handleApplyChanges}
+          loading={isApplying}
+          disabled={isApplying || isSending}
+          data-testid="chat-apply-changes-btn"
+        >
+          {#snippet leading()}<Icon name="Check" size={16} />{/snippet}
+          Apply changes
         </Button>
       {/if}
     {/snippet}

--- a/apps/web-pwa/src/routes/chat/ChatSessionPage.svelte
+++ b/apps/web-pwa/src/routes/chat/ChatSessionPage.svelte
@@ -3,6 +3,8 @@
   import { push } from 'svelte-spa-router';
   import { sessions, isLoadingSessions, sendMessage } from '../../lib/chatService.js';
   import { addToast } from '../../lib/toastStore.js';
+  import { callAuthorRecipe } from '@salt/firebase-sync';
+  import { saveRecipe as saveRecipeDoc } from '@salt/firebase-sync';
   import type { ChatSessionDoc } from '@salt/domain/schemas';
 
   interface Props {
@@ -48,6 +50,31 @@
     }
   }
 
+  // Save as recipe — calls the librarian flow and navigates to the new recipe.
+  let isSavingRecipe = $state(false);
+
+  async function handleSaveAsRecipe(): Promise<void> {
+    if (!session || isSavingRecipe) return;
+    isSavingRecipe = true;
+    const result = await callAuthorRecipe({ messages: session.messages });
+    if (result.kind !== 'ok') {
+      isSavingRecipe = false;
+      addToast('Failed to generate recipe.', 'destructive');
+      return;
+    }
+    const recipe = result.value;
+    const now = new Date().toISOString();
+    const stamped = { ...recipe, id: recipe.id, createdAt: now, updatedAt: now };
+    const saveResult = await saveRecipeDoc(stamped);
+    isSavingRecipe = false;
+    if (saveResult.kind !== 'ok') {
+      addToast('Failed to save recipe.', 'destructive');
+      return;
+    }
+    addToast('Recipe saved!', 'success');
+    push(`/recipes/${stamped.id}`);
+  }
+
   function handleKeydown(e: KeyboardEvent): void {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -75,6 +102,21 @@
     backLabel="Chef"
     class="flex flex-col"
   >
+    {#snippet actions()}
+      {#if !session.recipeId && session.messages.some((m) => m.role === 'assistant')}
+        <Button
+          size="sm"
+          variant="outline"
+          onclick={handleSaveAsRecipe}
+          loading={isSavingRecipe}
+          disabled={isSavingRecipe || isSending}
+          data-testid="chat-save-recipe-btn"
+        >
+          {#snippet leading()}<Icon name="BookOpen" size={16} />{/snippet}
+          Save as recipe
+        </Button>
+      {/if}
+    {/snippet}
     <!-- Message list -->
     <div
       class="flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-4 sm:px-6"

--- a/apps/web-pwa/src/routes/chat/ChatSessionPage.svelte
+++ b/apps/web-pwa/src/routes/chat/ChatSessionPage.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  import { Button, DetailPage, Icon, Spinner } from '@salt/ui-components';
+  import { push } from 'svelte-spa-router';
+  import { sessions, isLoadingSessions, sendMessage } from '../../lib/chatService.js';
+  import { addToast } from '../../lib/toastStore.js';
+  import type { ChatSessionDoc } from '@salt/domain/schemas';
+
+  interface Props {
+    params: { id: string };
+  }
+  let { params }: Props = $props();
+
+  const session = $derived(($sessions as ChatSessionDoc[]).find((s) => s.id === params.id) ?? null);
+
+  // Live-streamed partial text for the assistant reply in progress.
+  let streamingText = $state('');
+  let isSending = $state(false);
+  let inputText = $state('');
+
+  let messagesEnd: HTMLDivElement | undefined = $state();
+
+  $effect(() => {
+    // Scroll to bottom whenever messages or streaming text changes.
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    session?.messages.length;
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    streamingText;
+    messagesEnd?.scrollIntoView({ behavior: 'smooth' });
+  });
+
+  async function handleSend(): Promise<void> {
+    if (!session || !inputText.trim() || isSending) return;
+    const text = inputText.trim();
+    inputText = '';
+    isSending = true;
+    streamingText = '';
+
+    const result = await sendMessage(session, text, (chunk) => {
+      streamingText += chunk;
+    });
+
+    isSending = false;
+    streamingText = '';
+
+    if (result.kind !== 'ok') {
+      addToast('Failed to send message.', 'destructive');
+      inputText = text;
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void handleSend();
+    }
+  }
+</script>
+
+{#if session === null}
+  <div class="p-4 sm:p-6">
+    {#if $isLoadingSessions}
+      <div class="flex items-center gap-2 text-sm text-muted-foreground">
+        <Spinner size={16} />
+        Loading…
+      </div>
+    {:else}
+      <p class="text-sm text-muted-foreground">Chat not found.</p>
+      <Button variant="outline" class="mt-4" onclick={() => push('/chat')}>Back to chats</Button>
+    {/if}
+  </div>
+{:else}
+  <DetailPage
+    title={session.title}
+    onBack={() => push('/chat')}
+    backLabel="Chef"
+    class="flex flex-col"
+  >
+    <!-- Message list -->
+    <div
+      class="flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-4 sm:px-6"
+      data-testid="chat-messages"
+    >
+      {#if session.messages.length === 0 && !isSending}
+        <p class="text-center text-sm text-muted-foreground py-12">
+          Ask me anything about cooking.
+        </p>
+      {/if}
+
+      {#each session.messages as msg (msg.id)}
+        <div
+          class="flex flex-col gap-1 {msg.role === 'user' ? 'items-end' : 'items-start'}"
+          data-testid="chat-message-{msg.role}"
+        >
+          <div
+            class="max-w-[85%] rounded-2xl px-4 py-2 text-sm {msg.role === 'user'
+              ? 'bg-primary text-primary-foreground'
+              : 'bg-muted text-foreground'}"
+          >
+            {msg.text}
+          </div>
+        </div>
+      {/each}
+
+      <!-- Streaming assistant reply in progress -->
+      {#if isSending && streamingText}
+        <div class="flex flex-col gap-1 items-start" data-testid="chat-message-streaming">
+          <div class="max-w-[85%] rounded-2xl bg-muted px-4 py-2 text-sm text-foreground">
+            {streamingText}<span class="animate-pulse">▌</span>
+          </div>
+        </div>
+      {:else if isSending}
+        <div class="flex items-center gap-2 text-sm text-muted-foreground">
+          <Spinner size={14} />
+          Thinking…
+        </div>
+      {/if}
+
+      <div bind:this={messagesEnd}></div>
+    </div>
+
+    <!-- Input bar -->
+    <div class="border-t bg-background px-4 py-3 sm:px-6" data-testid="chat-input-bar">
+      <div class="flex items-end gap-2">
+        <textarea
+          class="flex-1 resize-none rounded-lg border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+          rows={1}
+          placeholder="Message the chef…"
+          bind:value={inputText}
+          onkeydown={handleKeydown}
+          disabled={isSending}
+          data-testid="chat-input"
+        ></textarea>
+        <Button
+          size="sm"
+          onclick={handleSend}
+          disabled={isSending || !inputText.trim()}
+          loading={isSending}
+          aria-label="Send"
+          data-testid="chat-send-btn"
+        >
+          {#snippet leading()}<Icon name="SendHorizontal" size={16} />{/snippet}
+          Send
+        </Button>
+      </div>
+    </div>
+  </DetailPage>
+{/if}

--- a/apps/web-pwa/src/routes/chat/ChatSessionPage.svelte
+++ b/apps/web-pwa/src/routes/chat/ChatSessionPage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button, DetailPage, Icon, Spinner } from '@salt/ui-components';
+  import { Button, DetailPage, Icon, Markdown, Spinner } from '@salt/ui-components';
   import { push } from 'svelte-spa-router';
   import { sessions, isLoadingSessions, sendMessage } from '../../lib/chatService.js';
   import { addToast } from '../../lib/toastStore.js';
@@ -196,7 +196,11 @@
               ? 'bg-primary text-primary-foreground'
               : 'bg-muted text-foreground'}"
           >
-            {msg.text}
+            {#if msg.role === 'assistant'}
+              <Markdown text={msg.text} />
+            {:else}
+              {msg.text}
+            {/if}
           </div>
         </div>
       {/each}
@@ -205,7 +209,7 @@
       {#if isSending && streamingText}
         <div class="flex flex-col gap-1 items-start" data-testid="chat-message-streaming">
           <div class="max-w-[85%] rounded-2xl bg-muted px-4 py-2 text-sm text-foreground">
-            {streamingText}<span class="animate-pulse">▌</span>
+            <Markdown text={streamingText} />
           </div>
         </div>
       {:else if isSending}

--- a/apps/web-pwa/src/routes/index.ts
+++ b/apps/web-pwa/src/routes/index.ts
@@ -12,6 +12,8 @@ import ShoppingListCreatePage from './shopping/ShoppingListCreatePage.svelte';
 import ShoppingListsManagePage from './shopping/ShoppingListsManagePage.svelte';
 import ShoppingListPage from './shopping/ShoppingListPage.svelte';
 import MealPlanWeekPage from './mealplan/MealPlanWeekPage.svelte';
+import ChatListPage from './chat/ChatListPage.svelte';
+import ChatSessionPage from './chat/ChatSessionPage.svelte';
 import RecipeListPage from './recipes/RecipeListPage.svelte';
 import RecipeEditPage from './recipes/RecipeEditPage.svelte';
 import RecipeViewPage from './recipes/RecipeViewPage.svelte';
@@ -32,6 +34,9 @@ export const routes: RouteDefinition = new Map([
   ['/shopping/lists', ShoppingListsManagePage],
   ['/shopping/:listId', ShoppingListPage],
   ['/mealplan', MealPlanWeekPage],
+  // Chat / AI Kitchen Assistant (issue #206).
+  ['/chat', ChatListPage],
+  ['/chat/:id', ChatSessionPage],
   // Recipe module (issue #179). More-specific static/edit routes precede the
   // parameterised view route.
   ['/recipes', RecipeListPage],

--- a/apps/web-pwa/src/routes/recipes/RecipeViewPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeViewPage.svelte
@@ -27,6 +27,8 @@
   import { hasLiveCanonMatch, type IngredientGroup, type Ingredient } from '@salt/domain';
   import { defaultListId } from '../../lib/shoppingListService.svelte.js';
   import { addToast } from '../../lib/toastStore.js';
+  import { auth } from '../../lib/auth.svelte.js';
+  import { createChatSession } from '../../lib/chatService.js';
   import AdminGuard from '../admin/AdminGuard.svelte';
 
   interface Props {
@@ -118,6 +120,23 @@
     addToListOpen = true;
   }
 
+  // ─── Ask / amend ────────────────────────────────────────────────────────────
+  let amendBusy = $state(false);
+
+  async function handleAskAmend(): Promise<void> {
+    if (!recipe) return;
+    const uid = auth.user?.uid;
+    if (!uid) return;
+    amendBusy = true;
+    const result = await createChatSession(uid, recipe.id);
+    amendBusy = false;
+    if (result.kind !== 'ok') {
+      addToast('Failed to open chat.', 'destructive');
+      return;
+    }
+    push(`/chat/${result.value.id}`);
+  }
+
   // ─── Delete ─────────────────────────────────────────────────────────────────
   let deleteOpen = $state(false);
   let deleteBusy = $state(false);
@@ -159,6 +178,17 @@
       class="p-4 sm:p-6"
     >
       {#snippet actions()}
+        <Button
+          size="sm"
+          variant="outline"
+          onclick={handleAskAmend}
+          loading={amendBusy}
+          disabled={amendBusy}
+          data-testid="recipe-ask-amend-button"
+        >
+          {#snippet leading()}<Icon name="ChefHat" size={16} />{/snippet}
+          Ask / amend
+        </Button>
         <Button
           size="sm"
           variant="outline"

--- a/docs/ai-kitchen-assistant.md
+++ b/docs/ai-kitchen-assistant.md
@@ -1,0 +1,132 @@
+# AI Kitchen Assistant
+
+The conversational AI feature: the **main point of the app**. It is one chat engine
+serving two purposes — a general kitchen assistant (open Q&A, recipe ideation) and a
+structured recipe author. This is the follow-on epic deferred from the recipe
+foundation (#179).
+
+## Design principles (load-bearing — do not violate)
+
+1. **The chef speaks in plain text.** Conversational turns have **no structured
+   output schema and no tools**. Structure is the librarian's job, applied only at
+   save time. Forcing structure or tool-use onto the chat is exactly what made the
+   earlier prototype feel constrained and produce sub-Gemini answers. Keep the chat
+   free.
+2. **Equipment is ambient context, never a tool.** The user's kit is small enough to
+   drop straight into the chef's system prompt ("here's the equipment available —
+   draw on it when it genuinely helps, ignore it otherwise"). No retrieval tool,
+   nothing the model feels obliged to call. The assistant must never be *bound* to
+   the user's equipment.
+3. **Pro-tier model for the chef.** Conversation quality is the whole point — use a
+   Pro-tier Gemini for the chef, not Flash. The librarian (structured extraction)
+   stays on Flash + `temperature: 0`, consistent with the other parse flows.
+4. **One agent, not three.** The user's "creative chef / kitchen engineer /
+   librarian" roles survive as *intentions*, not as a forced pipeline. The
+   "engineer" is just the user asking ("how do I make the most of my kit here?") —
+   the equipment context is already present, so the same agent answers. Only the
+   librarian is a genuinely separate (non-conversational) component.
+
+## Scope boundaries
+
+- "Contents of my kitchen" means **equipment + accessories only**. There is no
+  pantry/fridge inventory module and this feature does not add one.
+- A saved recipe **must canon-match** its ingredients (reuse the existing canon
+  pipeline). Adding to the shopping list or meal planner stays a **manual** action
+  (shopping-list add already exists).
+
+## Per-user data — a deliberate first
+
+Chats are the **first per-user-scoped data in Salt**. Everything else is
+family-shared with no `userId` anywhere; this is an intentional, recorded departure.
+
+- Chat documents carry `ownerUid` (= `request.auth.uid`).
+- New `firestore.rules` pattern: a caller may read/write a chat **only if they own
+  it** (`resource.data.ownerUid == request.auth.uid`, and on create
+  `request.resource.data.ownerUid == request.auth.uid`). This is the first
+  owner-scoped rule block; all prior blocks are "any authenticated member".
+- Retention ~2 weeks via an `expiresAt` timestamp + a **Firestore TTL policy**
+  (configured once per project via console/gcloud — infra, not rules). Each write
+  bumps `expiresAt` to now + 14 days.
+- **TTL setup (one-off, both projects):** In the Firebase console (or via
+  `gcloud firestore fields ttls update`), enable the TTL policy on the
+  `chatSessions` collection for the `expiresAt` field. This must be applied to
+  both the staging and production Firestore projects. The policy is infra, not
+  code — it does not live in `firestore.rules` or any deployed artefact.
+
+## Components
+
+```
+chat session doc (Firestore)         ← owned by web-pwa + firebase-sync (client writes)
+  └─ chef flow (CF, Genkit, streaming, plain text)   ← reads equipmentManifest, returns reply
+  └─ librarian flow (CF, Genkit, structured)         ← conversation → RecipeDoc draft
+        └─ reuses canonicaliseRecipeIngredients       ← canon-matches ingredients
+```
+
+### 1. Chat session (data + persistence)
+
+- Schema in `@salt/domain/schemas/chatSession.ts`, exported via the schemas index.
+- One doc per session at `chatSessions/{id}`:
+  `{ id, ownerUid, recipeId: string | null, title, messages: Message[],
+     createdAt, updatedAt, expiresAt }`.
+  `Message = { id, role: 'user' | 'assistant', text, createdAt }`.
+- `recipeId` set ⇒ the session is **attached to a recipe** (the "open chat alongside
+  a recipe" mode). `null` ⇒ general kitchen-assistant chat.
+- Messages are an **array in the session doc** (not a subcollection): simpler store,
+  TTL, and optimistic updates. A cooking chat will not approach the 1 MB doc ceiling;
+  note the bound. Per-token streaming is **not** persisted — the client holds the
+  partial assistant text in memory and writes the final message once on completion.
+- `firebase-sync` store (`chatSessionSubscription.ts` + writes) follows the
+  `recipeSubscription.ts` pattern exactly: `onSnapshot` + `safeParse` (skip+log
+  invalid on list, `Failure` on single-doc corruption), `ReadResult` envelopes.
+  Apply the **optimistic snapshot guard** (drop `onSnapshot` echoes older than the
+  newest local edit by `updatedAt`) — see existing optimistic stores.
+
+### 2. Chef flow (the conversation)
+
+- Genkit flow in `apps/cloud-functions/src/flows/chefChat.ts`, exposed via
+  `onCallGenkit` (gives streaming + `authPolicy: isSignedIn()` for free), region
+  `europe-west2`, `secrets: [geminiApiKey]`, App Check monitor-first
+  (`enforceAppCheck: false`, flip later with the rest).
+- **Streaming**: define the flow with a stream schema and emit chunks; the client
+  consumes via `httpsCallable(...).stream()`. This is the one piece of newer
+  plumbing — **validate it early and interactively** (WSL2 emulator quirks).
+- Input: `{ messages: Message[], newMessage: string }` (recent history window +
+  the new turn). The flow is **stateless** — it does not write chat docs.
+- The flow reads the **equipment manifest** doc server-side (admin SDK, like the
+  canon flows read the canon collection) and injects it into the system prompt as
+  ambient context. Client stays simple; equipment is always fresh.
+- Plain text out. **No `output` schema. No tools.** Wrap the generate call in
+  `withAiTimeout`.
+
+### 3. Librarian flow (conversation → recipe)
+
+- Genkit flow `apps/cloud-functions/src/flows/authorRecipe.ts`, structured output,
+  Flash + `temperature: 0`. Exposed via `onCallGenkit` (or `onCall` if it needs the
+  batch memory bump like `canonicaliseRecipeIngredients`).
+- Input: the conversation (or the portion the user points at). Output: a
+  `RecipeDoc`-shaped draft — title, description, metadata, ingredient groups
+  (`rawText`, `isOptional`), steps (with ids), and **step↔ingredient links emitted
+  directly** (the model names, per ingredient, the step it is first used in; the
+  server resolves ordinals to `firstUsedInStepId`). Do **not** post-compute this.
+- Canon: the draft's ingredients are run through the existing
+  `canonicaliseRecipeIngredients` path to fill `canonId` / `matchState`. The client
+  assembles the final `RecipeDoc` and persists with the existing `saveRecipe`.
+
+## Surfaces (web-pwa)
+
+- `/chat` — general kitchen-assistant chat (message list, streaming render).
+- Recipe-attached chat — opened alongside an existing recipe; same chat engine with
+  `recipeId` set; "apply changes" re-runs the librarian against the recipe.
+- "Save as recipe" action on a general chat → librarian → new recipe.
+
+## Constraints inherited from the architecture
+
+- All Gemini access via Genkit flows + callables in cloud-functions; **no AI keys in
+  the client**.
+- No new package and **no layer-map change** — schemas in `@salt/domain`, flows in
+  `cloud-functions`, adapter/store in `firebase-sync` + `web-pwa`, UI primitives via
+  `@salt/ui-components`.
+- Recipe schema is still greenfield (free to evolve); chat schema is brand-new
+  (no back-compat burden yet).
+</content>
+</invoke>

--- a/docs/salt-architecture.md
+++ b/docs/salt-architecture.md
@@ -1,390 +1,99 @@
-# Salt 2.0 — Architecture Contract v1.0
+# Salt 2.0 — Architecture Contract for AI Agents
 
-## 1. Purpose
+This file is the authoritative, machine-enforced architecture contract. Violating these rules will cause CI to fail. The full prose contract lives in [docs/salt-architecture.md](docs/salt-architecture.md).
 
-Salt 2.0 is a modular, enforceable architecture for a **Firestore-first PWA** with Firebase providing realtime data, persistent offline cache, and identity.
-The goal is to maintain strict separation between:
+## What this product is
 
-- UI (apps/web-pwa)
-- Domain logic (packages/domain)
-- Cloud sync / realtime / auth adapter (packages/adapters/firebase-sync)
-- Cloud Functions (apps/cloud-functions) — reserved for server‑side gen‑AI workloads
+Salt is a context-aware AI kitchen assistant. Users define their kitchen
+profile — the specialised equipment they own — and Salt uses that context
+to generate and adapt recipes optimised for their specific setup. It
+automates shopping list creation from recipes and supports weekly meal
+planning. It does not track in-stock groceries; the boundary is at the
+shopping list, not the pantry.
 
-The architecture must remain framework‑agnostic, testable, and resilient to change, while supporting:
+The core data flow is: kitchen profile → recipe generation/adaptation →
+meal plan → shopping list. Firestore is the live data layer throughout.
+The AI layer (Genkit) produces recipe and plan outputs that enter the
+domain at a trust boundary and are validated there before storage.
 
-- **Firestore as the source of truth.** `onSnapshot` listeners feed in-memory Svelte stores; all reads come from the stores, not from ad-hoc queries.
-- **Persistent offline cache.** Firestore's `persistentLocalCache()` replaces any manual IndexedDB layer — offline reads come from Firestore's own cache; offline writes are queued automatically and drained on reconnect.
-- **Last-write-wins per document.** No bespoke conflict resolution. If a specific document ever needs stronger guarantees, that is a per-document decision.
-- **Single-family workspace.** All authenticated members see all data; admin actions are gated per user.
+## How to work in this codebase
 
-### 1.1 Schema evolution and production data
+- If you're working from a GitHub issue, confirm your understanding of
+  the scope in one short paragraph before writing any code.
+- For open-ended tasks (bug fixes, UI tweaks, small changes), briefly
+  state what you're about to do and why before doing it.
+- If you discover something outside your current task that looks wrong,
+  flag it — do not fix it silently.
+- If you hit an ambiguity you can't resolve from context, stop and ask.
+  Do not make an assumption and proceed.
+- Pre-commit hooks enforce lint, typecheck, and boundary tests. If a
+  commit is rejected, fix the failure before doing anything else. Do not
+  use --no-verify under any circumstances.
+- For issue-based work, post a summary of what you built to the GitHub
+  issue before ending the session, including any deviations and why.
+- Do not refactor, improve, or tidy anything outside your current task,
+  even if it looks wrong. Flag it instead.
+- Do not resolve architecture questions by picking the simpler path. 
+- If something touches the layer map or hard rules in this file, stop and ask.
 
-Until the first production deploy, Salt is **greenfield** — no real data exists, so schema‑shape changes are free (drop a field, rename a collection, change a type) and **no migrations or back‑compat shims are written**.
-
-**That posture ends at launch.** Once production holds real family data, every schema‑shape change must account for documents already written: either keep the new shape backward‑compatible (tolerate old docs on read) or run an explicit one‑off migration. "Just change the shape" is no longer safe for production. Last‑write‑wins per document and the no‑tombstones / no‑soft‑delete rules are unchanged — this adds one standing gate: *does this change break existing production documents?*
-
----
-
-## 2. Mono‑repo structure (logical modules)
+## Layer map
 
 ```
-/apps
-  web-pwa                         # PWA front-end (UI only)
-  cloud-functions                 # Gen-AI workloads (embedText, arbitrateCanon)
-
-/packages
-  domain                          # Pure business logic, entities, validation, ports
-  shared-types                    # Cross-cutting types/interfaces only
-  ui-components                   # Shared UI primitives
-  testing-utils                   # Shared test helpers
-  adapters/
-    firebase-sync                 # Firebase Auth + Firestore implementation
-                                  # of realtime subscriptions, direct writes, and auth ports
-    ld-observability              # LaunchDarkly Observability SDK implementation
-                                  # of error reporting and match logging ports
+shared-types               →  (nothing)
+domain                     →  shared-types
+firebase-sync              →  domain, shared-types          # Firebase SDKs only; Firestore is the live data layer
+ld-observability           →  domain, shared-types          # LaunchDarkly browser SDK; default subpath
+ld-observability/server    →  domain, shared-types          # Ships CF spans to LD's OTLP endpoint; exposes a span-processor registration hook for CF-local concerns
+ui-components              →  (external only — shadcn/tailwind)
+testing-utils              →  shared-types, domain, firebase-sync, ld-observability
+web-pwa                    →  shared-types, domain, firebase-sync, ld-observability, ui-components
+cloud-functions            →  shared-types, domain, ld-observability/server
 ```
 
-`firebase-sync` and `ld-observability` are **siblings** — they do not depend on each other; both are wired together by the UI/composition layer.
-
----
-
-## 3. Dependency graph (allowed imports)
-
-### Allowed
-
-- web-pwa → domain, shared-types, ui-components, firebase-sync, ld-observability
-- cloud-functions → domain, shared-types, ld-observability/server
-- firebase-sync → domain, shared-types
-- ld-observability → domain, shared-types
-- domain → shared-types
-- shared-types → (no dependencies)
-
-### Forbidden
-
-- UI → Cloud Functions
-- UI → Firebase SDK directly
-- UI → IndexedDB / browser storage directly (narrow exception below)
-- UI → LaunchDarkly SDK directly
-- Domain → Firebase SDK / IndexedDB / Node / browser APIs
-- Domain → UI
-- Cloud Functions → UI
-- Cloud Functions → ld-observability (the default subpath wraps the browser-only LaunchDarkly SDK and cannot run in Node; use `ld-observability/server` instead)
-- Cloud Functions → firebase-sync (CF talks to Firestore directly via `firebase-admin`; `firebase-sync` wraps the browser SDK and is not for server-side use)
-- firebase-sync ↔ ld-observability (adapters must not import each other)
-- Any module → apps/web-pwa or apps/cloud-functions
-
-These rules must be enforced via ESLint, tsconfig project references, and commit gateway checks.
-
-#### Narrow exception: pre-authentication ephemeral state in `web-pwa`
-
-`apps/web-pwa` may use `window.localStorage` for pre-authentication ephemeral state that has no Firestore-backed alternative. The only sanctioned use today is the magic-link **pending email** in `apps/web-pwa/src/lib/auth.svelte.ts`: it must persist before any user is signed in (so `persistentLocalCache` cannot apply — there is no authenticated session to write to Firestore), and email clients open the magic link in a fresh tab/window, so `sessionStorage` would be lost. The exception is:
-
-- **Scoped to `apps/web-pwa` only.** It does **not** extend to any adapter (`firebase-sync`, `ld-observability`), `domain`, or `cloud-functions`.
-- **Limited to pre-auth ephemeral state.** It is not a general license to use browser storage for app data — all post-sign-in data still flows through Firestore's `persistentLocalCache`.
-- **Tolerant of failure.** Writes are wrapped so that a missing/blocked `localStorage` degrades gracefully (the magic link re-prompts for the email on return).
-
----
-
-## 4. Domain layer requirements
-
-The domain layer is pure TypeScript:
-
-- No Firebase imports
-- No browser APIs (including IndexedDB)
-- No Node APIs
-- No side effects
-- No I/O
-- No global state
-
-The domain exposes:
-
-- Entities and value objects for:
-  - Recipes (single-document model)
-  - Canon items (name, synonyms, aisle, optional embedding, thumbnail icon)
-  - Shopping lists (items, checked state, canon links)
-  - Members (email-keyed allowlist membership records, admin role, email normalisation)
-  - Meal plan (MealPlanConfig, MealPlanTemplate, MealPlanWeek, Day, Attendee, Weekday — weekly evening-meal planner with a weekday-keyed template and per-day guest count)
-- Commands (write operations)
-- Queries (read operations)
-- Validation rules and Zod schemas (via `@salt/domain/schemas` subpath) — covers all Firestore document shapes, callable CF inputs, and AI flow output types; TypeScript types are derived via `z.infer`
-- Ports (interfaces) for:
-  - `CanonLocalStorePort` / `AisleLocalStorePort` — in-memory store contracts used by domain commands; satisfied by the in-memory adapters in `web-pwa`
-  - `AuthProvider` — identity and workspace membership
-  - `EmbeddingPort` / `CanonArbitrationPort` / `MatchLoggingPort` — AI and observability ports used by `matchOrCreate`
-  - `EntryParsePort` — AI-fallback port for structured shopping-list entry parsing; implemented by the server-side Genkit adapter in `cloud-functions` and consumed by `onShoppingListItemWrite`
-
-The domain is the single source of truth for business logic, data shapes, and validation semantics.
-
----
-
-## 5. Workspace and access model
-
-Salt 2.0 is built for a **single shared family workspace**:
-
-- All authenticated members see all recipes, canon, shopping lists, and meal plan data.
-- There is no per‑recipe ACL; there are no private collections.
-- **Admin functions** (e.g. inviting members, managing canon at scale, destructive bulk operations) are gated by a per‑user `role` field on the workspace membership record.
-- Role checks are domain logic, not adapter logic. Adapters surface the role; domain decides what's allowed.
-- Security rules in the cloud backend mirror the domain rule: any workspace member can read/write workspace data; admin‑only mutations check role.
-
-This model is intentionally narrow. Multi‑workspace, sharing, or per‑document permissions are explicitly **out of scope** until a real requirement appears.
-
----
-
-## 6. Adapter requirements
-
-### 6.1 firebase-sync adapter
-
-- Implements realtime subscriptions and direct writes using Firestore `onSnapshot` and `setDoc`.
-- Implements `AuthProvider` using Firebase Auth.
-- Initialises Firestore with `persistentLocalCache()` in production (disabled in emulator tests to avoid stale cache).
-- Initialises Firebase App Check (reCAPTCHA Enterprise, `isTokenAutoRefreshEnabled: true`) when an optional `AppCheckConfig` is provided and emulators are not in use. Must initialise before any other Firebase service so tokens are attached to requests. The exported `AppCheckConfig` interface carries a public `siteKey` and an optional `debugToken` for unattested environments (local dev / CI hitting a real backend); the debug token must never be baked into a deployed bundle.
-- Exposes the following as its primary data API:
-  - Canon: `subscribeCanonItems`, `subscribeAisles`, `upsertCanonItem`, `deleteCanonItem`, `saveAisles`
-  - Shopping lists: `subscribeShoppingLists`, `listShoppingLists`, `createShoppingList`, `renameShoppingList`, `deleteShoppingList`
-  - Shopping list items: `subscribeShoppingListItems`, `listShoppingListItems`, `saveShoppingListItem`, `deleteShoppingListItem`, `deleteShoppingListItems`, `moveShoppingListItems`
-  - Shopping list config: `subscribeShoppingListsConfig`, `loadShoppingListsConfig`, `saveShoppingListsConfig`
-  - Members: `subscribeMembers`, `upsertMember`, `deleteMember`
-  - Meal plan: `subscribeMealPlanConfig`, `subscribeMealPlanTemplate`, `subscribeMealPlanWeek`, `saveMealPlanConfig`, `saveMealPlanTemplate`, `saveMealPlanWeek`
-  - Recipes: `subscribeRecipes`, `loadRecipe`, `saveRecipe`, `deleteRecipe`
-- Validates all Firestore document reads using Zod schemas from `@salt/domain/schemas`; collection and subscription reads skip invalid documents (log the error, return the valid subset); single-document reads return `Failure<StorageError>` on parse failure.
-- Must not import IndexedDB or any local‑storage code.
-- Must not contain UI logic.
-- Must not contain domain logic — including conflict resolution.
-- Must not leak Firebase types across the boundary.
-
-### 6.2 ld-observability adapter
-
-Ships two subpath entrypoints from a single package:
-
-**Default subpath (`@salt/ld-observability`)** — browser-only, bundled into `web-pwa`:
-- Implements `ErrorReportingPort` and `MatchLoggingPort` using the LaunchDarkly browser SDK.
-- Normalizes errors into `DomainError` categories before crossing the boundary.
-- Must not be imported by Cloud Functions.
-
-**Server subpath (`@salt/ld-observability/server`)** — Node-only, bundled into `cloud-functions`:
-- Initialises an OTel `NodeTracerProvider` that ships CF spans to LaunchDarkly's OTLP endpoint.
-- Implements `MatchLoggingPort` for the CF side via `createServerLDMatchLoggingAdapter`.
-- Exposes `addServerSpanProcessor` so CF-local concerns (e.g. Genkit dev-trace routing) can register additional span processors without touching the adapter internals.
-- Exposes `setActiveSpanName(name)` to rename the currently-active OTel span from inside a Genkit flow body, appending a human-readable entity descriptor (e.g. the item name) so traces are scannable in the LaunchDarkly trace list. No-op when observability is uninitialised or no span is active; length-capped at 80 characters.
-- `firebase-functions/logger` is used additively for top-level summary logs to Cloud Logging.
-
-Both subpaths share a runtime-neutral schema mapper (`src/shared/`) so the `canon.match` wire schema cannot drift between fast-path and CF emissions.
-
-Common rules for both subpaths:
-- May import the LaunchDarkly SDK; nothing else in the codebase may.
-- Must not import Firebase, IndexedDB, browser storage, UI, or other adapters.
-- Must not contain domain logic or business rules.
-
-### 6.3 Common rules
-
-- All adapters convert their backend's responses into domain entities or error types.
-- All adapters use `shared-types` for DTOs and result types.
-- Adapters must not import each other; all are composed at the application layer.
-- `firebase-sync` is the **only** module permitted to import Firebase SDKs.
-- `ld-observability` is the **only** module permitted to import the LaunchDarkly Observability SDK.
-- IndexedDB, `idb`, `idb-keyval` are **forbidden** everywhere. Offline persistence is provided by Firestore's `persistentLocalCache`.
-
----
-
-## 7. Adapter Error Contract
-
-Adapters must never leak Firebase, browser, or network‑layer errors across the boundary.
-All failures must be normalised into **domain‑level error types** defined in shared‑types.
-
-### 7.1 Error Shape
-
-All adapter functions return either:
-
-- `Success<T>`
-- `Failure<DomainError>`
-- `Conflict<T>` (for concurrent-write detection if needed in future)
-
-Adapters must not throw for expected operational failures.
-
-### 7.2 DomainError Categories
-
-DomainError is a closed set of error categories:
-
-- `AuthError` — unauthenticated, forbidden, expired session
-- `NotFound` — recipe, canon item, shopping list, workspace
-- `NetworkError` — offline, unreachable, transient network failure
-- `StorageError` — storage unavailable, quota exceeded, corruption detected
-- `SyncError` — failed write, invalid data
-- `ConflictError` — concurrent write detected
-- `ValidationError` — invalid input according to domain rules
-
-No Firebase error codes may cross the boundary.
-
-### 7.3 Loading States
-
-`isLoadingAisles` (exported from `canonService.ts`) is the single loading signal for the app — it starts `true` on `initCanonSync()` and clears once both the canon items and aisles `onSnapshot` callbacks have fired for the first time.
-
-### 7.4 Offline Behaviour
-
-- Reads come from Firestore's `persistentLocalCache` — no separate local store needed.
-- Writes are queued by Firestore automatically when offline and drained on reconnect.
-- No manual drain queue or manifest revision counter.
-
-### 7.5 Error Propagation Rules
-
-- Adapters **never throw** for operational errors.
-- Adapters **may throw** only for programmer errors (violated preconditions).
-- UI must handle all `Failure` states explicitly.
-
-### 7.6 Logging and Error Reporting
-
-- Adapters may log internal errors for diagnostics via the `ErrorReportingPort`.
-- All error reporting is mediated through `ErrorReportingPort`.
-- **Cloud Functions** log via `firebase-functions/logger` with structured JSON shaped to match the `DomainError` taxonomy (`{ scope, docId, errorCategory }`).
-
----
-
-## 8. Cloud Functions requirements
-
-Cloud Functions cover two categories of server-side work:
-
-1. **Gen-AI callables** (`embedText`, `arbitrateCanon`, `matchOrCreateCanon`, `canonicaliseRecipeIngredients`, `parseRecipeIngredients`, `identifyEquipment`, `populateEquipmentEntry`, `regenerateCanonIcon`) — HTTPS callables invoked by the client. All carry `enforceAppCheck: false` (monitor-first rollout — unverified requests are allowed but reported to App Check metrics; flip the shared `APP_CHECK_ENFORCEMENT` constant in `index.ts` to `{ enforceAppCheck: true }` once staging metrics confirm legitimate traffic passes attestation).
-2. **Firestore write triggers** (`onShoppingListItemWrite`, `onCanonItemWritten`) — respond to document writes and run domain logic server-side, writing results back to Firestore.
-3. **Identity Platform blocking functions** (`beforeMemberCreated`) — reject account creation for any email not on the member allowlist; requires Identity Platform to be enabled on the target project.
-
-Both categories are intentionally minimal.
-
-Cloud Functions:
-
-- Import domain + ld-observability/server (never the default `ld-observability` subpath, which wraps the browser-only SDK and cannot run in Node)
-- Talk to Firestore directly via `firebase-admin` — do not import `@salt/firebase-sync`, which wraps the browser SDK
-- Never import UI
-- Never contain business logic
-- Only orchestrate: input validation (via Zod schemas from `@salt/domain/schemas`; callable entry points throw `HttpsError('invalid-argument')` on parse failure), domain commands/queries, gen‑AI providers, and returning results
-- Must be stateless
-- Callables must be testable without Firebase emulators (via domain mocks); triggers use the Firestore emulator for write-back integration tests
-
----
-
-## 9. PWA (UI) requirements
-
-The PWA:
-
-- Imports domain, firebase-sync, ld-observability, ui-components, shared-types
-- Never imports Firebase SDK, IndexedDB, or LaunchDarkly SDK directly
-- Never contains business logic (including conflict resolution policy)
-- Uses domain commands/queries as its API
-- Wires `AuthProvider`, `ErrorReportingPort`, `MatchLoggingPort`, `EmbeddingPort`, and `CanonArbitrationPort` at composition time
-- Starts `initCanonSync()` and `initMealPlanSync()` from `App.svelte` when the user authenticates — subscriptions begin once at auth time, not on individual page mounts
-- In-memory Svelte stores (`canonItems`, `aisles`, `aisleUsage`) are the UI's read layer; `upsertCanonItem` and `saveAisles` are the write path
-- **Recipes** (`/recipes`, `/recipes/new`, `/recipes/:id/edit`, `/recipes/:id`): family-shared recipe store. All authenticated members can create, view, edit, and delete recipes. `recipeService` drives the pages; `subscribeRecipes` / `loadRecipe` / `saveRecipe` / `deleteRecipe` are the firebase-sync data operations. Ingredient parsing and canonicalisation are on-demand: the editor surfaces a per-row **Match** button and a batch **Canonicalise** button that call `parseRecipeIngredients` and `canonicaliseRecipeIngredients` respectively. `addRecipeToShoppingList` in `recipeService` evaluates each ingredient's live match via `hasLiveCanonMatch` so dangling canon references are added as raw text rather than carrying stale `canonId`s.
-- **Meal plan** (`/mealplan`): the weekly evening-meal planner, accessible to all members. Shows a seven-day week with prev/next/this-week navigation and a Load-template button. `mealPlanService` drives the page; subscriptions are started at auth time via `initMealPlanSync()`.
-- **Admin operator area** (`/admin` route group): `AdminGuard` redirects non-admins; the Members CRUD screen (`/admin/members`) lets admins add, edit, and remove allowlist members; `membersService` exposes a sorted roster store backed by `subscribeMembers`. Canon management (`/admin/canon`, `/admin/canon/new`, `/admin/canon/aisles`, `/admin/canon/:id`) is also gated here — canon stewardship is an operator function, not an everyday user activity, so the list, create, detail, and aisle management pages all sit under `AdminGuard`. The `needs_approval` count badge is surfaced on the Admin nav entry so operators can see the review queue from anywhere in the app. Meal plan template administration (`/admin/mealplan`) lets operators edit the standard weekday-keyed template and the `firstDayOfWeek` setting; gated by `AdminGuard` (cosmetic — Firestore rules allow any authenticated member to write meal plan documents). Client-side gating is cosmetic — real enforcement is in Firestore rules and the `beforeMemberCreated` blocking function.
-- Offline data is provided by Firestore's `persistentLocalCache`. The service worker never caches Firestore traffic or any app data.
-- **PWA installability (Tier-1):** A Workbox-generated service worker (`vite-plugin-pwa`, `generateSW` strategy) precaches the built app shell and static assets only. The service worker is the sole consumer of the Cache API; no other module may touch `caches` directly (CLAUDE.md hard rule #3). The SW is disabled in dev (no interference with HMR). Manifest identity is env-distinct: `VITE_PWA_NAME`, `VITE_PWA_SHORT_NAME`, and `VITE_PWA_THEME_COLOR` are read at build time from `.env.<mode>` so staging and production install as distinct apps. The auto-update flow (owned by `src/lib/pwa.ts`) defers page reloads to safe moments (hash route change or tab refocus) and never reloads mid-interaction.
-
----
-
-## 10. Shared types requirements
-
-shared-types contains:
-
-- DTOs
-- API request/response shapes
-- Cross-module enums
-- DomainError categories and result types (`Success` / `Failure` / `Conflict`)
-- Nothing with logic
-- Nothing that depends on Firebase, IndexedDB, or browser APIs
-
-This module must remain extremely small and stable.
-
----
-
-## 11. Enforcement rules
-
-### ESLint
-
-- Enforce allowed import graph (boundaries plugin)
-- Forbid Firebase imports outside firebase-sync
-- Forbid IndexedDB / browser storage imports everywhere
-- Forbid LaunchDarkly Observability SDK imports outside ld-observability
-- Forbid the default `ld-observability` subpath imports in cloud-functions (browser-only); `ld-observability/server` is allowed
-- Forbid firebase-sync ↔ ld-observability imports (sibling adapters must not import each other)
-- Forbid domain importing anything except shared-types
-- Forbid UI importing Cloud Functions
-- Forbid circular dependencies
-- Enforce strict TypeScript rules
-
-### tsconfig
-
-- Use project references to enforce module boundaries
-- Each module has its own tsconfig
-- Root tsconfig defines the dependency graph
-
-### Commit gateway
-
-Every commit must:
-
-- Pass linting
-- Pass type checks
-- Pass dependency graph checks
-- Pass unit tests
-- Pass formatting
-- Reject any Firebase import outside firebase-sync
-- Reject any IndexedDB import anywhere
-- Reject any LaunchDarkly SDK import outside ld-observability
-- Reject any UI → backend leakage
-- Reject any domain impurity (Node/browser/Firebase imports)
-
----
-
-## 12. Testing strategy
-
-### Domain
-
-- 100% unit testable without Firebase or IndexedDB
-- Pure logic tests, including validation
-
-### firebase-sync
-
-- Unit tests with mocks
-- Integration tests against the Firebase emulator (Firestore only; persistent cache disabled in emulator tests)
-
-### ld-observability
-
-- Unit tests with mocked LaunchDarkly SDK
-- Tests that error normalization preserves error context
-
-### Cloud Functions
-
-- Unit tests with mocked adapters
-- Integration tests with emulator
-
-### UI
-
-- Component tests
-- Integration tests (with all adapters wired to fakes)
-- E2E tests (Playwright against Firebase emulator)
-
----
-
-## 13. Deployment units
-
-- web-pwa → deployed as PWA
-- cloud-functions → deployed to Firebase Functions
-- firebase-sync → bundled into UI only (browser SDK; not imported by Cloud Functions)
-- ld-observability (default subpath) → bundled into UI only (browser-only SDK)
-- ld-observability/server → bundled into cloud-functions (Node SDK, OTLP exporter)
-- domain → bundled into UI and Cloud Functions
-- shared-types → type-only package
-
----
-
-## 14. Non-negotiables
-
-- No Firebase SDK in UI
-- No IndexedDB / browser storage anywhere — use Firestore's persistent cache (one narrow exception: pre-auth ephemeral state in `web-pwa`, see §3)
-- No LaunchDarkly SDK in UI or other adapters (only in ld-observability)
-- No business logic outside domain (including conflict resolution)
-- No cross-module imports outside the allowed graph
-- No global state
-- No leaking Firebase / LaunchDarkly types across boundaries
-- No circular dependencies
-- No untyped data flow
-- No per‑document ACLs or multi‑workspace logic until explicitly requested
+`firebase-sync` and `ld-observability` are **siblings** — they must not import each other. `@salt/ld-observability` ships two subpath entrypoints from a single package: the default subpath wraps the LaunchDarkly browser SDK and is for `web-pwa`; `@salt/ld-observability/server` wraps the LaunchDarkly Node SDK and is for `cloud-functions`. The two subpaths share a runtime-neutral schema mapper (`src/shared/`) so the `canon.match` wire schema cannot drift between fast-path and CF emissions. Cross-runtime imports are forbidden: `web-pwa` must not import `/server`, and `cloud-functions` must not import the default subpath.
+
+## Hard rules
+
+1. **Domain is pure.** `packages/domain` must not import Firebase, Node.js built-ins, browser APIs, or any I/O. No side effects. Pure functions and types only. Conflict resolution policy lives here.
+2. **Firebase SDK only in `firebase-sync`.** The only place `firebase` or `firebase-admin` may be imported is `packages/adapters/firebase-sync`.
+3. **No IndexedDB / browser storage.** No package may import `idb`, `idb-keyval`, or touch `window.indexedDB` / `localStorage` / `sessionStorage` / `caches` directly. Offline reads and writes are handled by Firestore's `persistentLocalCache`. **Narrow exception:** `apps/web-pwa` may use `window.localStorage` for pre-authentication ephemeral state that has no Firestore-backed alternative — specifically the magic-link pending email in `apps/web-pwa/src/lib/auth.svelte.ts`, which must persist before any user is signed in (email clients open the link in a fresh tab/window, so `sessionStorage` is unavailable). This exception is scoped to `apps/web-pwa` only and explicitly excludes all adapters; everything else stays forbidden.
+4. **Adapters do not import each other.** `firebase-sync` ↔ `ld-observability` is forbidden in both directions.
+5. **Cloud Functions do not import the default `@salt/ld-observability` subpath.** That subpath wraps the browser-only LaunchDarkly SDK and cannot run in Node. Server-side observability uses `@salt/ld-observability/server` (LaunchDarkly Node SDK). `firebase-functions/logger` continues to be used additively for CF-side match logs.
+6. **No importing apps.** Nothing may import `@salt/web-pwa` or `@salt/cloud-functions`.
+7. **UI primitives go through `@salt/ui-components`.** `apps/web-pwa` must never import `shadcn-svelte`, `bits-ui`, or `melt-ui` directly — always through `@salt/ui-components`.
+8. **No circular dependencies.** Enforced by dependency-cruiser.
+9. **`shared-types` imports nothing from `@salt/*`.** It may only depend on external packages or nothing.
+10. **Adapters never throw for operational errors.** All failures cross the boundary as `Failure<DomainError>` or `Conflict<T>` (see [docs/salt-architecture.md §7](docs/salt-architecture.md)).
+
+## Zod schema conventions
+
+- **Schemas live in `@salt/domain/schemas`.** All zod schemas are defined under `packages/domain/src/schemas/` and exported via the `@salt/domain/schemas` subpath. Do not define schemas in adapters, apps, or `@salt/shared-types`.
+- **Schema-first.** Define the zod schema first; derive the TypeScript type with `type Foo = z.infer<typeof FooSchema>`. Never maintain a hand-written type alongside a schema for the same shape.
+- **Validate at trust boundaries only.** Add `.parse()` or `.safeParse()` at: AI/Genkit flow outputs, Firestore document reads (in `firebase-sync`), callable CF inputs, and "type laundering" sites (`as` casts, `unknown` narrowings, `JSON.parse`, string → structured parsers). Do **not** add validation to internal domain → domain calls, adapter internals, or any code the TypeScript compiler already proves correct.
+- **Handle validation failures per boundary type.** Always use `.safeParse()`, then:
+  - **Adapter single-document reads** (e.g. `load(id)`) → return `Failure<DomainError>` (`{ kind: 'StorageError', reason: 'corruption' }`); do not throw across internal layer seams.
+  - **Adapter list reads & realtime subscriptions** → skip the invalid doc, log it, and return the valid subset; one corrupt doc must not fail the whole read. Stream-level errors still surface via `onError`.
+  - **Callable CF entrypoints** → `throw new HttpsError('invalid-argument', …)`; this is the Firebase callable protocol for rejecting bad client input, not an internal seam.
+  - **Firestore triggers** → log and return; there is no caller to surface a `Failure` to.
+- **Production schema changes need a back-compat check.** Pre-launch (greenfield) schema-shape changes are free. Once production holds real data, a schema-shape change must not break documents already written — keep it backward-compatible on read or run a one-off migration. See [docs/salt-architecture.md §1.1](docs/salt-architecture.md).
+
+## Enforcement
+
+- `pnpm lint` — ESLint with `eslint-plugin-boundaries` checks the import graph.
+- `pnpm typecheck` — TypeScript project references prevent out-of-graph imports at compile time.
+- `pnpm boundary:test` — Runs `.boundary-tests/run.sh` which lints deliberate violation fixtures and asserts each produces an error.
+- Pre-commit (Phase 3): Husky + lint-staged blocks bad commits locally.
+- CI (Phase 7): GitHub Actions blocks bad PRs before merge.
+
+## Package names
+
+| Path                                 | Package name              |
+|--------------------------------------|---------------------------|
+| `packages/shared-types`              | `@salt/shared-types`      |
+| `packages/domain`                    | `@salt/domain`            |
+| `packages/adapters/firebase-sync`    | `@salt/firebase-sync`     |
+| `packages/adapters/ld-observability` | `@salt/ld-observability`  |
+| `packages/ui-components`             | `@salt/ui-components`     |
+| `packages/testing-utils`             | `@salt/testing-utils`     |
+| `apps/web-pwa`                       | `@salt/web-pwa`           |
+| `apps/cloud-functions`               | `@salt/cloud-functions`   |

--- a/docs/salt-architecture.md
+++ b/docs/salt-architecture.md
@@ -1,99 +1,390 @@
-# Salt 2.0 — Architecture Contract for AI Agents
+# Salt 2.0 — Architecture Contract v1.0
 
-This file is the authoritative, machine-enforced architecture contract. Violating these rules will cause CI to fail. The full prose contract lives in [docs/salt-architecture.md](docs/salt-architecture.md).
+## 1. Purpose
 
-## What this product is
+Salt 2.0 is a modular, enforceable architecture for a **Firestore-first PWA** with Firebase providing realtime data, persistent offline cache, and identity.
+The goal is to maintain strict separation between:
 
-Salt is a context-aware AI kitchen assistant. Users define their kitchen
-profile — the specialised equipment they own — and Salt uses that context
-to generate and adapt recipes optimised for their specific setup. It
-automates shopping list creation from recipes and supports weekly meal
-planning. It does not track in-stock groceries; the boundary is at the
-shopping list, not the pantry.
+- UI (apps/web-pwa)
+- Domain logic (packages/domain)
+- Cloud sync / realtime / auth adapter (packages/adapters/firebase-sync)
+- Cloud Functions (apps/cloud-functions) — reserved for server‑side gen‑AI workloads
 
-The core data flow is: kitchen profile → recipe generation/adaptation →
-meal plan → shopping list. Firestore is the live data layer throughout.
-The AI layer (Genkit) produces recipe and plan outputs that enter the
-domain at a trust boundary and are validated there before storage.
+The architecture must remain framework‑agnostic, testable, and resilient to change, while supporting:
 
-## How to work in this codebase
+- **Firestore as the source of truth.** `onSnapshot` listeners feed in-memory Svelte stores; all reads come from the stores, not from ad-hoc queries.
+- **Persistent offline cache.** Firestore's `persistentLocalCache()` replaces any manual IndexedDB layer — offline reads come from Firestore's own cache; offline writes are queued automatically and drained on reconnect.
+- **Last-write-wins per document.** No bespoke conflict resolution. If a specific document ever needs stronger guarantees, that is a per-document decision.
+- **Single-family workspace.** All authenticated members see all data; admin actions are gated per user.
 
-- If you're working from a GitHub issue, confirm your understanding of
-  the scope in one short paragraph before writing any code.
-- For open-ended tasks (bug fixes, UI tweaks, small changes), briefly
-  state what you're about to do and why before doing it.
-- If you discover something outside your current task that looks wrong,
-  flag it — do not fix it silently.
-- If you hit an ambiguity you can't resolve from context, stop and ask.
-  Do not make an assumption and proceed.
-- Pre-commit hooks enforce lint, typecheck, and boundary tests. If a
-  commit is rejected, fix the failure before doing anything else. Do not
-  use --no-verify under any circumstances.
-- For issue-based work, post a summary of what you built to the GitHub
-  issue before ending the session, including any deviations and why.
-- Do not refactor, improve, or tidy anything outside your current task,
-  even if it looks wrong. Flag it instead.
-- Do not resolve architecture questions by picking the simpler path. 
-- If something touches the layer map or hard rules in this file, stop and ask.
+### 1.1 Schema evolution and production data
 
-## Layer map
+Until the first production deploy, Salt is **greenfield** — no real data exists, so schema‑shape changes are free (drop a field, rename a collection, change a type) and **no migrations or back‑compat shims are written**.
+
+**That posture ends at launch.** Once production holds real family data, every schema‑shape change must account for documents already written: either keep the new shape backward‑compatible (tolerate old docs on read) or run an explicit one‑off migration. "Just change the shape" is no longer safe for production. Last‑write‑wins per document and the no‑tombstones / no‑soft‑delete rules are unchanged — this adds one standing gate: *does this change break existing production documents?*
+
+---
+
+## 2. Mono‑repo structure (logical modules)
 
 ```
-shared-types               →  (nothing)
-domain                     →  shared-types
-firebase-sync              →  domain, shared-types          # Firebase SDKs only; Firestore is the live data layer
-ld-observability           →  domain, shared-types          # LaunchDarkly browser SDK; default subpath
-ld-observability/server    →  domain, shared-types          # Ships CF spans to LD's OTLP endpoint; exposes a span-processor registration hook for CF-local concerns
-ui-components              →  (external only — shadcn/tailwind)
-testing-utils              →  shared-types, domain, firebase-sync, ld-observability
-web-pwa                    →  shared-types, domain, firebase-sync, ld-observability, ui-components
-cloud-functions            →  shared-types, domain, ld-observability/server
+/apps
+  web-pwa                         # PWA front-end (UI only)
+  cloud-functions                 # Gen-AI workloads (embedText, arbitrateCanon)
+
+/packages
+  domain                          # Pure business logic, entities, validation, ports
+  shared-types                    # Cross-cutting types/interfaces only
+  ui-components                   # Shared UI primitives
+  testing-utils                   # Shared test helpers
+  adapters/
+    firebase-sync                 # Firebase Auth + Firestore implementation
+                                  # of realtime subscriptions, direct writes, and auth ports
+    ld-observability              # LaunchDarkly Observability SDK implementation
+                                  # of error reporting and match logging ports
 ```
 
-`firebase-sync` and `ld-observability` are **siblings** — they must not import each other. `@salt/ld-observability` ships two subpath entrypoints from a single package: the default subpath wraps the LaunchDarkly browser SDK and is for `web-pwa`; `@salt/ld-observability/server` wraps the LaunchDarkly Node SDK and is for `cloud-functions`. The two subpaths share a runtime-neutral schema mapper (`src/shared/`) so the `canon.match` wire schema cannot drift between fast-path and CF emissions. Cross-runtime imports are forbidden: `web-pwa` must not import `/server`, and `cloud-functions` must not import the default subpath.
+`firebase-sync` and `ld-observability` are **siblings** — they do not depend on each other; both are wired together by the UI/composition layer.
 
-## Hard rules
+---
 
-1. **Domain is pure.** `packages/domain` must not import Firebase, Node.js built-ins, browser APIs, or any I/O. No side effects. Pure functions and types only. Conflict resolution policy lives here.
-2. **Firebase SDK only in `firebase-sync`.** The only place `firebase` or `firebase-admin` may be imported is `packages/adapters/firebase-sync`.
-3. **No IndexedDB / browser storage.** No package may import `idb`, `idb-keyval`, or touch `window.indexedDB` / `localStorage` / `sessionStorage` / `caches` directly. Offline reads and writes are handled by Firestore's `persistentLocalCache`. **Narrow exception:** `apps/web-pwa` may use `window.localStorage` for pre-authentication ephemeral state that has no Firestore-backed alternative — specifically the magic-link pending email in `apps/web-pwa/src/lib/auth.svelte.ts`, which must persist before any user is signed in (email clients open the link in a fresh tab/window, so `sessionStorage` is unavailable). This exception is scoped to `apps/web-pwa` only and explicitly excludes all adapters; everything else stays forbidden.
-4. **Adapters do not import each other.** `firebase-sync` ↔ `ld-observability` is forbidden in both directions.
-5. **Cloud Functions do not import the default `@salt/ld-observability` subpath.** That subpath wraps the browser-only LaunchDarkly SDK and cannot run in Node. Server-side observability uses `@salt/ld-observability/server` (LaunchDarkly Node SDK). `firebase-functions/logger` continues to be used additively for CF-side match logs.
-6. **No importing apps.** Nothing may import `@salt/web-pwa` or `@salt/cloud-functions`.
-7. **UI primitives go through `@salt/ui-components`.** `apps/web-pwa` must never import `shadcn-svelte`, `bits-ui`, or `melt-ui` directly — always through `@salt/ui-components`.
-8. **No circular dependencies.** Enforced by dependency-cruiser.
-9. **`shared-types` imports nothing from `@salt/*`.** It may only depend on external packages or nothing.
-10. **Adapters never throw for operational errors.** All failures cross the boundary as `Failure<DomainError>` or `Conflict<T>` (see [docs/salt-architecture.md §7](docs/salt-architecture.md)).
+## 3. Dependency graph (allowed imports)
 
-## Zod schema conventions
+### Allowed
 
-- **Schemas live in `@salt/domain/schemas`.** All zod schemas are defined under `packages/domain/src/schemas/` and exported via the `@salt/domain/schemas` subpath. Do not define schemas in adapters, apps, or `@salt/shared-types`.
-- **Schema-first.** Define the zod schema first; derive the TypeScript type with `type Foo = z.infer<typeof FooSchema>`. Never maintain a hand-written type alongside a schema for the same shape.
-- **Validate at trust boundaries only.** Add `.parse()` or `.safeParse()` at: AI/Genkit flow outputs, Firestore document reads (in `firebase-sync`), callable CF inputs, and "type laundering" sites (`as` casts, `unknown` narrowings, `JSON.parse`, string → structured parsers). Do **not** add validation to internal domain → domain calls, adapter internals, or any code the TypeScript compiler already proves correct.
-- **Handle validation failures per boundary type.** Always use `.safeParse()`, then:
-  - **Adapter single-document reads** (e.g. `load(id)`) → return `Failure<DomainError>` (`{ kind: 'StorageError', reason: 'corruption' }`); do not throw across internal layer seams.
-  - **Adapter list reads & realtime subscriptions** → skip the invalid doc, log it, and return the valid subset; one corrupt doc must not fail the whole read. Stream-level errors still surface via `onError`.
-  - **Callable CF entrypoints** → `throw new HttpsError('invalid-argument', …)`; this is the Firebase callable protocol for rejecting bad client input, not an internal seam.
-  - **Firestore triggers** → log and return; there is no caller to surface a `Failure` to.
-- **Production schema changes need a back-compat check.** Pre-launch (greenfield) schema-shape changes are free. Once production holds real data, a schema-shape change must not break documents already written — keep it backward-compatible on read or run a one-off migration. See [docs/salt-architecture.md §1.1](docs/salt-architecture.md).
+- web-pwa → domain, shared-types, ui-components, firebase-sync, ld-observability
+- cloud-functions → domain, shared-types, ld-observability/server
+- firebase-sync → domain, shared-types
+- ld-observability → domain, shared-types
+- domain → shared-types
+- shared-types → (no dependencies)
 
-## Enforcement
+### Forbidden
 
-- `pnpm lint` — ESLint with `eslint-plugin-boundaries` checks the import graph.
-- `pnpm typecheck` — TypeScript project references prevent out-of-graph imports at compile time.
-- `pnpm boundary:test` — Runs `.boundary-tests/run.sh` which lints deliberate violation fixtures and asserts each produces an error.
-- Pre-commit (Phase 3): Husky + lint-staged blocks bad commits locally.
-- CI (Phase 7): GitHub Actions blocks bad PRs before merge.
+- UI → Cloud Functions
+- UI → Firebase SDK directly
+- UI → IndexedDB / browser storage directly (narrow exception below)
+- UI → LaunchDarkly SDK directly
+- Domain → Firebase SDK / IndexedDB / Node / browser APIs
+- Domain → UI
+- Cloud Functions → UI
+- Cloud Functions → ld-observability (the default subpath wraps the browser-only LaunchDarkly SDK and cannot run in Node; use `ld-observability/server` instead)
+- Cloud Functions → firebase-sync (CF talks to Firestore directly via `firebase-admin`; `firebase-sync` wraps the browser SDK and is not for server-side use)
+- firebase-sync ↔ ld-observability (adapters must not import each other)
+- Any module → apps/web-pwa or apps/cloud-functions
 
-## Package names
+These rules must be enforced via ESLint, tsconfig project references, and commit gateway checks.
 
-| Path                                 | Package name              |
-|--------------------------------------|---------------------------|
-| `packages/shared-types`              | `@salt/shared-types`      |
-| `packages/domain`                    | `@salt/domain`            |
-| `packages/adapters/firebase-sync`    | `@salt/firebase-sync`     |
-| `packages/adapters/ld-observability` | `@salt/ld-observability`  |
-| `packages/ui-components`             | `@salt/ui-components`     |
-| `packages/testing-utils`             | `@salt/testing-utils`     |
-| `apps/web-pwa`                       | `@salt/web-pwa`           |
-| `apps/cloud-functions`               | `@salt/cloud-functions`   |
+#### Narrow exception: pre-authentication ephemeral state in `web-pwa`
+
+`apps/web-pwa` may use `window.localStorage` for pre-authentication ephemeral state that has no Firestore-backed alternative. The only sanctioned use today is the magic-link **pending email** in `apps/web-pwa/src/lib/auth.svelte.ts`: it must persist before any user is signed in (so `persistentLocalCache` cannot apply — there is no authenticated session to write to Firestore), and email clients open the magic link in a fresh tab/window, so `sessionStorage` would be lost. The exception is:
+
+- **Scoped to `apps/web-pwa` only.** It does **not** extend to any adapter (`firebase-sync`, `ld-observability`), `domain`, or `cloud-functions`.
+- **Limited to pre-auth ephemeral state.** It is not a general license to use browser storage for app data — all post-sign-in data still flows through Firestore's `persistentLocalCache`.
+- **Tolerant of failure.** Writes are wrapped so that a missing/blocked `localStorage` degrades gracefully (the magic link re-prompts for the email on return).
+
+---
+
+## 4. Domain layer requirements
+
+The domain layer is pure TypeScript:
+
+- No Firebase imports
+- No browser APIs (including IndexedDB)
+- No Node APIs
+- No side effects
+- No I/O
+- No global state
+
+The domain exposes:
+
+- Entities and value objects for:
+  - Recipes (single-document model)
+  - Canon items (name, synonyms, aisle, optional embedding, thumbnail icon)
+  - Shopping lists (items, checked state, canon links)
+  - Members (email-keyed allowlist membership records, admin role, email normalisation)
+  - Meal plan (MealPlanConfig, MealPlanTemplate, MealPlanWeek, Day, Attendee, Weekday — weekly evening-meal planner with a weekday-keyed template and per-day guest count)
+- Commands (write operations)
+- Queries (read operations)
+- Validation rules and Zod schemas (via `@salt/domain/schemas` subpath) — covers all Firestore document shapes, callable CF inputs, and AI flow output types; TypeScript types are derived via `z.infer`
+- Ports (interfaces) for:
+  - `CanonLocalStorePort` / `AisleLocalStorePort` — in-memory store contracts used by domain commands; satisfied by the in-memory adapters in `web-pwa`
+  - `AuthProvider` — identity and workspace membership
+  - `EmbeddingPort` / `CanonArbitrationPort` / `MatchLoggingPort` — AI and observability ports used by `matchOrCreate`
+  - `EntryParsePort` — AI-fallback port for structured shopping-list entry parsing; implemented by the server-side Genkit adapter in `cloud-functions` and consumed by `onShoppingListItemWrite`
+
+The domain is the single source of truth for business logic, data shapes, and validation semantics.
+
+---
+
+## 5. Workspace and access model
+
+Salt 2.0 is built for a **single shared family workspace**:
+
+- All authenticated members see all recipes, canon, shopping lists, and meal plan data.
+- There is no per‑recipe ACL; there are no private collections.
+- **Admin functions** (e.g. inviting members, managing canon at scale, destructive bulk operations) are gated by a per‑user `role` field on the workspace membership record.
+- Role checks are domain logic, not adapter logic. Adapters surface the role; domain decides what's allowed.
+- Security rules in the cloud backend mirror the domain rule: any workspace member can read/write workspace data; admin‑only mutations check role.
+
+This model is intentionally narrow. Multi‑workspace, sharing, or per‑document permissions are explicitly **out of scope** until a real requirement appears.
+
+---
+
+## 6. Adapter requirements
+
+### 6.1 firebase-sync adapter
+
+- Implements realtime subscriptions and direct writes using Firestore `onSnapshot` and `setDoc`.
+- Implements `AuthProvider` using Firebase Auth.
+- Initialises Firestore with `persistentLocalCache()` in production (disabled in emulator tests to avoid stale cache).
+- Initialises Firebase App Check (reCAPTCHA Enterprise, `isTokenAutoRefreshEnabled: true`) when an optional `AppCheckConfig` is provided and emulators are not in use. Must initialise before any other Firebase service so tokens are attached to requests. The exported `AppCheckConfig` interface carries a public `siteKey` and an optional `debugToken` for unattested environments (local dev / CI hitting a real backend); the debug token must never be baked into a deployed bundle.
+- Exposes the following as its primary data API:
+  - Canon: `subscribeCanonItems`, `subscribeAisles`, `upsertCanonItem`, `deleteCanonItem`, `saveAisles`
+  - Shopping lists: `subscribeShoppingLists`, `listShoppingLists`, `createShoppingList`, `renameShoppingList`, `deleteShoppingList`
+  - Shopping list items: `subscribeShoppingListItems`, `listShoppingListItems`, `saveShoppingListItem`, `deleteShoppingListItem`, `deleteShoppingListItems`, `moveShoppingListItems`
+  - Shopping list config: `subscribeShoppingListsConfig`, `loadShoppingListsConfig`, `saveShoppingListsConfig`
+  - Members: `subscribeMembers`, `upsertMember`, `deleteMember`
+  - Meal plan: `subscribeMealPlanConfig`, `subscribeMealPlanTemplate`, `subscribeMealPlanWeek`, `saveMealPlanConfig`, `saveMealPlanTemplate`, `saveMealPlanWeek`
+  - Recipes: `subscribeRecipes`, `loadRecipe`, `saveRecipe`, `deleteRecipe`
+- Validates all Firestore document reads using Zod schemas from `@salt/domain/schemas`; collection and subscription reads skip invalid documents (log the error, return the valid subset); single-document reads return `Failure<StorageError>` on parse failure.
+- Must not import IndexedDB or any local‑storage code.
+- Must not contain UI logic.
+- Must not contain domain logic — including conflict resolution.
+- Must not leak Firebase types across the boundary.
+
+### 6.2 ld-observability adapter
+
+Ships two subpath entrypoints from a single package:
+
+**Default subpath (`@salt/ld-observability`)** — browser-only, bundled into `web-pwa`:
+- Implements `ErrorReportingPort` and `MatchLoggingPort` using the LaunchDarkly browser SDK.
+- Normalizes errors into `DomainError` categories before crossing the boundary.
+- Must not be imported by Cloud Functions.
+
+**Server subpath (`@salt/ld-observability/server`)** — Node-only, bundled into `cloud-functions`:
+- Initialises an OTel `NodeTracerProvider` that ships CF spans to LaunchDarkly's OTLP endpoint.
+- Implements `MatchLoggingPort` for the CF side via `createServerLDMatchLoggingAdapter`.
+- Exposes `addServerSpanProcessor` so CF-local concerns (e.g. Genkit dev-trace routing) can register additional span processors without touching the adapter internals.
+- Exposes `setActiveSpanName(name)` to rename the currently-active OTel span from inside a Genkit flow body, appending a human-readable entity descriptor (e.g. the item name) so traces are scannable in the LaunchDarkly trace list. No-op when observability is uninitialised or no span is active; length-capped at 80 characters.
+- `firebase-functions/logger` is used additively for top-level summary logs to Cloud Logging.
+
+Both subpaths share a runtime-neutral schema mapper (`src/shared/`) so the `canon.match` wire schema cannot drift between fast-path and CF emissions.
+
+Common rules for both subpaths:
+- May import the LaunchDarkly SDK; nothing else in the codebase may.
+- Must not import Firebase, IndexedDB, browser storage, UI, or other adapters.
+- Must not contain domain logic or business rules.
+
+### 6.3 Common rules
+
+- All adapters convert their backend's responses into domain entities or error types.
+- All adapters use `shared-types` for DTOs and result types.
+- Adapters must not import each other; all are composed at the application layer.
+- `firebase-sync` is the **only** module permitted to import Firebase SDKs.
+- `ld-observability` is the **only** module permitted to import the LaunchDarkly Observability SDK.
+- IndexedDB, `idb`, `idb-keyval` are **forbidden** everywhere. Offline persistence is provided by Firestore's `persistentLocalCache`.
+
+---
+
+## 7. Adapter Error Contract
+
+Adapters must never leak Firebase, browser, or network‑layer errors across the boundary.
+All failures must be normalised into **domain‑level error types** defined in shared‑types.
+
+### 7.1 Error Shape
+
+All adapter functions return either:
+
+- `Success<T>`
+- `Failure<DomainError>`
+- `Conflict<T>` (for concurrent-write detection if needed in future)
+
+Adapters must not throw for expected operational failures.
+
+### 7.2 DomainError Categories
+
+DomainError is a closed set of error categories:
+
+- `AuthError` — unauthenticated, forbidden, expired session
+- `NotFound` — recipe, canon item, shopping list, workspace
+- `NetworkError` — offline, unreachable, transient network failure
+- `StorageError` — storage unavailable, quota exceeded, corruption detected
+- `SyncError` — failed write, invalid data
+- `ConflictError` — concurrent write detected
+- `ValidationError` — invalid input according to domain rules
+
+No Firebase error codes may cross the boundary.
+
+### 7.3 Loading States
+
+`isLoadingAisles` (exported from `canonService.ts`) is the single loading signal for the app — it starts `true` on `initCanonSync()` and clears once both the canon items and aisles `onSnapshot` callbacks have fired for the first time.
+
+### 7.4 Offline Behaviour
+
+- Reads come from Firestore's `persistentLocalCache` — no separate local store needed.
+- Writes are queued by Firestore automatically when offline and drained on reconnect.
+- No manual drain queue or manifest revision counter.
+
+### 7.5 Error Propagation Rules
+
+- Adapters **never throw** for operational errors.
+- Adapters **may throw** only for programmer errors (violated preconditions).
+- UI must handle all `Failure` states explicitly.
+
+### 7.6 Logging and Error Reporting
+
+- Adapters may log internal errors for diagnostics via the `ErrorReportingPort`.
+- All error reporting is mediated through `ErrorReportingPort`.
+- **Cloud Functions** log via `firebase-functions/logger` with structured JSON shaped to match the `DomainError` taxonomy (`{ scope, docId, errorCategory }`).
+
+---
+
+## 8. Cloud Functions requirements
+
+Cloud Functions cover two categories of server-side work:
+
+1. **Gen-AI callables** (`embedText`, `arbitrateCanon`, `matchOrCreateCanon`, `canonicaliseRecipeIngredients`, `parseRecipeIngredients`, `identifyEquipment`, `populateEquipmentEntry`, `regenerateCanonIcon`) — HTTPS callables invoked by the client. All carry `enforceAppCheck: false` (monitor-first rollout — unverified requests are allowed but reported to App Check metrics; flip the shared `APP_CHECK_ENFORCEMENT` constant in `index.ts` to `{ enforceAppCheck: true }` once staging metrics confirm legitimate traffic passes attestation).
+2. **Firestore write triggers** (`onShoppingListItemWrite`, `onCanonItemWritten`) — respond to document writes and run domain logic server-side, writing results back to Firestore.
+3. **Identity Platform blocking functions** (`beforeMemberCreated`) — reject account creation for any email not on the member allowlist; requires Identity Platform to be enabled on the target project.
+
+Both categories are intentionally minimal.
+
+Cloud Functions:
+
+- Import domain + ld-observability/server (never the default `ld-observability` subpath, which wraps the browser-only SDK and cannot run in Node)
+- Talk to Firestore directly via `firebase-admin` — do not import `@salt/firebase-sync`, which wraps the browser SDK
+- Never import UI
+- Never contain business logic
+- Only orchestrate: input validation (via Zod schemas from `@salt/domain/schemas`; callable entry points throw `HttpsError('invalid-argument')` on parse failure), domain commands/queries, gen‑AI providers, and returning results
+- Must be stateless
+- Callables must be testable without Firebase emulators (via domain mocks); triggers use the Firestore emulator for write-back integration tests
+
+---
+
+## 9. PWA (UI) requirements
+
+The PWA:
+
+- Imports domain, firebase-sync, ld-observability, ui-components, shared-types
+- Never imports Firebase SDK, IndexedDB, or LaunchDarkly SDK directly
+- Never contains business logic (including conflict resolution policy)
+- Uses domain commands/queries as its API
+- Wires `AuthProvider`, `ErrorReportingPort`, `MatchLoggingPort`, `EmbeddingPort`, and `CanonArbitrationPort` at composition time
+- Starts `initCanonSync()` and `initMealPlanSync()` from `App.svelte` when the user authenticates — subscriptions begin once at auth time, not on individual page mounts
+- In-memory Svelte stores (`canonItems`, `aisles`, `aisleUsage`) are the UI's read layer; `upsertCanonItem` and `saveAisles` are the write path
+- **Recipes** (`/recipes`, `/recipes/new`, `/recipes/:id/edit`, `/recipes/:id`): family-shared recipe store. Currently admin-only — all three route pages are wrapped in `AdminGuard` and the nav entry is appended only for admins, while the module is incomplete (issue #179). `recipeService` drives the pages; `subscribeRecipes` / `loadRecipe` / `saveRecipe` / `deleteRecipe` are the firebase-sync data operations. Ingredient parsing and canonicalisation are on-demand: the editor surfaces a per-row **Match** button and a batch **Canonicalise** button that call `parseRecipeIngredients` and `canonicaliseRecipeIngredients` respectively. Recipe-to-shopping-list extraction opens a review sheet (`RecipeAddToListSheet`) where each ingredient row shows Add/Check toggles driven by `recipeItemAddDefault` (canon `shoppingBehavior` → add/check/skip defaults); confirmed items land on the list, with "check" rows flagged `needsCheck` for a quick confirm/drop affordance on the shopping screen. `buildRecipeAddPlan` evaluates each ingredient's live match via `hasLiveCanonMatch` so dangling canon references are added as raw text rather than carrying stale `canonId`s.
+- **Meal plan** (`/mealplan`): the weekly evening-meal planner, accessible to all members. Shows a seven-day week with prev/next/this-week navigation and a Load-template button. `mealPlanService` drives the page; subscriptions are started at auth time via `initMealPlanSync()`.
+- **Admin operator area** (`/admin` route group): `AdminGuard` redirects non-admins; the Members CRUD screen (`/admin/members`) lets admins add, edit, and remove allowlist members; `membersService` exposes a sorted roster store backed by `subscribeMembers`. Canon management (`/admin/canon`, `/admin/canon/new`, `/admin/canon/aisles`, `/admin/canon/:id`) is also gated here — canon stewardship is an operator function, not an everyday user activity, so the list, create, detail, and aisle management pages all sit under `AdminGuard`. The `needs_approval` count badge is surfaced on the Admin nav entry so operators can see the review queue from anywhere in the app. Meal plan template administration (`/admin/mealplan`) lets operators edit the standard weekday-keyed template and the `firstDayOfWeek` setting; gated by `AdminGuard` (cosmetic — Firestore rules allow any authenticated member to write meal plan documents). Client-side gating is cosmetic — real enforcement is in Firestore rules and the `beforeMemberCreated` blocking function.
+- Offline data is provided by Firestore's `persistentLocalCache`. The service worker never caches Firestore traffic or any app data.
+- **PWA installability (Tier-1):** A Workbox-generated service worker (`vite-plugin-pwa`, `generateSW` strategy) precaches the built app shell and static assets only. The service worker is the sole consumer of the Cache API; no other module may touch `caches` directly (CLAUDE.md hard rule #3). The SW is disabled in dev (no interference with HMR). Manifest identity is env-distinct: `VITE_PWA_NAME`, `VITE_PWA_SHORT_NAME`, and `VITE_PWA_THEME_COLOR` are read at build time from `.env.<mode>` so staging and production install as distinct apps. The auto-update flow (owned by `src/lib/pwa.ts`) defers page reloads to safe moments (hash route change or tab refocus) and never reloads mid-interaction.
+
+---
+
+## 10. Shared types requirements
+
+shared-types contains:
+
+- DTOs
+- API request/response shapes
+- Cross-module enums
+- DomainError categories and result types (`Success` / `Failure` / `Conflict`)
+- Nothing with logic
+- Nothing that depends on Firebase, IndexedDB, or browser APIs
+
+This module must remain extremely small and stable.
+
+---
+
+## 11. Enforcement rules
+
+### ESLint
+
+- Enforce allowed import graph (boundaries plugin)
+- Forbid Firebase imports outside firebase-sync
+- Forbid IndexedDB / browser storage imports everywhere
+- Forbid LaunchDarkly Observability SDK imports outside ld-observability
+- Forbid the default `ld-observability` subpath imports in cloud-functions (browser-only); `ld-observability/server` is allowed
+- Forbid firebase-sync ↔ ld-observability imports (sibling adapters must not import each other)
+- Forbid domain importing anything except shared-types
+- Forbid UI importing Cloud Functions
+- Forbid circular dependencies
+- Enforce strict TypeScript rules
+
+### tsconfig
+
+- Use project references to enforce module boundaries
+- Each module has its own tsconfig
+- Root tsconfig defines the dependency graph
+
+### Commit gateway
+
+Every commit must:
+
+- Pass linting
+- Pass type checks
+- Pass dependency graph checks
+- Pass unit tests
+- Pass formatting
+- Reject any Firebase import outside firebase-sync
+- Reject any IndexedDB import anywhere
+- Reject any LaunchDarkly SDK import outside ld-observability
+- Reject any UI → backend leakage
+- Reject any domain impurity (Node/browser/Firebase imports)
+
+---
+
+## 12. Testing strategy
+
+### Domain
+
+- 100% unit testable without Firebase or IndexedDB
+- Pure logic tests, including validation
+
+### firebase-sync
+
+- Unit tests with mocks
+- Integration tests against the Firebase emulator (Firestore only; persistent cache disabled in emulator tests)
+
+### ld-observability
+
+- Unit tests with mocked LaunchDarkly SDK
+- Tests that error normalization preserves error context
+
+### Cloud Functions
+
+- Unit tests with mocked adapters
+- Integration tests with emulator
+
+### UI
+
+- Component tests
+- Integration tests (with all adapters wired to fakes)
+- E2E tests (Playwright against Firebase emulator)
+
+---
+
+## 13. Deployment units
+
+- web-pwa → deployed as PWA
+- cloud-functions → deployed to Firebase Functions
+- firebase-sync → bundled into UI only (browser SDK; not imported by Cloud Functions)
+- ld-observability (default subpath) → bundled into UI only (browser-only SDK)
+- ld-observability/server → bundled into cloud-functions (Node SDK, OTLP exporter)
+- domain → bundled into UI and Cloud Functions
+- shared-types → type-only package
+
+---
+
+## 14. Non-negotiables
+
+- No Firebase SDK in UI
+- No IndexedDB / browser storage anywhere — use Firestore's persistent cache (one narrow exception: pre-auth ephemeral state in `web-pwa`, see §3)
+- No LaunchDarkly SDK in UI or other adapters (only in ld-observability)
+- No business logic outside domain (including conflict resolution)
+- No cross-module imports outside the allowed graph
+- No global state
+- No leaking Firebase / LaunchDarkly types across boundaries
+- No circular dependencies
+- No untyped data flow
+- No per‑document ACLs or multi‑workspace logic until explicitly requested

--- a/firestore.rules
+++ b/firestore.rules
@@ -68,6 +68,17 @@ service cloud.firestore {
     match /recipes/{recipeId} {
       allow read, write: if request.auth != null;
     }
+    // Chat sessions (issue #206) — the first per-user-scoped data in Salt.
+    // A session may only be read or written by the user who owns it.
+    // On create, the client must set ownerUid to their own uid.
+    // List queries are scoped to ownerUid == request.auth.uid via client-side
+    // where() so the rule only needs to check the authenticated user.
+    match /chatSessions/{sessionId} {
+      allow read, write: if request.auth != null
+        && resource.data.ownerUid == request.auth.uid;
+      allow create: if request.auth != null
+        && request.resource.data.ownerUid == request.auth.uid;
+    }
     match /{document=**} {
       allow read, write: if false;
     }

--- a/packages/adapters/firebase-sync/src/authorRecipeCallable.ts
+++ b/packages/adapters/firebase-sync/src/authorRecipeCallable.ts
@@ -1,0 +1,31 @@
+import { getFunctions, httpsCallable } from 'firebase/functions';
+import { failure, success, type DomainError, type ReadResult } from '@salt/shared-types';
+import type { AuthorRecipeInput } from '@salt/domain/schemas';
+import type { RecipeDoc } from '@salt/domain/schemas';
+
+const REGION = 'europe-west2';
+
+function classifyError(err: unknown): DomainError {
+  const code = (err as { code?: string }).code ?? '';
+  if (code === 'functions/unauthenticated') return { kind: 'AuthError', reason: 'unauthenticated' };
+  if (code === 'functions/permission-denied') return { kind: 'AuthError', reason: 'forbidden' };
+  return { kind: 'NetworkError', reason: 'transient' };
+}
+
+// Calls the librarian flow: sends a conversation and receives a canon-matched
+// RecipeDoc draft. The client should add/override id + timestamps before
+// persisting with saveRecipe.
+export async function callAuthorRecipe(
+  input: AuthorRecipeInput,
+): Promise<ReadResult<RecipeDoc, DomainError>> {
+  try {
+    const fn = httpsCallable<AuthorRecipeInput, RecipeDoc>(
+      getFunctions(undefined, REGION),
+      'authorRecipe',
+    );
+    const res = await fn(input);
+    return success(res.data);
+  } catch (err) {
+    return failure(classifyError(err));
+  }
+}

--- a/packages/adapters/firebase-sync/src/chatCallables.ts
+++ b/packages/adapters/firebase-sync/src/chatCallables.ts
@@ -1,0 +1,39 @@
+import { getFunctions, httpsCallable } from 'firebase/functions';
+import { failure, success, type DomainError, type ReadResult } from '@salt/shared-types';
+import type { ChefChatInput } from '@salt/domain/schemas';
+
+const REGION = 'europe-west2';
+
+function getErr(err: unknown): DomainError {
+  const code = (err as { code?: string }).code ?? '';
+  if (code === 'functions/unauthenticated') {
+    return { kind: 'AuthError', reason: 'unauthenticated' };
+  }
+  if (code === 'functions/permission-denied') {
+    return { kind: 'AuthError', reason: 'forbidden' };
+  }
+  return { kind: 'NetworkError', reason: 'transient' };
+}
+
+// Streams the chef's reply chunk-by-chunk. onChunk is called for each text
+// fragment as it arrives. The returned promise resolves to the full reply text
+// once the stream is complete, or a Failure on error.
+export async function streamChefChat(
+  input: ChefChatInput,
+  onChunk: (chunk: string) => void,
+): Promise<ReadResult<string, DomainError>> {
+  try {
+    const fn = httpsCallable<ChefChatInput, string, string>(
+      getFunctions(undefined, REGION),
+      'chefChat',
+    );
+    const { stream, data } = await fn.stream(input);
+    for await (const chunk of stream) {
+      onChunk(chunk);
+    }
+    const result = await data;
+    return success(result);
+  } catch (err) {
+    return failure(getErr(err));
+  }
+}

--- a/packages/adapters/firebase-sync/src/chatSessionSubscription.ts
+++ b/packages/adapters/firebase-sync/src/chatSessionSubscription.ts
@@ -1,0 +1,93 @@
+import {
+  getFirestore,
+  collection,
+  doc,
+  setDoc,
+  deleteDoc,
+  getDoc,
+  onSnapshot,
+  query,
+  where,
+} from 'firebase/firestore';
+import { getApp } from 'firebase/app';
+import type { DomainError, ReadResult } from '@salt/shared-types';
+import { success, failure } from '@salt/shared-types';
+import { ChatSessionSchema } from '@salt/domain/schemas';
+import type { ChatSessionDoc } from '@salt/domain/schemas';
+import { classifyFirestoreError } from './firestoreErrors.js';
+
+// Chat session persistence (issue #206, Phase 1). One doc per session at
+// chatSessions/{id}. Per-user scoped: every read/write is filtered by ownerUid.
+// Messages are stored as an array in the session doc (not a subcollection).
+// saveChatSession bumps expiresAt to now + 14 days on every write; a Firestore
+// TTL policy on chatSessions.expiresAt handles server-side expiry (infra step).
+
+const COLLECTION = 'chatSessions';
+const TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+
+function expiresAt(): string {
+  return new Date(Date.now() + TTL_MS).toISOString();
+}
+
+export function subscribeChatSessions(
+  ownerUid: string,
+  onSessions: (sessions: ChatSessionDoc[]) => void,
+  onError: (err: DomainError) => void,
+): () => void {
+  const db = getFirestore(getApp());
+  const q = query(collection(db, COLLECTION), where('ownerUid', '==', ownerUid));
+  return onSnapshot(
+    q,
+    (snap) => {
+      const valid: ChatSessionDoc[] = [];
+      for (const d of snap.docs) {
+        const result = ChatSessionSchema.safeParse(d.data());
+        if (result.success) {
+          valid.push(result.data);
+        } else {
+          console.error(`[ChatSessionSchema] Document ${d.id} failed validation`, result.error);
+        }
+      }
+      onSessions(valid);
+    },
+    (err) => onError(classifyFirestoreError(err)),
+  );
+}
+
+export async function loadChatSession(
+  id: string,
+): Promise<ReadResult<ChatSessionDoc | null, DomainError>> {
+  try {
+    const db = getFirestore(getApp());
+    const snap = await getDoc(doc(db, COLLECTION, id));
+    if (!snap.exists()) return success(null);
+    const result = ChatSessionSchema.safeParse(snap.data());
+    if (!result.success) return failure({ kind: 'StorageError', reason: 'corruption' });
+    return success(result.data);
+  } catch (err) {
+    return failure(classifyFirestoreError(err));
+  }
+}
+
+export async function saveChatSession(
+  session: ChatSessionDoc,
+): Promise<ReadResult<void, DomainError>> {
+  try {
+    const db = getFirestore(getApp());
+    const stamped: ChatSessionDoc = { ...session, expiresAt: expiresAt() };
+    await setDoc(doc(db, COLLECTION, stamped.id), { ...stamped });
+    return success(undefined);
+  } catch (err) {
+    return failure(classifyFirestoreError(err));
+  }
+}
+
+export async function deleteChatSession(id: string): Promise<ReadResult<void, DomainError>> {
+  try {
+    const db = getFirestore(getApp());
+    await deleteDoc(doc(db, COLLECTION, id));
+    return success(undefined);
+  } catch (err) {
+    return failure(classifyFirestoreError(err));
+  }
+}

--- a/packages/adapters/firebase-sync/src/equipmentManifestSubscription.ts
+++ b/packages/adapters/firebase-sync/src/equipmentManifestSubscription.ts
@@ -2,11 +2,12 @@ import { getFirestore, doc, setDoc, onSnapshot } from 'firebase/firestore';
 import { getApp } from 'firebase/app';
 import type { EquipmentManifest } from '@salt/domain';
 import type { DomainError } from '@salt/shared-types';
-import { EquipmentManifestSchema } from '@salt/domain/schemas';
+import {
+  EquipmentManifestSchema,
+  EQUIPMENT_MANIFEST_COLLECTION,
+  EQUIPMENT_MANIFEST_DOC_ID,
+} from '@salt/domain/schemas';
 import { classifyFirestoreError } from './firestoreErrors.js';
-
-const EQUIPMENT_MANIFEST_COLLECTION = 'equipmentManifest';
-const EQUIPMENT_MANIFEST_DOC_ID = 'current';
 
 export function subscribeEquipmentManifest(
   onManifest: (manifest: EquipmentManifest | null) => void,

--- a/packages/adapters/firebase-sync/src/index.ts
+++ b/packages/adapters/firebase-sync/src/index.ts
@@ -36,6 +36,12 @@ export {
 } from './shoppingListsConfigSubscription.js';
 export { subscribeMembers, upsertMember, deleteMember } from './membersSubscription.js';
 export { subscribeRecipes, loadRecipe, saveRecipe, deleteRecipe } from './recipeSubscription.js';
+export {
+  subscribeChatSessions,
+  loadChatSession,
+  saveChatSession,
+  deleteChatSession,
+} from './chatSessionSubscription.js';
 export { callParseRecipeIngredients } from './recipeCallables.js';
 export {
   subscribeMealPlanConfig,

--- a/packages/adapters/firebase-sync/src/index.ts
+++ b/packages/adapters/firebase-sync/src/index.ts
@@ -42,6 +42,7 @@ export {
   saveChatSession,
   deleteChatSession,
 } from './chatSessionSubscription.js';
+export { streamChefChat } from './chatCallables.js';
 export { callParseRecipeIngredients } from './recipeCallables.js';
 export {
   subscribeMealPlanConfig,

--- a/packages/adapters/firebase-sync/src/index.ts
+++ b/packages/adapters/firebase-sync/src/index.ts
@@ -43,6 +43,7 @@ export {
   deleteChatSession,
 } from './chatSessionSubscription.js';
 export { streamChefChat } from './chatCallables.js';
+export { callAuthorRecipe } from './authorRecipeCallable.js';
 export { callParseRecipeIngredients } from './recipeCallables.js';
 export {
   subscribeMealPlanConfig,

--- a/packages/domain/src/schemas/authorRecipe.ts
+++ b/packages/domain/src/schemas/authorRecipe.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import { MessageSchema } from './chatSession.js';
+
+// Input to the librarian (authorRecipe) flow: the full conversation that the
+// user wants to turn into a recipe (issue #206, Phase 4).
+export const AuthorRecipeInputSchema = z.object({
+  messages: z.array(MessageSchema),
+});
+
+export type AuthorRecipeInput = z.infer<typeof AuthorRecipeInputSchema>;
+
+// The shape the AI model emits inside the flow (never leaves the CF boundary).
+// The model uses 0-based step ordinals for ingredient links; the flow resolves
+// them to step IDs before returning the final RecipeDoc to the client.
+export const LibrarianIngredientSchema = z.object({
+  rawText: z.string(),
+  isOptional: z.boolean(),
+  // Index into the steps array (0-based) for the step where this ingredient
+  // is first used. null = no specific step assignment.
+  firstUsedInStepOrdinal: z.number().int().nullable(),
+});
+
+export const LibrarianGroupSchema = z.object({
+  name: z.string().nullable(),
+  ingredients: z.array(LibrarianIngredientSchema),
+});
+
+export const LibrarianStepSchema = z.object({
+  text: z.string(),
+  timerMinutes: z.number().int().nullable(),
+  note: z.string().nullable(),
+});
+
+export const LibrarianOutputSchema = z.object({
+  title: z.string(),
+  description: z.string().nullable(),
+  servings: z.number().nullable(),
+  totalTimeMinutes: z.number().nullable(),
+  prepTimeMinutes: z.number().nullable(),
+  cookTimeMinutes: z.number().nullable(),
+  tags: z.array(z.string()),
+  ingredientGroups: z.array(LibrarianGroupSchema),
+  steps: z.array(LibrarianStepSchema),
+  notes: z.string().nullable(),
+});
+
+export type AuthorRecipeInput_ = z.infer<typeof AuthorRecipeInputSchema>;
+export type LibrarianIngredient = z.infer<typeof LibrarianIngredientSchema>;
+export type LibrarianGroup = z.infer<typeof LibrarianGroupSchema>;
+export type LibrarianStep = z.infer<typeof LibrarianStepSchema>;
+export type LibrarianOutput = z.infer<typeof LibrarianOutputSchema>;

--- a/packages/domain/src/schemas/chatSession.ts
+++ b/packages/domain/src/schemas/chatSession.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const MessageSchema = z.object({
+  id: z.string(),
+  role: z.enum(['user', 'assistant']),
+  text: z.string(),
+  createdAt: z.string(),
+});
+
+export const ChatSessionSchema = z.object({
+  id: z.string(),
+  schemaVersion: z.literal(1),
+  ownerUid: z.string(),
+  recipeId: z.string().nullable(),
+  title: z.string(),
+  messages: z.array(MessageSchema),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  expiresAt: z.string(),
+});
+
+export type MessageDoc = z.infer<typeof MessageSchema>;
+export type ChatSessionDoc = z.infer<typeof ChatSessionSchema>;

--- a/packages/domain/src/schemas/chefChat.ts
+++ b/packages/domain/src/schemas/chefChat.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { MessageSchema } from './chatSession.js';
+
+// Input schema for the chefChat streaming flow (issue #206, Phase 2).
+// The flow is stateless: it receives the recent message history + the new turn.
+// recipeId is set for recipe-attached sessions; the flow reads the recipe
+// server-side and injects it as context when non-null.
+export const ChefChatInputSchema = z.object({
+  messages: z.array(MessageSchema),
+  newMessage: z.string(),
+  recipeId: z.string().nullable(),
+});
+
+export type ChefChatInput = z.infer<typeof ChefChatInputSchema>;

--- a/packages/domain/src/schemas/equipmentManifest.ts
+++ b/packages/domain/src/schemas/equipmentManifest.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
 
+// Canonical Firestore location of the single shared equipment manifest. Both the
+// client store (firebase-sync) and the server-side chef flow (cloud-functions)
+// read this doc; sharing the identifiers here is the one source of truth so the
+// two sides can't drift (which silently broke the chef's equipment context once).
+export const EQUIPMENT_MANIFEST_COLLECTION = 'equipmentManifest';
+export const EQUIPMENT_MANIFEST_DOC_ID = 'current';
+
 export const AccessorySchema = z.object({
   id: z.string(),
   name: z.string(),

--- a/packages/domain/src/schemas/index.ts
+++ b/packages/domain/src/schemas/index.ts
@@ -95,6 +95,9 @@ export type {
 export { MessageSchema, ChatSessionSchema } from './chatSession.js';
 export type { MessageDoc, ChatSessionDoc } from './chatSession.js';
 
+export { ChefChatInputSchema } from './chefChat.js';
+export type { ChefChatInput } from './chefChat.js';
+
 export {
   SingleQuantitySchema,
   RangeQuantitySchema,

--- a/packages/domain/src/schemas/index.ts
+++ b/packages/domain/src/schemas/index.ts
@@ -54,6 +54,8 @@ export {
   AccessorySchema,
   EquipmentItemSchema,
   EquipmentManifestSchema,
+  EQUIPMENT_MANIFEST_COLLECTION,
+  EQUIPMENT_MANIFEST_DOC_ID,
 } from './equipmentManifest.js';
 export type { AccessoryDoc, EquipmentItemDoc, EquipmentManifestDoc } from './equipmentManifest.js';
 

--- a/packages/domain/src/schemas/index.ts
+++ b/packages/domain/src/schemas/index.ts
@@ -98,6 +98,15 @@ export type { MessageDoc, ChatSessionDoc } from './chatSession.js';
 export { ChefChatInputSchema } from './chefChat.js';
 export type { ChefChatInput } from './chefChat.js';
 
+export { AuthorRecipeInputSchema, LibrarianOutputSchema } from './authorRecipe.js';
+export type {
+  AuthorRecipeInput,
+  LibrarianOutput,
+  LibrarianGroup,
+  LibrarianIngredient,
+  LibrarianStep,
+} from './authorRecipe.js';
+
 export {
   SingleQuantitySchema,
   RangeQuantitySchema,

--- a/packages/domain/src/schemas/index.ts
+++ b/packages/domain/src/schemas/index.ts
@@ -92,6 +92,9 @@ export type {
   ParseRecipeIngredientsOutput,
 } from './parseRecipeIngredients.js';
 
+export { MessageSchema, ChatSessionSchema } from './chatSession.js';
+export type { MessageDoc, ChatSessionDoc } from './chatSession.js';
+
 export {
   SingleQuantitySchema,
   RangeQuantitySchema,

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.0",
     "svelte": "^5.55.7",
     "svelte-dnd-action": "^0.9.69",
+    "svelte-exmarkdown": "^5.0.2",
     "tailwind-merge": "^2.5.0"
   },
   "devDependencies": {

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -37,6 +37,7 @@ export { default as Grid } from './primitives/Grid/Grid.svelte';
 export { default as Heading } from './primitives/Heading/Heading.svelte';
 export { default as Icon } from './primitives/Icon/Icon.svelte';
 export { default as Inline } from './primitives/Inline/Inline.svelte';
+export { default as Markdown } from './primitives/Markdown/Markdown.svelte';
 export { default as Popover } from './primitives/Popover/Popover.svelte';
 export { default as PopoverContent } from './primitives/Popover/PopoverContent.svelte';
 export { default as PopoverTrigger } from './primitives/Popover/PopoverTrigger.svelte';

--- a/packages/ui-components/src/primitives/Markdown/Markdown.svelte
+++ b/packages/ui-components/src/primitives/Markdown/Markdown.svelte
@@ -1,0 +1,118 @@
+<!-- Renders a markdown string as safe DOM. Used for assistant chat replies
+     (issue #206), which arrive as markdown. Built on svelte-exmarkdown, which
+     renders to real Svelte components (no {@html}) and drops raw HTML by default
+     via remark-rehype — so LLM output is XSS-safe by construction with no
+     bespoke sanitizer. GFM (tables, strikethrough, autolinks) is enabled. -->
+<script lang="ts">
+  import { Markdown as ExMarkdown } from 'svelte-exmarkdown';
+  import { gfmPlugin } from 'svelte-exmarkdown/gfm';
+  import { cn } from '../../lib/cn';
+
+  let { text, class: className }: { text: string; class?: string } = $props();
+
+  const plugins = [gfmPlugin()];
+</script>
+
+<div class={cn('salt-md', className)}>
+  <ExMarkdown md={text} {plugins} />
+</div>
+
+<style>
+  .salt-md :global(:first-child) {
+    margin-top: 0;
+  }
+  .salt-md :global(:last-child) {
+    margin-bottom: 0;
+  }
+  .salt-md :global(p) {
+    margin: 0;
+  }
+  .salt-md :global(p + p) {
+    margin-top: 0.5rem;
+  }
+  .salt-md :global(ul),
+  .salt-md :global(ol) {
+    margin: 0.25rem 0;
+    padding-left: 1.25rem;
+  }
+  .salt-md :global(ul) {
+    list-style: disc;
+  }
+  .salt-md :global(ol) {
+    list-style: decimal;
+  }
+  .salt-md :global(li) {
+    margin: 0.125rem 0;
+  }
+  .salt-md :global(li > ul),
+  .salt-md :global(li > ol) {
+    margin: 0.125rem 0;
+  }
+  .salt-md :global(h1),
+  .salt-md :global(h2),
+  .salt-md :global(h3),
+  .salt-md :global(h4),
+  .salt-md :global(h5),
+  .salt-md :global(h6) {
+    font-weight: 600;
+    line-height: 1.3;
+    margin: 0.5rem 0 0.25rem;
+  }
+  .salt-md :global(h1) {
+    font-size: 1.125rem;
+  }
+  .salt-md :global(h2) {
+    font-size: 1.0625rem;
+  }
+  .salt-md :global(h3) {
+    font-size: 1rem;
+  }
+  .salt-md :global(strong) {
+    font-weight: 600;
+  }
+  .salt-md :global(em) {
+    font-style: italic;
+  }
+  .salt-md :global(a) {
+    text-decoration: underline;
+  }
+  .salt-md :global(code) {
+    font-family: ui-monospace, monospace;
+    font-size: 0.875em;
+    background: rgb(0 0 0 / 0.06);
+    padding: 0.0625rem 0.25rem;
+    border-radius: 0.25rem;
+  }
+  .salt-md :global(pre) {
+    background: rgb(0 0 0 / 0.06);
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    overflow-x: auto;
+    margin: 0.5rem 0;
+  }
+  .salt-md :global(pre code) {
+    background: none;
+    padding: 0;
+  }
+  .salt-md :global(blockquote) {
+    border-left: 3px solid currentColor;
+    opacity: 0.85;
+    padding-left: 0.75rem;
+    margin: 0.5rem 0;
+  }
+  .salt-md :global(hr) {
+    border: none;
+    border-top: 1px solid currentColor;
+    opacity: 0.2;
+    margin: 0.5rem 0;
+  }
+  .salt-md :global(table) {
+    border-collapse: collapse;
+    margin: 0.5rem 0;
+  }
+  .salt-md :global(th),
+  .salt-md :global(td) {
+    border: 1px solid currentColor;
+    padding: 0.25rem 0.5rem;
+  }
+</style>

--- a/packages/ui-components/src/primitives/Markdown/Markdown.svelte
+++ b/packages/ui-components/src/primitives/Markdown/Markdown.svelte
@@ -1,8 +1,4 @@
-<!-- Renders a markdown string as safe DOM. Used for assistant chat replies
-     (issue #206), which arrive as markdown. Built on svelte-exmarkdown, which
-     renders to real Svelte components (no {@html}) and drops raw HTML by default
-     via remark-rehype — so LLM output is XSS-safe by construction with no
-     bespoke sanitizer. GFM (tables, strikethrough, autolinks) is enabled. -->
+<!-- spec: ai-kitchen-assistant.md §Surfaces v1.0 -->
 <script lang="ts">
   import { Markdown as ExMarkdown } from 'svelte-exmarkdown';
   import { gfmPlugin } from 'svelte-exmarkdown/gfm';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,7 +114,7 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.0.0
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.0
         version: 10.5.0(postcss@8.5.10)
@@ -126,7 +126,7 @@ importers:
         version: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
       vite:
         specifier: ^6.0.0
-        version: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   apps/web-pwa:
     dependencies:
@@ -160,13 +160,13 @@ importers:
         version: 1.59.1
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.0.0
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.2.0
-        version: 5.3.1(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
+        version: 5.3.1(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
       '@testing-library/user-event':
         specifier: ^14.5.0
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -202,10 +202,10 @@ importers:
         version: 9.3.0
       vite:
         specifier: ^6.0.0
-        version: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-plugin-pwa:
         specifier: ^1.3.0
-        version: 1.3.0(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
+        version: 1.3.0(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
       vitest-axe:
         specifier: ^0.1.0
         version: 0.1.0(vitest@4.1.8)
@@ -311,6 +311,9 @@ importers:
       svelte-dnd-action:
         specifier: ^0.9.69
         version: 0.9.69(svelte@5.55.7(@typescript-eslint/types@8.59.0))
+      svelte-exmarkdown:
+        specifier: ^5.0.2
+        version: 5.0.2(svelte@5.55.7(@typescript-eslint/types@8.59.0))
       tailwind-merge:
         specifier: ^2.5.0
         version: 2.6.1
@@ -3149,6 +3152,9 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -3167,6 +3173,9 @@ packages:
   '@types/express@4.17.25':
     resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
@@ -3181,6 +3190,9 @@ packages:
 
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/memcached@2.2.10':
     resolution: {integrity: sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==}
@@ -3241,6 +3253,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -3303,6 +3318,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.59.0':
     resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@vitest/coverage-v8@4.1.8':
     resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
@@ -3582,6 +3600,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -3753,6 +3774,9 @@ packages:
   caniuse-lite@1.0.30001790:
     resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -3768,6 +3792,9 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -4102,6 +4129,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deeks@3.1.0:
     resolution: {integrity: sha512-e7oWH1LzIdv/prMQ7pmlDlaVoL64glqzvNgkgQNgyec9ORPHrT2jaOqMtRyqJuwWjtfb6v+2rk9pmaHj+F137A==}
     engines: {node: '>= 16'}
@@ -4165,6 +4195,9 @@ packages:
 
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -4327,6 +4360,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
@@ -5563,6 +5600,9 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -5612,6 +5652,9 @@ packages:
   map-stream@0.1.0:
     resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marked-terminal@7.3.0:
     resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
     engines: {node: '>=16.0.0'}
@@ -5626,6 +5669,42 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -5657,6 +5736,90 @@ packages:
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -6391,6 +6554,18 @@ packages:
     resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
     hasBin: true
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -6830,6 +7005,11 @@ packages:
     peerDependencies:
       svelte: '>=3.23.0 || ^5.0.0-next.0'
 
+  svelte-exmarkdown@5.0.2:
+    resolution: {integrity: sha512-/GhWbh0TBd7OPsL6IhQZm4BVuglP5MP4lVwBDnIF8IYfmHfwfY0z/nu78L8FDwJM2pP+DW8045g+jUhM357U1w==}
+    peerDependencies:
+      svelte: ^5.1.3
+
   svelte-spa-router@5.0.1:
     resolution: {integrity: sha512-AU/4rosuCnkMLqVYV+HRYP/jLVBAhGzeIUaPGaSmFj7wLfyfZeW18iSiYlMEj2y4Uh3+8GYUt3tvObJiBmgzyA==}
 
@@ -6974,9 +7154,15 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   triple-beam@1.4.1:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -7104,9 +7290,27 @@ packages:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universal-analytics@0.5.4:
     resolution: {integrity: sha512-db38BYsx+oZEx0bc+PeGmIwG+YiYH5Xluhxf9EBnL39U4+DAXJtXQHLJ+zzTH36lx/N54/WKQQYnh0kQWJ74yg==}
@@ -7193,6 +7397,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-plugin-pwa@1.3.0:
     resolution: {integrity: sha512-c5kMgN+ITrOtHXp8PAtk2uOIEea6XjP/unCGxOWWBzQ6qa65qj/awHg0wf+QF9E/2u9vh86LqxPwzEPNbM2r5A==}
@@ -7632,6 +7842,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -10854,14 +11067,14 @@ snapshots:
     dependencies:
       svelte: 5.55.7(@typescript-eslint/types@8.59.0)
 
-  '@testing-library/svelte@5.3.1(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)':
+  '@testing-library/svelte@5.3.1(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.55.7(@typescript-eslint/types@8.59.0))
       svelte: 5.55.7(@typescript-eslint/types@8.59.0)
     optionalDependencies:
-      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@testing-library/svelte@5.3.1(svelte@5.55.7(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
@@ -10932,6 +11145,10 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
@@ -10954,6 +11171,10 @@ snapshots:
       '@types/qs': 6.15.0
       '@types/serve-static': 1.15.10
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/http-errors@2.0.5': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
@@ -10966,6 +11187,10 @@ snapshots:
       '@types/node': 25.6.0
 
   '@types/long@4.0.2': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/memcached@2.2.10':
     dependencies:
@@ -11041,6 +11266,8 @@ snapshots:
   '@types/triple-beam@1.3.5': {}
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -11138,6 +11365,8 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
+  '@ungap/structured-clone@1.3.1': {}
+
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -11161,13 +11390,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.8(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -11453,6 +11682,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -11656,6 +11887,8 @@ snapshots:
 
   caniuse-lite@1.0.30001790: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -11666,6 +11899,8 @@ snapshots:
   chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
+
+  character-entities@2.0.2: {}
 
   chardet@2.1.1: {}
 
@@ -11979,6 +12214,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deeks@3.1.0: {}
 
   deep-equal-in-any-order@2.2.0:
@@ -12051,6 +12290,10 @@ snapshots:
   detect-libc@2.1.2: {}
 
   devalue@5.8.1: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   didyoumean@1.2.2: {}
 
@@ -12291,6 +12534,8 @@ snapshots:
   escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   escodegen@2.1.0:
     dependencies:
@@ -13917,6 +14162,8 @@ snapshots:
 
   long@5.3.2: {}
 
+  longest-streak@3.1.0: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@11.5.1: {}
@@ -13962,6 +14209,8 @@ snapshots:
 
   map-stream@0.1.0: {}
 
+  markdown-table@3.0.4: {}
+
   marked-terminal@7.3.0(marked@13.0.3):
     dependencies:
       ansi-escapes: 7.3.0
@@ -13976,6 +14225,120 @@ snapshots:
   marked@13.0.3: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   media-typer@0.3.0: {}
 
@@ -13994,6 +14357,197 @@ snapshots:
   merge2@1.4.1: {}
 
   methods@1.1.2: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -14725,6 +15279,40 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -15342,6 +15930,16 @@ snapshots:
     dependencies:
       svelte: 5.55.7(@typescript-eslint/types@8.59.0)
 
+  svelte-exmarkdown@5.0.2(svelte@5.55.7(@typescript-eslint/types@8.59.0)):
+    dependencies:
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      svelte: 5.55.7(@typescript-eslint/types@8.59.0)
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   svelte-spa-router@5.0.1:
     dependencies:
       regexparam: 2.0.2
@@ -15550,7 +16148,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  trim-lines@3.0.1: {}
+
   triple-beam@1.4.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -15688,9 +16290,42 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.2.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   universal-analytics@0.5.4:
     dependencies:
@@ -15770,12 +16405,22 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-pwa@1.3.0(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite-plugin-pwa@1.3.0(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.16
-      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       workbox-build: 7.4.1
       workbox-window: 7.4.1
     transitivePeerDependencies:
@@ -15849,12 +16494,12 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lodash-es: 4.18.1
       redent: 3.0.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
-  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -15871,7 +16516,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -16267,3 +16912,5 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- Phases 1–5 of the AI Kitchen Assistant epic (issue #206)
- Chat session schema, Firestore adapter, and owner-scoped security rules (phase 1)
- Streaming Genkit chef flow with pro-tier model, equipment + recipe context injection (phase 2)
- Kitchen-assistant chat UI with streaming render (phase 3)
- Librarian flow: canon matching and save-as-recipe from chat (phase 4)
- Recipe-attached chat and apply-changes flow (phase 5)
- Polish: Markdown rendering component, equipment context refinements, streaming fixes

## Test plan

- [ ] Start a new chat session and send a message — confirm streaming response renders correctly with Markdown
- [ ] Verify equipment and saved recipes appear in AI context (chef references them in replies)
- [ ] Use "save as recipe" from a chat response — confirm recipe appears in recipe list
- [ ] Use "apply changes" — confirm recipe is updated
- [ ] Attach an existing recipe to a chat session — confirm context is injected
- [ ] Confirm chat history persists across page reloads (Firestore subscription)
- [ ] All 1514 unit tests pass (`pnpm test`)

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)