### PR TITLE
docs: recipes are production-backed, no longer greenfield

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ cloud-functions            →  shared-types, domain, ld-observability/server
 ## Workflow
 
 - **Issue-first for substantial changes.** New packages, new dependencies, layer-map edits, and cross-package refactors require a GitHub issue and explicit go-ahead before implementation. Design Q&A in chat is not a greenlight.
-- **Production data back-compat.** Canon, Aisles, Equipment, Shopping List, and Meal Planner collections hold real production data — schema changes must be backward-compatible on read, or require a one-off migration. Recipe schema changes are currently free (greenfield). See also: Zod schema conventions below.
+- **Production data back-compat.** Canon, Aisles, Equipment, Shopping List, Meal Planner, and Recipes collections hold real production data — schema changes must be backward-compatible on read, or require a one-off migration. (Recipes lost their greenfield status when the module shipped to all members in #240, 2026-06-17; treat recipe schema changes like any other production collection from here on.) See also: Zod schema conventions below.
 
 ## Zod schema conventions
 

--- a/docs/ai-kitchen-assistant.md
+++ b/docs/ai-kitchen-assistant.md
@@ -126,7 +126,9 @@ chat session doc (Firestore)         ← owned by web-pwa + firebase-sync (clien
 - No new package and **no layer-map change** — schemas in `@salt/domain`, flows in
   `cloud-functions`, adapter/store in `firebase-sync` + `web-pwa`, UI primitives via
   `@salt/ui-components`.
-- Recipe schema is still greenfield (free to evolve); chat schema is brand-new
+- Recipe schema now holds live production data (module shipped to all members
+  in #240, 2026-06-17) — recipe schema changes need back-compat on read or a
+  migration, like any other production collection. Chat schema is brand-new
   (no back-compat burden yet).
 </content>
 </invoke>


### PR DESCRIPTION
## Summary
The recipe module shipped to all members in #240 (2026-06-17), so the **Recipes** collection now holds live production data. This updates the architecture contract and docs so future recipe schema changes are treated like any other production collection (back-compat on read or a one-off migration) instead of free-to-evolve.

## Changes
- **CLAUDE.md** — added Recipes to the production-backed collections list under "Production data back-compat", with a dated note on the greenfield→live transition.
- **docs/ai-kitchen-assistant.md** — flipped the forward-looking "recipe schema is still greenfield (free to evolve)" guidance to require back-compat/migration.

## Left intentionally
- `docs/recipe-module.md` (#180 schema extensions) — past-tense history, accurate as a record of what was true when those fields were added.
- General greenfield framing in `docs/salt-architecture.md` §1.1, `docs/meal-planning.md`, `docs/releases.md` — not recipe-specific forward guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)