### PR TITLE
chore: add /defect command and correct matching-pipeline docs

### DIFF
--- a/.claude/commands/defect.md
+++ b/.claude/commands/defect.md
@@ -1,0 +1,99 @@
+# Defect Spec
+
+I want to investigate and fix: $ARGUMENTS
+
+## When to use this
+This is the heavyweight path — Explore agents, a tracked issue, the decision audit trail. It earns its weight only when at least one is true:
+- the root cause is non-obvious and needs tracing across files/packages to locate;
+- there is a real scope fork the user should decide (targeted vs broad, hotfix vs full fix);
+- blast radius matters — production data may already be corrupted, or a behavior contract changes;
+- it needs a tracked issue anyway (CLAUDE.md issue-first: new deps, layer-map edits, cross-package refactors).
+
+If the cause is obvious, the change is contained to a file or two, and there is no decision for the user to make, **do not run this** — just fix it inline (with a regression test) and report. When unsure, say so and ask before spinning up the full flow.
+
+## Step 1 — Reproduce & triage
+Confirm the defect is real before theorising. Reproduce it (run the failing test, the command, the flow) and capture concrete evidence — error text, a failing assertion, a log line, a trace. Then state plainly:
+- **Is it a real defect, a flake, or intended behavior?** If intermittent, characterize frequency. If the "buggy" behavior turns out to be intended, stop and report that instead of inventing a fix.
+- **First-guess severity / blast radius:** who or what is affected, and is any production data being corrupted while the bug is live?
+
+Do not propose a fix yet.
+
+## Step 2 — Root-cause investigation
+Trace the symptom to the mechanism in code. Spawn Explore subagents for breadth when the trail crosses files or packages. Report:
+- The exact code path with `file:line` references and the precise mechanism — quote the code.
+- Whether **more than one** bug contributes (investigations often surface a second).
+- **Behavior that must be preserved** — adjacent correct behavior the fix must not regress, and the tests that encode it.
+- Constraints from CLAUDE.md / docs that bound the fix (layers, purity, schema/back-compat).
+
+Verify the root cause empirically where you can (a probe, or a test that pinpoints it) rather than asserting it.
+
+## Step 3 — Clarify with user
+Ask me to decide the forks the investigation surfaced. Typical ones:
+- **Fix scope** — minimal/targeted vs a broader retune of the surrounding logic.
+- **Existing data** — does live/production data already need remediation, or fix-forward only?
+- **Urgency** — minimal hotfix now vs the full fix.
+
+Surface the regression risks. Do not propose implementation detail yet.
+
+## Step 4 — Draft and post the issue
+Once we've agreed, post a GitHub issue.
+
+**Issue metadata:**
+- Title: `fix: <concise defect description>` (imperative, no trailing period)
+- Labels: `bug` (plus area labels, e.g. `canon`, `domain`)
+
+**Issue body — use exactly this structure:**
+
+---
+## Observed vs Expected
+**Observed:** [The symptom, concretely, with a real example. Written so a non-coder recognises it.]
+**Expected:** [What should happen instead.]
+
+## Reproduction
+[Smallest reliable steps / command / test that shows the defect. Note frequency if intermittent.]
+
+## Root Cause
+[The mechanism, with `file:line` references and quoted code. If multiple bugs contribute, list each.
+Written for a fresh agent: enough to find and understand the fault without re-investigating.]
+
+## Blast Radius
+[What else the same mechanism affects. Is production data already corrupted — and if so, what would
+remediation require? What is the risk of NOT fixing.]
+
+## Architecture Notes & Constraints
+[Layer map references, packages touched, constraints from CLAUDE.md (purity, schema/back-compat).
+**Behavior that must be preserved**, and the tests that encode it. What must NOT be done.
+Written for a fresh Sonnet agent.]
+
+## Open Questions / Decisions
+[Every fork raised in Step 3, each as:
+- **Decision:** what was chosen
+- **Why:** the reasoning
+- **Rejected:** the alternative(s) and why not
+Unresolved items stay listed as open questions, not silently assumed away. This is the audit trail.]
+
+## Phases
+[One `### Phase` block per phase. A defect almost always pairs the fix with a regression test in
+Phase 1; add a docs phase when a behavior contract changes, and a data-remediation phase only if
+Step 3 chose to remediate. Repeat the block for every phase — do not collapse into one.]
+
+### Phase 1: [Name]
+**Scope:** [What gets changed — precise, not vague]
+**Verifiable outcome:** [What proves it is fixed — ideally a regression test that fails before the change and passes after]
+**Technical deliverables:** [Files, functions, tests]
+**Must not touch:** [Explicitly out of scope; the preserved behavior]
+
+### Phase 2: [Name]
+**Scope:** [...]
+**Verifiable outcome:** [...]
+**Technical deliverables:** [...]
+**Must not touch:** [...]
+
+[...continue through Phase N...]
+
+## Definition of Done
+[Checkable acceptance criteria: the defect no longer reproduces; a regression test guards it;
+preserved behavior stays green; no schema/data regressions.]
+---
+
+After posting: share the issue URL and ask me to confirm the **Root Cause and Fix Approach** before any implementation starts. Do not write code.

