### PR TITLE
fix(canon): stage-4 edit-distance candidates bind only on positive AI match

### DIFF
--- a/docs/matching-pipeline.md
+++ b/docs/matching-pipeline.md
@@ -55,14 +55,15 @@ flowchart TD
     S5 --> S6[Stage 6\nMerge w/ token+similarity ≥ 0.60]
 
     S6 -->|0 candidates| EMPTY[Arbitrate w/ empty shortlist\nfor aisle + metadata]
-    S6 -->|1 candidate| MATCH
+    S6 -->|1 candidate, stage 2 token| MATCH
+    S6 -->|1 candidate, stage 4/5| ARB
     S6 -->|≥2 candidates| ARB
 
     EMPTY --> CREATEAI
 
     ARB -->|AI 'match' w/ valid id| AIMATCH[appendCanonSynonym on chosen\nReturn ai_arbitrated]
     ARB -->|AI 'new' from non-empty shortlist| CREATEAI2[Create new w/ AI metadata]
-    ARB -->|AI error / unknown id / 'no-match'| FALLBACK[Fall back: highest-confidence\ncandidate; appendCanonSynonym\nflags needs_approval\nReturn ai_arbitrated]
+    ARB -->|AI error / unknown id / 'no-match'| FALLBACK[Fall back: highest-confidence\nnon-stage-4 candidate; needs_approval\nstage-4-only shortlist creates new\nReturn ai_arbitrated]
 
     MATCH --> LOG[Log canon.match path=cf]
     AIMATCH --> LOG
@@ -104,8 +105,11 @@ Gemini embedding of the query, cosine similarity against every canon item with a
 Stage 6 re-runs token overlap and string similarity at the lower **0.60** `aiThreshold` and merges them with stage-5 candidates into a single deduplicated shortlist ordered by confidence.
 
 - 0 candidates → arbitrate with an empty shortlist (purely for aisle/metadata) and create.
