### PR TITLE
fix(web-pwa): keep loading screen up until Firebase restores session

### DIFF
--- a/apps/web-pwa/src/lib/auth.svelte.ts
+++ b/apps/web-pwa/src/lib/auth.svelte.ts
@@ -63,7 +63,11 @@ class AuthStore {
   private async maybeCompleteFromUrl(): Promise<void> {
     const url = window.location.href;
     if (!authProvider.isMagicLink(url)) {
-      this.loading = false;
+      // Not a magic-link return. Leave `loading` true and let the auth-state
+      // observer resolve it: Firebase restores a persisted session
+      // asynchronously, so `getCurrentUser()` is still null here on a cold
+      // load. Setting `loading = false` now would flash the login screen for
+      // the 1–5s the SDK takes to rehydrate an already-signed-in user.
       return;
     }
     const email = readPendingEmail();


### PR DESCRIPTION
## Problem

When an already-authenticated user loads the app, the sign-in screen flashes for ~1–5s (network-dependent) before the app appears, making users think they need to sign in again.

## Root cause

The "Signing you in…" loading screen already exists in `AuthGate`, but `auth.loading` was being resolved to `false` too early:

- Firebase restores a persisted session **asynchronously** — `auth.currentUser` is `null` synchronously on a cold load, so `getCurrentUser()` in the `AuthStore` constructor returns `null`.
- `maybeCompleteFromUrl()` then immediately set `loading = false` on any non-magic-link load. With `loading = false` and `user = null`, `AuthGate` dropped through to render `LoginPage`.
- The authoritative "Firebase finished restoring the session" signal is the `onAuthStateChanged` observer, which fires 1–5s later and only then sets the user.

## Fix

On a non-magic-link load, leave `loading` true and let the auth-state observer resolve it. The observer already sets `loading = false` — with the restored user (→ app) or `null` (→ login screen). Magic-link paths are unchanged.

Net effect: an already-authenticated user sees the "Signing you in…" screen until Firebase confirms the session, instead of a flash of the sign-in form.

## Testing

Hard to reproduce on a local machine — the emulators restore the session too fast to see the flash. Needs verification in **staging** against real network latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)