--- a/docs/matching-pipeline.md
+++ b/docs/matching-pipeline.md
@@ -248,7 +248,7 @@ Three adapters write the `MatchLogEntry`. The two LD adapters share a runtime-ne
 
 The fast-path's `canon.add` span and the CF's `canon.matchOrCreateCanon` span are designed to be linked by W3C trace context so a fast-path-ambiguous → CF-resolved flow renders as a single distributed trace in LaunchDarkly. The client extracts `traceparent` (and `tracestate` when present) from its active span via [`extractTraceHeaders`](../packages/adapters/ld-observability/src/init.ts) and piggy-backs it on the callable payload as `_trace`. `httpsCallable` is used because it's the project's standard wire — custom request headers aren't first-class in that API, hence the payload-level propagation.
 
-**Why it is currently dormant:** When the CF flow span is parented under the browser trace, Genkit treats it as a non-root span and the Genkit Dev UI's trace list filters it out, making local development and debugging significantly harder. The infrastructure to re-enable propagation (passing `_trace` headers to `runWithExtractedTraceContext` in `apps/cloud-functions/src/index.ts`) is a one-line change at the call site. The `_trace` field is still forwarded by `canonMatching.ts` and accepted by the CF's `InputSchema` so the wire shape remains stable while propagation is disabled.
+**Why it is currently dormant:** When the CF flow span is parented under the browser trace, Genkit treats it as a non-root span and the Genkit Dev UI's trace list filters it out, making local development and debugging significantly harder. The infrastructure to re-enable propagation (passing `_trace` headers to `runWithExtractedTraceContext` in `apps/cloud-functions/src/index.ts`) is a one-line change at the call site. The `_trace` field is still forwarded by `canonMatching.ts`; the CF's `MatchOrCreateCanonInputSchema` does not declare it, but the handler validates against that schema and then forwards the raw `request.data` (not the stripped parse result) to the flow, so `_trace` survives and the wire shape remains stable while propagation is disabled.
 
 ---
 
@@ -260,13 +260,17 @@ A recipe canonicalises many ingredient names at once (a 35-ingredient recipe). T
 
 ### One path: batch, with single as `n = 1`
 
-`matchOrCreate`'s body splits into a per-item core and a batch orchestrator, and the single-item entry point becomes a thin alias:
+`matchOrCreate`'s body is a **three-phase batch orchestrator** that fans each phase across the whole input list, and the single-item entry point becomes a thin alias:
 
