### PR TITLE
fix(dev): make emulator/dev tasks stop and restart safely on macOS

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,24 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "Stop Firebase Emulators",
+      "detail": "Gracefully stop the emulators (runs export-on-exit so dev data is preserved). Use this instead of the terminate button on the 'Firebase Emulators' task — terminating that task signals only the top of the process tree and does NOT reach firebase, so the export never runs.",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["stop:emulators"],
+      "isBackground": false,
+      "problemMatcher": [],
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated",
+        "close": false,
+        "showReuseMessage": true,
+        "clear": false
+      }
+    },
+    {
       "label": "Firebase Emulators",
       "type": "shell",
       "command": "pnpm",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "test:coverage": "vitest run --coverage",
     "format": "prettier --write \"**/*.{ts,js,svelte,css,html}\"",
     "format:check": "prettier --check \"**/*.{ts,js,svelte,css,html}\"",
-    "dev": "pnpm --filter @salt/web-pwa dev",
+    "dev": "node scripts/free-ports.mjs 5173 && exec pnpm --filter @salt/web-pwa dev",
     "dev:kitchen-sink": "pnpm --filter @salt/kitchen-sink dev",
-    "dev:genkit": "pnpm --filter @salt/cloud-functions dev",
-    "dev:emulators": "node scripts/stop-emulators.mjs && pnpm --filter @salt/cloud-functions build && (cp apps/cloud-functions/.secret.local apps/cloud-functions/dist/.secret.local 2>/dev/null || true) && NODE_OPTIONS='--disable-warning=DEP0040' GENKIT_ENV=dev GENKIT_TELEMETRY_SERVER=http://localhost:4033 firebase emulators:start --import=./.emulator-data --export-on-exit=./.emulator-data || true",
+    "dev:genkit": "node scripts/free-ports.mjs 4001 4033 3100 && exec pnpm --filter @salt/cloud-functions dev",
+    "dev:emulators": "node scripts/stop-emulators.mjs && pnpm --filter @salt/cloud-functions build && (cp apps/cloud-functions/.secret.local apps/cloud-functions/dist/.secret.local 2>/dev/null || true) && exec env NODE_OPTIONS='--disable-warning=DEP0040' GENKIT_ENV=dev GENKIT_TELEMETRY_SERVER=http://localhost:4033 firebase emulators:start --import=./.emulator-data --export-on-exit=./.emulator-data",
+    "stop:emulators": "node scripts/stop-emulators.mjs",
     "test:emulator": "node scripts/test-emulator.mjs"
   },
   "lint-staged": {

--- a/scripts/free-ports.mjs
+++ b/scripts/free-ports.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Frees the given TCP ports by terminating whatever is LISTENing on them:
+// SIGTERM first, then SIGKILL any survivors. Cross-platform via lsof (macOS and
+// Linux); no `fuser` (Linux/WSL-only, no -k on BSD/macOS).
+//
+// Used as a pre-start step in dev tasks so a *restart* can always rebind its
+// ports even if the previous run was stopped abruptly and orphaned a process
+// (e.g. a task-runner "restart" button that signals only the top of the tree
+// and leaves a deep child — like genkit's tsx/node leaf — holding a port).
+//
+// NOTE: this is a blunt kill with NO data export. It is only for stateless dev
+// servers (vite, genkit). The Firebase emulators must NOT use this — they use
+// scripts/stop-emulators.mjs, which preserves dev data via export-on-exit.
+
+import { execSync } from 'child_process';
+
+const ports = process.argv
+  .slice(2)
+  .map(Number)
+  .filter((n) => Number.isInteger(n) && n > 0);
+
+if (ports.length === 0) {
+  console.log('free-ports: no ports given, nothing to do.');
+  process.exit(0);
+}
+
+const SIGKILL_GRACE_MS = 5_000;
+const POLL_MS = 300;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function listeningPids(port) {
+  try {
+    const out = execSync(`lsof -nP -iTCP:${port} -sTCP:LISTEN -t`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return [...new Set(out.split(/\s+/).filter(Boolean).map(Number))];
+  } catch {
+    // lsof exits non-zero when nothing matches — port is free.
+    return [];
+  }
+}
+
+function occupiedPids() {
+  return [...new Set(ports.flatMap(listeningPids))];
+}
+
+function kill(pids, signal) {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // already gone — best effort
+    }
+  }
+}
+
+const initial = occupiedPids();
+if (initial.length === 0) {
+  console.log(`free-ports: ports ${ports.join(', ')} already free.`);
+  process.exit(0);
+}
+
+console.log(`free-ports: SIGTERM to PIDs ${initial.join(', ')} on ports ${ports.join(', ')}...`);
+kill(initial, 'SIGTERM');
+
+const deadline = Date.now() + SIGKILL_GRACE_MS;
+while (Date.now() < deadline) {
+  await sleep(POLL_MS);
+  if (occupiedPids().length === 0) {
+    console.log('free-ports: all ports free.');
+    process.exit(0);
+  }
+}
+
+const survivors = occupiedPids();
+if (survivors.length > 0) {
+  console.warn(`free-ports: SIGKILL to survivors ${survivors.join(', ')}...`);
+  kill(survivors, 'SIGKILL');
+  await sleep(500);
+}
+
+const stillBusy = occupiedPids();
+if (stillBusy.length > 0) {
+  console.error(
+    `free-ports: PIDs ${stillBusy.join(', ')} still holding ports ${ports.join(', ')}.`,
+  );
+  process.exit(1);
+}
+console.log('free-ports: all ports free.');
+process.exit(0);

