### PR TITLE
fix(canon): prevent duplicate canon items from authorRecipe flow

### DIFF
--- a/apps/cloud-functions/src/flows/authorRecipe.ts
+++ b/apps/cloud-functions/src/flows/authorRecipe.ts
@@ -6,6 +6,7 @@ import type { RecipeDoc, IngredientGroupDoc } from '@salt/domain/schemas';
 import { withAiTimeout } from '../adapters/withAiTimeout.js';
 import { ai } from '../genkit.js';
 import { canonicaliseRecipeIngredientsFlow } from './canonicaliseRecipeIngredients.js';
+import { parseRecipeIngredientsFlow } from './parseRecipeIngredients.js';
 
 // Flash + temperature:0 for the librarian — accuracy over creativity (issue #206).
 const LIBRARIAN_MODEL = googleAI.model('gemini-flash-latest');
@@ -66,12 +67,33 @@ async function assembleDraft(raw: LibrarianOutput): Promise<RecipeDoc> {
     }
   }
 
+  // Parse raw texts to extract clean item names (strips quantity, unit, prep phrases).
+  // This mirrors what recipeService.canonicaliseIngredients does on the manual-entry path
+  // and ensures the canon matching stages see "garlic" not "1 head of garlic".
+  const parsedItemMap = new Map<string, string>();
+  if (allIngredients.length > 0) {
+    try {
+      const joinedRawText = allIngredients.map((i) => i.rawText).join('\n');
+      const parseResult = await parseRecipeIngredientsFlow({ rawText: joinedRawText });
+      for (const group of parseResult) {
+        for (const item of group.items) {
+          if (item.parsed?.item) parsedItemMap.set(item.rawText, item.parsed.item);
+        }
+      }
+    } catch {
+      // Parse failure is non-fatal — fall back to rawText as rawName below.
+    }
+  }
+
   // Batch canonicalise all ingredient raw texts.
   let canonResults: Awaited<ReturnType<typeof canonicaliseRecipeIngredientsFlow>> = [];
   if (allIngredients.length > 0) {
     try {
       canonResults = await canonicaliseRecipeIngredientsFlow({
-        items: allIngredients.map((i) => ({ rawName: i.rawText, rawText: i.rawText })),
+        items: allIngredients.map((i) => ({
+          rawName: parsedItemMap.get(i.rawText) ?? i.rawText,
+          rawText: i.rawText,
+        })),
       });
     } catch {
       // Canon failure is non-fatal — ingredients land as pending.

--- a/packages/domain/src/canon/commands/matchOrCreate.ts
+++ b/packages/domain/src/canon/commands/matchOrCreate.ts
@@ -441,6 +441,14 @@ async function applyClassification(
     newExtras = { reasoning: arbitrationFailureReasoning(arbResult) };
   }
 
+  // Failsafe: the AI may return a clean canonical name (e.g. "Garlic") that
+  // already exists in the snapshot even though the raw name (e.g. "1 head of
+  // garlic") failed all deterministic stages. Check before creating a duplicate.
+  const canonNameHit = findSnapshotMatch(createName, snapshot);
+  if (canonNameHit) {
+    return resolveMatch(store, canonNameHit, rawName, 'ai_arbitrated', commitLog);
+  }
+
   return persistNew(store, ids, createName, finalAisleId, commitLog, newExtras);
 }
 


### PR DESCRIPTION
Fixes #202

## Root cause

The `authorRecipe` Cloud Function was passing raw ingredient text (e.g. `"1 head of garlic"`) directly as `rawName` to canonicalisation, while the manual recipe entry path in `recipeService.ts` passes the clean parsed item name (e.g. `"garlic"`). Quantity/unit/filler tokens collapse token-overlap and string similarity scores below threshold, so existing canon items like `"Garlic"` were never found — resulting in a new duplicate being created every time.

## Changes

**Primary fix — `apps/cloud-functions/src/flows/authorRecipe.ts`**

Call `parseRecipeIngredientsFlow` over all raw ingredient texts before canonicalisation. This extracts the clean item name (`parsed.item`) for each ingredient, which is then passed as `rawName` to `canonicaliseRecipeIngredientsFlow`. Mirrors exactly what `recipeService.canonicaliseIngredients` does on the manual-entry path. Parse failure is non-fatal — falls back to raw text.

**Failsafe — `packages/domain/src/canon/commands/matchOrCreate.ts`**

In the empty-shortlist branch, after the AI returns a canonical name (e.g. `"Garlic"`), check the snapshot with `findSnapshotMatch` before calling `persistNew`. If the AI-returned name already exists, resolve as `ai_arbitrated` against the existing item instead of creating a duplicate. This catches the secondary case (e.g. your second White Wine) where the raw text fails all deterministic stages but the AI correctly identifies the existing canonical name.

## Test plan

- [ ] Author a recipe via chat that includes ingredients already in canon (garlic, salt, olive oil, lemon juice, white wine)
- [ ] Verify no new canon items are created for those ingredients — they should resolve to the existing ones
- [ ] Verify novel ingredients still create new canon items correctly
- [ ] Verify the recipe still assembles correctly with `canonId` and `matchState: 'matched'` set

https://claude.ai/code/session_01YR8ZWu2Lsu2s1qiWb7tcHT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YR8ZWu2Lsu2s1qiWb7tcHT)_