### PR TITLE
ci(deploy): grant allUsers invoker on callables after deploy (#234)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -72,3 +72,11 @@ jobs:
       # GEMINI_API_KEY / LD_SDK_KEY are already in prod Secret Manager.
       - name: Deploy to Firebase (production)
         run: pnpm exec firebase deploy -P production --non-interactive --force
+
+      # `firebase deploy --non-interactive` skips the "allow unauthenticated
+      # invocations?" prompt, so newly created/updated 2nd-gen callables come up
+      # PRIVATE and reject browser calls with a 403/no-CORS error (#234). The
+      # callables auth the *user* inside the function; Cloud Run must still allow
+      # allUsers to invoke. Re-apply that binding here. Idempotent.
+      - name: Grant public invoker on client callables
+        run: ./scripts/grant-callable-invokers.sh s2-prod-e46bd

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -128,3 +128,12 @@ jobs:
       - name: Deploy to Firebase (staging)
         if: ${{ steps.guard.outputs.should_deploy == 'true' }}
         run: pnpm exec firebase deploy -P staging --non-interactive --force
+
+      # `firebase deploy --non-interactive` skips the "allow unauthenticated
+      # invocations?" prompt, so newly created/updated 2nd-gen callables come up
+      # PRIVATE and reject browser calls with a 403/no-CORS error (#234). The
+      # callables auth the *user* inside the function; Cloud Run must still allow
+      # allUsers to invoke. Re-apply that binding here. Idempotent.
+      - name: Grant public invoker on client callables
+        if: ${{ steps.guard.outputs.should_deploy == 'true' }}
+        run: ./scripts/grant-callable-invokers.sh s2-stage-ccb22

--- a/scripts/grant-callable-invokers.sh
+++ b/scripts/grant-callable-invokers.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Grant `allUsers` the Cloud Run invoker role on every client-facing callable
+# Cloud Function.
+#
+# WHY THIS EXISTS
+# ---------------
+# Salt's callables authenticate the *user* inside the function (authPolicy:
+# isSignedIn() / a manual request.auth check). The underlying Cloud Run service
+# must still allow `allUsers` to *invoke* it — auth then happens one layer up,
+# in the function body. For 2nd-gen callables, `firebase deploy` only grants
+# that public-invoker binding when it can show the interactive "allow
+# unauthenticated invocations?" prompt. Our CI deploys run with
+# `--non-interactive`, so that prompt is skipped and a newly created/updated
+# callable comes up PRIVATE. Cloud Run then rejects browser calls at the front
+# door with a 403 that carries no CORS headers, which the browser surfaces as:
+#
+#   "No 'Access-Control-Allow-Origin' header is present on the requested resource"
+#
+# i.e. a misleading CORS error that is really a missing IAM binding. See #234.
+#
+# This script re-applies the binding deterministically after every deploy. It is
+# idempotent: granting a binding that already exists is a no-op success.
+#
+# USAGE
+#   scripts/grant-callable-invokers.sh <gcp-project-id>
+#
+# Requires an authenticated gcloud (the deploy workflows authenticate via WIF
+# before calling this). The active principal needs run.services.setIamPolicy
+# (e.g. roles/run.admin).
+
+set -euo pipefail
+
+PROJECT="${1:?usage: grant-callable-invokers.sh <gcp-project-id>}"
+REGION="europe-west2"
+
+# Client-facing callables only — these are invoked over HTTPS from web-pwa.
+# Firestore triggers (onCanonItemWritten, onShoppingListItemWrite) and auth
+# blocking functions (beforeMemberCreated) are NOT HTTP-invoked and must stay
+# private, so they are deliberately excluded. Keep this list in sync with the
+# onCall/onCallGenkit exports in apps/cloud-functions/src/index.ts.
+CALLABLES=(
+  embedText
+  arbitrateCanon
+  matchOrCreateCanon
+  canonicaliseRecipeIngredients
+  identifyEquipment
+  populateEquipmentEntry
+  parseRecipeIngredients
+  authorRecipe
+  chefChat
+  generateChatTitle
+  regenerateCanonIcon
+)
+
+echo "Granting allUsers invoker on ${#CALLABLES[@]} callables in ${PROJECT} (${REGION})"
+
+failed=()
+for fn in "${CALLABLES[@]}"; do
+  # The 2nd-gen Cloud Run service name is the lowercased function name.
+  svc="$(echo "$fn" | tr '[:upper:]' '[:lower:]')"
+  echo "== ${fn} (run service: ${svc}) =="
+  if ! gcloud run services add-iam-policy-binding "$svc" \
+        --region="$REGION" \
+        --project="$PROJECT" \
+        --member="allUsers" \
+        --role="roles/run.invoker" \
+        --quiet; then
+    echo "::warning::failed to grant invoker on ${fn}"
+    failed+=("$fn")
+  fi
+done
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  echo "::error::could not grant invoker on: ${failed[*]}"
+  exit 1
+fi
+
+echo "All callable invoker bindings applied."


### PR DESCRIPTION
## What

Adds a post-deploy step to **both** deploy workflows (staging + production) that re-applies the `allUsers` → `roles/run.invoker` binding to every client-facing callable, via a new shared idempotent script `scripts/grant-callable-invokers.sh`.

## Why

Both workflows deploy with `firebase deploy --non-interactive --force`. For 2nd-gen callables, `firebase deploy` only grants the public-invoker binding when it can show the interactive "allow unauthenticated invocations?" prompt — which `--non-interactive` skips. So a newly created/updated callable comes up **private**, and Cloud Run rejects browser calls at the front door with a 403 that carries no CORS headers. The browser surfaces this as a misleading:

> No 'Access-Control-Allow-Origin' header is present on the requested resource

Salt's callables authenticate the *user* inside the function (`authPolicy: isSignedIn()` / a manual `request.auth` check); Cloud Run must still allow `allUsers` to *invoke* — auth then happens one layer up. This bug hit `identifyEquipment`, then `populateEquipmentEntry`, on staging while adding equipment (#234). It surfaces one function at a time as each new callable is first invoked, and will eventually hit prod the same way.

## How

- `scripts/grant-callable-invokers.sh <project>` loops the client-facing callables and runs `gcloud run services add-iam-policy-binding ... --member=allUsers --role=roles/run.invoker`. Idempotent; fails the step (with a summary) if any binding can't be applied.
- The callable list is the single source of truth — keep it in sync with the `onCall`/`onCallGenkit` exports in `apps/cloud-functions/src/index.ts`. Firestore triggers and auth blocking functions are deliberately excluded (not HTTP-invoked).
- Wired in after the deploy step in `deploy-staging.yml` and `deploy-production.yml`.

## Prerequisite / note

The WIF deploy service account needs `run.services.setIamPolicy` (e.g. `roles/run.admin`) for the grant to succeed. If CI fails on this step with a permissions error, that role must be added to the deployer SA in each project.

This does **not** retroactively fix the currently-broken staging functions — run the grant script (or `scripts/grant-callable-invokers.sh s2-stage-ccb22` locally) once to clear the existing failures; thereafter every deploy keeps the bindings in place.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)