### PR TITLE
fix(ci): unbreak main — format extension.js + reset leaked dialog pointer-events

### DIFF
--- a/apps/web-pwa/tests/setup.ts
+++ b/apps/web-pwa/tests/setup.ts
@@ -1,4 +1,15 @@
 import '@testing-library/jest-dom/vitest';
-import { expect } from 'vitest';
+import { afterEach, expect } from 'vitest';
 import * as matchers from 'vitest-axe/matchers';
 expect.extend(matchers);
+
+// Dialog/AlertDialog primitives (bits-ui) make the page inert while open by
+// setting `pointer-events: none` on <body>, and restore it in a close-time
+// effect. When a test ends with a dialog still mounted, Testing Library's
+// auto-cleanup unmounts the component before that restore effect flushes, so
+// the inert style leaks onto <body> and the *next* test's user-event clicks
+// fail with "element has `pointer-events: none`". Reset it after every test so
+// dialog tests can't poison their successors. Harmless when no dialog ran.
+afterEach(() => {
+  document.body.style.pointerEvents = '';
+});

--- a/tools/task-pilot-extension/extension.js
+++ b/tools/task-pilot-extension/extension.js
@@ -205,9 +205,7 @@ class TaskPilotProvider {
   }
 
   runningExecution(label) {
-    return vscode.tasks.taskExecutions.find(
-      (execution) => getTaskLabel(execution.task) === label,
-    );
+    return vscode.tasks.taskExecutions.find((execution) => getTaskLabel(execution.task) === label);
   }
 
   async findTask(label) {


### PR DESCRIPTION
## Why main is red

main's CI has been failing since 2026-06-13. Two latent defects, the first masking the second:

1. **Format check fails.** `tools/task-pilot-extension/extension.js` landed via a `[skip ci]` commit and was never prettier-formatted. `pnpm format:check` scans the whole tree, so it fails on main **and on every branch cut from main** (this is why PRs #219 and #221 fail their `Lint, typecheck, test, boundary` job at the Format check step). Fixed by running prettier on the file.

2. **Masked test-isolation flake.** Because format:check fails first, the `Test` step never runs on main — hiding a flaky failure in `MealPlanWeekPage.test.ts`. bits-ui's `AlertDialog` sets `pointer-events: none` on `<body>` while open and restores it on close. When a test ends with a dialog still mounted, Testing Library's auto-cleanup unmounts the component before the restore effect flushes, leaking the inert style onto `<body>`; the **next** test's `user-event` click then fails with `element has pointer-events: none`. Fixed by resetting `document.body.style.pointerEvents` in a shared `afterEach`.

## Verification

Full CI suite run locally, all green: `format:check`, `lint`, `typecheck`, `test` (1514 passed), `boundary:test`, `provenance:check`, `theme:check`. The previously-failing `MealPlanWeekPage.test.ts` now passes in the full-file run (14/14).

This is the foundational fix; once merged, the open PRs rebase onto green main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)