### PR TITLE
chore: approve native build scripts via pnpm onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,13 @@
     ]
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "@firebase/util",
+      "esbuild",
+      "protobufjs",
+      "re2",
+      "sharp"
+    ],
     "overrides": {
       "@opentelemetry/api": "1.9.0",
       "@tootallnate/once": "^2.0.1",


### PR DESCRIPTION
## What

Pin the trusted lifecycle-script packages in `package.json` under `pnpm.onlyBuiltDependencies`:

```json
"onlyBuiltDependencies": ["@firebase/util", "esbuild", "protobufjs", "re2", "sharp"]
```

## Why

pnpm 10 gates dependency build/install scripts behind an approval list. On a clean `pnpm install` (e.g. a fresh clone or a new git worktree) these scripts are skipped, producing:

```
Ignored build scripts: @firebase/util, esbuild, protobufjs, re2, sharp.
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

The most consequential casualty is **re2**, whose native addon (`re2.node`) never gets compiled, so anything depending on it can fail at runtime. Approvals are stored per-project config, so without this each new checkout/worktree has to run the interactive `pnpm approve-builds` by hand.

Pinning the set makes installs run these scripts automatically and reproducibly across checkouts and worktrees.

## Notes

- Lockfile unchanged — `onlyBuiltDependencies` doesn't affect resolution.
- The listed packages are the exact set pnpm flagged as ignored in a clean install.
- Verified: after this change a fresh `pnpm install` compiles `re2.node` and emits no ignored-build warning. Pre-commit typecheck + dependency-cruiser pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)