--- a/scripts/stop-emulators.mjs
+++ b/scripts/stop-emulators.mjs
@@ -1,18 +1,22 @@
 #!/usr/bin/env node
-// Gracefully stops Firebase emulators via SIGTERM to the hub process.
-// SIGTERM lets the hub run its cleanup handlers, including --export-on-exit,
-// so dev data in .emulator-data/ is preserved.
-// Escalates to SIGKILL (hub) then fuser -k (port-level) for orphaned JVM
-// processes that survive hub teardown (common in WSL).
+// Gracefully stops Firebase emulators via SIGTERM to the hub (CLI) process.
+// SIGTERM to the firebase CLI lets it run its cleanup handlers, including
+// --export-on-exit, so dev data in .emulator-data/ is preserved. Signalling the
+// JVM children directly would NOT trigger export-on-exit, so we always resolve
+// and signal the CLI process, never the port children, on the graceful path.
+// Escalates to SIGKILL (CLI) then port-level termination for orphaned children
+// (e.g. the Firestore JVM) that survive hub teardown.
+// Cross-platform: process resolution uses `lsof` (macOS/Linux), not `fuser`
+// (which is Linux/WSL-only and has no -k on BSD/macOS).
 // Exits 0 when all emulator ports are free; exits 1 if any remain occupied.
 
-import { execSync } from "child_process";
-import fs from "fs";
-import net from "net";
-import os from "os";
-import path from "path";
+import { execSync } from 'child_process';
+import fs from 'fs';
+import net from 'net';
+import os from 'os';
+import path from 'path';
 
-const HUB_URL = "http://localhost:4400/emulators";
+const HUB_URL = 'http://localhost:4400/emulators';
 const PORTS = [4400, 8080, 9099, 5001, 5002, 9199];
 const TIMEOUT_MS = 30_000;
 const SIGKILL_TIMEOUT_MS = 5_000;
