### PR TITLE
fix: bundle sharp for linux emulator container + portable husky hooks (macOS migration)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,10 @@
-# Use absolute path to pnpm for sandboxed environments
-/home/eggman/.local/share/pnpm/pnpm exec lint-staged
-/home/eggman/.local/share/pnpm/pnpm typecheck
-/home/eggman/.local/share/pnpm/pnpm depcruise --config .dependency-cruiser.cjs packages apps
+# Resolve pnpm from PATH so the hook is portable across machines/shells
+# (macOS, Linux, WSL). Falls back to corepack if pnpm isn't on PATH.
+pnpm_bin="$(command -v pnpm || true)"
+if [ -z "$pnpm_bin" ]; then
+  pnpm_bin="corepack pnpm"
+fi
+
+$pnpm_bin exec lint-staged
+$pnpm_bin typecheck
+$pnpm_bin depcruise --config .dependency-cruiser.cjs packages apps

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,8 @@
-/home/eggman/.local/share/pnpm/pnpm test
+# Resolve pnpm from PATH so the hook is portable across machines/shells
+# (macOS, Linux, WSL). Falls back to corepack if pnpm isn't on PATH.
+pnpm_bin="$(command -v pnpm || true)"
+if [ -z "$pnpm_bin" ]; then
+  pnpm_bin="corepack pnpm"
+fi
+
+$pnpm_bin test

--- a/apps/cloud-functions/package.json
+++ b/apps/cloud-functions/package.json
@@ -8,7 +8,7 @@
     "node": "22"
   },
   "scripts": {
-    "build": "rm -rf dist && esbuild src/index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:firebase-admin --external:firebase-admin/* --external:firebase-functions --external:firebase-functions/* --external:sharp --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\" && cp src/flows/assets/canon-icon-seed.png dist/canon-icon-seed.png && node scripts/write-deploy-package.mjs && npm install --prefix dist --omit=dev --no-audit --no-fund --loglevel=error",
+    "build": "rm -rf dist && esbuild src/index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:firebase-admin --external:firebase-admin/* --external:firebase-functions --external:firebase-functions/* --external:sharp --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\" && cp src/flows/assets/canon-icon-seed.png dist/canon-icon-seed.png && node scripts/write-deploy-package.mjs && npm install --prefix dist --omit=dev --no-audit --no-fund --loglevel=error --os=linux --cpu=$(node -p process.arch) --libc=glibc --include=optional",
     "dev": "NODE_OPTIONS='--disable-warning=DEP0040' genkit start --port 4001 -- tsx --env-file=.secret.local --watch src/dev.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
Two build/tooling fixes surfaced by the Intel/WSL → macOS (Apple Silicon) host move.

## 1. sharp binary for the Linux emulator container
The Cloud Functions `build` ran `npm install --prefix dist` on the **build host**, baking a host-platform sharp native binary into `dist/node_modules`. That `dist` is bind-mounted **read-only** into the linux test-emulator container, where a macOS (non-linux) binary fails to load — Functions triggers never register, the container healthcheck stays `unhealthy`, and `docker compose up --wait` (e2e `globalSetup`) blocks until timeout. Playwright never launches.

It worked on the old WSL2 box only because host (linux-x64) and container (linux-x64) arch coincided.

**Fix:** force the dist install to target the container platform —
`--os=linux` (always; the emulator is linux, GCP reinstalls sharp on deploy) and `--cpu=$(node -p process.arch)` so it follows the host arch, which Docker also uses for the container (arm64 on Apple Silicon / Windows-on-ARM, x64 elsewhere). `--libc=glibc` matches the `bookworm-slim` base image. Portable across macOS, Linux, and CI with no per-OS branching.

**Verified:** bundle now ships `sharp-linux-arm64`; emulator stack reaches `healthy` in ~11s with all 13 function definitions loaded.

## 2. Portable husky hooks
`.husky/pre-commit` and `.husky/pre-push` hardcoded `/home/eggman/.local/share/pnpm/pnpm` — a WSL path that doesn't exist on macOS, blocking every commit and push. Now resolve `pnpm` from `PATH` with a `corepack` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)