### PR TITLE
fix(cloud-functions): add native host sharp binary for the local emulator

### DIFF
--- a/apps/cloud-functions/package.json
+++ b/apps/cloud-functions/package.json
@@ -8,7 +8,7 @@
     "node": "22"
   },
   "scripts": {
-    "build": "rm -rf dist && esbuild src/index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:firebase-admin --external:firebase-admin/* --external:firebase-functions --external:firebase-functions/* --external:sharp --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\" && cp src/flows/assets/canon-icon-seed.png dist/canon-icon-seed.png && node scripts/write-deploy-package.mjs && npm install --prefix dist --omit=dev --no-audit --no-fund --loglevel=error --os=linux --cpu=$(node -p process.arch) --libc=glibc --include=optional",
+    "build": "rm -rf dist && esbuild src/index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:firebase-admin --external:firebase-admin/* --external:firebase-functions --external:firebase-functions/* --external:sharp --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\" && cp src/flows/assets/canon-icon-seed.png dist/canon-icon-seed.png && node scripts/write-deploy-package.mjs && npm install --prefix dist --omit=dev --no-audit --no-fund --loglevel=error --os=linux --cpu=$(node -p process.arch) --libc=glibc --include=optional && node scripts/add-native-sharp.mjs",
     "dev": "NODE_OPTIONS='--disable-warning=DEP0040' genkit start --port 4001 -- tsx --env-file=.secret.local --watch src/dev.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/apps/cloud-functions/scripts/add-native-sharp.mjs
+++ b/apps/cloud-functions/scripts/add-native-sharp.mjs
@@ -1,0 +1,63 @@
+// Ensures dist/node_modules contains the HOST platform's sharp native binary.
+//
+// The build's main `npm install --prefix dist ... --os=linux` deliberately
+// targets the Linux test-emulator container and the Cloud Functions runtime
+// (see apps/cloud-functions/package.json "build"). That install bakes ONLY a
+// Linux sharp binary into dist. But `pnpm dev:emulators` runs the Functions
+// emulator NATIVELY on the dev host (e.g. macOS arm64), where a Linux-only
+// binary fails to load — sharp throws on require, the Functions codebase fails
+// to analyze, NO triggers register, and every callable 404s (which the browser
+// surfaces, misleadingly, as a CORS error).
+//
+// This step adds the host's sharp binary ALONGSIDE the Linux one. It is a no-op
+// on Linux (the main install already covered it) and harmless on deploy (GCP
+// reinstalls against dist/package.json) and in the Linux container (the extra
+// non-Linux binary is simply ignored by sharp's runtime loader).
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const distRoot = resolve(pkgRoot, 'dist');
+
+const { platform, arch } = process;
+
+// The main install already targets Linux; nothing to add when the host is Linux.
+if (platform === 'linux') {
+  console.log('add-native-sharp: host is linux, main install already covers it — skipping');
+  process.exit(0);
+}
+
+const sharpVersion = JSON.parse(
+  readFileSync(resolve(distRoot, 'node_modules/sharp/package.json'), 'utf8'),
+).version;
+
+const platformPkg = `@img/sharp-${platform}-${arch}@${sharpVersion}`;
+const libvipsPkg = `@img/sharp-libvips-${platform}-${arch}`;
+
+console.log(`add-native-sharp: adding ${platformPkg} for native emulator on ${platform}-${arch}`);
+
+// --no-save: don't touch dist/package.json (the deploy manifest stays Linux-clean).
+// Explicit package names + --no-save add binaries without pruning the Linux ones.
+execFileSync(
+  'npm',
+  [
+    'install',
+    '--prefix',
+    distRoot,
+    '--no-save',
+    '--no-audit',
+    '--no-fund',
+    '--loglevel=error',
+    `--os=${platform}`,
+    `--cpu=${arch}`,
+    '--include=optional',
+    platformPkg,
+    libvipsPkg,
+  ],
+  { stdio: 'inherit' },
+);
+
+console.log('add-native-sharp: done');


### PR DESCRIPTION
## Problem

Running the AI chef locally failed with what looked like a CORS error:

```
Access to fetch at 'http://127.0.0.1:5001/demo-salt/europe-west2/chefChat'
blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present
```

It wasn't CORS. The Functions emulator **crashed on load**, so zero triggers registered and every callable returned `404` — and a 404 has no `Access-Control-Allow-Origin` header, which the browser reports as a CORS preflight failure.

Real cause, from `firebase-debug.log`:

```
Error: Could not load the "sharp" module using the darwin-arm64 runtime
functions: Failed to load function definition from source: Functions codebase
          could not be analyzed successfully.
```

`baaf8f7` changed the CF build to install **Linux-only** sharp binaries into `dist/` (`--os=linux`) — correct for the e2e Docker container and GCP deploy. But `pnpm dev:emulators` runs the Functions emulator **natively on the dev host** (macOS arm64 since the migration), where a Linux-only sharp binary can't load.

## Fix

Add a post-build step that drops the **host platform's** sharp binary into `dist` alongside the Linux one:

- `scripts/add-native-sharp.mjs` — installs `@img/sharp-<host>` into `dist/node_modules`. No-op on Linux (the main install already covers it); harmless in the container / on deploy, where sharp's runtime loader ignores the non-matching binary.
- `package.json` build — appends `&& node scripts/add-native-sharp.mjs`.

One `build` now serves all three: native macOS dev, the Linux e2e container, and deploy.

## Verification

- Fresh `build` ships both `sharp-darwin-arm64` and `sharp-linux-arm64`; sharp loads cleanly on darwin (`libvips 8.17.3`).
- AI chef confirmed streaming locally after an emulator restart.
- Full suite green (1514 tests) via the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)