### PR TITLE
feat(web-pwa): reorder nav, default to shopping, unhide recipes

### DIFF
--- a/apps/web-pwa/e2e/canon-sync.spec.ts
+++ b/apps/web-pwa/e2e/canon-sync.spec.ts
@@ -15,7 +15,13 @@
  */
 import { expect, test } from './fixtures/test';
 import { gotoAndSignIn, uniqueEmail } from './helpers/auth';
-import { getAisles, getCanonItem, seedAisles, seedCanonItem } from './helpers/seed';
+import {
+  getAisles,
+  getCanonItem,
+  seedAisles,
+  seedCanonItem,
+  waitForCanonReady,
+} from './helpers/seed';
 
 // How long to wait for cross-tab propagation (emulator is fast but sync is async).
 const CONVERGENCE_TIMEOUT = 20_000;
@@ -47,6 +53,12 @@ test.describe('canon sync — two-tab convergence', () => {
       await gotoAndSignIn(page1, emailA);
       await gotoAndSignIn(page2, emailB);
 
+      // Both tabs must have their canon listeners attached and settled before
+      // any cross-tab write — otherwise a listener attaching mid-navigation can
+      // miss the delta on the emulator's forced long-polling transport (#199).
+      await waitForCanonReady(page1);
+      await waitForCanonReady(page2);
+
       // Tab A seeds a new canon item.
       await seedCanonItem(page1, { id: itemId, name: 'Sync Test Item' });
 
@@ -75,6 +87,12 @@ test.describe('canon sync — two-tab convergence', () => {
       await gotoAndSignIn(page1, emailA);
       await gotoAndSignIn(page2, emailB);
 
+      // Both tabs must have their canon listeners attached and settled before
+      // any cross-tab write — otherwise a listener attaching mid-navigation can
+      // miss the delta on the emulator's forced long-polling transport (#199).
+      await waitForCanonReady(page1);
+      await waitForCanonReady(page2);
+
       // Tab A writes aisles.
       const created = await seedAisles(page1, ['Produce', 'Dairy']);
       expect(created).toHaveLength(2);
@@ -100,6 +118,12 @@ test.describe('canon sync — two-tab convergence', () => {
 
       await gotoAndSignIn(page1, emailA);
       await gotoAndSignIn(page2, emailB);
+
+      // Both tabs must have their canon listeners attached and settled before
+      // any cross-tab write — otherwise a listener attaching mid-navigation can
+      // miss the delta on the emulator's forced long-polling transport (#199).
+      await waitForCanonReady(page1);
+      await waitForCanonReady(page2);
 
       // Write an aisle first.
       await seedAisles(page1, ['Bakery']);
@@ -135,6 +159,12 @@ test.describe('canon sync — two-tab convergence', () => {
 
       await gotoAndSignIn(page1, emailA);
       await gotoAndSignIn(page2, emailB);
+
+      // Both tabs must have their canon listeners attached and settled before
+      // any cross-tab write — otherwise a listener attaching mid-navigation can
+      // miss the delta on the emulator's forced long-polling transport (#199).
+      await waitForCanonReady(page1);
+      await waitForCanonReady(page2);
 
       // Take ctx1 offline via the SDK (more reliable than browser-level setOffline on WSL).
       await page1.evaluate(() => window.__e2e!.setFirestoreOffline(true));

--- a/apps/web-pwa/e2e/helpers/seed.ts
+++ b/apps/web-pwa/e2e/helpers/seed.ts
@@ -28,6 +28,17 @@ export async function getCanonItem(page: Page, id: string): Promise<CanonItem | 
   return page.evaluate((i) => window.__e2e!.getCanonItem(i), id);
 }
 
+// Wait until a tab's canon sync has attached and delivered its first snapshot.
+// Cross-tab convergence tests call this on the reader tab before the writer
+// seeds: it ensures the reader's onSnapshot listeners settle in a calm window
+// rather than mid-navigation, where the emulator's forced long-polling
+// transport can drop the update (residual flake, #199).
+export async function waitForCanonReady(page: Page): Promise<void> {
+  await page.waitForFunction(() => window.__e2e?.isCanonSynced() === true, null, {
+    timeout: 15_000,
+  });
+}
+
 export async function clearAllStores(page: Page): Promise<void> {
   await page.evaluate(() => window.__e2e!.clearStores());
 }

--- a/apps/web-pwa/src/App.svelte
+++ b/apps/web-pwa/src/App.svelte
@@ -12,7 +12,7 @@
   } from '@salt/ui-components';
   import AuthGate from './components/AuthGate.svelte';
   import { auth } from './lib/auth.svelte.js';
-  import { navItems, adminNavItem, recipesNavItem } from './lib/nav.js';
+  import { navItems, adminNavItem } from './lib/nav.js';
   import { routes } from './routes/index.js';
   import { toasts, dismissToast } from './lib/toastStore.js';
   import { canonItems, initCanonSync } from './lib/canonService.js';
@@ -60,9 +60,6 @@
   const needsApprovalCount = $derived($canonItems.filter((i) => i.needs_approval).length);
   const decoratedNavItems = $derived([
     ...navItems,
-    // Recipes is admin-only for now (incomplete module, #179) — same cosmetic
-    // gating as the operator entry below.
-    ...(isAdmin ? [recipesNavItem] : []),
     ...(isAdmin
       ? [needsApprovalCount > 0 ? { ...adminNavItem, badge: needsApprovalCount } : adminNavItem]
       : []),

--- a/apps/web-pwa/src/lib/e2eHooks.ts
+++ b/apps/web-pwa/src/lib/e2eHooks.ts
@@ -3,7 +3,7 @@ import { upsertCanonItem, setFirestoreNetwork } from '@salt/firebase-sync';
 import type { CanonItem } from '@salt/domain';
 import { devSignIn } from './auth.svelte.js';
 import { addAislesBulk, aisles } from './aisleService.js';
-import { canonItems } from './canonService.js';
+import { canonItems, isLoadingAisles } from './canonService.js';
 import { seedEquipmentManifest, getEquipmentSnapshot } from './equipmentService.js';
 import {
   getShoppingListsSnapshot,
@@ -60,6 +60,13 @@ export function installE2EHooks(): void {
 
     getAisles() {
       return get(aisles);
+    },
+
+    isCanonSynced() {
+      // initCanonSync sets isLoadingAisles=false once both the items and aisles
+      // listeners have fired their first snapshot — our "listeners attached and
+      // settled" signal for the convergence tests.
+      return !get(isLoadingAisles);
     },
 
     async getCanonItem(id) {

--- a/apps/web-pwa/src/lib/nav.ts
+++ b/apps/web-pwa/src/lib/nav.ts
@@ -3,7 +3,6 @@ import {
   BookOpen,
   CalendarDays,
   ChefHat,
-  Home,
   Settings,
   Shield,
   ShoppingCart,
@@ -11,25 +10,14 @@ import {
 import type { NavItem } from '@salt/ui-components';
 
 export const navItems: NavItem[] = [
-  { id: 'home', label: 'Home', icon: Home, href: '#/' },
   { id: 'shopping', label: 'Shop', icon: ShoppingCart, href: '#/shopping' },
-  { id: 'mealplan', label: 'Meals', icon: CalendarDays, href: '#/mealplan' },
-  { id: 'equipment', label: 'Kitchen', icon: Blender, href: '#/equipment' },
+  { id: 'mealplan', label: 'Planner', icon: CalendarDays, href: '#/mealplan' },
+  { id: 'recipes', label: 'Recipes', icon: BookOpen, href: '#/recipes' },
   // AI Kitchen Assistant (issue #206) — available to all members.
   { id: 'chat', label: 'Chef', icon: ChefHat, href: '#/chat' },
+  { id: 'equipment', label: 'Equipment', icon: Blender, href: '#/equipment' },
   { id: 'settings', label: 'Settings', icon: Settings, href: '#/settings' },
 ];
-
-// The recipe module is still incomplete (issue #179). Until it's ready for
-// everyone, keep it out of the default nav and surface it only to admins — the
-// same cosmetic gating used for the operator area. Route-level AdminGuard on the
-// recipe pages is the matching server-agnostic backstop against direct URLs.
-export const recipesNavItem: NavItem = {
-  id: 'recipes',
-  label: 'Recipes',
-  icon: BookOpen,
-  href: '#/recipes',
-};
 
 // Operator-area entry (issues #155, #157). Appended to the nav only for admins —
 // see App.svelte, which also hangs the canon needs-approval badge here now that

--- a/apps/web-pwa/src/lib/types/e2e.d.ts
+++ b/apps/web-pwa/src/lib/types/e2e.d.ts
@@ -23,6 +23,11 @@ export interface E2EBridge {
   seedCanonItem(input: SeedCanonItemInput): Promise<CanonItem>;
   getAisles(): readonly Aisle[];
   getCanonItem(id: string): Promise<CanonItem | null>;
+  // True once the canon sync (items + aisles onSnapshot listeners) has
+  // delivered its first snapshot — i.e. the listeners are attached and settled.
+  // Cross-tab convergence tests wait on this before the writer tab seeds, so
+  // the reader's listener attaches in a calm window rather than mid-navigation.
+  isCanonSynced(): boolean;
   clearStores(): Promise<void>;
   setFirestoreOffline(offline: boolean): Promise<void>;
   seedEquipmentManifest(manifest: EquipmentManifest): Promise<void>;

--- a/apps/web-pwa/src/routes/index.ts
+++ b/apps/web-pwa/src/routes/index.ts
@@ -1,5 +1,4 @@
 import type { RouteDefinition } from 'svelte-spa-router';
-import HomePage from './home/HomePage.svelte';
 import CanonListPage from './canon/CanonListPage.svelte';
 import CanonCreatePage from './canon/CanonCreatePage.svelte';
 import CanonDetailPage from './canon/CanonDetailPage.svelte';
@@ -26,7 +25,8 @@ import NotFound from './NotFound.svelte';
 
 // More-specific static routes must precede parameterised ones when using a Map.
 export const routes: RouteDefinition = new Map([
-  ['/', HomePage],
+  // Shopping is the default view; '/' redirects to the user's shopping list.
+  ['/', ShoppingListRedirectPage],
   ['/equipment', EquipmentListPage],
   ['/equipment/new', EquipmentCapturePage],
   ['/equipment/:id', EquipmentEditPage],

--- a/apps/web-pwa/src/routes/recipes/RecipeEditPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeEditPage.svelte
@@ -22,7 +22,6 @@
   } from '../../lib/recipeService.js';
   import { canonItems } from '../../lib/canonService.js';
   import { addToast } from '../../lib/toastStore.js';
-  import AdminGuard from '../admin/AdminGuard.svelte';
 
   interface Props {
     // Present on /recipes/:id/edit; absent (undefined) on /recipes/new.
@@ -334,427 +333,414 @@
   const pageTitle = $derived(editingId === null ? 'New recipe' : 'Edit recipe');
 </script>
 
-<!-- Recipe module gated to admins while incomplete (#179). -->
-<AdminGuard>
-  <DetailPage title={pageTitle} onBack={handleCancel} backLabel="Recipes" class="p-4 sm:p-6">
-    {#snippet actions()}
-      <Button variant="outline" size="sm" onclick={handleCancel} disabled={saving}>Cancel</Button>
-      <Button
-        size="sm"
-        onclick={handleSave}
-        loading={saving}
-        disabled={!canSave || saving}
-        data-testid="recipe-save-btn"
-      >
-        Save
-      </Button>
-    {/snippet}
+<DetailPage title={pageTitle} onBack={handleCancel} backLabel="Recipes" class="p-4 sm:p-6">
+  {#snippet actions()}
+    <Button variant="outline" size="sm" onclick={handleCancel} disabled={saving}>Cancel</Button>
+    <Button
+      size="sm"
+      onclick={handleSave}
+      loading={saving}
+      disabled={!canSave || saving}
+      data-testid="recipe-save-btn"
+    >
+      Save
+    </Button>
+  {/snippet}
 
-    <div class="flex flex-col gap-8" data-testid="recipe-editor">
-      <!-- Basics -->
-      <section class="flex flex-col gap-3">
-        <TextField
-          label="Title"
-          placeholder="e.g. Spiced lentil dahl"
-          value={draft.title}
-          onValueChange={(v) => (draft = { ...draft, title: v })}
-          required
-          data-testid="recipe-title-input"
-        />
-        <TextArea
-          label="Description"
-          placeholder="A short description (optional)"
-          value={draft.description ?? ''}
-          onValueChange={(v) => (draft = { ...draft, description: v.trim() === '' ? null : v })}
-          rows={2}
-          autoresize
-          data-testid="recipe-description-input"
-        />
-      </section>
+  <div class="flex flex-col gap-8" data-testid="recipe-editor">
+    <!-- Basics -->
+    <section class="flex flex-col gap-3">
+      <TextField
+        label="Title"
+        placeholder="e.g. Spiced lentil dahl"
+        value={draft.title}
+        onValueChange={(v) => (draft = { ...draft, title: v })}
+        required
+        data-testid="recipe-title-input"
+      />
+      <TextArea
+        label="Description"
+        placeholder="A short description (optional)"
+        value={draft.description ?? ''}
+        onValueChange={(v) => (draft = { ...draft, description: v.trim() === '' ? null : v })}
+        rows={2}
+        autoresize
+        data-testid="recipe-description-input"
+      />
+    </section>
 
-      <!-- Ingredient groups -->
-      <section class="flex flex-col gap-3">
-        <div class="flex items-center justify-between">
-          <p class="text-sm font-medium">Ingredients</p>
+    <!-- Ingredient groups -->
+    <section class="flex flex-col gap-3">
+      <div class="flex items-center justify-between">
+        <p class="text-sm font-medium">Ingredients</p>
+        <div class="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onclick={() => (showPasteArea = !showPasteArea)}
+            data-testid="recipe-parse-toggle-btn"
+          >
+            {#snippet leading()}<Icon name="Wand2" size={16} />{/snippet}
+            Parse from text
+          </Button>
+          <Button variant="outline" size="sm" onclick={addGroup} data-testid="recipe-add-group-btn">
+            {#snippet leading()}<Icon name="Plus" size={16} />{/snippet}
+            Add group
+          </Button>
+        </div>
+      </div>
+
+      {#if showPasteArea}
+        <div
+          class="flex flex-col gap-2 rounded border border-border bg-muted/50 p-3"
+          data-testid="recipe-parse-area"
+        >
+          <p class="text-sm text-muted-foreground">
+            Paste an ingredient list. The AI will detect groups and structure each ingredient while
+            preserving the original text.
+          </p>
+          <TextArea
+            label="Ingredient list"
+            placeholder="1 cup plain flour, sifted&#10;2 eggs&#10;&#10;For the sauce:&#10;2 cloves garlic, crushed"
+            value={pasteText}
+            onValueChange={(v) => (pasteText = v)}
+            rows={6}
+            autoresize
+            data-testid="recipe-parse-text-input"
+          />
           <div class="flex gap-2">
             <Button
-              variant="outline"
               size="sm"
-              onclick={() => (showPasteArea = !showPasteArea)}
-              data-testid="recipe-parse-toggle-btn"
+              onclick={handleParse}
+              loading={parsing}
+              disabled={pasteText.trim() === '' || parsing}
+              data-testid="recipe-parse-btn"
             >
-              {#snippet leading()}<Icon name="Wand2" size={16} />{/snippet}
-              Parse from text
+              Parse
             </Button>
             <Button
-              variant="outline"
+              variant="ghost"
               size="sm"
-              onclick={addGroup}
-              data-testid="recipe-add-group-btn"
+              onclick={() => {
+                showPasteArea = false;
+                pasteText = '';
+              }}
             >
-              {#snippet leading()}<Icon name="Plus" size={16} />{/snippet}
-              Add group
+              Cancel
             </Button>
           </div>
         </div>
+      {/if}
 
-        {#if showPasteArea}
-          <div
-            class="flex flex-col gap-2 rounded border border-border bg-muted/50 p-3"
-            data-testid="recipe-parse-area"
-          >
-            <p class="text-sm text-muted-foreground">
-              Paste an ingredient list. The AI will detect groups and structure each ingredient
-              while preserving the original text.
-            </p>
-            <TextArea
-              label="Ingredient list"
-              placeholder="1 cup plain flour, sifted&#10;2 eggs&#10;&#10;For the sauce:&#10;2 cloves garlic, crushed"
-              value={pasteText}
-              onValueChange={(v) => (pasteText = v)}
-              rows={6}
-              autoresize
-              data-testid="recipe-parse-text-input"
+      {#if draft.ingredients.length === 0}
+        <p class="text-sm text-muted-foreground">
+          No ingredient groups yet. Add a group to start entering ingredients.
+        </p>
+      {/if}
+
+      {#each draft.ingredients as group, gIdx (group.id)}
+        <div
+          class="flex flex-col gap-3 rounded border border-border bg-card p-3"
+          data-testid="recipe-group"
+          data-group-id={group.id}
+        >
+          <div class="flex items-end gap-2">
+            <TextField
+              label="Group name"
+              placeholder="e.g. For the sauce (leave blank for the main list)"
+              value={group.name ?? ''}
+              onValueChange={(v) => setGroupName(group.id, v)}
+              class="flex-1"
+              data-testid="recipe-group-name-input"
             />
-            <div class="flex gap-2">
-              <Button
-                size="sm"
-                onclick={handleParse}
-                loading={parsing}
-                disabled={pasteText.trim() === '' || parsing}
-                data-testid="recipe-parse-btn"
-              >
-                Parse
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onclick={() => {
-                  showPasteArea = false;
-                  pasteText = '';
-                }}
-              >
-                Cancel
-              </Button>
-            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onclick={() => moveGroup(gIdx, -1)}
+              disabled={gIdx === 0}
+              aria-label="Move group up"
+            >
+              <Icon name="ChevronUp" size={16} />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onclick={() => moveGroup(gIdx, 1)}
+              disabled={gIdx === draft.ingredients.length - 1}
+              aria-label="Move group down"
+            >
+              <Icon name="ChevronDown" size={16} />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onclick={() => removeGroup(group.id)}
+              aria-label="Remove group"
+              data-testid="recipe-remove-group-btn"
+            >
+              <Icon name="Trash2" size={16} />
+            </Button>
           </div>
-        {/if}
 
-        {#if draft.ingredients.length === 0}
-          <p class="text-sm text-muted-foreground">
-            No ingredient groups yet. Add a group to start entering ingredients.
-          </p>
-        {/if}
-
-        {#each draft.ingredients as group, gIdx (group.id)}
-          <div
-            class="flex flex-col gap-3 rounded border border-border bg-card p-3"
-            data-testid="recipe-group"
-            data-group-id={group.id}
-          >
-            <div class="flex items-end gap-2">
+          {#each group.items as ingredient (ingredient.id)}
+            <div
+              class="flex items-center gap-2"
+              data-testid="recipe-ingredient"
+              data-ingredient-id={ingredient.id}
+            >
               <TextField
-                label="Group name"
-                placeholder="e.g. For the sauce (leave blank for the main list)"
-                value={group.name ?? ''}
-                onValueChange={(v) => setGroupName(group.id, v)}
+                label="Ingredient"
+                placeholder="e.g. 1 ½ cups plain flour, sifted"
+                value={ingredient.rawText}
+                onValueChange={(v) => setIngredientRawText(group, ingredient.id, v)}
                 class="flex-1"
-                data-testid="recipe-group-name-input"
+                data-testid="recipe-ingredient-input"
+              />
+              {#if ingredient.rawText.trim() !== '' && !hasLiveCanonMatch(ingredient, liveCanonIds)}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onclick={() => handleMatchIngredient(group, ingredient)}
+                  loading={matchingIds[ingredient.id] ?? false}
+                  disabled={matchingIds[ingredient.id] ?? false}
+                  aria-label="Not matched — tap to match this ingredient"
+                  title="Not matched — tap to match this ingredient"
+                  class="shrink-0 text-destructive"
+                  data-testid="recipe-ingredient-match-btn"
+                >
+                  <Icon name="CircleX" size={16} />
+                </Button>
+              {/if}
+              <Switch
+                label="Optional"
+                checked={ingredient.isOptional}
+                onCheckedChange={(c) => setIngredientOptional(group, ingredient.id, c)}
               />
               <Button
                 variant="ghost"
                 size="sm"
-                onclick={() => moveGroup(gIdx, -1)}
-                disabled={gIdx === 0}
-                aria-label="Move group up"
+                onclick={() => removeIngredient(group, ingredient.id)}
+                aria-label="Remove ingredient"
+              >
+                <Icon name="X" size={16} />
+              </Button>
+            </div>
+          {/each}
+
+          <Button
+            variant="ghost"
+            size="sm"
+            onclick={() => addIngredient(group)}
+            class="self-start"
+            data-testid="recipe-add-ingredient-btn"
+          >
+            {#snippet leading()}<Icon name="Plus" size={16} />{/snippet}
+            Add ingredient
+          </Button>
+        </div>
+      {/each}
+    </section>
+
+    <!-- Steps -->
+    <section class="flex flex-col gap-3">
+      <div class="flex items-center justify-between">
+        <p class="text-sm font-medium">Method</p>
+        <Button variant="outline" size="sm" onclick={addStepRow} data-testid="recipe-add-step-btn">
+          {#snippet leading()}<Icon name="Plus" size={16} />{/snippet}
+          Add step
+        </Button>
+      </div>
+
+      {#if draft.steps.length === 0}
+        <p class="text-sm text-muted-foreground">No steps yet.</p>
+      {/if}
+
+      {#each draft.steps as step, sIdx (step.id)}
+        <div
+          class="flex flex-col gap-2 rounded border border-border bg-card p-3"
+          data-testid="recipe-step"
+          data-step-id={step.id}
+        >
+          <div class="flex items-start gap-2">
+            <span class="mt-2 text-sm font-medium text-muted-foreground">{sIdx + 1}.</span>
+            <TextArea
+              label="Step"
+              placeholder="Describe this step"
+              value={step.text}
+              onValueChange={(v) => setStepText(step.id, v)}
+              rows={2}
+              autoresize
+              class="flex-1"
+              data-testid="recipe-step-input"
+            />
+            <div class="flex flex-col">
+              <Button
+                variant="ghost"
+                size="sm"
+                onclick={() => moveStep(sIdx, -1)}
+                disabled={sIdx === 0}
+                aria-label="Move step up"
               >
                 <Icon name="ChevronUp" size={16} />
               </Button>
               <Button
                 variant="ghost"
                 size="sm"
-                onclick={() => moveGroup(gIdx, 1)}
-                disabled={gIdx === draft.ingredients.length - 1}
-                aria-label="Move group down"
+                onclick={() => moveStep(sIdx, 1)}
+                disabled={sIdx === draft.steps.length - 1}
+                aria-label="Move step down"
               >
                 <Icon name="ChevronDown" size={16} />
               </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onclick={() => removeGroup(group.id)}
-                aria-label="Remove group"
-                data-testid="recipe-remove-group-btn"
-              >
-                <Icon name="Trash2" size={16} />
-              </Button>
             </div>
-
-            {#each group.items as ingredient (ingredient.id)}
-              <div
-                class="flex items-center gap-2"
-                data-testid="recipe-ingredient"
-                data-ingredient-id={ingredient.id}
-              >
-                <TextField
-                  label="Ingredient"
-                  placeholder="e.g. 1 ½ cups plain flour, sifted"
-                  value={ingredient.rawText}
-                  onValueChange={(v) => setIngredientRawText(group, ingredient.id, v)}
-                  class="flex-1"
-                  data-testid="recipe-ingredient-input"
-                />
-                {#if ingredient.rawText.trim() !== '' && !hasLiveCanonMatch(ingredient, liveCanonIds)}
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onclick={() => handleMatchIngredient(group, ingredient)}
-                    loading={matchingIds[ingredient.id] ?? false}
-                    disabled={matchingIds[ingredient.id] ?? false}
-                    aria-label="Not matched — tap to match this ingredient"
-                    title="Not matched — tap to match this ingredient"
-                    class="shrink-0 text-destructive"
-                    data-testid="recipe-ingredient-match-btn"
-                  >
-                    <Icon name="CircleX" size={16} />
-                  </Button>
-                {/if}
-                <Switch
-                  label="Optional"
-                  checked={ingredient.isOptional}
-                  onCheckedChange={(c) => setIngredientOptional(group, ingredient.id, c)}
-                />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onclick={() => removeIngredient(group, ingredient.id)}
-                  aria-label="Remove ingredient"
-                >
-                  <Icon name="X" size={16} />
-                </Button>
-              </div>
-            {/each}
-
             <Button
               variant="ghost"
               size="sm"
-              onclick={() => addIngredient(group)}
-              class="self-start"
-              data-testid="recipe-add-ingredient-btn"
+              onclick={() => removeStep(step.id)}
+              aria-label="Remove step"
             >
-              {#snippet leading()}<Icon name="Plus" size={16} />{/snippet}
-              Add ingredient
+              <Icon name="Trash2" size={16} />
             </Button>
           </div>
-        {/each}
-      </section>
 
-      <!-- Steps -->
-      <section class="flex flex-col gap-3">
-        <div class="flex items-center justify-between">
-          <p class="text-sm font-medium">Method</p>
-          <Button
-            variant="outline"
-            size="sm"
-            onclick={addStepRow}
-            data-testid="recipe-add-step-btn"
-          >
-            {#snippet leading()}<Icon name="Plus" size={16} />{/snippet}
-            Add step
-          </Button>
-        </div>
-
-        {#if draft.steps.length === 0}
-          <p class="text-sm text-muted-foreground">No steps yet.</p>
-        {/if}
-
-        {#each draft.steps as step, sIdx (step.id)}
-          <div
-            class="flex flex-col gap-2 rounded border border-border bg-card p-3"
-            data-testid="recipe-step"
-            data-step-id={step.id}
-          >
-            <div class="flex items-start gap-2">
-              <span class="mt-2 text-sm font-medium text-muted-foreground">{sIdx + 1}.</span>
-              <TextArea
-                label="Step"
-                placeholder="Describe this step"
-                value={step.text}
-                onValueChange={(v) => setStepText(step.id, v)}
-                rows={2}
-                autoresize
+          <div class="flex items-center gap-3 pl-6">
+            <Switch
+              label="Timer"
+              checked={step.timer !== null}
+              onCheckedChange={(c) => toggleStepTimer(step.id, c)}
+            />
+            {#if step.timer}
+              <TextField
+                label="Minutes"
+                inputmode="numeric"
+                value={String(step.timer.durationMinutes)}
+                onValueChange={(v) => setStepTimerMinutes(step.id, v)}
+                class="w-28"
+                data-testid="recipe-step-timer-minutes"
+              />
+              <TextField
+                label="Timer label"
+                placeholder="e.g. until golden"
+                value={step.timer.description ?? ''}
+                onValueChange={(v) => setStepTimerDescription(step.id, v)}
                 class="flex-1"
-                data-testid="recipe-step-input"
+                data-testid="recipe-step-timer-description"
               />
-              <div class="flex flex-col">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onclick={() => moveStep(sIdx, -1)}
-                  disabled={sIdx === 0}
-                  aria-label="Move step up"
-                >
-                  <Icon name="ChevronUp" size={16} />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onclick={() => moveStep(sIdx, 1)}
-                  disabled={sIdx === draft.steps.length - 1}
-                  aria-label="Move step down"
-                >
-                  <Icon name="ChevronDown" size={16} />
-                </Button>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onclick={() => removeStep(step.id)}
-                aria-label="Remove step"
-              >
-                <Icon name="Trash2" size={16} />
-              </Button>
-            </div>
-
-            <div class="flex items-center gap-3 pl-6">
-              <Switch
-                label="Timer"
-                checked={step.timer !== null}
-                onCheckedChange={(c) => toggleStepTimer(step.id, c)}
-              />
-              {#if step.timer}
-                <TextField
-                  label="Minutes"
-                  inputmode="numeric"
-                  value={String(step.timer.durationMinutes)}
-                  onValueChange={(v) => setStepTimerMinutes(step.id, v)}
-                  class="w-28"
-                  data-testid="recipe-step-timer-minutes"
-                />
-                <TextField
-                  label="Timer label"
-                  placeholder="e.g. until golden"
-                  value={step.timer.description ?? ''}
-                  onValueChange={(v) => setStepTimerDescription(step.id, v)}
-                  class="flex-1"
-                  data-testid="recipe-step-timer-description"
-                />
-              {/if}
-            </div>
-
-            <div class="pl-6">
-              <TextArea
-                label="Note (optional)"
-                placeholder="Any note for this step"
-                value={step.note ?? ''}
-                onValueChange={(v) => setStepNote(step.id, v)}
-                rows={2}
-                autoresize
-                data-testid="recipe-step-note-input"
-              />
-            </div>
+            {/if}
           </div>
-        {/each}
-      </section>
 
-      <!-- Metadata -->
-      <section class="flex flex-col gap-3">
-        <p class="text-sm font-medium">Details</p>
-        <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <TextField
-            label="Servings"
-            inputmode="numeric"
-            value={draft.metadata.servings === null ? '' : String(draft.metadata.servings)}
-            onValueChange={(v) => setMetadata({ servings: parseNumberOrNull(v) })}
-            data-testid="recipe-servings-input"
-          />
-          <TextField
-            label="Prep (min)"
-            inputmode="numeric"
-            value={draft.metadata.prepTimeMinutes === null
-              ? ''
-              : String(draft.metadata.prepTimeMinutes)}
-            onValueChange={(v) => setMetadata({ prepTimeMinutes: parseNumberOrNull(v) })}
-            data-testid="recipe-prep-input"
-          />
-          <TextField
-            label="Cook (min)"
-            inputmode="numeric"
-            value={draft.metadata.cookTimeMinutes === null
-              ? ''
-              : String(draft.metadata.cookTimeMinutes)}
-            onValueChange={(v) => setMetadata({ cookTimeMinutes: parseNumberOrNull(v) })}
-            data-testid="recipe-cook-input"
-          />
-          <TextField
-            label="Total (min)"
-            inputmode="numeric"
-            value={draft.metadata.totalTimeMinutes === null
-              ? ''
-              : String(draft.metadata.totalTimeMinutes)}
-            onValueChange={(v) => setMetadata({ totalTimeMinutes: parseNumberOrNull(v) })}
-            data-testid="recipe-total-input"
-          />
-        </div>
-        <!-- Tag picker -->
-        <div class="flex flex-col gap-1.5">
-          <p class="text-sm font-medium">Tags</p>
-          <div
-            class="flex min-h-9 flex-wrap items-center gap-1.5 rounded border border-input bg-background px-3 py-1.5 focus-within:ring-2 focus-within:ring-ring"
-          >
-            {#each draft.metadata.tags as tag (tag)}
-              <span
-                class="inline-flex items-center gap-1 rounded bg-muted px-2 py-0.5 text-xs font-medium"
-              >
-                {tag}
-                <button
-                  type="button"
-                  class="text-muted-foreground hover:text-foreground"
-                  onclick={() => removeTag(tag)}
-                  aria-label="Remove {tag}"
-                >
-                  <Icon name="X" size={10} />
-                </button>
-              </span>
-            {/each}
-            <input
-              type="text"
-              class="min-w-24 flex-1 bg-transparent py-0.5 text-sm outline-none placeholder:text-muted-foreground"
-              placeholder={draft.metadata.tags.length === 0 ? 'Add tags…' : ''}
-              bind:value={tagInput}
-              onkeydown={handleTagKeydown}
-              data-testid="recipe-tags-input"
+          <div class="pl-6">
+            <TextArea
+              label="Note (optional)"
+              placeholder="Any note for this step"
+              value={step.note ?? ''}
+              onValueChange={(v) => setStepNote(step.id, v)}
+              rows={2}
+              autoresize
+              data-testid="recipe-step-note-input"
             />
           </div>
-          {#if availableSuggestions.length > 0}
-            <div class="flex flex-wrap gap-1.5">
-              {#each availableSuggestions as tag (tag)}
-                <button
-                  type="button"
-                  class="rounded border border-dashed border-muted-foreground/40 px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:border-muted-foreground hover:text-foreground"
-                  onclick={() => addTag(tag)}
-                >
-                  + {tag}
-                </button>
-              {/each}
-            </div>
-          {/if}
         </div>
-      </section>
+      {/each}
+    </section>
 
-      <!-- Notes -->
-      <section class="flex flex-col gap-3">
-        <p class="text-sm font-medium">Notes</p>
-        <TextArea
-          label="Notes"
-          placeholder="Anything else worth remembering"
-          value={draft.notes ?? ''}
-          onValueChange={(v) => (draft = { ...draft, notes: v.trim() === '' ? null : v })}
-          rows={3}
-          autoresize
-          data-testid="recipe-notes-input"
+    <!-- Metadata -->
+    <section class="flex flex-col gap-3">
+      <p class="text-sm font-medium">Details</p>
+      <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <TextField
+          label="Servings"
+          inputmode="numeric"
+          value={draft.metadata.servings === null ? '' : String(draft.metadata.servings)}
+          onValueChange={(v) => setMetadata({ servings: parseNumberOrNull(v) })}
+          data-testid="recipe-servings-input"
         />
-      </section>
-    </div>
-  </DetailPage>
-</AdminGuard>
+        <TextField
+          label="Prep (min)"
+          inputmode="numeric"
+          value={draft.metadata.prepTimeMinutes === null
+            ? ''
+            : String(draft.metadata.prepTimeMinutes)}
+          onValueChange={(v) => setMetadata({ prepTimeMinutes: parseNumberOrNull(v) })}
+          data-testid="recipe-prep-input"
+        />
+        <TextField
+          label="Cook (min)"
+          inputmode="numeric"
+          value={draft.metadata.cookTimeMinutes === null
+            ? ''
+            : String(draft.metadata.cookTimeMinutes)}
+          onValueChange={(v) => setMetadata({ cookTimeMinutes: parseNumberOrNull(v) })}
+          data-testid="recipe-cook-input"
+        />
+        <TextField
+          label="Total (min)"
+          inputmode="numeric"
+          value={draft.metadata.totalTimeMinutes === null
+            ? ''
+            : String(draft.metadata.totalTimeMinutes)}
+          onValueChange={(v) => setMetadata({ totalTimeMinutes: parseNumberOrNull(v) })}
+          data-testid="recipe-total-input"
+        />
+      </div>
+      <!-- Tag picker -->
+      <div class="flex flex-col gap-1.5">
+        <p class="text-sm font-medium">Tags</p>
+        <div
+          class="flex min-h-9 flex-wrap items-center gap-1.5 rounded border border-input bg-background px-3 py-1.5 focus-within:ring-2 focus-within:ring-ring"
+        >
+          {#each draft.metadata.tags as tag (tag)}
+            <span
+              class="inline-flex items-center gap-1 rounded bg-muted px-2 py-0.5 text-xs font-medium"
+            >
+              {tag}
+              <button
+                type="button"
+                class="text-muted-foreground hover:text-foreground"
+                onclick={() => removeTag(tag)}
+                aria-label="Remove {tag}"
+              >
+                <Icon name="X" size={10} />
+              </button>
+            </span>
+          {/each}
+          <input
+            type="text"
+            class="min-w-24 flex-1 bg-transparent py-0.5 text-sm outline-none placeholder:text-muted-foreground"
+            placeholder={draft.metadata.tags.length === 0 ? 'Add tags…' : ''}
+            bind:value={tagInput}
+            onkeydown={handleTagKeydown}
+            data-testid="recipe-tags-input"
+          />
+        </div>
+        {#if availableSuggestions.length > 0}
+          <div class="flex flex-wrap gap-1.5">
+            {#each availableSuggestions as tag (tag)}
+              <button
+                type="button"
+                class="rounded border border-dashed border-muted-foreground/40 px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:border-muted-foreground hover:text-foreground"
+                onclick={() => addTag(tag)}
+              >
+                + {tag}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    </section>
+
+    <!-- Notes -->
+    <section class="flex flex-col gap-3">
+      <p class="text-sm font-medium">Notes</p>
+      <TextArea
+        label="Notes"
+        placeholder="Anything else worth remembering"
+        value={draft.notes ?? ''}
+        onValueChange={(v) => (draft = { ...draft, notes: v.trim() === '' ? null : v })}
+        rows={3}
+        autoresize
+        data-testid="recipe-notes-input"
+      />
+    </section>
+  </div>
+</DetailPage>

--- a/apps/web-pwa/src/routes/recipes/RecipeListPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeListPage.svelte
@@ -2,7 +2,6 @@
   import { Button, ListPage } from '@salt/ui-components';
   import { push } from 'svelte-spa-router';
   import { recipes, isLoadingRecipes } from '../../lib/recipeService.js';
-  import AdminGuard from '../admin/AdminGuard.svelte';
 
   const sorted = $derived([...$recipes].sort((a, b) => a.title.localeCompare(b.title)));
 
@@ -11,46 +10,43 @@
   }
 </script>
 
-<!-- Recipe module gated to admins while incomplete (#179). -->
-<AdminGuard>
-  <ListPage
-    title="Recipes"
-    description="Your recipe collection."
-    isLoading={$isLoadingRecipes}
-    isEmpty={sorted.length === 0}
-    class="p-4 sm:p-6"
-  >
-    {#snippet actions()}
-      <Button size="sm" onclick={() => push('/recipes/new')} data-testid="recipe-new-btn">
-        New recipe
-      </Button>
-    {/snippet}
+<ListPage
+  title="Recipes"
+  description="Your recipe collection."
+  isLoading={$isLoadingRecipes}
+  isEmpty={sorted.length === 0}
+  class="p-4 sm:p-6"
+>
+  {#snippet actions()}
+    <Button size="sm" onclick={() => push('/recipes/new')} data-testid="recipe-new-btn">
+      New recipe
+    </Button>
+  {/snippet}
 
-    {#snippet empty()}
-      <div class="flex flex-col items-center gap-3 py-12 text-center">
-        <p class="text-sm text-muted-foreground">No recipes yet.</p>
-        <Button size="sm" onclick={() => push('/recipes/new')}>Create your first recipe</Button>
-      </div>
-    {/snippet}
+  {#snippet empty()}
+    <div class="flex flex-col items-center gap-3 py-12 text-center">
+      <p class="text-sm text-muted-foreground">No recipes yet.</p>
+      <Button size="sm" onclick={() => push('/recipes/new')}>Create your first recipe</Button>
+    </div>
+  {/snippet}
 
-    {#snippet children()}
-      <ul class="flex flex-col gap-1" data-testid="recipe-list">
-        {#each sorted as recipe (recipe.id)}
-          <li>
-            <button
-              class="w-full rounded px-2 py-2 text-left text-sm font-medium hover:bg-muted"
-              onclick={() => push(`/recipes/${recipe.id}`)}
-              data-testid="recipe-list-item"
-              data-recipe-id={recipe.id}
-            >
-              {recipe.title}
-              <span class="ml-2 text-xs font-normal text-muted-foreground">
-                {ingredientCount(recipe)} ingredient{ingredientCount(recipe) === 1 ? '' : 's'}
-              </span>
-            </button>
-          </li>
-        {/each}
-      </ul>
-    {/snippet}
-  </ListPage>
-</AdminGuard>
+  {#snippet children()}
+    <ul class="flex flex-col gap-1" data-testid="recipe-list">
+      {#each sorted as recipe (recipe.id)}
+        <li>
+          <button
+            class="w-full rounded px-2 py-2 text-left text-sm font-medium hover:bg-muted"
+            onclick={() => push(`/recipes/${recipe.id}`)}
+            data-testid="recipe-list-item"
+            data-recipe-id={recipe.id}
+          >
+            {recipe.title}
+            <span class="ml-2 text-xs font-normal text-muted-foreground">
+              {ingredientCount(recipe)} ingredient{ingredientCount(recipe) === 1 ? '' : 's'}
+            </span>
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/snippet}
+</ListPage>

--- a/apps/web-pwa/src/routes/recipes/RecipeViewPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeViewPage.svelte
@@ -34,7 +34,6 @@
   import { auth } from '../../lib/auth.svelte.js';
   import { createChatSession, sessions, sendMessage } from '../../lib/chatService.js';
   import { callAuthorRecipe, saveRecipe as saveRecipeDoc } from '@salt/firebase-sync';
-  import AdminGuard from '../admin/AdminGuard.svelte';
 
   interface Props {
     params: { id: string };
@@ -274,384 +273,379 @@
   }
 </script>
 
-<!-- Recipe module gated to admins while incomplete (#179). -->
-<AdminGuard>
-  {#if recipe === null}
-    <div class="p-4 sm:p-6">
-      {#if $isLoadingRecipes}
-        <p class="text-sm text-muted-foreground">Loading…</p>
-      {:else}
-        <p class="text-sm text-muted-foreground">Recipe not found.</p>
-        <Button variant="outline" class="mt-4" onclick={() => push('/recipes')}
-          >Back to recipes</Button
-        >
-      {/if}
-    </div>
-  {:else}
-    <DetailPage
-      title={recipe.title}
-      onBack={() => push('/recipes')}
-      backLabel="Recipes"
-      class="p-4 sm:p-6"
-    >
-      {#snippet actions()}
-        <Button
-          size="sm"
-          variant="outline"
-          onclick={handleAskAmend}
-          loading={amendBusy}
-          disabled={amendBusy}
-          data-testid="recipe-ask-amend-button"
-        >
-          {#snippet leading()}<Icon name="ChefHat" size={16} />{/snippet}
-          Ask / amend
-        </Button>
-        <Button
-          size="sm"
-          variant="outline"
-          onclick={openAddToList}
-          data-testid="recipe-add-to-list-button"
-        >
-          {#snippet leading()}<Icon name="ShoppingCart" size={16} />{/snippet}
-          Add to list
-        </Button>
-        <Button
-          size="sm"
-          onclick={() => push(`/recipes/${recipe.id}/edit`)}
-          data-testid="recipe-edit-button"
-        >
-          {#snippet leading()}<Icon name="Pencil" size={16} />{/snippet}
-          Edit
-        </Button>
-        <Button
-          variant="destructive"
-          size="sm"
-          onclick={() => (deleteOpen = true)}
-          data-testid="recipe-delete-button"
-        >
-          {#snippet leading()}<Icon name="Trash2" size={16} />{/snippet}
-          Delete
-        </Button>
-      {/snippet}
+{#if recipe === null}
+  <div class="p-4 sm:p-6">
+    {#if $isLoadingRecipes}
+      <p class="text-sm text-muted-foreground">Loading…</p>
+    {:else}
+      <p class="text-sm text-muted-foreground">Recipe not found.</p>
+      <Button variant="outline" class="mt-4" onclick={() => push('/recipes')}
+        >Back to recipes</Button
+      >
+    {/if}
+  </div>
+{:else}
+  <DetailPage
+    title={recipe.title}
+    onBack={() => push('/recipes')}
+    backLabel="Recipes"
+    class="p-4 sm:p-6"
+  >
+    {#snippet actions()}
+      <Button
+        size="sm"
+        variant="outline"
+        onclick={handleAskAmend}
+        loading={amendBusy}
+        disabled={amendBusy}
+        data-testid="recipe-ask-amend-button"
+      >
+        {#snippet leading()}<Icon name="ChefHat" size={16} />{/snippet}
+        Ask / amend
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        onclick={openAddToList}
+        data-testid="recipe-add-to-list-button"
+      >
+        {#snippet leading()}<Icon name="ShoppingCart" size={16} />{/snippet}
+        Add to list
+      </Button>
+      <Button
+        size="sm"
+        onclick={() => push(`/recipes/${recipe.id}/edit`)}
+        data-testid="recipe-edit-button"
+      >
+        {#snippet leading()}<Icon name="Pencil" size={16} />{/snippet}
+        Edit
+      </Button>
+      <Button
+        variant="destructive"
+        size="sm"
+        onclick={() => (deleteOpen = true)}
+        data-testid="recipe-delete-button"
+      >
+        {#snippet leading()}<Icon name="Trash2" size={16} />{/snippet}
+        Delete
+      </Button>
+    {/snippet}
 
-      <div class="grid gap-4 lg:grid-cols-[2fr_1fr] lg:gap-6" data-testid="recipe-view">
-        <!-- Left column: main recipe content -->
-        <div class="flex flex-col gap-4">
-          <!-- Description + meta chips -->
-          {#if recipe.description || timeParts().length > 0 || recipe.metadata.tags.length > 0}
-            <Card>
-              <CardContent class="flex flex-col gap-3 p-4">
-                {#if recipe.description}
-                  <p class="text-sm text-muted-foreground">{recipe.description}</p>
-                {/if}
-                {#if timeParts().length > 0 || recipe.metadata.tags.length > 0}
-                  <div class="flex flex-wrap items-center gap-2">
-                    {#each timeParts() as part (part)}
-                      <span class="rounded bg-muted px-2 py-1 text-xs text-muted-foreground"
-                        >{part}</span
-                      >
-                    {/each}
-                    {#each recipe.metadata.tags as tag (tag)}
-                      <span class="rounded bg-muted px-2 py-1 text-xs text-muted-foreground"
-                        >#{tag}</span
-                      >
-                    {/each}
-                  </div>
-                {/if}
-              </CardContent>
-            </Card>
-          {/if}
-
-          <!-- Ingredients -->
+    <div class="grid gap-4 lg:grid-cols-[2fr_1fr] lg:gap-6" data-testid="recipe-view">
+      <!-- Left column: main recipe content -->
+      <div class="flex flex-col gap-4">
+        <!-- Description + meta chips -->
+        {#if recipe.description || timeParts().length > 0 || recipe.metadata.tags.length > 0}
           <Card>
-            <CardHeader class="px-4 pt-4 pb-0">
-              <div class="flex items-center justify-between">
-                <CardTitle class="text-sm">Ingredients</CardTitle>
-                {#if hasParsedPending}
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onclick={handleCanonicalise}
-                    loading={canonalising}
-                    disabled={canonalising}
-                    data-testid="recipe-canonicalise-button"
-                  >
-                    {#snippet leading()}<Icon name="Link" size={14} />{/snippet}
-                    Canonicalise
-                  </Button>
-                {/if}
-              </div>
-            </CardHeader>
-            <CardContent class="px-4 pb-4 pt-3">
-              {#if recipe.ingredients.length === 0}
-                <p class="text-sm text-muted-foreground">No ingredients.</p>
+            <CardContent class="flex flex-col gap-3 p-4">
+              {#if recipe.description}
+                <p class="text-sm text-muted-foreground">{recipe.description}</p>
               {/if}
-              {#each recipe.ingredients as group (group.id)}
-                <div class="flex flex-col gap-1 [&+&]:mt-3" data-testid="recipe-view-group">
-                  {#if group.name}
-                    <p
-                      class="text-xs font-medium uppercase tracking-wide text-muted-foreground"
-                      data-testid="recipe-view-group-name"
+              {#if timeParts().length > 0 || recipe.metadata.tags.length > 0}
+                <div class="flex flex-wrap items-center gap-2">
+                  {#each timeParts() as part (part)}
+                    <span class="rounded bg-muted px-2 py-1 text-xs text-muted-foreground"
+                      >{part}</span
                     >
-                      {group.name}
-                    </p>
-                  {/if}
-                  <ul class="flex flex-col gap-1">
-                    {#each group.items as ingredient (ingredient.id)}
-                      <li class="text-sm" data-testid="recipe-view-ingredient">
-                        {ingredient.rawText}{#if ingredient.parsed?.displayText && ingredient.parsed?.quantity && ingredient.parsed?.unit}<span
-                            class="ml-1 text-xs text-muted-foreground"
-                            >({formatMetricQty(ingredient.parsed.quantity)}{ingredient.parsed
-                              .unit})</span
-                          >{/if}{#if ingredient.isOptional}<span
-                            class="ml-1 text-xs text-muted-foreground">(optional)</span
-                          >{/if}{#if !hasLiveCanonMatch(ingredient, liveCanonIds)}<button
-                            type="button"
-                            class="ml-1 text-xs text-destructive hover:underline disabled:opacity-50"
-                            title="Not matched — tap to match"
-                            aria-label="Not matched — tap to match"
-                            onclick={() => handleRematch(group, ingredient)}
-                            disabled={matchingIds[ingredient.id] ?? false}
-                            data-testid="match-state-unmatched"
-                            >{(matchingIds[ingredient.id] ?? false) ? '…' : '✗'}</button
-                          >{/if}
-                      </li>
-                    {/each}
-                  </ul>
+                  {/each}
+                  {#each recipe.metadata.tags as tag (tag)}
+                    <span class="rounded bg-muted px-2 py-1 text-xs text-muted-foreground"
+                      >#{tag}</span
+                    >
+                  {/each}
                 </div>
-              {/each}
+              {/if}
             </CardContent>
           </Card>
+        {/if}
 
-          <!-- Method -->
-          <Card>
-            <CardHeader class="px-4 pt-4 pb-0">
-              <CardTitle class="text-sm">Method</CardTitle>
-            </CardHeader>
-            <CardContent class="px-4 pb-4 pt-3">
-              {#if recipe.steps.length === 0}
-                <p class="text-sm text-muted-foreground">No steps.</p>
-              {/if}
-              <ol class="flex flex-col gap-4">
-                {#each recipe.steps as step, idx (step.id)}
-                  <li class="flex gap-3 text-sm" data-testid="recipe-view-step">
-                    <span class="mt-0.5 shrink-0 font-semibold text-muted-foreground"
-                      >{idx + 1}</span
-                    >
-                    <div class="flex flex-1 flex-col gap-1.5">
-                      <span>{step.text}</span>
-                      {#if step.note}
-                        <div
-                          class="flex items-start gap-2 rounded border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-700 dark:bg-amber-950/60 dark:text-amber-300"
-                          data-testid="recipe-step-note-content"
-                        >
-                          <Icon
-                            name="TriangleAlert"
-                            size={13}
-                            class="mt-0.5 shrink-0 text-amber-500"
-                          />
-                          <span class="whitespace-pre-wrap">{step.note}</span>
-                        </div>
-                      {/if}
-                      {#if step.timer}
-                        <span class="text-xs text-muted-foreground">
-                          ⏱ {step.timer.durationMinutes} min{step.timer.description
-                            ? ` — ${step.timer.description}`
-                            : ''}
-                        </span>
-                      {/if}
-                    </div>
-                  </li>
-                {/each}
-              </ol>
-            </CardContent>
-          </Card>
-
-          <!-- Notes -->
-          {#if recipe.notes}
-            <Card>
-              <CardHeader class="px-4 pt-4 pb-0">
-                <CardTitle class="text-sm">Notes</CardTitle>
-              </CardHeader>
-              <CardContent class="px-4 pb-4 pt-3">
-                <p class="whitespace-pre-wrap text-sm text-muted-foreground">{recipe.notes}</p>
-              </CardContent>
-            </Card>
-          {/if}
-        </div>
-
-        <!-- Right column: embedded chat sidebar (desktop only) -->
-        <div class="hidden lg:sticky lg:top-4 lg:flex lg:flex-col lg:self-start">
-          <Card class="flex flex-col overflow-hidden" style="height: calc(100dvh - 5.5rem)">
-            <CardHeader class="shrink-0 border-b px-4 py-3">
-              <div class="flex items-center justify-between">
-                <CardTitle class="text-sm">Chef Chat</CardTitle>
-                {#if activeSession}
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onclick={() => push(`/chat/${activeSession!.id}`)}
-                    aria-label="Open full chat"
-                  >
-                    <Icon name="ExternalLink" size={14} />
-                  </Button>
-                {/if}
-              </div>
-              {#if !activeSession}
-                <CardDescription class="text-xs">
-                  Chat about this recipe while you cook.
-                </CardDescription>
-              {/if}
-            </CardHeader>
-
-            {#if activeSession === null}
-              <!-- No session yet: prompt to start -->
-              <CardContent
-                class="flex flex-1 flex-col items-center justify-center gap-3 p-4 text-center"
-              >
-                <p class="text-sm text-muted-foreground">
-                  Ask your chef to refine this recipe, scale it, or answer cooking questions.
-                </p>
+        <!-- Ingredients -->
+        <Card>
+          <CardHeader class="px-4 pt-4 pb-0">
+            <div class="flex items-center justify-between">
+              <CardTitle class="text-sm">Ingredients</CardTitle>
+              {#if hasParsedPending}
                 <Button
                   size="sm"
                   variant="outline"
-                  class="w-full"
-                  onclick={handleStartSidebarChat}
-                  loading={amendBusy}
-                  disabled={amendBusy}
+                  onclick={handleCanonicalise}
+                  loading={canonalising}
+                  disabled={canonalising}
+                  data-testid="recipe-canonicalise-button"
                 >
-                  {#snippet leading()}<Icon name="ChefHat" size={16} />{/snippet}
-                  Start a chat
+                  {#snippet leading()}<Icon name="Link" size={14} />{/snippet}
+                  Canonicalise
                 </Button>
-              </CardContent>
-            {:else}
-              <!-- Messages -->
-              <div class="flex-1 overflow-y-auto p-4">
-                <div class="flex flex-col gap-3">
-                  {#if activeSession.messages.length === 0 && !sidebarIsSending}
-                    <p class="py-8 text-center text-xs text-muted-foreground">
-                      Ask me anything about this recipe.
-                    </p>
-                  {/if}
-                  {#each activeSession.messages as msg (msg.id)}
-                    <div class="flex {msg.role === 'user' ? 'justify-end' : 'justify-start'}">
-                      <div
-                        class="max-w-[90%] text-sm {msg.role === 'user'
-                          ? 'rounded-lg bg-muted px-3 py-2'
-                          : ''}"
-                      >
-                        {#if msg.role === 'assistant'}
-                          <Markdown text={msg.text} />
-                        {:else}
-                          {msg.text}
-                        {/if}
-                      </div>
-                    </div>
-                  {/each}
-                  {#if sidebarIsSending && sidebarStreamingText}
-                    <div class="flex justify-start">
-                      <div class="max-w-[90%] text-sm">
-                        <Markdown text={sidebarStreamingText} />
-                      </div>
-                    </div>
-                  {:else if sidebarIsSending}
-                    <div class="flex items-center gap-2 text-xs text-muted-foreground">
-                      <Spinner size={12} />
-                      Thinking…
-                    </div>
-                  {/if}
-                  <div bind:this={sidebarMessagesEnd}></div>
-                </div>
-              </div>
-
-              <!-- Update recipe -->
-              {#if activeSession.messages.some((m) => m.role === 'assistant')}
-                <div class="shrink-0 border-t px-3 pt-3">
-                  <Button
-                    variant="outline"
-                    class="w-full"
-                    onclick={handleSidebarApplyChanges}
-                    loading={sidebarIsApplying}
-                    disabled={sidebarIsApplying || sidebarIsSending}
-                    data-testid="sidebar-apply-changes-btn"
-                  >
-                    {#snippet leading()}<Icon name="RefreshCw" size={14} />{/snippet}
-                    Update recipe
-                  </Button>
-                </div>
               {/if}
+            </div>
+          </CardHeader>
+          <CardContent class="px-4 pb-4 pt-3">
+            {#if recipe.ingredients.length === 0}
+              <p class="text-sm text-muted-foreground">No ingredients.</p>
+            {/if}
+            {#each recipe.ingredients as group (group.id)}
+              <div class="flex flex-col gap-1 [&+&]:mt-3" data-testid="recipe-view-group">
+                {#if group.name}
+                  <p
+                    class="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+                    data-testid="recipe-view-group-name"
+                  >
+                    {group.name}
+                  </p>
+                {/if}
+                <ul class="flex flex-col gap-1">
+                  {#each group.items as ingredient (ingredient.id)}
+                    <li class="text-sm" data-testid="recipe-view-ingredient">
+                      {ingredient.rawText}{#if ingredient.parsed?.displayText && ingredient.parsed?.quantity && ingredient.parsed?.unit}<span
+                          class="ml-1 text-xs text-muted-foreground"
+                          >({formatMetricQty(ingredient.parsed.quantity)}{ingredient.parsed
+                            .unit})</span
+                        >{/if}{#if ingredient.isOptional}<span
+                          class="ml-1 text-xs text-muted-foreground">(optional)</span
+                        >{/if}{#if !hasLiveCanonMatch(ingredient, liveCanonIds)}<button
+                          type="button"
+                          class="ml-1 text-xs text-destructive hover:underline disabled:opacity-50"
+                          title="Not matched — tap to match"
+                          aria-label="Not matched — tap to match"
+                          onclick={() => handleRematch(group, ingredient)}
+                          disabled={matchingIds[ingredient.id] ?? false}
+                          data-testid="match-state-unmatched"
+                          >{(matchingIds[ingredient.id] ?? false) ? '…' : '✗'}</button
+                        >{/if}
+                    </li>
+                  {/each}
+                </ul>
+              </div>
+            {/each}
+          </CardContent>
+        </Card>
 
-              <!-- Input -->
-              <div class="shrink-0 border-t p-3">
-                <div class="flex items-end gap-2">
-                  <div
-                    class="flex flex-1 items-start rounded-md border border-input bg-background px-3 text-sm focus-within:ring-2 focus-within:ring-ring {sidebarIsSending
-                      ? 'opacity-50'
-                      : ''}"
-                  >
-                    <textarea
-                      bind:this={sidebarInputEl}
-                      class="flex-1 resize-none bg-transparent py-2 outline-none placeholder:text-muted-foreground"
-                      rows={2}
-                      placeholder="Message the chef…"
-                      value={sidebarInputText}
-                      onkeydown={handleSidebarKeydown}
-                      oninput={handleSidebarInput}
-                      disabled={sidebarIsSending}
-                    ></textarea>
+        <!-- Method -->
+        <Card>
+          <CardHeader class="px-4 pt-4 pb-0">
+            <CardTitle class="text-sm">Method</CardTitle>
+          </CardHeader>
+          <CardContent class="px-4 pb-4 pt-3">
+            {#if recipe.steps.length === 0}
+              <p class="text-sm text-muted-foreground">No steps.</p>
+            {/if}
+            <ol class="flex flex-col gap-4">
+              {#each recipe.steps as step, idx (step.id)}
+                <li class="flex gap-3 text-sm" data-testid="recipe-view-step">
+                  <span class="mt-0.5 shrink-0 font-semibold text-muted-foreground">{idx + 1}</span>
+                  <div class="flex flex-1 flex-col gap-1.5">
+                    <span>{step.text}</span>
+                    {#if step.note}
+                      <div
+                        class="flex items-start gap-2 rounded border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-700 dark:bg-amber-950/60 dark:text-amber-300"
+                        data-testid="recipe-step-note-content"
+                      >
+                        <Icon
+                          name="TriangleAlert"
+                          size={13}
+                          class="mt-0.5 shrink-0 text-amber-500"
+                        />
+                        <span class="whitespace-pre-wrap">{step.note}</span>
+                      </div>
+                    {/if}
+                    {#if step.timer}
+                      <span class="text-xs text-muted-foreground">
+                        ⏱ {step.timer.durationMinutes} min{step.timer.description
+                          ? ` — ${step.timer.description}`
+                          : ''}
+                      </span>
+                    {/if}
                   </div>
-                  <Button
-                    size="sm"
-                    onclick={handleSidebarSend}
-                    disabled={sidebarIsSending || !sidebarInputText.trim()}
-                    loading={sidebarIsSending}
-                    aria-label="Send"
-                  >
-                    {#snippet leading()}<Icon name="SendHorizontal" size={14} />{/snippet}
-                    Send
-                  </Button>
-                </div>
+                </li>
+              {/each}
+            </ol>
+          </CardContent>
+        </Card>
+
+        <!-- Notes -->
+        {#if recipe.notes}
+          <Card>
+            <CardHeader class="px-4 pt-4 pb-0">
+              <CardTitle class="text-sm">Notes</CardTitle>
+            </CardHeader>
+            <CardContent class="px-4 pb-4 pt-3">
+              <p class="whitespace-pre-wrap text-sm text-muted-foreground">{recipe.notes}</p>
+            </CardContent>
+          </Card>
+        {/if}
+      </div>
+
+      <!-- Right column: embedded chat sidebar (desktop only) -->
+      <div class="hidden lg:sticky lg:top-4 lg:flex lg:flex-col lg:self-start">
+        <Card class="flex flex-col overflow-hidden" style="height: calc(100dvh - 5.5rem)">
+          <CardHeader class="shrink-0 border-b px-4 py-3">
+            <div class="flex items-center justify-between">
+              <CardTitle class="text-sm">Chef Chat</CardTitle>
+              {#if activeSession}
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onclick={() => push(`/chat/${activeSession!.id}`)}
+                  aria-label="Open full chat"
+                >
+                  <Icon name="ExternalLink" size={14} />
+                </Button>
+              {/if}
+            </div>
+            {#if !activeSession}
+              <CardDescription class="text-xs">
+                Chat about this recipe while you cook.
+              </CardDescription>
+            {/if}
+          </CardHeader>
+
+          {#if activeSession === null}
+            <!-- No session yet: prompt to start -->
+            <CardContent
+              class="flex flex-1 flex-col items-center justify-center gap-3 p-4 text-center"
+            >
+              <p class="text-sm text-muted-foreground">
+                Ask your chef to refine this recipe, scale it, or answer cooking questions.
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                class="w-full"
+                onclick={handleStartSidebarChat}
+                loading={amendBusy}
+                disabled={amendBusy}
+              >
+                {#snippet leading()}<Icon name="ChefHat" size={16} />{/snippet}
+                Start a chat
+              </Button>
+            </CardContent>
+          {:else}
+            <!-- Messages -->
+            <div class="flex-1 overflow-y-auto p-4">
+              <div class="flex flex-col gap-3">
+                {#if activeSession.messages.length === 0 && !sidebarIsSending}
+                  <p class="py-8 text-center text-xs text-muted-foreground">
+                    Ask me anything about this recipe.
+                  </p>
+                {/if}
+                {#each activeSession.messages as msg (msg.id)}
+                  <div class="flex {msg.role === 'user' ? 'justify-end' : 'justify-start'}">
+                    <div
+                      class="max-w-[90%] text-sm {msg.role === 'user'
+                        ? 'rounded-lg bg-muted px-3 py-2'
+                        : ''}"
+                    >
+                      {#if msg.role === 'assistant'}
+                        <Markdown text={msg.text} />
+                      {:else}
+                        {msg.text}
+                      {/if}
+                    </div>
+                  </div>
+                {/each}
+                {#if sidebarIsSending && sidebarStreamingText}
+                  <div class="flex justify-start">
+                    <div class="max-w-[90%] text-sm">
+                      <Markdown text={sidebarStreamingText} />
+                    </div>
+                  </div>
+                {:else if sidebarIsSending}
+                  <div class="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Spinner size={12} />
+                    Thinking…
+                  </div>
+                {/if}
+                <div bind:this={sidebarMessagesEnd}></div>
+              </div>
+            </div>
+
+            <!-- Update recipe -->
+            {#if activeSession.messages.some((m) => m.role === 'assistant')}
+              <div class="shrink-0 border-t px-3 pt-3">
+                <Button
+                  variant="outline"
+                  class="w-full"
+                  onclick={handleSidebarApplyChanges}
+                  loading={sidebarIsApplying}
+                  disabled={sidebarIsApplying || sidebarIsSending}
+                  data-testid="sidebar-apply-changes-btn"
+                >
+                  {#snippet leading()}<Icon name="RefreshCw" size={14} />{/snippet}
+                  Update recipe
+                </Button>
               </div>
             {/if}
-          </Card>
-        </div>
-      </div>
-    </DetailPage>
-  {/if}
 
-  <!-- Add to shopping list review sheet -->
-  {#if recipe && $defaultListId}
-    <RecipeAddToListSheet {recipe} listId={$defaultListId} bind:open={addToListOpen} />
-  {/if}
-
-  <!-- Delete confirm dialog -->
-  <Dialog
-    bind:open={deleteOpen}
-    onOpenChange={(v) => {
-      if (!v) deleteBusy = false;
-    }}
-  >
-    <DialogContent>
-      <div class="flex flex-col gap-4" data-testid="recipe-delete-dialog">
-        <DialogHeader>
-          <DialogTitle>Delete "{recipe?.title ?? ''}"?</DialogTitle>
-          <DialogDescription>This action cannot be undone.</DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button variant="outline" onclick={() => (deleteOpen = false)} disabled={deleteBusy}>
-            Cancel
-          </Button>
-          <Button
-            variant="destructive"
-            onclick={handleDelete}
-            loading={deleteBusy}
-            disabled={deleteBusy}
-            data-testid="recipe-delete-confirm"
-          >
-            Delete
-          </Button>
-        </DialogFooter>
+            <!-- Input -->
+            <div class="shrink-0 border-t p-3">
+              <div class="flex items-end gap-2">
+                <div
+                  class="flex flex-1 items-start rounded-md border border-input bg-background px-3 text-sm focus-within:ring-2 focus-within:ring-ring {sidebarIsSending
+                    ? 'opacity-50'
+                    : ''}"
+                >
+                  <textarea
+                    bind:this={sidebarInputEl}
+                    class="flex-1 resize-none bg-transparent py-2 outline-none placeholder:text-muted-foreground"
+                    rows={2}
+                    placeholder="Message the chef…"
+                    value={sidebarInputText}
+                    onkeydown={handleSidebarKeydown}
+                    oninput={handleSidebarInput}
+                    disabled={sidebarIsSending}
+                  ></textarea>
+                </div>
+                <Button
+                  size="sm"
+                  onclick={handleSidebarSend}
+                  disabled={sidebarIsSending || !sidebarInputText.trim()}
+                  loading={sidebarIsSending}
+                  aria-label="Send"
+                >
+                  {#snippet leading()}<Icon name="SendHorizontal" size={14} />{/snippet}
+                  Send
+                </Button>
+              </div>
+            </div>
+          {/if}
+        </Card>
       </div>
-    </DialogContent>
-  </Dialog>
-</AdminGuard>
+    </div>
+  </DetailPage>
+{/if}
+
+<!-- Add to shopping list review sheet -->
+{#if recipe && $defaultListId}
+  <RecipeAddToListSheet {recipe} listId={$defaultListId} bind:open={addToListOpen} />
+{/if}
+
+<!-- Delete confirm dialog -->
+<Dialog
+  bind:open={deleteOpen}
+  onOpenChange={(v) => {
+    if (!v) deleteBusy = false;
+  }}
+>
+  <DialogContent>
+    <div class="flex flex-col gap-4" data-testid="recipe-delete-dialog">
+      <DialogHeader>
+        <DialogTitle>Delete "{recipe?.title ?? ''}"?</DialogTitle>
+        <DialogDescription>This action cannot be undone.</DialogDescription>
+      </DialogHeader>
+      <DialogFooter>
+        <Button variant="outline" onclick={() => (deleteOpen = false)} disabled={deleteBusy}>
+          Cancel
+        </Button>
+        <Button
+          variant="destructive"
+          onclick={handleDelete}
+          loading={deleteBusy}
+          disabled={deleteBusy}
+          data-testid="recipe-delete-confirm"
+        >
+          Delete
+        </Button>
+      </DialogFooter>
+    </div>
+  </DialogContent>
+</Dialog>


### PR DESCRIPTION
## Summary
- Make **Shopping** the default view: `/` now redirects through `ShoppingListRedirectPage` (same logic as `/shopping`); removes the Home nav entry and the orphaned `HomePage` reference.
- Reorder the nav to **Shop → Planner → Recipes → Chef → Equipment → Settings → Admin**. Renames **Meals → Planner** and **Kitchen → Equipment**.
- Surface **Recipes** to all members: moves it into the default nav and drops the admin-only gating, including the route-level `AdminGuard` wrappers on the recipe list/edit/view pages. The **Admin** entry remains admin-gated.

## Nav order

| # | Label | Route | Visibility |
|---|-------|-------|-----------|
| 1 | Shop | `#/shopping` | all |
| 2 | Planner (was Meals) | `#/mealplan` | all |
| 3 | Recipes (moved up, ungated) | `#/recipes` | all |
| 4 | Chef | `#/chat` | all |
| 5 | Equipment (was Kitchen) | `#/equipment` | all |
| 6 | Settings | `#/settings` | all |
| 7 | Admin | `#/admin` | admin only |

## Note
The recipe `AdminGuard` wrappers existed because the module was marked incomplete (#179). Removing them exposes the recipe module to all members — worth confirming it's ready for non-admins before merge.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` / dependency-cruiser (via pre-commit)
- [ ] Manual: signed in as a non-admin, app opens on the shopping list and Recipes is reachable from the nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)