@@ -32,8 +36,8 @@ function findHubPid() {
   const files = fs.readdirSync(tmp).filter((f) => /^hub-.+\.json$/.test(f));
   for (const file of files) {
     try {
-      const data = JSON.parse(fs.readFileSync(path.join(tmp, file), "utf8"));
-      if (typeof data.pid === "number") return data.pid;
+      const data = JSON.parse(fs.readFileSync(path.join(tmp, file), 'utf8'));
+      if (typeof data.pid === 'number') return data.pid;
     } catch {
       // malformed or unreadable locator — skip
     }
@@ -41,12 +45,60 @@ function findHubPid() {
   return null;
 }
 
+// PIDs of processes LISTENING on a port. Uses lsof so it works on macOS and
+// Linux alike (fuser has no -k on BSD/macOS and is unavailable on many setups).
+function listeningPids(port) {
+  try {
+    const out = execSync(`lsof -nP -iTCP:${port} -sTCP:LISTEN -t`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return [...new Set(out.split(/\s+/).filter(Boolean).map(Number))];
+  } catch {
+    // lsof exits non-zero when nothing matches — no listener on this port.
+    return [];
+  }
+}
+
+// Resolve the firebase CLI (hub) PID: prefer the locator file, fall back to
+// whatever is listening on the hub port (4400). This is the process that runs
+// --export-on-exit, so it is the one we SIGTERM to preserve data.
+function resolveHubPid() {
+  const fromLocator = findHubPid();
+  if (fromLocator !== null) return fromLocator;
+  const [fromPort] = listeningPids(4400);
+  return fromPort ?? null;
+}
+
+function killPids(pids, signal) {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // process already gone — best effort
+    }
+  }
+}
+
+// Terminate whatever is listening on the given ports: SIGTERM, wait, then
+// SIGKILL survivors. Used only for orphaned children with no live CLI parent
+// (export-on-exit is impossible once the CLI is gone), so losing in-memory
+// state here is unavoidable, not a regression.
+async function terminatePorts(ports) {
+  const pids = [...new Set(ports.flatMap(listeningPids))];
+  if (pids.length === 0) return;
+  killPids(pids, 'SIGTERM');
+  if (await waitForPorts(SIGKILL_TIMEOUT_MS)) return;
+  killPids([...new Set(ports.flatMap(listeningPids))], 'SIGKILL');
+  await new Promise((r) => setTimeout(r, 500));
+}
+
 function portIsFree(port) {
   return new Promise((resolve) => {
     const server = net.createServer();
-    server.once("error", () => resolve(false));
-    server.once("listening", () => server.close(() => resolve(true)));
-    server.listen(port, "127.0.0.1");
+    server.once('error', () => resolve(false));
+    server.once('listening', () => server.close(() => resolve(true)));
+    server.listen(port, '127.0.0.1');
   });
 }
 
@@ -65,31 +117,11 @@ async function waitForPorts(timeoutMs = TIMEOUT_MS) {
   return false;
 }
 
-function forceKillPorts(ports) {
-  for (const port of ports) {
-    try {
-      execSync(`fuser -k ${port}/tcp 2>/dev/null`, { stdio: "ignore" });
-    } catch {
-      // fuser not available or no process on port — best effort
-    }
-  }
-}
-
-function gracefulKillPorts(ports) {
-  for (const port of ports) {
-    try {
-      execSync(`fuser -k -TERM ${port}/tcp 2>/dev/null`, { stdio: "ignore" });
-    } catch {
-      // fuser not available or no process on port — best effort
-    }
-  }
-}
-
 async function assertPortsFree() {
   const busy = await getOccupiedPorts();
   if (busy.length === 0) return;
   console.error(
-    `stop-emulators: ports ${busy.join(", ")} still occupied — environment may be broken.`
+    `stop-emulators: ports ${busy.join(', ')} still occupied — environment may be broken.`,
   );
   process.exit(1);
 }
@@ -98,79 +130,71 @@ async function main() {
   if (!(await hubIsRunning())) {
     const busy = await getOccupiedPorts();
     if (busy.length === 0) {
-      console.log("stop-emulators: no hub found, nothing to do.");
+      console.log('stop-emulators: no hub found, nothing to do.');
       process.exit(0);
     }
-    // Orphaned emulator subprocesses (e.g. JVM) survived hub teardown.
+    // Orphaned emulator subprocesses (e.g. JVM) survived hub teardown. There is
+    // no live CLI to run --export-on-exit, so just terminate them.
     console.warn(
-      `stop-emulators: no hub but ports ${busy.join(", ")} occupied — force-killing orphaned processes...`
+      `stop-emulators: no hub but ports ${busy.join(', ')} occupied — terminating orphaned processes...`,
     );
-    forceKillPorts(busy);
-    await new Promise((r) => setTimeout(r, 1000));
+    await terminatePorts(busy);
     await assertPortsFree();
-    console.log("stop-emulators: all ports free after force-kill.");
+    console.log('stop-emulators: all ports free after cleanup.');
     process.exit(0);
   }
 
-  const pid = findHubPid();
+  // Hub is alive. Signal the firebase CLI process (not the JVM children) so
+  // --export-on-exit runs and dev data in .emulator-data/ is preserved.
+  const pid = resolveHubPid();
   if (pid === null) {
-    // Hub is alive but we can't address it by PID (locator file missing or
-    // outside the tmpdir we search). Don't silently exit — we know there's
-    // something to kill. Send SIGTERM via port lookup so --export-on-exit
-    // still runs and dev data is preserved; escalate to SIGKILL if that times out.
+    // Hub responds but we can't resolve its PID (no locator file and nothing
+    // listening on 4400). We can't trigger export-on-exit without the CLI PID;
+    // terminate by port so the next startup isn't blocked. Data export is not
+    // possible in this rare state.
     const busy = await getOccupiedPorts();
     console.warn(
-      `stop-emulators: hub responding but locator file not found — sending SIGTERM via fuser to ports ${busy.join(", ")}...`
+      `stop-emulators: hub responding but PID unresolved — terminating ports ${busy.join(', ')} (export-on-exit not possible)...`,
     );
-    gracefulKillPorts(busy);
-    if (await waitForPorts()) {
-      console.log("stop-emulators: all ports free, emulators stopped.");
-      process.exit(0);
-    }
-    console.warn(
-      `stop-emulators: SIGTERM timed out after ${TIMEOUT_MS / 1000}s — escalating to SIGKILL (fuser -k)...`
-    );
-    forceKillPorts(await getOccupiedPorts());
-    await new Promise((r) => setTimeout(r, 1000));
+    await terminatePorts(busy);
     await assertPortsFree();
-    console.log("stop-emulators: all ports free after force-kill.");
+    console.log('stop-emulators: all ports free after cleanup.');
     process.exit(0);
   }
 
-  console.log(`stop-emulators: sending SIGTERM to hub process (pid ${pid})...`);
+  console.log(
+    `stop-emulators: sending SIGTERM to hub process (pid ${pid}) — running export-on-exit...`,
+  );
   try {
-    process.kill(pid, "SIGTERM");
+    process.kill(pid, 'SIGTERM');
   } catch (err) {
-    if (err.code !== "ESRCH") throw err;
-    console.log("stop-emulators: hub process already gone, checking ports...");
+    if (err.code !== 'ESRCH') throw err;
+    console.log('stop-emulators: hub process already gone, checking ports...');
   }
 
   if (await waitForPorts()) {
-    console.log("stop-emulators: all ports free, emulators stopped.");
+    console.log('stop-emulators: all ports free, emulators stopped (data exported).');
     process.exit(0);
   }
 
   console.warn(
-    `stop-emulators: SIGTERM timed out after ${TIMEOUT_MS / 1000}s — escalating to SIGKILL (pid ${pid})...`
+    `stop-emulators: SIGTERM timed out after ${TIMEOUT_MS / 1000}s — escalating to SIGKILL (pid ${pid})...`,
   );
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // process already gone
-  }
+  killPids([pid], 'SIGKILL');
 
   if (await waitForPorts(SIGKILL_TIMEOUT_MS)) {
-    console.log("stop-emulators: all ports free after SIGKILL.");
+    console.log('stop-emulators: all ports free after SIGKILL.');
     process.exit(0);
   }
 
   // Hub kill didn't free all ports — orphaned child processes (e.g. JVM) remain.
   const busy = await getOccupiedPorts();
-  console.warn(`stop-emulators: ports ${busy.join(", ")} still occupied after SIGKILL — force-killing orphaned processes...`);
-  forceKillPorts(busy);
-  await new Promise((r) => setTimeout(r, 1000));
+  console.warn(
+    `stop-emulators: ports ${busy.join(', ')} still occupied after SIGKILL — terminating orphaned processes...`,
+  );
+  await terminatePorts(busy);
   await assertPortsFree();
-  console.log("stop-emulators: all ports free after force-kill.");
+  console.log('stop-emulators: all ports free after cleanup.');
   process.exit(0);
 }
 


### PR DESCRIPTION
Emulator dev data was lost on abrupt stops because --export-on-exit never ran: the stop signal never reached the firebase CLI process, and the script's fallback cleanup used `fuser` (Linux/WSL-only; no -k on BSD/macOS).

- stop-emulators.mjs: replace `fuser` with lsof-based process resolution so it works on macOS; always SIGTERM the firebase CLI (not the JVM children) so --export-on-exit runs and dev data is preserved.
- package.json: add `stop:emulators`; `exec` the long-running process in dev:emulators / dev / dev:genkit so a terminate signal reaches it and triggers a clean shutdown; add pre-start port cleanup (free-ports.mjs) to dev / dev:genkit so a restart always rebinds its ports even if a prior run orphaned a deep child (e.g. genkit's tsx/node leaf on :3100).
- free-ports.mjs: new cross-platform, blunt port-freer for stateless dev servers (no data export — emulators keep using stop-emulators.mjs).
- .vscode/tasks.json: add "Stop Firebase Emulators" task for a guaranteed clean shutdown from the task UI.