-- 1 candidate → `match` directly without calling arbitration.
+- 1 candidate, **from token overlap (stage 2)** → `match` directly without calling arbitration.
+- 1 candidate, **from string similarity (stage 4) or embedding (stage 5)** → AI arbitration (treated like a multi-candidate shortlist; see [Stage 4 is AI-confirm-only](#stage-4-edit-distance-is-ai-confirm-only)).
 - ≥2 candidates → AI arbitration on the shortlist.
+
+A lone candidate bypasses AI only when it comes from token overlap — structural word-sharing ("olive oil" → "olive oil extra"). Edit-distance and embedding similarity are coincidence-prone signals that must be AI-confirmed before they bind.
 
 ---
 
@@ -117,13 +121,17 @@ When `rawText` (the original user entry) differs from the normalised item name, 
 
 ### AI-fallback rule (behavioural contract)
 
-The pipeline falls back to the **highest-confidence shortlist candidate**, flagged `needs_approval` (set by `appendCanonSynonym`), on any of these three triggers:
+The pipeline falls back to the **highest-confidence shortlist candidate that is not a pure edit-distance (stage-4) match**, flagged `needs_approval` (set by `appendCanonSynonym`), on any of these three triggers:
 
 1. **AI adapter error.**
 2. **AI returns `kind: 'match'` with an `itemId` not present in the shortlist** (unknown id).
 3. **AI returns `kind: 'no-match'` from a non-empty shortlist.**
 
-`AI 'new'` is the **only** path that creates a brand-new item from a non-empty shortlist.
+`AI 'new'` is the **only** path that creates a brand-new item from a non-empty shortlist — except that a shortlist whose only members are stage-4 candidates also creates a new item (the fallback skips them; see below).
+
+#### Stage 4 (edit distance) is AI-confirm-only
+
+Edit-distance (stage-4) candidates in the `[0.60, 0.85)` band are spelling coincidences, not confident matches — `"olives"` and `"limes"` normalise to `"olive"`/`"lime"` and score exactly **0.60** Levenshtein. Such a candidate binds **only** when the AI returns a positive `kind: 'match'` for it. It never binds via the lone-candidate shortcut (Stage 6, above) nor via this degraded fallback. A stage-4-only shortlist therefore resolves to a **new item** on AI error / unknown-id / `no-match`, rather than silently merging unrelated foods. Token overlap (stage 2) and embedding (stage 5) candidates remain valid fallback targets. Genuine typos are unaffected: they either clear stage 4's 0.85 stop or normalise to an exact stage-1 hit inside `findClosestMatch`, never reaching this band.
 
 The empty-shortlist case is different: with no candidates to fall back to, AI error or `'no-match'` results in a fresh create (with whatever aisle/metadata arbitration managed to return, or none). All four entry points (canon add, shopping list add, recipe add, recipe ingredient update) inherit this same rule via the shared CF.
 
@@ -132,10 +140,10 @@ The empty-shortlist case is different: with no candidates to fall back to, AI er
 | AI response (non-empty shortlist) | Pipeline action | Decision returned |
 |---|---|---|
 | `match` with valid `itemId` | `appendCanonSynonym` on chosen item; AI `reasoning` stored on item if present | `ai_arbitrated` |
-| `match` with unknown `itemId` | Fall back to top-confidence candidate, flag `needs_approval` | `ai_arbitrated` |
+| `match` with unknown `itemId` | Fall back to top-confidence **non-stage-4** candidate, flag `needs_approval`; stage-4-only shortlist creates new | `ai_arbitrated` / `created` |
 | `new` (with metadata) | Create new item with AI-suggested aisle, behaviour, unit; `reasoning` stored if present | `created` |
-| `no-match` | Fall back to top-confidence candidate, flag `needs_approval` | `ai_arbitrated` |
-| Error | Fall back to top-confidence candidate, flag `needs_approval` | `ai_arbitrated` |
+| `no-match` | Fall back to top-confidence **non-stage-4** candidate, flag `needs_approval`; stage-4-only shortlist creates new | `ai_arbitrated` / `created` |
+| Error | Fall back to top-confidence **non-stage-4** candidate, flag `needs_approval`; stage-4-only shortlist creates new | `ai_arbitrated` / `created` |
 
 ### Why fall back rather than create new
 

--- a/packages/domain/src/canon/commands/matchOrCreate.ts
+++ b/packages/domain/src/canon/commands/matchOrCreate.ts
@@ -299,7 +299,16 @@ async function classifyOne(
   );
   const shortlist = buildShortlist(embedCandidates, items, normalisedName);
 
-  if (shortlist.length === 1 && shortlist[0]!.stage !== 5) {
+  // A lone shortlist candidate may bypass AI arbitration only when it comes from
+  // token overlap (stage 2) — structural word-sharing, the legitimate fast path
+  // (e.g. "olive oil" → "olive oil extra"). Edit-distance (stage 4) and
+  // embedding (stage 5) candidates in the [aiThreshold, stop) band are
+  // similarity coincidences, not confident matches — "olives" vs "limes"
+  // normalises to "olive"/"lime" and scores exactly 0.6 Levenshtein — so they
+  // escalate to AI like the rest of the shortlist instead of silently binding.
+  // Genuine typos already clear stage 4's 0.85 stop (or normalise to an exact
+  // stage-1 hit) inside findClosestMatch and never reach here.
+  if (shortlist.length === 1 && shortlist[0]!.stage === 2) {
     return { kind: 'direct_match', item: shortlist[0]!.item, rawName, logBuilder, commitLog };
   }
 
@@ -419,8 +428,13 @@ async function applyClassification(
       }
       // decision.kind === 'no-match': fall through to highest-confidence fallback
     }
-    // AI errored, returned unknown id, or said no-match
-    const fallback = shortlist[0];
+    // AI errored, returned unknown id, or said no-match. Fall back to the best
+    // candidate — but never to a pure edit-distance (stage-4) neighbour. Those
+    // are spelling coincidences ("olives" vs "limes" — 0.6 Levenshtein) that
+    // bind only on a POSITIVE AI match, never via this degraded path. Token
+    // overlap (stage 2) and embedding (stage 5) candidates stay valid fallbacks;
+    // a stage-4-only shortlist creates a new item instead of mis-binding.
+    const fallback = shortlist.find((c) => c.stage !== 4);
     if (fallback) {
       const currentItem = snapshot.get(fallback.item.id) ?? fallback.item;
       return resolveMatch(store, currentItem, rawName, 'ai_arbitrated', commitLog);

--- a/packages/domain/tests/canon/matchOrCreate.test.ts
+++ b/packages/domain/tests/canon/matchOrCreate.test.ts
@@ -299,6 +299,33 @@ describe('stage 6 — single near-miss: direct match', () => {
   });
 });
 
+// ─── Stage 6: lone edit-distance near-miss → AI, never a silent match ────────
+// Regression: "olives" vs "limes" normalises to "olive" vs "lime", a Levenshtein
+// similarity of exactly 0.6 — at aiThreshold but only stage 4 (edit distance, a
+// spelling coincidence). A lone stage-4 candidate must NOT auto-bind the way a
+// stage-2 token candidate does; it escalates to AI like embeddings, so unrelated
+// foods are never silently merged.
+
+describe('stage 6 — lone edit-distance near-miss escalates to AI', () => {
+  it('does not silently match "olives" to "limes"', async () => {
+    const limes = canonItem({ id: 'lime1', name: 'limes' });
+    const arbitrateSpy = vi.fn().mockResolvedValue({ kind: 'ok', value: { kind: 'no-match' } });
+    const { run } = makePipeline({
+      items: [limes],
+      arbitration: { arbitrate: arbitrateSpy },
+    });
+    const result = await run('olives');
+    // It consults AI rather than auto-binding to the 0.6 Levenshtein neighbour…
+    expect(arbitrateSpy).toHaveBeenCalled();
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      // …and with a no-match verdict a fresh canon item is created, not limes.
+      expect(result.value.item.id).not.toBe('lime1');
+      expect(result.value.decision).not.toBe('matched');
+    }
+  });
+});
+
 // ─── Stage 6: multiple near-misses → AI arbitration is sole decider ──────────
 
 describe('stage 6 — multiple near-misses: AI arbitrates', () => {


### PR DESCRIPTION
Closes #248.

## Problem
With `"limes"` in the canon, adding `"olives"` was silently recorded as a synonym of limes — no AI check, no review flag. `normaliseName` reduces both to `"olive"`/`"lime"`, a Levenshtein similarity of exactly **0.60** (at `aiThreshold`, but only stage 4 / edit distance). Two paths bound this coincidence with no positive AI confirmation:

1. **Lone-candidate shortcut** — `shortlist.length === 1 && stage !== 5` returned a `direct_match` with no AI call.
2. **Degraded fallback** — on AI `no-match`/error, the code bound `shortlist[0]` anyway, so even a correct "these don't match" verdict still merged olives into limes.

## Fix
One principle: **edit-distance (stage-4) candidates bind only on a positive AI `match` verdict** — never via the lone-candidate shortcut, never via the degraded fallback.

- Lone-candidate shortcut restricted to **token-overlap (stage 2)** candidates.
- Degraded fallback skips stage-4 candidates (`shortlist.find(c => c.stage !== 4)`); a stage-4-only shortlist creates a new item.

Mirrors how stage 5 (embeddings) is already excluded from the lone shortcut.

## Preserved (verified by existing tests)
- Lone **stage-2** token near-miss still direct-matches without AI (`"olive oil"` → `"olive oil extra"`).
- **Stage-5** embedding candidate still binds-as-synonym-with-approval on `no-match`.
- AI-error fallback still binds the best **non-stage-4** candidate, flagged `needs_approval`.
- Genuine typos unaffected — they clear stage 4's 0.85 stop or normalise to an exact stage-1 hit.

## Scope
- Domain-only (`packages/domain`); no thresholds, schema, adapter, or app changes. Fix-forward — no production-data remediation (see #248 decisions).
- Adds a regression test (`olives` vs `limes`).
- Updates `docs/matching-pipeline.md` (Stage 6 outcomes, AI-fallback rule + table, mermaid flow).

## Verification
- `pnpm --filter @salt/domain test` → 547 passed
- `pnpm typecheck`, `pnpm lint` → clean
- cloud-functions suite → 115 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)