### PR TITLE
fix(recipes): make Chef Chat sidebar stick within the viewport

### DIFF
--- a/apps/web-pwa/src/routes/recipes/RecipeViewPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeViewPage.svelte
@@ -480,8 +480,10 @@
       </div>
 
       <!-- Right column: embedded chat sidebar (desktop only) -->
-      <div class="hidden lg:sticky lg:top-4 lg:flex lg:flex-col lg:self-start">
-        <Card class="flex flex-col overflow-hidden" style="height: calc(100dvh - 5.5rem)">
+      <div class="hidden lg:flex lg:flex-col">
+        <Card
+          class="flex flex-col overflow-hidden lg:sticky lg:top-4 lg:min-h-0 lg:max-h-[calc(100dvh_-_5.5rem)] lg:flex-1"
+        >
           <CardHeader class="shrink-0 border-b px-4 py-3">
             <div class="flex items-center justify-between">
               <CardTitle class="text-sm">Chef Chat</CardTitle>
@@ -525,7 +527,7 @@
             </CardContent>
           {:else}
             <!-- Messages -->
-            <div class="flex-1 overflow-y-auto p-4">
+            <div class="min-h-0 flex-1 overflow-y-auto p-4">
               <div class="flex flex-col gap-3">
                 {#if activeSession.messages.length === 0 && !sidebarIsSending}
                   <p class="py-8 text-center text-xs text-muted-foreground">

--- a/packages/ui-components/src/layout/AppShell/AppShell.svelte
+++ b/packages/ui-components/src/layout/AppShell/AppShell.svelte
@@ -16,7 +16,7 @@
   }: AppShellProps = $props();
 </script>
 
-<div class={cn('flex min-h-screen flex-col bg-background text-foreground', className)}>
+<div class={cn('flex h-dvh flex-col bg-background text-foreground', className)}>
   <TopBar {title} {actions} />
 
   <div class="flex flex-1 overflow-hidden">


### PR DESCRIPTION
## Summary
- Constrain `AppShell` to the dynamic viewport height (`h-dvh` instead of `min-h-screen`) so the shell defines a bounded scroll container.
- Make the desktop Chef Chat card on the recipe view stick to the top with a bounded `max-height`, so the message list scrolls internally instead of growing the page.
- Add `min-h-0` to the messages scroll region so flex overflow works correctly.

## Test plan
- [ ] Open a recipe on desktop (lg+) and scroll — Chef Chat sidebar stays pinned within the viewport.
- [ ] Long chat histories scroll inside the card rather than expanding the page.
- [ ] Verify no regression to the overall app shell layout on other routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)