-- **`resolveOne(input, snapshot, aisles, ports)`** — stages 1–6 + arbitration + persist. The sole source of truth for matching behaviour. Reads candidates from the injected `snapshot`; persists via `ports.store.upsert`.
-- **`matchOrCreateBatch(inputs, ports)`** — the one matching function. Loads snapshot + aisles **once**, batch-embeds all names into a cache (below), then calls `resolveOne` per input against a growing in-memory snapshot. Returns an order-preserving array of `MatchOrCreateResult`.
-- **`matchOrCreate(input, ports)`** — unchanged public signature, now a one-line alias: `(await matchOrCreateBatch([input], ports))[0]`. The hot single-item path (add-item, shopping-list trigger, single ingredient update) runs through the same orchestration with a batch of one — a one-element embed call and a one-entry map. Negligible overhead; zero behavioural difference.
+- **`matchOrCreateBatch(inputs, ports)`** — the one matching function. Loads snapshot + aisles **once**, batch-embeds all names into a cache (below), then runs three phases:
+  1. **Classify** — `classifyOne(input, snapshot, aisles, ports)` runs stages 1–5 plus shortlist construction for **every** input in parallel. **No AI calls and no persist.** Each input is classified as a direct match, a no-AI create, or "needs arbitration".
+  2. **Arbitrate** — every classification tagged `needs_ai` fires its `arbitrate` call in parallel. For a 35-ingredient recipe this collapses ~35 × 3 s sequential into ~3 s total — the entire reason the batch path exists.
+  3. **Apply** — `applyClassification(classification, arbOutcome, snapshot, ports)` applies the classification + AI result and persists via `ports.store.upsert`, **in order**, folding each resolved `CanonItem` back into the snapshot so later inputs see it.
 
-Because single-item *is* a batch of one, there is no second implementation to keep in step. The parity test below confirms `batch([x])` behaves like `batch([x, y, z])` for the same `x` — true by construction — rather than reconciling two code paths.
+  Returns an order-preserving array of `MatchOrCreateResult`.
+- **`matchOrCreate(input, ports)`** — unchanged public signature, now a one-line alias: `(await matchOrCreateBatch([input], ports))[0]`. The hot single-item path (add-item, shopping-list trigger, single ingredient update) runs through the same three phases with a batch of one — a one-element embed call, one classify, at most one arbitrate. Negligible overhead; zero behavioural difference.
+
+The single source of truth for matching behaviour is the `classifyOne` → arbitrate → `applyClassification` chain; there is no separate per-item resolver and no second implementation to keep in step. The parity test below confirms `batch([x])` behaves like `batch([x, y, z])` for the same `x` — true by construction — rather than reconciling two code paths.
 
 The two **Cloud Function callables** are unaffected by this: `matchOrCreateCanon` (single-item callers) and `canonicaliseRecipeIngredients` (recipe batch) both call into the one domain `matchOrCreateBatch`. Keeping both callables is a wire/API decision; the matching logic underneath is single-sourced.
 
@@ -297,7 +301,7 @@ A stored match (`canonId` + `matchState: 'matched'`) is a pointer into the canon
 
 ### Edits clear the match eagerly
 
-When an item's `rawText` changes, the old match is provably wrong, so it is cleared at the moment of the edit — `parsed`/`canonId` → `null`, `matchState` → `'pending'`.
+When an item's `rawText` changes, the old match is provably wrong, so it is cleared at the moment of the edit — `canonId` → `null`, `matchState` → `'pending'`.
 
 - **Shopping list:** `editItemRawText` resets the fields, and the `onShoppingListItemWrite` trigger re-matches automatically. No user action needed.
 - **Recipe ingredients:** there is no per-ingredient trigger — recipe matching is on-demand batch (see [Batch entry point](#batch-entry-point--recipe-ingredient-canonicalisation)). The editor clears the match on edit, and the user re-runs matching explicitly: the per-row **Match** button in edit mode, or the view-page **Canonicalise** button (batch).


### PR DESCRIPTION
## Summary

Two changes on this branch:

1. **`/defect` slash command** (`50fe667`) — adds a defect-investigation slash command.
2. **matching-pipeline.md corrections** (`bdac0e7`) — realigns the doc with the code after a review found four drifts:
   - Rewrote the batch section to describe the actual three-phase orchestrator (`classifyOne` → parallel `arbitrate` → `applyClassification`) instead of a non-existent sequential `resolveOne`. This captures the cross-input parallelism that's the whole reason the batch path exists.
   - Fixed a stray `t` that corrupted the stage-6 mermaid edge.
   - Edit-clear resets `canonId`/`matchState` only — there is no `parsed` field on `ShoppingListItem`.
   - Clarified that `_trace` survives via raw `request.data` forwarding, not via `MatchOrCreateCanonInputSchema` (which does not declare it).

## Verification

Doc-only changes were checked against `packages/domain/src/canon/commands/matchOrCreate.ts`, `editItemRawText.ts`, `matchOrCreateCanonInput.ts`, and `apps/cloud-functions/src/index.ts`. Pre-commit typecheck + dependency-cruiser passed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)