### PR TITLE
feat(recipes): import recipes from a URL with AI extraction and British/metric conversion

### DIFF
--- a/apps/cloud-functions/src/adapters/jsonLdRecipe.ts
+++ b/apps/cloud-functions/src/adapters/jsonLdRecipe.ts
@@ -1,0 +1,245 @@
+import { z } from 'genkit';
+
+// schema.org/Recipe JSON-LD extraction (recipe URL import epic, Phase 3).
+//
+// Many mainstream recipe sites embed a machine-readable recipe as
+// `<script type="application/ld+json">…</script>`. When present this is far more
+// reliable than scraping rendered HTML: the structure (ingredients, steps,
+// times, yield) is already separated for us. We still hand the *content* to
+// Gemini afterwards so it can convert units to metric and ingredient
+// names/spelling to British — JSON-LD gives structure, the model converts.
+//
+// This is UNTRUSTED input from an arbitrary page (a trust boundary): the script
+// block can contain anything. We extract candidate blocks with a dependency-free
+// regex (no cheerio/jsdom — issue-gated), `JSON.parse` each one defensively, and
+// validate the shape with Zod (`safeParse`). Anything that doesn't look like a
+// Recipe is discarded.
+
+// schema.org allows several shapes for the same field. These permissive coercers
+// flatten them to the simple forms the rest of the pipeline wants.
+
+// A schema.org text value can be a bare string, a {@value}/{name} object, or an
+// array of those. Collapse to a single trimmed string (first non-empty).
+function coerceText(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const t = value.trim();
+    return t.length > 0 ? t : null;
+  }
+  if (Array.isArray(value)) {
+    for (const v of value) {
+      const t = coerceText(v);
+      if (t !== null) return t;
+    }
+    return null;
+  }
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    return coerceText(obj['@value'] ?? obj['name'] ?? obj['text']);
+  }
+  return null;
+}
+
+// A list of texts (ingredients, instruction strings). schema.org instructions
+// can be plain strings, HowToStep objects ({text}), or HowToSection objects
+// ({itemListElement:[…]}). Flatten recursively to clean strings.
+function coerceTextList(value: unknown): string[] {
+  if (value === null || value === undefined) return [];
+  const out: string[] = [];
+  const push = (v: unknown): void => {
+    if (Array.isArray(v)) {
+      for (const item of v) push(item);
+      return;
+    }
+    if (v && typeof v === 'object') {
+      const obj = v as Record<string, unknown>;
+      // HowToSection → recurse into its steps.
+      if (obj['itemListElement'] !== undefined) {
+        push(obj['itemListElement']);
+        return;
+      }
+      const t = coerceText(obj['text'] ?? obj['name'] ?? obj['@value']);
+      if (t !== null) out.push(t);
+      return;
+    }
+    const t = coerceText(v);
+    if (t !== null) out.push(t);
+  };
+  push(value);
+  return out;
+}
+
+// recipeYield can be "4", "4 servings", ["4","4 servings"], or a number.
+function coerceServings(value: unknown): number | null {
+  const text = typeof value === 'number' ? String(value) : coerceText(value);
+  if (text === null) return null;
+  const match = /\d+/.exec(text);
+  if (match === null) return null;
+  const n = Number.parseInt(match[0], 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+// ISO-8601 durations (PT1H30M) → minutes. schema.org uses these for prep/cook/
+// total times. Returns null for anything we can't parse.
+function coerceDurationMinutes(value: unknown): number | null {
+  const text = coerceText(value);
+  if (text === null) return null;
+  // PnDTnHnMnS — we only care about D/H/M (time-side M = minutes).
+  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(text.trim());
+  if (match === null) return null;
+  const days = match[1] ? Number.parseInt(match[1], 10) : 0;
+  const hours = match[2] ? Number.parseInt(match[2], 10) : 0;
+  const mins = match[3] ? Number.parseInt(match[3], 10) : 0;
+  const total = days * 24 * 60 + hours * 60 + mins;
+  return total > 0 ? total : null;
+}
+
+// The normalized, pipeline-friendly shape we hand back to the flow. All fields
+// are already collapsed from schema.org's many representations.
+export interface JsonLdRecipe {
+  readonly title: string;
+  readonly description: string | null;
+  readonly servings: number | null;
+  readonly totalTimeMinutes: number | null;
+  readonly prepTimeMinutes: number | null;
+  readonly cookTimeMinutes: number | null;
+  readonly tags: string[];
+  readonly ingredients: string[];
+  readonly steps: string[];
+}
+
+// A permissive Zod schema for the RAW schema.org Recipe node. We only assert the
+// minimum we need to trust it; every field is optional + unknown because the page
+// author controls the shape. This is the trust-boundary validation required by
+// CLAUDE.md for untrusted parsed input.
+const RawJsonLdRecipeSchema = z
+  .object({
+    '@type': z.unknown(),
+    name: z.unknown().optional(),
+    headline: z.unknown().optional(),
+    description: z.unknown().optional(),
+    recipeYield: z.unknown().optional(),
+    yield: z.unknown().optional(),
+    totalTime: z.unknown().optional(),
+    prepTime: z.unknown().optional(),
+    cookTime: z.unknown().optional(),
+    keywords: z.unknown().optional(),
+    recipeCategory: z.unknown().optional(),
+    recipeCuisine: z.unknown().optional(),
+    recipeIngredient: z.unknown().optional(),
+    ingredients: z.unknown().optional(),
+    recipeInstructions: z.unknown().optional(),
+  })
+  .passthrough();
+
+// Does an @type (string or array) include "Recipe"?
+function isRecipeType(typeValue: unknown): boolean {
+  if (typeof typeValue === 'string') return typeValue.toLowerCase() === 'recipe';
+  if (Array.isArray(typeValue)) {
+    return typeValue.some((t) => typeof t === 'string' && t.toLowerCase() === 'recipe');
+  }
+  return false;
+}
+
+// keywords can be a comma-joined string or an array. recipeCategory/Cuisine are
+// single useful tags. Normalize to a deduped list of trimmed strings.
+function coerceTags(node: Record<string, unknown>): string[] {
+  const tags: string[] = [];
+  const kw = node['keywords'];
+  if (typeof kw === 'string') {
+    for (const part of kw.split(',')) {
+      const t = part.trim();
+      if (t.length > 0) tags.push(t);
+    }
+  } else {
+    tags.push(...coerceTextList(kw));
+  }
+  tags.push(...coerceTextList(node['recipeCategory']));
+  tags.push(...coerceTextList(node['recipeCuisine']));
+  const seen = new Set<string>();
+  return tags.filter((t) => {
+    const key = t.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+// Convert one validated raw schema.org node into our normalized shape, or null
+// if it lacks the bare minimum (a title and at least one ingredient).
+function normalizeRecipeNode(raw: z.infer<typeof RawJsonLdRecipeSchema>): JsonLdRecipe | null {
+  const node = raw as Record<string, unknown>;
+  const title = coerceText(node['name'] ?? node['headline']);
+  const ingredients = coerceTextList(node['recipeIngredient'] ?? node['ingredients']);
+  if (title === null || ingredients.length === 0) return null;
+
+  return {
+    title,
+    description: coerceText(node['description']),
+    servings: coerceServings(node['recipeYield'] ?? node['yield']),
+    totalTimeMinutes: coerceDurationMinutes(node['totalTime']),
+    prepTimeMinutes: coerceDurationMinutes(node['prepTime']),
+    cookTimeMinutes: coerceDurationMinutes(node['cookTime']),
+    tags: coerceTags(node),
+    ingredients,
+    steps: coerceTextList(node['recipeInstructions']),
+  };
+}
+
+// Walk an arbitrary parsed JSON-LD value (object, array, or @graph container)
+// and collect every Recipe node found. Recurses into @graph and nested arrays.
+function collectRecipeNodes(parsed: unknown, out: JsonLdRecipe[]): void {
+  if (Array.isArray(parsed)) {
+    for (const item of parsed) collectRecipeNodes(item, out);
+    return;
+  }
+  if (!parsed || typeof parsed !== 'object') return;
+  const obj = parsed as Record<string, unknown>;
+
+  // @graph holds the real list of entities on many sites.
+  if (Array.isArray(obj['@graph'])) {
+    collectRecipeNodes(obj['@graph'], out);
+  }
+
+  if (isRecipeType(obj['@type'])) {
+    const validated = RawJsonLdRecipeSchema.safeParse(obj);
+    if (validated.success) {
+      const normalized = normalizeRecipeNode(validated.data);
+      if (normalized !== null) out.push(normalized);
+    }
+  }
+}
+
+// Pull every `<script type="application/ld+json">…</script>` block's INNER text
+// out of an HTML string with a dependency-free regex. Handles attribute order,
+// single/double quotes, extra attributes, and whitespace. Returns raw JSON
+// strings (not yet parsed).
+function extractJsonLdBlocks(html: string): string[] {
+  const blocks: string[] = [];
+  const re =
+    /<script\b[^>]*\btype\s*=\s*['"]application\/ld\+json['"][^>]*>([\s\S]*?)<\/script\s*>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(html)) !== null) {
+    const body = match[1];
+    if (body !== undefined && body.trim().length > 0) blocks.push(body);
+  }
+  return blocks;
+}
+
+// Extract the first usable schema.org/Recipe from a page's HTML, or null if the
+// page has no parseable JSON-LD Recipe. Malformed JSON in one block never throws
+// — it's skipped and we move on to the next block.
+export function extractRecipeJsonLd(html: string): JsonLdRecipe | null {
+  const recipes: JsonLdRecipe[] = [];
+  for (const block of extractJsonLdBlocks(html)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(block);
+    } catch {
+      // A page may have invalid JSON-LD; skip and keep looking.
+      continue;
+    }
+    collectRecipeNodes(parsed, recipes);
+    if (recipes.length > 0) return recipes[0]!;
+  }
+  return null;
+}

--- a/apps/cloud-functions/src/adapters/ssrfFetch.ts
+++ b/apps/cloud-functions/src/adapters/ssrfFetch.ts
@@ -1,0 +1,202 @@
+import https from 'node:https';
+import { lookup as dnsLookupCb } from 'node:dns';
+import type { LookupAddress, LookupAllOptions, LookupOneOptions, LookupOptions } from 'node:dns';
+import { isHttpsScheme, parseImportUrl, isPublicIp } from '@salt/domain';
+
+// SSRF-guarded HTTP(S) fetch for the URL-import flow. Lives in cloud-functions
+// (Node-only) — the *pure* classification policy (https-only, IP ranges) lives
+// in @salt/domain; this module performs the live DNS resolution + connection
+// enforcement and the byte/time/redirect caps.
+//
+// Defence in depth against SSRF / DNS-rebinding:
+//   1. https-only scheme check (domain helper).
+//   2. A custom `lookup` passed to https.request runs at connect time and
+//      re-classifies every resolved address — so the IP we actually connect to
+//      is the one that was validated (closing the TOCTOU/DNS-rebinding window
+//      where a hostname resolves public on a pre-check then private at connect).
+//   3. Manual redirect handling: each hop is re-parsed, re-scheme-checked, and
+//      re-resolved through the same guarded lookup. A redirect to an internal
+//      host is refused.
+//   4. Response size cap (abort once exceeded) and a wall-clock timeout.
+//   5. Only text/html is accepted.
+
+export const MAX_RESPONSE_BYTES = 2 * 1024 * 1024; // ~2 MB
+export const FETCH_TIMEOUT_MS = 12_000; // wall-clock cap for the whole fetch
+export const MAX_REDIRECTS = 5;
+const USER_AGENT = 'SaltRecipeImporter/1.0 (+https://salt.app; recipe import bot)';
+
+// Why a fetch failed. 'blocked' is an SSRF refusal (caller maps to blocked-url,
+// no internal detail leaked); everything else is a reach/transport failure.
+export type SsrfFetchErrorReason =
+  | 'blocked' // non-https, private/internal host, or redirect to internal
+  | 'dns' // host did not resolve
+  | 'timeout'
+  | 'connection' // socket / TLS error
+  | 'http-status' // non-2xx
+  | 'too-large'
+  | 'wrong-content-type';
+
+export class SsrfFetchError extends Error {
+  constructor(
+    readonly reason: SsrfFetchErrorReason,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SsrfFetchError';
+  }
+}
+
+export interface SsrfFetchResult {
+  readonly html: string;
+  readonly finalUrl: string;
+}
+
+// A DNS lookup that rejects when *any* resolved address is non-public. Used as
+// the `lookup` option on https.request so enforcement happens at connect time.
+function guardedLookup(
+  hostname: string,
+  options: LookupOneOptions | LookupAllOptions | LookupOptions,
+  callback: (
+    err: NodeJS.ErrnoException | null,
+    address: string | LookupAddress[],
+    family?: number,
+  ) => void,
+): void {
+  // Force `all` so we can inspect every candidate address; we pick the first
+  // public one. If any address is non-public we refuse the whole connection.
+  dnsLookupCb(hostname, { ...options, all: true }, (err, addresses) => {
+    if (err) {
+      callback(err, '', undefined);
+      return;
+    }
+    if (!addresses || addresses.length === 0) {
+      callback(new Error('no addresses'), '', undefined);
+      return;
+    }
+    for (const a of addresses) {
+      if (!isPublicIp(a.address)) {
+        const blocked: NodeJS.ErrnoException = Object.assign(
+          new Error('SSRF: resolved address is not public'),
+          { code: 'SSRF_BLOCKED' },
+        );
+        callback(blocked, '', undefined);
+        return;
+      }
+    }
+    const first = addresses[0]!;
+    // Honour the caller's requested shape: `all:true` wants the array.
+    if ((options as LookupAllOptions).all) {
+      callback(null, addresses, undefined);
+    } else {
+      callback(null, first.address, first.family);
+    }
+  });
+}
+
+// Validate a single URL string for the SSRF guard (scheme + obvious IP-literal
+// hosts). DNS-based host validation happens in guardedLookup at connect time.
+function assertUrlAllowed(raw: string): URL {
+  const parsed = parseImportUrl(raw);
+  if (parsed === null) throw new SsrfFetchError('blocked', 'unparseable url');
+  if (!isHttpsScheme(parsed.protocol)) {
+    throw new SsrfFetchError('blocked', 'non-https scheme');
+  }
+  return new URL(parsed.href);
+}
+
+function fetchOnce(url: URL, signalAbort: AbortSignal): Promise<SingleFetch> {
+  return new Promise<SingleFetch>((resolve, reject) => {
+    const req = https.request(
+      url,
+      {
+        method: 'GET',
+        lookup: guardedLookup,
+        headers: {
+          'User-Agent': USER_AGENT,
+          Accept: 'text/html,application/xhtml+xml',
+        },
+        signal: signalAbort,
+      },
+      (res) => {
+        const status = res.statusCode ?? 0;
+        const location = res.headers['location'];
+
+        // Redirect — drain and report the next hop to the caller.
+        if (status >= 300 && status < 400 && typeof location === 'string') {
+          res.resume(); // discard body
+          resolve({ kind: 'redirect', location });
+          return;
+        }
+
+        if (status < 200 || status >= 300) {
+          res.resume();
+          reject(new SsrfFetchError('http-status', `status ${status}`));
+          return;
+        }
+
+        const contentType = String(res.headers['content-type'] ?? '');
+        if (!contentType.toLowerCase().includes('text/html')) {
+          res.resume();
+          reject(new SsrfFetchError('wrong-content-type', `content-type ${contentType}`));
+          return;
+        }
+
+        const chunks: Buffer[] = [];
+        let total = 0;
+        res.on('data', (chunk: Buffer) => {
+          total += chunk.length;
+          if (total > MAX_RESPONSE_BYTES) {
+            res.destroy();
+            reject(new SsrfFetchError('too-large', 'response exceeded size cap'));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        res.on('end', () => {
+          resolve({ kind: 'body', html: Buffer.concat(chunks).toString('utf8') });
+        });
+        res.on('error', (err) => reject(mapSocketError(err)));
+      },
+    );
+
+    req.on('error', (err) => reject(mapSocketError(err)));
+    req.end();
+  });
+}
+
+type SingleFetch = { kind: 'body'; html: string } | { kind: 'redirect'; location: string };
+
+function mapSocketError(err: unknown): SsrfFetchError {
+  if (err instanceof SsrfFetchError) return err;
+  const e = err as NodeJS.ErrnoException;
+  if (e.code === 'SSRF_BLOCKED') return new SsrfFetchError('blocked', 'blocked address');
+  const dnsFailed =
+    e.code === 'ENOTFOUND' || e.code === 'EAI_AGAIN' || /no addresses/.test(e.message ?? '');
+  if (dnsFailed) return new SsrfFetchError('dns', 'dns lookup failed');
+  if (e.name === 'AbortError' || e.code === 'ABORT_ERR') {
+    return new SsrfFetchError('timeout', 'fetch timed out');
+  }
+  return new SsrfFetchError('connection', e.message ?? 'connection error');
+}
+
+// Fetch a recipe page through the SSRF guard. Follows up to MAX_REDIRECTS
+// redirects, re-validating each hop. Returns the raw HTML and the final URL.
+export async function ssrfGuardedFetch(rawUrl: string): Promise<SsrfFetchResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    let current = assertUrlAllowed(rawUrl);
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      const result = await fetchOnce(current, controller.signal);
+      if (result.kind === 'body') {
+        return { html: result.html, finalUrl: current.href };
+      }
+      // Resolve the redirect target against the current URL, then re-validate.
+      const next = new URL(result.location, current);
+      current = assertUrlAllowed(next.href);
+    }
+    throw new SsrfFetchError('connection', 'too many redirects');
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/cloud-functions/src/flows/extractRecipeFromUrl.ts
+++ b/apps/cloud-functions/src/flows/extractRecipeFromUrl.ts
@@ -1,0 +1,263 @@
+import { z } from 'genkit';
+import { googleAI } from '@genkit-ai/google-genai';
+import { isHttpsScheme, parseImportUrl } from '@salt/domain';
+import { ExtractRecipeFromUrlInputSchema, ExtractRecipeAIOutputSchema } from '@salt/domain/schemas';
+import type { ExtractRecipeAIOutput, UrlImportFailureCode } from '@salt/domain/schemas';
+import type { RecipeDoc, IngredientGroupDoc } from '@salt/domain/schemas';
+import { withAiTimeout } from '../adapters/withAiTimeout.js';
+import { ai } from '../genkit.js';
+import { ssrfGuardedFetch, SsrfFetchError } from '../adapters/ssrfFetch.js';
+import { canonicaliseRecipeIngredientsFlow } from './canonicaliseRecipeIngredients.js';
+import { parseRecipeIngredientsFlow } from './parseRecipeIngredients.js';
+
+// SSRF-hardened URL import (recipe URL import epic, Phase 1).
+//
+// Pipeline: validate URL → SSRF-guarded fetch (raw HTML) → Gemini extraction
+// (metric + British conversion) → reuse parse/canonicalise flows for ingredient
+// matching → assemble a RecipeDoc draft with source.type='url'.
+//
+// The flow throws a UrlImportError tagged with a failure code; the onCall
+// entrypoint maps each code to the right HttpsError + user-facing copy.
+
+// Flash + temperature:0 — accuracy over creativity, mirrors the librarian flow.
+const EXTRACT_MODEL = googleAI.model('gemini-flash-latest');
+
+// JSON-LD parsing is a LATER phase — we send the raw page HTML to the model and
+// rely on it to find the recipe. Cap the HTML we forward so a huge page can't
+// blow the prompt budget; recipes always appear well within the first chunk.
+const MAX_HTML_CHARS = 200_000;
+
+export type { UrlImportFailureCode };
+
+export class UrlImportError extends Error {
+  constructor(
+    readonly code: UrlImportFailureCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'UrlImportError';
+  }
+}
+
+const OutputSchema = z.custom<RecipeDoc>();
+
+export const extractRecipeFromUrlFlow = ai.defineFlow(
+  {
+    name: 'extractRecipeFromUrl',
+    inputSchema: ExtractRecipeFromUrlInputSchema,
+    outputSchema: OutputSchema,
+  },
+  async ({ url }): Promise<RecipeDoc> => {
+    // 1. Validate the URL shape + scheme before any I/O. The SSRF guard does
+    //    the resolved-IP enforcement; here we reject garbage and non-https.
+    const parsed = parseImportUrl(url);
+    if (parsed === null) {
+      throw new UrlImportError('invalid-url', 'unparseable url');
+    }
+    if (!isHttpsScheme(parsed.protocol)) {
+      throw new UrlImportError('blocked-url', 'non-https scheme');
+    }
+
+    // 2. SSRF-guarded fetch — raw HTML.
+    let html: string;
+    try {
+      const fetched = await ssrfGuardedFetch(url);
+      html = fetched.html;
+    } catch (err) {
+      if (err instanceof SsrfFetchError) {
+        if (err.reason === 'blocked') {
+          throw new UrlImportError('blocked-url', 'ssrf guard refused');
+        }
+        // dns / timeout / connection / http-status / too-large / wrong-content-type
+        throw new UrlImportError('fetch-failed', `fetch failed: ${err.reason}`);
+      }
+      throw new UrlImportError('fetch-failed', 'fetch failed');
+    }
+
+    // 3. Gemini extraction + metric/British conversion.
+    const trimmedHtml = html.length > MAX_HTML_CHARS ? html.slice(0, MAX_HTML_CHARS) : html;
+    let extracted: ExtractRecipeAIOutput;
+    try {
+      const result = await withAiTimeout(
+        'extractRecipeFromUrl',
+        () =>
+          ai.generate({
+            model: EXTRACT_MODEL,
+            system: EXTRACT_SYSTEM,
+            prompt: `Source URL: ${parsed.href}\n\nPage HTML:\n${trimmedHtml}`,
+            output: { schema: ExtractRecipeAIOutputSchema },
+            config: { temperature: 0 },
+          }),
+        { timeoutMs: 55_000, retries: 0 },
+      );
+      const validated = ExtractRecipeAIOutputSchema.safeParse(result.output);
+      if (!validated.success) {
+        throw new UrlImportError(
+          'ai-failed',
+          `extractor returned invalid structure: ${validated.error.message}`,
+        );
+      }
+      extracted = validated.data;
+    } catch (err) {
+      if (err instanceof UrlImportError) throw err;
+      // AI timeout / transport / model error all surface as ai-failed.
+      throw new UrlImportError('ai-failed', err instanceof Error ? err.message : 'ai error');
+    }
+
+    // 4. Did the model find a recipe?
+    if (!extracted.isRecipe || extracted.ingredientGroups.length === 0) {
+      throw new UrlImportError('not-a-recipe', 'no recipe found on page');
+    }
+
+    // 5. Assemble the draft (reuses parse + canonicalise flows).
+    return assembleDraft(extracted, parsed.href);
+  },
+);
+
+// Mirrors authorRecipe.assembleDraft: assign step IDs, parse ingredient raw
+// texts to clean item names, batch-canonicalise, thread structured `parsed`,
+// resolve step ordinals → IDs. Differs only in source.type='url' + url.
+async function assembleDraft(raw: ExtractRecipeAIOutput, sourceUrl: string): Promise<RecipeDoc> {
+  const now = new Date().toISOString();
+
+  const steps = raw.steps.map((s) => ({
+    id: crypto.randomUUID(),
+    text: s.text,
+    timer: s.timerMinutes !== null ? { durationMinutes: s.timerMinutes, description: null } : null,
+    note: s.note,
+  }));
+
+  type IngMeta = { groupIdx: number; itemIdx: number; rawText: string };
+  const allIngredients: IngMeta[] = [];
+  for (let gi = 0; gi < raw.ingredientGroups.length; gi++) {
+    const group = raw.ingredientGroups[gi]!;
+    for (let ii = 0; ii < group.ingredients.length; ii++) {
+      allIngredients.push({ groupIdx: gi, itemIdx: ii, rawText: group.ingredients[ii]!.rawText });
+    }
+  }
+
+  // Parse raw texts → clean item names + structured parsed objects, keyed by
+  // rawText. Parse failure is non-fatal (falls back to rawText / parsed:null).
+  const parsedItemMap = new Map<string, string>();
+  type ParsedIngredient = Awaited<
+    ReturnType<typeof parseRecipeIngredientsFlow>
+  >[number]['items'][number]['parsed'];
+  const parsedMap = new Map<string, ParsedIngredient>();
+  if (allIngredients.length > 0) {
+    try {
+      const joinedRawText = allIngredients.map((i) => i.rawText).join('\n');
+      const parseResult = await parseRecipeIngredientsFlow({ rawText: joinedRawText });
+      for (const group of parseResult) {
+        for (const item of group.items) {
+          if (item.parsed?.item) parsedItemMap.set(item.rawText, item.parsed.item);
+          if (item.parsed) parsedMap.set(item.rawText, item.parsed);
+        }
+      }
+    } catch {
+      // non-fatal
+    }
+  }
+
+  // Batch canonicalise. Failure is non-fatal — ingredients land as pending.
+  let canonResults: Awaited<ReturnType<typeof canonicaliseRecipeIngredientsFlow>> = [];
+  if (allIngredients.length > 0) {
+    try {
+      canonResults = await canonicaliseRecipeIngredientsFlow({
+        items: allIngredients.map((i) => ({
+          rawName: parsedItemMap.get(i.rawText) ?? i.rawText,
+          rawText: i.rawText,
+        })),
+      });
+    } catch {
+      // non-fatal
+    }
+  }
+
+  const ingredientGroups: IngredientGroupDoc[] = raw.ingredientGroups.map((group, gi) => ({
+    id: crypto.randomUUID(),
+    name: group.name,
+    items: group.ingredients.map((ing, ii) => {
+      const flatIdx = allIngredients.findIndex((m) => m.groupIdx === gi && m.itemIdx === ii);
+      const canon = flatIdx >= 0 ? canonResults[flatIdx] : undefined;
+
+      const canonId = canon && canon.kind === 'ok' ? (canon.value.item as { id: string }).id : null;
+      const matchState: 'matched' | 'pending' | 'failed' =
+        canon && canon.kind === 'ok' ? 'matched' : canon ? 'failed' : 'pending';
+
+      const ord = ing.firstUsedInStepOrdinal;
+      const firstUsedInStepId =
+        ord !== null && ord >= 0 && ord < steps.length ? steps[ord]!.id : null;
+
+      return {
+        id: crypto.randomUUID(),
+        rawText: ing.rawText,
+        parsed: parsedMap.get(ing.rawText) ?? null,
+        canonId,
+        matchState,
+        isOptional: ing.isOptional,
+        firstUsedInStepId,
+      };
+    }),
+  }));
+
+  return {
+    id: crypto.randomUUID(),
+    schemaVersion: 1,
+    title: raw.title,
+    description: raw.description,
+    ingredients: ingredientGroups,
+    steps,
+    metadata: {
+      servings: raw.servings,
+      totalTimeMinutes: raw.totalTimeMinutes,
+      prepTimeMinutes: raw.prepTimeMinutes,
+      cookTimeMinutes: raw.cookTimeMinutes,
+      tags: raw.tags
+        .map((t) => t.toLowerCase().trim().replace(/\s+/g, '-'))
+        .filter((t) => t.length > 0),
+    },
+    source: { type: 'url', url: sourceUrl },
+    notes: raw.notes,
+    image: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+const EXTRACT_SYSTEM = `You are a precise recipe extraction assistant. You are given the raw HTML \
+of a web page and its source URL. Extract a single complete recipe from the page and convert it \
+fully to UK conventions.
+
+## Is it a recipe?
+- Set isRecipe=false (and leave the other fields at sensible empties) ONLY when the page contains no \
+cooking recipe at all (e.g. a news article, a product listing, a 404). If a recipe is present, \
+isRecipe=true.
+
+## Conversion rules (apply to EVERYTHING)
+- Metric only: convert all quantities to metric. Volumes in millilitres/litres, weights in grams/kilograms. \
+Convert cups, sticks, ounces, pounds, fluid ounces, tablespoons and teaspoons. Temperatures in °C only — \
+never Fahrenheit; convert and round sensibly (e.g. 350°F → 180°C).
+- British spelling and terms throughout: "courgette" not "zucchini", "aubergine" not "eggplant", \
+"coriander" (leaf) not "cilantro", "spring onion" not "scallion/green onion", "plain flour" not \
+"all-purpose flour", "caster sugar"/"icing sugar" not "superfine/powdered sugar", "minced beef" not \
+"ground beef", "prawns" not "shrimp", "rocket" not "arugula", "beetroot" not "beets", "swede" not \
+"rutabaga", "grill" not "broil", "tin" not "can", "kitchen paper" not "paper towel". Use British \
+spelling everywhere (e.g. "flavour", "colour").
+
+## Fields
+- title: clear, concise recipe name.
+- description: 1–2 sentence summary, or null.
+- servings: integer portions, or null if not stated.
+- totalTimeMinutes/prepTimeMinutes/cookTimeMinutes: integers in minutes, or null.
+- tags: short lowercase keywords (e.g. ["vegetarian","quick","pasta"]). Empty array if none.
+- ingredientGroups: group ingredients by course/stage (null name = default group).
+  Each ingredient: rawText (the ingredient line, already converted to metric + British spelling/terms — \
+this is what the rest of the pipeline parses, so write a clean natural line e.g. "240ml whole milk" or \
+"2 cloves garlic, crushed"), isOptional (true only if explicitly optional), firstUsedInStepOrdinal \
+(0-based index into the steps array for the first step that uses this ingredient; null if none obvious).
+- steps: numbered method steps. Each step: text (clear instruction, British terms, °C only), \
+timerMinutes (integer or null), note (a genuine warning/non-obvious caveat only; null for routine steps).
+- notes: the author's overall notes/tips, or null.
+
+Extract only what is present on the page. Do not invent ingredients or steps. Ignore page navigation, \
+ads, comments, and unrelated content.`;

--- a/apps/cloud-functions/src/flows/extractRecipeFromUrl.ts
+++ b/apps/cloud-functions/src/flows/extractRecipeFromUrl.ts
@@ -7,14 +7,18 @@ import type { RecipeDoc, IngredientGroupDoc } from '@salt/domain/schemas';
 import { withAiTimeout } from '../adapters/withAiTimeout.js';
 import { ai } from '../genkit.js';
 import { ssrfGuardedFetch, SsrfFetchError } from '../adapters/ssrfFetch.js';
+import { extractRecipeJsonLd, type JsonLdRecipe } from '../adapters/jsonLdRecipe.js';
 import { canonicaliseRecipeIngredientsFlow } from './canonicaliseRecipeIngredients.js';
 import { parseRecipeIngredientsFlow } from './parseRecipeIngredients.js';
 
-// SSRF-hardened URL import (recipe URL import epic, Phase 1).
+// SSRF-hardened URL import (recipe URL import epic, Phases 1 & 3).
 //
-// Pipeline: validate URL → SSRF-guarded fetch (raw HTML) → Gemini extraction
-// (metric + British conversion) → reuse parse/canonicalise flows for ingredient
-// matching → assemble a RecipeDoc draft with source.type='url'.
+// Pipeline: validate URL → SSRF-guarded fetch (raw HTML) → prefer schema.org/
+// Recipe JSON-LD parsed straight from the page (Phase 3) and feed its structured
+// fields to Gemini for unit/spelling conversion; otherwise fall back to handing
+// the cleaned HTML to Gemini to both find AND convert the recipe → reuse parse/
+// canonicalise flows for ingredient matching → assemble a RecipeDoc draft with
+// source.type='url'.
 //
 // The flow throws a UrlImportError tagged with a failure code; the onCall
 // entrypoint maps each code to the right HttpsError + user-facing copy.
@@ -22,10 +26,16 @@ import { parseRecipeIngredientsFlow } from './parseRecipeIngredients.js';
 // Flash + temperature:0 — accuracy over creativity, mirrors the librarian flow.
 const EXTRACT_MODEL = googleAI.model('gemini-flash-latest');
 
-// JSON-LD parsing is a LATER phase — we send the raw page HTML to the model and
-// rely on it to find the recipe. Cap the HTML we forward so a huge page can't
-// blow the prompt budget; recipes always appear well within the first chunk.
+// When no JSON-LD Recipe is present we forward the raw page HTML to the model.
+// Cap it so a huge page can't blow the prompt budget; recipes always appear well
+// within the first chunk.
 const MAX_HTML_CHARS = 200_000;
+
+// How much AI-extracted content counts as "rich enough" to be a real recipe when
+// the page carried NO JSON-LD Recipe. With JSON-LD absent AND the model returning
+// barely anything, we treat the page as not-a-recipe rather than a thin draft.
+const MIN_INGREDIENTS_NO_JSON_LD = 2;
+const MIN_STEPS_NO_JSON_LD = 1;
 
 export type { UrlImportFailureCode };
 
@@ -74,8 +84,20 @@ export const extractRecipeFromUrlFlow = ai.defineFlow(
       throw new UrlImportError('fetch-failed', 'fetch failed');
     }
 
-    // 3. Gemini extraction + metric/British conversion.
-    const trimmedHtml = html.length > MAX_HTML_CHARS ? html.slice(0, MAX_HTML_CHARS) : html;
+    // 3. Prefer schema.org/Recipe JSON-LD if the page embeds it (Phase 3). It is
+    //    untrusted input from an arbitrary page, so jsonLdRecipe validates every
+    //    block with Zod (safeParse) before returning a normalised recipe. A hit
+    //    gives us reliable structure; the model still converts units + spelling.
+    const jsonLd = extractRecipeJsonLd(html);
+
+    // 4. Gemini extraction + metric/British conversion. When we have JSON-LD we
+    //    feed the model the already-structured fields to CONVERT (not to hunt for
+    //    a recipe inside HTML); otherwise we fall back to handing it the page HTML
+    //    to both find and convert the recipe.
+    const { system, prompt } = jsonLd
+      ? buildJsonLdPrompt(jsonLd, parsed.href)
+      : buildHtmlPrompt(html, parsed.href);
+
     let extracted: ExtractRecipeAIOutput;
     try {
       const result = await withAiTimeout(
@@ -83,8 +105,8 @@ export const extractRecipeFromUrlFlow = ai.defineFlow(
         () =>
           ai.generate({
             model: EXTRACT_MODEL,
-            system: EXTRACT_SYSTEM,
-            prompt: `Source URL: ${parsed.href}\n\nPage HTML:\n${trimmedHtml}`,
+            system,
+            prompt,
             output: { schema: ExtractRecipeAIOutputSchema },
             config: { temperature: 0 },
           }),
@@ -104,15 +126,85 @@ export const extractRecipeFromUrlFlow = ai.defineFlow(
       throw new UrlImportError('ai-failed', err instanceof Error ? err.message : 'ai error');
     }
 
-    // 4. Did the model find a recipe?
-    if (!extracted.isRecipe || extracted.ingredientGroups.length === 0) {
+    // 5. Did we actually find a recipe? JSON-LD is a strong positive signal: a
+    //    validated schema.org/Recipe with ingredients means the page IS a recipe,
+    //    so we only require the model to have emitted ingredient groups. With NO
+    //    JSON-LD we lean on the model's own isRecipe flag PLUS content richness —
+    //    a page with no JSON-LD Recipe and barely any extracted content is treated
+    //    as not-a-recipe (same failure code, stronger signal).
+    if (!hasUsableRecipe(extracted, jsonLd !== null)) {
       throw new UrlImportError('not-a-recipe', 'no recipe found on page');
     }
 
-    // 5. Assemble the draft (reuses parse + canonicalise flows).
+    // 6. Assemble the draft (reuses parse + canonicalise flows).
     return assembleDraft(extracted, parsed.href);
   },
 );
+
+// Tighten the not-a-recipe decision now that JSON-LD gives a stronger signal.
+// - hadJsonLd: a validated schema.org/Recipe was present on the page. That alone
+//   is strong evidence the page IS a recipe, so we accept as long as the model
+//   produced at least one ingredient.
+// - no JSON-LD: fall back to the model's own isRecipe flag AND require the
+//   extracted content to be more than trivially thin (a stray ingredient list in
+//   a blog post shouldn't pass as a recipe). This keeps the failure taxonomy
+//   intact — it only fires not-a-recipe on a stronger combined signal.
+function hasUsableRecipe(extracted: ExtractRecipeAIOutput, hadJsonLd: boolean): boolean {
+  const ingredientCount = extracted.ingredientGroups.reduce(
+    (sum, g) => sum + g.ingredients.length,
+    0,
+  );
+  if (hadJsonLd) {
+    return ingredientCount > 0;
+  }
+  return (
+    extracted.isRecipe &&
+    ingredientCount >= MIN_INGREDIENTS_NO_JSON_LD &&
+    extracted.steps.length >= MIN_STEPS_NO_JSON_LD
+  );
+}
+
+// Build the prompt for the JSON-LD path: hand the model the already-structured
+// recipe so it converts units → metric and names/spelling → British WITHOUT
+// having to locate the recipe inside noisy HTML. isRecipe is effectively given.
+function buildJsonLdPrompt(
+  recipe: JsonLdRecipe,
+  sourceUrl: string,
+): {
+  system: string;
+  prompt: string;
+} {
+  const lines: string[] = [];
+  lines.push(`Title: ${recipe.title}`);
+  if (recipe.description !== null) lines.push(`Description: ${recipe.description}`);
+  if (recipe.servings !== null) lines.push(`Servings: ${recipe.servings}`);
+  if (recipe.totalTimeMinutes !== null)
+    lines.push(`Total time (minutes): ${recipe.totalTimeMinutes}`);
+  if (recipe.prepTimeMinutes !== null) lines.push(`Prep time (minutes): ${recipe.prepTimeMinutes}`);
+  if (recipe.cookTimeMinutes !== null) lines.push(`Cook time (minutes): ${recipe.cookTimeMinutes}`);
+  if (recipe.tags.length > 0) lines.push(`Keywords: ${recipe.tags.join(', ')}`);
+  lines.push('');
+  lines.push('Ingredients:');
+  for (const ing of recipe.ingredients) lines.push(`- ${ing}`);
+  lines.push('');
+  lines.push('Method:');
+  recipe.steps.forEach((step, i) => lines.push(`${i + 1}. ${step}`));
+
+  return {
+    system: EXTRACT_SYSTEM_JSON_LD,
+    prompt: `Source URL: ${sourceUrl}\n\nStructured recipe data (schema.org/Recipe):\n${lines.join('\n')}`,
+  };
+}
+
+// Build the prompt for the HTML fallback path (no JSON-LD found): the model both
+// finds the recipe in the page and converts it.
+function buildHtmlPrompt(html: string, sourceUrl: string): { system: string; prompt: string } {
+  const trimmedHtml = html.length > MAX_HTML_CHARS ? html.slice(0, MAX_HTML_CHARS) : html;
+  return {
+    system: EXTRACT_SYSTEM,
+    prompt: `Source URL: ${sourceUrl}\n\nPage HTML:\n${trimmedHtml}`,
+  };
+}
 
 // Mirrors authorRecipe.assembleDraft: assign step IDs, parse ingredient raw
 // texts to clean item names, batch-canonicalise, thread structured `parsed`,
@@ -224,27 +316,44 @@ async function assembleDraft(raw: ExtractRecipeAIOutput, sourceUrl: string): Pro
   };
 }
 
-const EXTRACT_SYSTEM = `You are a precise recipe extraction assistant. You are given the raw HTML \
-of a web page and its source URL. Extract a single complete recipe from the page and convert it \
-fully to UK conventions.
-
-## Is it a recipe?
-- Set isRecipe=false (and leave the other fields at sensible empties) ONLY when the page contains no \
-cooking recipe at all (e.g. a news article, a product listing, a 404). If a recipe is present, \
-isRecipe=true.
-
-## Conversion rules (apply to EVERYTHING)
+// Shared conversion + field rules, reused by both the HTML-fallback prompt and
+// the JSON-LD prompt so unit/spelling conversion can't drift between the paths.
+const CONVERSION_RULES = `## Conversion rules (apply to EVERYTHING)
 - Metric only: convert all quantities to metric. Volumes in millilitres/litres, weights in grams/kilograms. \
 Convert cups, sticks, ounces, pounds, fluid ounces, tablespoons and teaspoons. Temperatures in °C only — \
 never Fahrenheit; convert and round sensibly (e.g. 350°F → 180°C).
-- British spelling and terms throughout: "courgette" not "zucchini", "aubergine" not "eggplant", \
-"coriander" (leaf) not "cilantro", "spring onion" not "scallion/green onion", "plain flour" not \
-"all-purpose flour", "caster sugar"/"icing sugar" not "superfine/powdered sugar", "minced beef" not \
-"ground beef", "prawns" not "shrimp", "rocket" not "arugula", "beetroot" not "beets", "swede" not \
-"rutabaga", "grill" not "broil", "tin" not "can", "kitchen paper" not "paper towel". Use British \
-spelling everywhere (e.g. "flavour", "colour").
+- British spelling and terms throughout. Always translate American ingredient names and terms to British:
+  - cilantro (leaf) → coriander
+  - eggplant → aubergine
+  - zucchini → courgette
+  - scallion / green onion → spring onion
+  - arugula → rocket
+  - shrimp → prawns
+  - ground beef → beef mince (likewise ground pork/lamb → pork/lamb mince)
+  - all-purpose flour → plain flour
+  - self-rising flour → self-raising flour
+  - confectioners' / powdered sugar → icing sugar
+  - superfine sugar → caster sugar
+  - granulated sugar → caster sugar (unless it must stay granulated)
+  - light/dark brown sugar → light/dark soft brown sugar
+  - heavy cream → double cream; half-and-half / light cream → single cream
+  - whole milk stays whole milk; "milk" stays milk
+  - beets → beetroot
+  - rutabaga → swede
+  - snow peas → mangetout
+  - bell pepper → pepper (e.g. red pepper)
+  - chickpeas / garbanzo beans → chickpeas
+  - cornstarch → cornflour
+  - molasses → treacle (black treacle for blackstrap)
+  - golden raisins → sultanas
+  - baking soda → bicarbonate of soda
+  - shredded/desiccated coconut → desiccated coconut
+  - jelly → jam; jello → jelly
+  - skillet → frying pan; broil → grill; can → tin
+  - paper towel → kitchen paper; plastic wrap → cling film; parchment paper → baking paper
+- Use British spelling everywhere (e.g. "flavour", "colour", "caramelise").`;
 
-## Fields
+const FIELD_RULES = `## Fields
 - title: clear, concise recipe name.
 - description: 1–2 sentence summary, or null.
 - servings: integer portions, or null if not stated.
@@ -257,7 +366,37 @@ this is what the rest of the pipeline parses, so write a clean natural line e.g.
 (0-based index into the steps array for the first step that uses this ingredient; null if none obvious).
 - steps: numbered method steps. Each step: text (clear instruction, British terms, °C only), \
 timerMinutes (integer or null), note (a genuine warning/non-obvious caveat only; null for routine steps).
-- notes: the author's overall notes/tips, or null.
+- notes: the author's overall notes/tips, or null.`;
+
+const EXTRACT_SYSTEM = `You are a precise recipe extraction assistant. You are given the raw HTML \
+of a web page and its source URL. Extract a single complete recipe from the page and convert it \
+fully to UK conventions.
+
+## Is it a recipe?
+- Set isRecipe=false (and leave the other fields at sensible empties) ONLY when the page contains no \
+cooking recipe at all (e.g. a news article, a product listing, a 404). If a recipe is present, \
+isRecipe=true.
+
+${CONVERSION_RULES}
+
+${FIELD_RULES}
 
 Extract only what is present on the page. Do not invent ingredients or steps. Ignore page navigation, \
 ads, comments, and unrelated content.`;
+
+// JSON-LD path: the recipe has already been located and structured for us by the
+// page's schema.org/Recipe data, so the model's job is conversion + tidy-up, not
+// hunting through HTML. isRecipe is therefore true.
+const EXTRACT_SYSTEM_JSON_LD = `You are a precise recipe extraction assistant. You are given a single \
+recipe already extracted as structured schema.org/Recipe data (title, ingredients, method, times). \
+Your job is to faithfully convert it to UK conventions and return it in the required shape. The input \
+is genuine recipe data, so set isRecipe=true.
+
+## Faithfulness
+- Use ONLY the ingredients, steps, times and servings given. Do not invent, add, drop or reorder \
+content. Keep every ingredient and every method step. Preserve any ingredient groupings/headings if \
+present in the data.
+
+${CONVERSION_RULES}
+
+${FIELD_RULES}`;

--- a/apps/cloud-functions/src/index.ts
+++ b/apps/cloud-functions/src/index.ts
@@ -6,6 +6,7 @@ import {
   MatchOrCreateCanonInputSchema,
   CanonicaliseRecipeIngredientsInputSchema,
   AuthorRecipeInputSchema,
+  ExtractRecipeFromUrlInputSchema,
 } from '@salt/domain/schemas';
 import {
   initServerObservability,
@@ -21,6 +22,11 @@ import { populateEquipmentEntryFlow } from './flows/populateEquipmentEntry.js';
 import { parseRecipeIngredientsFlow } from './flows/parseRecipeIngredients.js';
 import { chefChatFlow } from './flows/chefChat.js';
 import { authorRecipeFlow } from './flows/authorRecipe.js';
+import {
+  extractRecipeFromUrlFlow,
+  UrlImportError,
+  type UrlImportFailureCode,
+} from './flows/extractRecipeFromUrl.js';
 import { generateChatTitleFlow } from './flows/generateChatTitle.js';
 import { onShoppingListItemWrite } from './triggers/onShoppingListItemWrite.js';
 import { onCanonItemWritten } from './triggers/onCanonItemWritten.js';
@@ -184,6 +190,62 @@ export const authorRecipe = onCall(
     }
     await whenServerObservabilityReady();
     return authorRecipeFlow(parsed.data);
+  },
+);
+
+// SSRF-hardened URL import (recipe URL import epic). Uses onCall (not
+// onCallGenkit) so we can map the flow's UrlImportError taxonomy to specific
+// HttpsError codes with user-safe copy (no internal SSRF detail leaked), and
+// bump memory for the batch canonicalisation like authorRecipe. The flow does
+// outbound DNS + a network fetch in addition to the AI call, so the function
+// timeout is generous.
+function mapUrlImportFailure(code: UrlImportFailureCode): HttpsError {
+  switch (code) {
+    case 'invalid-url':
+      return new HttpsError('invalid-argument', "That doesn't look like a valid web address.");
+    case 'blocked-url':
+      // No internal detail leaked.
+      return new HttpsError('invalid-argument', "That link can't be imported.");
+    case 'fetch-failed':
+      return new HttpsError(
+        'unavailable',
+        "We couldn't reach that page — it may be down, paywalled, or blocking us.",
+      );
+    case 'not-a-recipe':
+      return new HttpsError('failed-precondition', "We couldn't find a recipe on that page.");
+    case 'ai-failed':
+      return new HttpsError(
+        'internal',
+        'The recipe reader had trouble with that page — try again, or add it manually.',
+      );
+  }
+}
+
+export const extractRecipeFromUrl = onCall(
+  {
+    ...APP_CHECK_ENFORCEMENT,
+    secrets: [geminiApiKey, ldSdkKey],
+    timeoutSeconds: 120,
+    memory: '512MiB',
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Sign in required.');
+    }
+    const parsed = ExtractRecipeFromUrlInputSchema.safeParse(request.data);
+    if (!parsed.success) {
+      throw new HttpsError('invalid-argument', "That doesn't look like a valid web address.");
+    }
+    await whenServerObservabilityReady();
+    try {
+      return await extractRecipeFromUrlFlow(parsed.data);
+    } catch (err) {
+      if (err instanceof UrlImportError) throw mapUrlImportFailure(err.code);
+      throw new HttpsError(
+        'internal',
+        'The recipe reader had trouble with that page — try again, or add it manually.',
+      );
+    }
   },
 );
 

--- a/apps/cloud-functions/tests/adapters/jsonLdRecipe.test.ts
+++ b/apps/cloud-functions/tests/adapters/jsonLdRecipe.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { extractRecipeJsonLd } from '../../src/adapters/jsonLdRecipe.js';
+
+// Helper to wrap a JSON-LD payload in a script block inside a minimal page.
+function page(...jsonLdBlocks: string[]): string {
+  const scripts = jsonLdBlocks
+    .map((b) => `<script type="application/ld+json">${b}</script>`)
+    .join('\n');
+  return `<!doctype html><html><head>${scripts}</head><body>...</body></html>`;
+}
+
+const RECIPE = {
+  '@context': 'https://schema.org',
+  '@type': 'Recipe',
+  name: 'Test Pancakes',
+  description: 'Fluffy American pancakes.',
+  recipeYield: '4 servings',
+  prepTime: 'PT10M',
+  cookTime: 'PT15M',
+  totalTime: 'PT25M',
+  keywords: 'breakfast, easy',
+  recipeCategory: 'Breakfast',
+  recipeIngredient: ['2 cups all-purpose flour', '1 cup milk', '2 eggs'],
+  recipeInstructions: [
+    { '@type': 'HowToStep', text: 'Mix the dry ingredients.' },
+    { '@type': 'HowToStep', text: 'Whisk in the wet ingredients.' },
+    { '@type': 'HowToStep', text: 'Cook on a hot pan.' },
+  ],
+};
+
+describe('extractRecipeJsonLd', () => {
+  it('extracts a top-level Recipe node', () => {
+    const recipe = extractRecipeJsonLd(page(JSON.stringify(RECIPE)));
+    expect(recipe).not.toBeNull();
+    expect(recipe?.title).toBe('Test Pancakes');
+    expect(recipe?.description).toBe('Fluffy American pancakes.');
+    expect(recipe?.servings).toBe(4);
+    expect(recipe?.prepTimeMinutes).toBe(10);
+    expect(recipe?.cookTimeMinutes).toBe(15);
+    expect(recipe?.totalTimeMinutes).toBe(25);
+    expect(recipe?.ingredients).toEqual(['2 cups all-purpose flour', '1 cup milk', '2 eggs']);
+    expect(recipe?.steps).toEqual([
+      'Mix the dry ingredients.',
+      'Whisk in the wet ingredients.',
+      'Cook on a hot pan.',
+    ]);
+    expect(recipe?.tags).toContain('breakfast');
+    expect(recipe?.tags).toContain('easy');
+  });
+
+  it('finds a Recipe inside an @graph array', () => {
+    const graph = {
+      '@context': 'https://schema.org',
+      '@graph': [
+        { '@type': 'WebSite', name: 'A blog' },
+        { '@type': 'Organization', name: 'Publisher' },
+        RECIPE,
+      ],
+    };
+    const recipe = extractRecipeJsonLd(page(JSON.stringify(graph)));
+    expect(recipe?.title).toBe('Test Pancakes');
+    expect(recipe?.ingredients).toHaveLength(3);
+  });
+
+  it('handles a Recipe whose @type is an array', () => {
+    const multi = { ...RECIPE, '@type': ['Recipe', 'NewsArticle'] };
+    const recipe = extractRecipeJsonLd(page(JSON.stringify(multi)));
+    expect(recipe?.title).toBe('Test Pancakes');
+  });
+
+  it('scans multiple script blocks and skips the non-recipe ones', () => {
+    const html = page(
+      JSON.stringify({ '@type': 'BreadcrumbList', itemListElement: [] }),
+      JSON.stringify(RECIPE),
+    );
+    const recipe = extractRecipeJsonLd(html);
+    expect(recipe?.title).toBe('Test Pancakes');
+  });
+
+  it('skips a malformed JSON block without throwing and finds the valid one', () => {
+    const html = page('{ this is not valid json ]', JSON.stringify(RECIPE));
+    const recipe = extractRecipeJsonLd(html);
+    expect(recipe?.title).toBe('Test Pancakes');
+  });
+
+  it('returns null when there is no Recipe JSON-LD', () => {
+    const html = page(
+      JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'NewsArticle',
+        headline: 'News',
+      }),
+    );
+    expect(extractRecipeJsonLd(html)).toBeNull();
+  });
+
+  it('returns null when there are no JSON-LD blocks at all', () => {
+    expect(extractRecipeJsonLd('<html><body><h1>Just a page</h1></body></html>')).toBeNull();
+  });
+
+  it('rejects a Recipe node with no ingredients (too thin to trust)', () => {
+    const thin = { '@type': 'Recipe', name: 'Empty', recipeIngredient: [] };
+    expect(extractRecipeJsonLd(page(JSON.stringify(thin)))).toBeNull();
+  });
+
+  it('flattens HowToSection instructions into a flat list of steps', () => {
+    const sectioned = {
+      ...RECIPE,
+      recipeInstructions: [
+        {
+          '@type': 'HowToSection',
+          name: 'Batter',
+          itemListElement: [
+            { '@type': 'HowToStep', text: 'Combine flour and milk.' },
+            { '@type': 'HowToStep', text: 'Rest the batter.' },
+          ],
+        },
+        { '@type': 'HowToStep', text: 'Fry.' },
+      ],
+    };
+    const recipe = extractRecipeJsonLd(page(JSON.stringify(sectioned)));
+    expect(recipe?.steps).toEqual(['Combine flour and milk.', 'Rest the batter.', 'Fry.']);
+  });
+
+  it('accepts plain-string instructions', () => {
+    const stringy = {
+      ...RECIPE,
+      recipeInstructions: 'Mix everything. Cook it. Serve.',
+    };
+    const recipe = extractRecipeJsonLd(page(JSON.stringify(stringy)));
+    expect(recipe?.steps).toEqual(['Mix everything. Cook it. Serve.']);
+  });
+
+  it('parses keywords given as an array', () => {
+    const arrKeywords = { ...RECIPE, keywords: ['vegan', 'quick'] };
+    const recipe = extractRecipeJsonLd(page(JSON.stringify(arrKeywords)));
+    expect(recipe?.tags).toEqual(expect.arrayContaining(['vegan', 'quick']));
+  });
+
+  it('coerces a numeric recipeYield', () => {
+    const numYield = { ...RECIPE, recipeYield: 6 };
+    const recipe = extractRecipeJsonLd(page(JSON.stringify(numYield)));
+    expect(recipe?.servings).toBe(6);
+  });
+
+  it('handles script tags with extra attributes and reversed attribute order', () => {
+    const html = `<script class="yoast" data-x="1" type='application/ld+json'>${JSON.stringify(
+      RECIPE,
+    )}</script>`;
+    const recipe = extractRecipeJsonLd(html);
+    expect(recipe?.title).toBe('Test Pancakes');
+  });
+});

--- a/apps/web-pwa/src/lib/recipeService.ts
+++ b/apps/web-pwa/src/lib/recipeService.ts
@@ -4,6 +4,7 @@ import {
   deleteRecipe as deleteRecipeDoc,
   callParseRecipeIngredients,
   callCanonicaliseRecipeIngredients,
+  callExtractRecipeFromUrl,
   saveShoppingListItem,
 } from '@salt/firebase-sync';
 import { createLDErrorReportingAdapter } from '@salt/ld-observability';
@@ -16,8 +17,9 @@ import type {
   SourceRef,
   CanonItem,
 } from '@salt/domain';
+import type { UrlImportFailureCode } from '@salt/domain/schemas';
 import { hasLiveCanonMatch } from '@salt/domain';
-import { success, type DomainError, type ReadResult } from '@salt/shared-types';
+import { failure, success, type DomainError, type ReadResult } from '@salt/shared-types';
 import { getCanonItemsSnapshot } from './canonService.js';
 import { writable, get } from 'svelte/store';
 import type { Readable } from 'svelte/store';
@@ -108,6 +110,57 @@ export async function parseIngredients(
   rawText: string,
 ): Promise<ReadResult<IngredientGroup[], DomainError>> {
   return callParseRecipeIngredients(rawText);
+}
+
+// ─── URL import ────────────────────────────────────────────────────────────────
+// SSRF-hardened import: paste a recipe URL, get back a fully-converted (metric +
+// British) draft. The draft is NOT persisted here — the caller hydrates the
+// editor with it so the user reviews/saves. On failure we return a specific,
+// friendly message keyed off the import failure code; the UI shows it and lets
+// the user fall back to manual/chat.
+
+// User-facing copy per failure code. Mirrors the CF entrypoint's HttpsError
+// messages but lives client-side so we never depend on the server message text.
+const URL_IMPORT_COPY: Record<UrlImportFailureCode, string> = {
+  'invalid-url': "That doesn't look like a valid web address.",
+  'blocked-url': "That link can't be imported.",
+  'fetch-failed': "We couldn't reach that page — it may be down, paywalled, or blocking us.",
+  'not-a-recipe': "We couldn't find a recipe on that page.",
+  'ai-failed': 'The recipe reader had trouble with that page — try again, or add it manually.',
+};
+
+export function urlImportMessage(code: UrlImportFailureCode): string {
+  return URL_IMPORT_COPY[code];
+}
+
+// Import a recipe from a URL. Returns the assembled draft as a Recipe entity
+// (RecipeDoc is structurally identical), with source.type='url' already set.
+// `updatedAt` is left as the server stamp; the editor re-stamps on save.
+export async function importRecipeFromUrl(
+  url: string,
+): Promise<ReadResult<Recipe, UrlImportFailureCode>> {
+  const result = await callExtractRecipeFromUrl({ url: url.trim() });
+  if (result.kind !== 'ok') return failure(result.error);
+  // RecipeDoc and Recipe are the same shape (the adapter casts both ways on
+  // read/write); accept the draft as a Recipe for the editor.
+  return success(result.value as unknown as Recipe);
+}
+
+// Hand-off slot for the imported draft. The list page imports, stashes the
+// draft here, then routes to /recipes/new; the edit page consumes it once on
+// mount (single-use — taking it clears it so a later blank "New recipe" doesn't
+// pick up a stale import). Kept in module state (not the route) because the
+// draft is a rich object that doesn't belong in a URL.
+let _pendingImportDraft: Recipe | null = null;
+
+export function stashImportedDraft(draft: Recipe): void {
+  _pendingImportDraft = draft;
+}
+
+export function takeImportedDraft(): Recipe | null {
+  const d = _pendingImportDraft;
+  _pendingImportDraft = null;
+  return d;
 }
 
 // Canonicalise all parsed-but-unmatched ingredients in a recipe via a single

--- a/apps/web-pwa/src/routes/recipes/RecipeEditPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeEditPage.svelte
@@ -125,6 +125,17 @@
     }
   }
 
+  // ─── Source helpers ───────────────────────────────────────────────────────────
+  // The source URL is surfaced so imported recipes show their provenance and it
+  // survives an edit/save. An empty url clears the source entirely (back to a
+  // manual recipe); a non-empty url marks it as url-sourced.
+  const sourceUrl = $derived(draft.source?.type === 'url' ? (draft.source.url ?? '') : '');
+
+  function setSourceUrl(value: string): void {
+    const trimmed = value.trim();
+    draft = { ...draft, source: trimmed === '' ? null : { type: 'url', url: trimmed } };
+  }
+
   // ─── Ingredient-group helpers ─────────────────────────────────────────────────
   function setGroups(groups: IngredientGroup[]): void {
     draft = { ...draft, ingredients: groups };
@@ -691,6 +702,15 @@
           data-testid="recipe-total-input"
         />
       </div>
+      <!-- Source -->
+      <TextField
+        label="Source URL"
+        type="url"
+        placeholder="https://example.com/original-recipe (optional)"
+        value={sourceUrl}
+        onValueChange={setSourceUrl}
+        data-testid="recipe-source-input"
+      />
       <!-- Tag picker -->
       <div class="flex flex-col gap-1.5">
         <p class="text-sm font-medium">Tags</p>

--- a/apps/web-pwa/src/routes/recipes/RecipeEditPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeEditPage.svelte
@@ -19,6 +19,7 @@
     persistRecipe,
     parseIngredients,
     matchIngredient,
+    takeImportedDraft,
   } from '../../lib/recipeService.js';
   import { canonItems } from '../../lib/canonService.js';
   import { addToast } from '../../lib/toastStore.js';
@@ -43,6 +44,13 @@
   let loaded = $state(false);
 
   function buildInitialDraft(): Recipe {
+    // On /recipes/new, consume a one-shot imported draft if the URL-import flow
+    // stashed one (single-use: takeImportedDraft clears it). Clone so editing
+    // doesn't mutate the stashed object. Otherwise start from a blank recipe.
+    if ((params?.id ?? null) === null) {
+      const imported = takeImportedDraft();
+      if (imported) return cloneRecipe(imported);
+    }
     return emptyRecipe(crypto.randomUUID(), new Date().toISOString());
   }
 

--- a/apps/web-pwa/src/routes/recipes/RecipeListPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeListPage.svelte
@@ -1,12 +1,43 @@
 <script lang="ts">
-  import { Button, ListPage } from '@salt/ui-components';
+  import { Button, ListPage, Icon, TextField } from '@salt/ui-components';
   import { push } from 'svelte-spa-router';
-  import { recipes, isLoadingRecipes } from '../../lib/recipeService.js';
+  import {
+    recipes,
+    isLoadingRecipes,
+    importRecipeFromUrl,
+    urlImportMessage,
+    stashImportedDraft,
+  } from '../../lib/recipeService.js';
+  import { addToast } from '../../lib/toastStore.js';
 
   const sorted = $derived([...$recipes].sort((a, b) => a.title.localeCompare(b.title)));
 
   function ingredientCount(recipe: (typeof sorted)[number]): number {
     return recipe.ingredients.reduce((n, g) => n + g.items.length, 0);
+  }
+
+  // ─── Import from URL ──────────────────────────────────────────────────────────
+  let showImport = $state(false);
+  let importUrl = $state('');
+  let importing = $state(false);
+
+  async function handleImport(): Promise<void> {
+    const url = importUrl.trim();
+    if (importing || url === '') return;
+    importing = true;
+    const result = await importRecipeFromUrl(url);
+    importing = false;
+    if (result.kind !== 'ok') {
+      // Friendly, specific message; the input stays open so the user can fix the
+      // URL and retry, or fall back to manual/chat.
+      addToast(urlImportMessage(result.error), 'destructive');
+      return;
+    }
+    // Hand the converted draft to the editor and route into it pre-filled.
+    stashImportedDraft(result.value);
+    showImport = false;
+    importUrl = '';
+    push('/recipes/new');
   }
 </script>
 
@@ -18,6 +49,15 @@
   class="p-4 sm:p-6"
 >
   {#snippet actions()}
+    <Button
+      variant="outline"
+      size="sm"
+      onclick={() => (showImport = !showImport)}
+      data-testid="recipe-import-url-toggle"
+    >
+      {#snippet leading()}<Icon name="Link" size={16} />{/snippet}
+      Import from URL
+    </Button>
     <Button size="sm" onclick={() => push('/recipes/new')} data-testid="recipe-new-btn">
       New recipe
     </Button>
@@ -26,11 +66,90 @@
   {#snippet empty()}
     <div class="flex flex-col items-center gap-3 py-12 text-center">
       <p class="text-sm text-muted-foreground">No recipes yet.</p>
-      <Button size="sm" onclick={() => push('/recipes/new')}>Create your first recipe</Button>
+      <div class="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onclick={() => (showImport = !showImport)}
+          data-testid="recipe-import-url-toggle-empty"
+        >
+          {#snippet leading()}<Icon name="Link" size={16} />{/snippet}
+          Import from URL
+        </Button>
+        <Button size="sm" onclick={() => push('/recipes/new')}>Create your first recipe</Button>
+      </div>
+      {#if showImport}
+        <div
+          class="mt-2 flex w-full max-w-md flex-col gap-2 rounded border border-border bg-muted/50 p-3 text-left"
+          data-testid="recipe-import-url-area"
+        >
+          <div class="flex items-end gap-2">
+            <TextField
+              label="Recipe URL"
+              placeholder="https://example.com/recipe"
+              value={importUrl}
+              onValueChange={(v) => (importUrl = v)}
+              class="flex-1"
+              data-testid="recipe-import-url-input"
+            />
+            <Button
+              size="sm"
+              onclick={handleImport}
+              loading={importing}
+              disabled={importUrl.trim() === '' || importing}
+              data-testid="recipe-import-url-btn"
+            >
+              Import
+            </Button>
+          </div>
+        </div>
+      {/if}
     </div>
   {/snippet}
 
   {#snippet children()}
+    {#if showImport}
+      <div
+        class="mb-3 flex flex-col gap-2 rounded border border-border bg-muted/50 p-3"
+        data-testid="recipe-import-url-area"
+      >
+        <p class="text-sm text-muted-foreground">
+          Paste a recipe link. We'll read the page and convert it to metric and British terms — then
+          drop you into the editor to review and save.
+        </p>
+        <div class="flex items-end gap-2">
+          <TextField
+            label="Recipe URL"
+            placeholder="https://example.com/recipe"
+            value={importUrl}
+            onValueChange={(v) => (importUrl = v)}
+            class="flex-1"
+            data-testid="recipe-import-url-input"
+          />
+          <Button
+            size="sm"
+            onclick={handleImport}
+            loading={importing}
+            disabled={importUrl.trim() === '' || importing}
+            data-testid="recipe-import-url-btn"
+          >
+            Import
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onclick={() => {
+              showImport = false;
+              importUrl = '';
+            }}
+            disabled={importing}
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    {/if}
+
     <ul class="flex flex-col gap-1" data-testid="recipe-list">
       {#each sorted as recipe (recipe.id)}
         <li>

--- a/apps/web-pwa/src/routes/recipes/RecipeViewPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeViewPage.svelte
@@ -42,6 +42,14 @@
 
   const recipe = $derived($recipes.find((r) => r.id === params.id) ?? null);
 
+  // Outbound link to the original recipe, only for url-sourced (imported) recipes
+  // with a non-empty url. Manual/legacy recipes (source null) render nothing.
+  const sourceUrl = $derived(
+    recipe?.source?.type === 'url' && (recipe.source.url ?? '').trim() !== ''
+      ? recipe.source.url!
+      : null,
+  );
+
   function timeParts(): string[] {
     if (!recipe) return [];
     const m = recipe.metadata;
@@ -335,7 +343,7 @@
       <!-- Left column: main recipe content -->
       <div class="flex flex-col gap-4">
         <!-- Description + meta chips -->
-        {#if recipe.description || timeParts().length > 0 || recipe.metadata.tags.length > 0}
+        {#if recipe.description || timeParts().length > 0 || recipe.metadata.tags.length > 0 || sourceUrl}
           <Card>
             <CardContent class="flex flex-col gap-3 p-4">
               {#if recipe.description}
@@ -354,6 +362,18 @@
                     >
                   {/each}
                 </div>
+              {/if}
+              {#if sourceUrl}
+                <a
+                  href={sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center gap-1.5 self-start text-sm text-primary hover:underline"
+                  data-testid="recipe-source-link"
+                >
+                  <Icon name="ExternalLink" size={14} />
+                  View original recipe
+                </a>
               {/if}
             </CardContent>
           </Card>

--- a/packages/adapters/firebase-sync/src/index.ts
+++ b/packages/adapters/firebase-sync/src/index.ts
@@ -44,7 +44,7 @@ export {
 } from './chatSessionSubscription.js';
 export { streamChefChat, callGenerateChatTitle } from './chatCallables.js';
 export { callAuthorRecipe } from './authorRecipeCallable.js';
-export { callParseRecipeIngredients } from './recipeCallables.js';
+export { callParseRecipeIngredients, callExtractRecipeFromUrl } from './recipeCallables.js';
 export {
   subscribeMealPlanConfig,
   subscribeMealPlanTemplate,

--- a/packages/adapters/firebase-sync/src/recipeCallables.ts
+++ b/packages/adapters/firebase-sync/src/recipeCallables.ts
@@ -1,6 +1,11 @@
 import { getFunctions, httpsCallable } from 'firebase/functions';
 import { failure, success, type DomainError, type ReadResult } from '@salt/shared-types';
 import type { IngredientGroup } from '@salt/domain';
+import type {
+  ExtractRecipeFromUrlInput,
+  RecipeDoc,
+  UrlImportFailureCode,
+} from '@salt/domain/schemas';
 
 export async function callParseRecipeIngredients(
   rawText: string,
@@ -21,5 +26,54 @@ export async function callParseRecipeIngredients(
       return failure({ kind: 'AuthError', reason: 'forbidden' });
     }
     return failure({ kind: 'NetworkError', reason: 'transient' });
+  }
+}
+
+// Map the callable's HttpsError code → the URL-import failure vocabulary. The
+// CF entrypoint deliberately maps each UrlImportError code to a distinct gRPC
+// code (see apps/cloud-functions/src/index.ts:mapUrlImportFailure), so the
+// reverse mapping here is exact. The error channel carries the failure code
+// directly (not a DomainError) because the import failures are import-specific
+// and the web copy map keys off them. Adapters never throw — every failure
+// crosses as a Failure.
+function classifyUrlImportError(err: unknown): UrlImportFailureCode {
+  const code = (err as { code?: string }).code ?? '';
+  switch (code) {
+    case 'functions/invalid-argument':
+      // Covers both invalid-url and blocked-url. The CF copy distinguishes
+      // them via the message; the client treats both as "can't import this
+      // address" — we surface blocked-url (the stricter, no-detail message)
+      // only when the message indicates a blocked link, else invalid-url.
+      return /can't be imported/i.test(String((err as { message?: string }).message ?? ''))
+        ? 'blocked-url'
+        : 'invalid-url';
+    case 'functions/unavailable':
+      return 'fetch-failed';
+    case 'functions/failed-precondition':
+      return 'not-a-recipe';
+    case 'functions/deadline-exceeded':
+    case 'functions/internal':
+      return 'ai-failed';
+    default:
+      // Network/transport hiccup before the function ran — treat as unreachable.
+      return 'fetch-failed';
+  }
+}
+
+// SSRF-hardened URL import. Sends a URL, receives a fully-assembled, metric +
+// British recipe draft (source.type='url'). On failure returns the specific
+// UrlImportFailureCode so the caller can show the right copy.
+export async function callExtractRecipeFromUrl(
+  input: ExtractRecipeFromUrlInput,
+): Promise<ReadResult<RecipeDoc, UrlImportFailureCode>> {
+  try {
+    const fn = httpsCallable<ExtractRecipeFromUrlInput, RecipeDoc>(
+      getFunctions(undefined, 'europe-west2'),
+      'extractRecipeFromUrl',
+    );
+    const res = await fn(input);
+    return success(res.data);
+  } catch (err) {
+    return failure(classifyUrlImportError(err));
   }
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -236,6 +236,16 @@ export {
   clearIngredientMatch,
   flattenIngredients,
 } from './recipe/index.js';
+export type { ParsedImportUrl, IpClass } from './recipe/index.js';
+export {
+  parseImportUrl,
+  isHttpsScheme,
+  hostnameAsIpLiteral,
+  classifyIp,
+  isPublicIp,
+  isIpv4,
+  isIpv6,
+} from './recipe/index.js';
 
 // Cross-cutting ports.
 export type { ErrorReportingPort } from './ErrorReportingPort.js';

--- a/packages/domain/src/recipe/index.ts
+++ b/packages/domain/src/recipe/index.ts
@@ -20,3 +20,16 @@ export type { Recipe, RecipeImage, RecipeMetadata, RecipeSource } from './entiti
 export { emptyRecipe, emptyIngredientGroup, newIngredient, newStep } from './commands/builders.js';
 export { clearIngredientMatch } from './commands/clearIngredientMatch.js';
 export { flattenIngredients } from './queries/ingredients.js';
+
+// URL import — pure SSRF/URL classification helpers (no I/O). The live fetch +
+// DNS resolution lives in cloud-functions; this module only holds the policy.
+export type { ParsedImportUrl, IpClass } from './urlImport/index.js';
+export {
+  parseImportUrl,
+  isHttpsScheme,
+  hostnameAsIpLiteral,
+  classifyIp,
+  isPublicIp,
+  isIpv4,
+  isIpv6,
+} from './urlImport/index.js';

--- a/packages/domain/src/recipe/urlImport/index.ts
+++ b/packages/domain/src/recipe/urlImport/index.ts
@@ -1,0 +1,12 @@
+// URL import — pure SSRF/URL helpers (no I/O). The live fetch + DNS resolution
+// lives in cloud-functions; this module only holds the classification policy.
+export type { ParsedImportUrl, IpClass } from './ssrf.js';
+export {
+  parseImportUrl,
+  isHttpsScheme,
+  hostnameAsIpLiteral,
+  classifyIp,
+  isPublicIp,
+  isIpv4,
+  isIpv6,
+} from './ssrf.js';

--- a/packages/domain/src/recipe/urlImport/ssrf.ts
+++ b/packages/domain/src/recipe/urlImport/ssrf.ts
@@ -1,0 +1,261 @@
+// Pure URL/host-classification helpers for the SSRF-hardened URL import
+// (issue: recipe URL import). These are *pure* — no fetch, no DNS, no Node
+// built-ins, no I/O. The live DNS resolution + connection enforcement lives in
+// cloud-functions (which calls classifyIp on every resolved address and on the
+// IP actually connected to). Keeping the classification rules here means the
+// "is this address public?" policy is one auditable, unit-testable place that
+// both the resolved-address check and the connected-IP re-check share.
+
+// ─── URL parsing & scheme ────────────────────────────────────────────────────
+
+export interface ParsedImportUrl {
+  readonly href: string;
+  readonly protocol: string; // e.g. "https:"
+  readonly hostname: string; // bare host (no brackets for IPv6)
+}
+
+// Parse a user-supplied web address into the fields the SSRF guard needs.
+// Pure: no WHATWG `URL` constructor (unavailable in the domain's lib and would
+// be a browser/Node API), no I/O. A regex covers the absolute-URL shape the
+// guard cares about — scheme + authority host. The live fetch in cloud-functions
+// re-parses with the real `URL` and resolves DNS; this is the pre-flight check
+// (reject garbage / non-https / IP-literal internal hosts before any network).
+// Returns null when `raw` is not an absolute URL with a host.
+const ABSOLUTE_URL_RE = /^([a-zA-Z][a-zA-Z0-9+.-]*:)\/\/([^/?#]*)([/?#].*)?$/;
+
+export function parseImportUrl(raw: string): ParsedImportUrl | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  const m = ABSOLUTE_URL_RE.exec(trimmed);
+  if (m === null) return null;
+
+  const protocol = m[1]!.toLowerCase();
+  let authority = m[2]!;
+  if (authority === '') return null;
+
+  // Strip userinfo ("user:pass@host").
+  const at = authority.lastIndexOf('@');
+  if (at >= 0) authority = authority.slice(at + 1);
+
+  let hostname: string;
+  if (authority.startsWith('[')) {
+    // IPv6 literal: "[::1]:443" → "::1".
+    const close = authority.indexOf(']');
+    if (close < 0) return null;
+    hostname = authority.slice(1, close);
+  } else {
+    // Strip an optional ":port".
+    const colon = authority.indexOf(':');
+    hostname = colon >= 0 ? authority.slice(0, colon) : authority;
+  }
+  if (hostname === '') return null;
+
+  return { href: trimmed, protocol, hostname };
+}
+
+// https-only. http, ftp, file, data, etc. are all rejected — the SSRF guard
+// only permits encrypted public web fetches.
+export function isHttpsScheme(protocol: string): boolean {
+  return protocol === 'https:';
+}
+
+// A hostname that is itself an IP literal can skip DNS resolution but must still
+// be classified directly (an attacker can put a private IP straight in the URL).
+// Returns the normalised IP string when the hostname is an IP literal, else null.
+export function hostnameAsIpLiteral(hostname: string): string | null {
+  if (isIpv4(hostname)) return hostname;
+  // IPv6 literals may arrive with a zone id ("fe80::1%eth0"); drop it.
+  const noZone = hostname.split('%')[0] ?? hostname;
+  if (isIpv6(noZone)) return noZone;
+  return null;
+}
+
+// ─── IP classification ───────────────────────────────────────────────────────
+
+export type IpClass = 'public' | 'loopback' | 'private' | 'link-local' | 'unspecified' | 'special'; // multicast, reserved, documentation, etc.
+
+// A non-public class means: refuse the fetch. The CF guard treats every value
+// other than 'public' as blocked.
+export function isPublicIp(ip: string): boolean {
+  return classifyIp(ip) === 'public';
+}
+
+// Classify an IP address string (IPv4 or IPv6, including IPv4-mapped IPv6).
+// Throws nothing — an unparseable string is treated as 'special' (blocked),
+// which is the safe default for an SSRF guard.
+export function classifyIp(ip: string): IpClass {
+  const trimmed = ip.trim();
+  const noZone = trimmed.split('%')[0] ?? trimmed;
+
+  if (isIpv4(noZone)) return classifyIpv4(noZone);
+  if (isIpv6(noZone)) return classifyIpv6(noZone);
+  return 'special';
+}
+
+// ─── IPv4 ────────────────────────────────────────────────────────────────────
+
+export function isIpv4(s: string): boolean {
+  return parseIpv4Octets(s) !== null;
+}
+
+function parseIpv4Octets(s: string): [number, number, number, number] | null {
+  const parts = s.split('.');
+  if (parts.length !== 4) return null;
+  const octets: number[] = [];
+  for (const part of parts) {
+    // Reject empty / non-numeric / out-of-range; allow 1–3 digits.
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const n = Number(part);
+    if (n < 0 || n > 255) return null;
+    octets.push(n);
+  }
+  return [octets[0]!, octets[1]!, octets[2]!, octets[3]!];
+}
+
+function classifyIpv4(s: string): IpClass {
+  const octets = parseIpv4Octets(s);
+  if (octets === null) return 'special';
+  const [a, b, c] = octets;
+
+  // 0.0.0.0/8 — "this network" / unspecified.
+  if (a === 0) return 'unspecified';
+  // 127.0.0.0/8 — loopback.
+  if (a === 127) return 'loopback';
+  // 10.0.0.0/8 — private.
+  if (a === 10) return 'private';
+  // 172.16.0.0/12 — private.
+  if (a === 172 && b! >= 16 && b! <= 31) return 'private';
+  // 192.168.0.0/16 — private.
+  if (a === 192 && b === 168) return 'private';
+  // 169.254.0.0/16 — link-local (incl. cloud metadata 169.254.169.254).
+  if (a === 169 && b === 254) return 'link-local';
+  // 100.64.0.0/10 — carrier-grade NAT (shared address space); treat as private.
+  if (a === 100 && b! >= 64 && b! <= 127) return 'private';
+  // IETF protocol assignments / TEST-NET documentation ranges.
+  if (a === 192 && b === 0 && c === 0) return 'special';
+  if (a === 192 && b === 0 && c === 2) return 'special';
+  if (a === 198 && (b === 18 || b === 19)) return 'special';
+  if (a === 198 && b === 51 && c === 100) return 'special';
+  if (a === 203 && b === 0 && c === 113) return 'special';
+  // 224.0.0.0/4 multicast; 240.0.0.0/4 reserved; 255.255.255.255 broadcast.
+  if (a! >= 224) return 'special';
+
+  return 'public';
+}
+
+// ─── IPv6 ────────────────────────────────────────────────────────────────────
+
+export function isIpv6(s: string): boolean {
+  return expandIpv6(s) !== null;
+}
+
+// Expand an IPv6 address to its 8 hextets (numbers 0–65535). Handles "::"
+// compression and embedded IPv4 ("::ffff:1.2.3.4", "::1.2.3.4"). Returns null
+// when not a valid IPv6 string.
+function expandIpv6(s: string): number[] | null {
+  if (!s.includes(':')) return null;
+
+  // Split off an embedded IPv4 tail if present (last segment contains a dot).
+  let head = s;
+  let embeddedV4: [number, number, number, number] | null = null;
+  const lastColon = s.lastIndexOf(':');
+  const tail = s.slice(lastColon + 1);
+  if (tail.includes('.')) {
+    const v4 = parseIpv4Octets(tail);
+    if (v4 === null) return null;
+    embeddedV4 = v4;
+    head = s.slice(0, lastColon + 1); // keep the trailing colon for splitting
+  }
+
+  const doubleColonCount = (head.match(/::/g) ?? []).length;
+  if (doubleColonCount > 1) return null;
+
+  let groups: string[];
+  if (doubleColonCount === 1) {
+    const [left, right] = head.split('::');
+    const leftParts = left === '' ? [] : left!.split(':').filter((p) => p !== '');
+    const rightParts = right === '' ? [] : right!.split(':').filter((p) => p !== '');
+    const v4Hextets = embeddedV4 ? 2 : 0;
+    const missing = 8 - (leftParts.length + rightParts.length + v4Hextets);
+    if (missing < 0) return null;
+    groups = [...leftParts, ...Array<string>(missing).fill('0'), ...rightParts];
+  } else {
+    // No compression: strip a trailing colon left from the embedded-v4 split.
+    const cleaned = head.endsWith(':') ? head.slice(0, -1) : head;
+    groups = cleaned.split(':').filter((p) => p !== '');
+  }
+
+  const hextets: number[] = [];
+  for (const g of groups) {
+    if (!/^[0-9a-fA-F]{1,4}$/.test(g)) return null;
+    hextets.push(parseInt(g, 16));
+  }
+  if (embeddedV4) {
+    hextets.push((embeddedV4[0] << 8) | embeddedV4[1]);
+    hextets.push((embeddedV4[2] << 8) | embeddedV4[3]);
+  }
+  if (hextets.length !== 8) return null;
+  return hextets;
+}
+
+function classifyIpv6(s: string): IpClass {
+  const h = expandIpv6(s);
+  if (h === null) return 'special';
+
+  // Unspecified ::.
+  if (h.every((x) => x === 0)) return 'unspecified';
+  // Loopback ::1.
+  if (
+    h[0] === 0 &&
+    h[1] === 0 &&
+    h[2] === 0 &&
+    h[3] === 0 &&
+    h[4] === 0 &&
+    h[5] === 0 &&
+    h[6] === 0 &&
+    h[7] === 1
+  ) {
+    return 'loopback';
+  }
+
+  // IPv4-mapped ::ffff:a.b.c.d (h[5] === 0xffff, first five hextets zero) —
+  // classify by the embedded IPv4 so a mapped private/loopback address is caught.
+  if (h[0] === 0 && h[1] === 0 && h[2] === 0 && h[3] === 0 && h[4] === 0 && h[5] === 0xffff) {
+    return classifyIpv4(hextetsToIpv4(h[6]!, h[7]!));
+  }
+  // IPv4-compatible ::a.b.c.d (deprecated) — first six hextets zero, non-zero tail.
+  if (
+    h[0] === 0 &&
+    h[1] === 0 &&
+    h[2] === 0 &&
+    h[3] === 0 &&
+    h[4] === 0 &&
+    h[5] === 0 &&
+    (h[6] !== 0 || h[7] !== 0)
+  ) {
+    return classifyIpv4(hextetsToIpv4(h[6]!, h[7]!));
+  }
+
+  const first = h[0]!;
+  // fe80::/10 — link-local.
+  if ((first & 0xffc0) === 0xfe80) return 'link-local';
+  // fc00::/7 — unique local addresses (private).
+  if ((first & 0xfe00) === 0xfc00) return 'private';
+  // ff00::/8 — multicast.
+  if ((first & 0xff00) === 0xff00) return 'special';
+  // 2001:db8::/32 — documentation.
+  if (first === 0x2001 && h[1] === 0x0db8) return 'special';
+  // 2001:0000::/32 — Teredo; 2002::/16 — 6to4 (can tunnel to internal v4).
+  if (first === 0x2001 && h[1] === 0) return 'special';
+  if (first === 0x2002) return 'special';
+
+  return 'public';
+}
+
+function hextetsToIpv4(hi: number, lo: number): string {
+  const a = (hi >> 8) & 0xff;
+  const b = hi & 0xff;
+  const c = (lo >> 8) & 0xff;
+  const d = lo & 0xff;
+  return `${a}.${b}.${c}.${d}`;
+}

--- a/packages/domain/src/schemas/extractRecipeFromUrl.ts
+++ b/packages/domain/src/schemas/extractRecipeFromUrl.ts
@@ -1,0 +1,91 @@
+import { z } from 'zod';
+import { RecipeSchema } from './recipe.js';
+
+// SSRF-hardened URL import (recipe URL import epic, Phase 1).
+//
+// Input: a single user-supplied web address. Output: a fully-assembled recipe
+// draft (the same shape as a stored recipe document) with `source.type = 'url'`.
+// The client adds nothing — it hydrates the editor straight from this draft.
+
+export const ExtractRecipeFromUrlInputSchema = z.object({
+  // Validated again inside the flow against the SSRF guard; here we only assert
+  // it is a non-empty string. The flow rejects non-https / private hosts.
+  url: z.string().min(1),
+});
+
+export type ExtractRecipeFromUrlInput = z.infer<typeof ExtractRecipeFromUrlInputSchema>;
+
+// The flow returns a complete recipe draft. Reuse the canonical RecipeSchema so
+// the draft is guaranteed to be a valid, persistable recipe document.
+export const ExtractRecipeFromUrlOutputSchema = RecipeSchema;
+
+export type ExtractRecipeFromUrlOutput = z.infer<typeof ExtractRecipeFromUrlOutputSchema>;
+
+// The closed set of user-facing failure modes for URL import. The CF flow tags
+// each failure with one of these; the callable wrapper re-derives it from the
+// HttpsError code so the client can show the right copy without leaking SSRF
+// internals. Defined here (pure type) so the CF, the wrapper, and the web copy
+// map all agree on the same vocabulary.
+//   - invalid-url: not a valid web address.
+//   - blocked-url: refused by the SSRF guard (non-https / private / internal).
+//   - fetch-failed: DNS / connect / timeout / non-200 / too-large / wrong type.
+//   - not-a-recipe: page fetched but no recipe found.
+//   - ai-failed: AI timeout or unparseable/invalid model output.
+export const URL_IMPORT_FAILURE_CODES = [
+  'invalid-url',
+  'blocked-url',
+  'fetch-failed',
+  'not-a-recipe',
+  'ai-failed',
+] as const;
+
+export type UrlImportFailureCode = (typeof URL_IMPORT_FAILURE_CODES)[number];
+
+// ─── AI extraction output ─────────────────────────────────────────────────────
+// The shape Gemini emits inside the flow (never leaves the CF boundary). The
+// model extracts the recipe AND converts everything to metric + British
+// spelling/terms/ingredient names. Ingredient `rawText` is the British/metric
+// line that then feeds the existing parse/canonicalise flows. Step ordinals are
+// resolved to step IDs by the flow before the RecipeDoc is assembled — mirrors
+// the librarian (authorRecipe) flow.
+
+export const ExtractedIngredientSchema = z.object({
+  // The ingredient line, already converted to metric + British spelling/terms.
+  rawText: z.string(),
+  isOptional: z.boolean(),
+  // 0-based index into the steps array for the first step that uses this
+  // ingredient. null = no specific step assignment.
+  firstUsedInStepOrdinal: z.number().int().nullable(),
+});
+
+export const ExtractedIngredientGroupSchema = z.object({
+  name: z.string().nullable(),
+  ingredients: z.array(ExtractedIngredientSchema),
+});
+
+export const ExtractedStepSchema = z.object({
+  text: z.string(),
+  timerMinutes: z.number().int().nullable(),
+  note: z.string().nullable(),
+});
+
+export const ExtractRecipeAIOutputSchema = z.object({
+  // false when the page is not a recipe at all → maps to the not-a-recipe
+  // failure. true with a populated recipe otherwise.
+  isRecipe: z.boolean(),
+  title: z.string(),
+  description: z.string().nullable(),
+  servings: z.number().nullable(),
+  totalTimeMinutes: z.number().nullable(),
+  prepTimeMinutes: z.number().nullable(),
+  cookTimeMinutes: z.number().nullable(),
+  tags: z.array(z.string()),
+  ingredientGroups: z.array(ExtractedIngredientGroupSchema),
+  steps: z.array(ExtractedStepSchema),
+  notes: z.string().nullable(),
+});
+
+export type ExtractedIngredient = z.infer<typeof ExtractedIngredientSchema>;
+export type ExtractedIngredientGroup = z.infer<typeof ExtractedIngredientGroupSchema>;
+export type ExtractedStep = z.infer<typeof ExtractedStepSchema>;
+export type ExtractRecipeAIOutput = z.infer<typeof ExtractRecipeAIOutputSchema>;

--- a/packages/domain/src/schemas/index.ts
+++ b/packages/domain/src/schemas/index.ts
@@ -113,6 +113,25 @@ export type {
 } from './authorRecipe.js';
 
 export {
+  ExtractRecipeFromUrlInputSchema,
+  ExtractRecipeFromUrlOutputSchema,
+  ExtractRecipeAIOutputSchema,
+  ExtractedIngredientSchema,
+  ExtractedIngredientGroupSchema,
+  ExtractedStepSchema,
+  URL_IMPORT_FAILURE_CODES,
+} from './extractRecipeFromUrl.js';
+export type {
+  ExtractRecipeFromUrlInput,
+  ExtractRecipeFromUrlOutput,
+  ExtractRecipeAIOutput,
+  ExtractedIngredient,
+  ExtractedIngredientGroup,
+  ExtractedStep,
+  UrlImportFailureCode,
+} from './extractRecipeFromUrl.js';
+
+export {
   SingleQuantitySchema,
   RangeQuantitySchema,
   MixedQuantitySchema,

--- a/packages/domain/tests/recipe/ssrf.test.ts
+++ b/packages/domain/tests/recipe/ssrf.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseImportUrl,
+  isHttpsScheme,
+  hostnameAsIpLiteral,
+  classifyIp,
+  isPublicIp,
+  isIpv4,
+  isIpv6,
+} from '@salt/domain';
+
+describe('parseImportUrl', () => {
+  it('parses a valid https url', () => {
+    const p = parseImportUrl('https://example.com/recipes/cake');
+    expect(p).not.toBeNull();
+    expect(p!.protocol).toBe('https:');
+    expect(p!.hostname).toBe('example.com');
+  });
+
+  it('strips IPv6 brackets from hostname', () => {
+    const p = parseImportUrl('https://[::1]/x');
+    expect(p!.hostname).toBe('::1');
+  });
+
+  it('returns null for garbage / relative / empty', () => {
+    expect(parseImportUrl('not a url')).toBeNull();
+    expect(parseImportUrl('/relative/path')).toBeNull();
+    expect(parseImportUrl('   ')).toBeNull();
+  });
+});
+
+describe('isHttpsScheme', () => {
+  it('accepts only https', () => {
+    expect(isHttpsScheme('https:')).toBe(true);
+    expect(isHttpsScheme('http:')).toBe(false);
+    expect(isHttpsScheme('ftp:')).toBe(false);
+    expect(isHttpsScheme('file:')).toBe(false);
+    expect(isHttpsScheme('data:')).toBe(false);
+  });
+});
+
+describe('hostnameAsIpLiteral', () => {
+  it('recognises IPv4 / IPv6 literals, rejects names', () => {
+    expect(hostnameAsIpLiteral('10.0.0.1')).toBe('10.0.0.1');
+    expect(hostnameAsIpLiteral('::1')).toBe('::1');
+    expect(hostnameAsIpLiteral('example.com')).toBeNull();
+  });
+  it('drops an IPv6 zone id', () => {
+    expect(hostnameAsIpLiteral('fe80::1%eth0')).toBe('fe80::1');
+  });
+});
+
+describe('IPv4 classification', () => {
+  it('flags loopback, private, link-local, unspecified', () => {
+    expect(classifyIp('127.0.0.1')).toBe('loopback');
+    expect(classifyIp('10.1.2.3')).toBe('private');
+    expect(classifyIp('172.16.0.1')).toBe('private');
+    expect(classifyIp('172.31.255.255')).toBe('private');
+    expect(classifyIp('192.168.1.1')).toBe('private');
+    expect(classifyIp('169.254.169.254')).toBe('link-local'); // cloud metadata
+    expect(classifyIp('100.64.0.1')).toBe('private'); // CGNAT
+    expect(classifyIp('0.0.0.0')).toBe('unspecified');
+  });
+
+  it('does NOT flag 172.15/172.32 (outside the /12)', () => {
+    expect(classifyIp('172.15.0.1')).toBe('public');
+    expect(classifyIp('172.32.0.1')).toBe('public');
+  });
+
+  it('treats public addresses as public', () => {
+    expect(isPublicIp('8.8.8.8')).toBe(true);
+    expect(isPublicIp('1.1.1.1')).toBe(true);
+    expect(isPublicIp('93.184.216.34')).toBe(true);
+  });
+
+  it('flags multicast/reserved/doc ranges', () => {
+    expect(classifyIp('224.0.0.1')).toBe('special');
+    expect(classifyIp('240.0.0.1')).toBe('special');
+    expect(classifyIp('192.0.2.5')).toBe('special'); // TEST-NET-1
+    expect(classifyIp('203.0.113.5')).toBe('special'); // TEST-NET-3
+    expect(isPublicIp('169.254.169.254')).toBe(false);
+  });
+
+  it('rejects malformed IPv4', () => {
+    expect(isIpv4('999.1.1.1')).toBe(false);
+    expect(isIpv4('1.2.3')).toBe(false);
+    expect(isIpv4('1.2.3.4.5')).toBe(false);
+    expect(isIpv4('a.b.c.d')).toBe(false);
+  });
+});
+
+describe('IPv6 classification', () => {
+  it('flags loopback / unspecified / link-local / ULA', () => {
+    expect(classifyIp('::1')).toBe('loopback');
+    expect(classifyIp('::')).toBe('unspecified');
+    expect(classifyIp('fe80::1')).toBe('link-local');
+    expect(classifyIp('fc00::1')).toBe('private');
+    expect(classifyIp('fd12:3456::1')).toBe('private');
+    expect(classifyIp('ff02::1')).toBe('special'); // multicast
+  });
+
+  it('classifies IPv4-mapped IPv6 by the embedded v4', () => {
+    expect(classifyIp('::ffff:127.0.0.1')).toBe('loopback');
+    expect(classifyIp('::ffff:10.0.0.1')).toBe('private');
+    expect(classifyIp('::ffff:169.254.169.254')).toBe('link-local');
+    expect(classifyIp('::ffff:8.8.8.8')).toBe('public');
+    // hex form of the mapped address
+    expect(classifyIp('::ffff:7f00:1')).toBe('loopback');
+  });
+
+  it('treats global unicast as public', () => {
+    expect(isPublicIp('2606:4700:4700::1111')).toBe(true);
+    expect(classifyIp('2001:db8::1')).toBe('special'); // documentation
+  });
+
+  it('validates IPv6 syntax', () => {
+    expect(isIpv6('::1')).toBe(true);
+    expect(isIpv6('2001:db8::1')).toBe(true);
+    expect(isIpv6('not:ipv6:::')).toBe(false);
+    expect(isIpv6('gggg::1')).toBe(false);
+    expect(isIpv6('1.2.3.4')).toBe(false);
+  });
+
+  it('treats unparseable input as special (blocked)', () => {
+    expect(classifyIp('not-an-ip')).toBe('special');
+    expect(isPublicIp('garbage')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements recipe import from a URL with AI extraction and British/metric conversion (Closes #260), built in three phases.

A member pastes a recipe URL from the recipes list → the server performs an SSRF-hardened fetch → Gemini extracts the recipe and converts it to British conventions (metric units, British spelling, British ingredient names) → the member lands in the existing recipe editor pre-filled, reviews, and saves. Nothing is persisted until Save. Every imported recipe keeps a "View original recipe" link back to its source.

## Phases

**Phase 1 — SSRF-hardened URL import end-to-end** (`36ae5c3`)
- Pure URL/host-classification helpers in `@salt/domain` + flow input/output schemas (`@salt/domain/schemas`).
- `extractRecipeFromUrl` Genkit flow with an SSRF-guarded fetch: https-only, connect-time resolved-IP range checks (DNS-rebinding/TOCTOU defence), per-hop redirect re-validation, ~2MB size cap, wall-clock timeout, text/html-only, descriptive UA.
- Gemini extraction + metric/British conversion wrapped in `withAiTimeout`, reusing the existing parse/canonicalise ingredient flows.
- `onCall` entrypoint (declares `geminiApiKey`), full failure taxonomy → stable `HttpsError` codes + friendly copy, firebase-sync callable wrapper, `recipeService` orchestration, and the "Import from URL" button that drops the user into the existing editor pre-filled with `source: { type: 'url', url }`. No schema migration.

**Phase 2 — Source provenance display** (`c77a3da`)
- "View original recipe" link on the recipe view page (`target=_blank rel=noopener noreferrer`), shown only for `source.type === 'url'` with a non-empty url; manual/legacy recipes show nothing.
- Editable Source URL field in the editor; `pruneDraft` preserves `source` through save.

**Phase 3 — Extraction quality** (`4d66d81`)
- Dependency-free schema.org/Recipe JSON-LD extraction (regex + `JSON.parse` + Zod at the trust boundary), preferred before the HTML-to-Gemini fallback; 13 focused unit tests.
- Expanded American→British ingredient mappings shared across both prompts so conversion can't drift.
- JSON-LD-aware `not-a-recipe` signal (same failure code), tightening partial-extraction rejection.

## Key decisions
- **SSRF guard ships in Phase 1, not deferred** — pure host classification in `@salt/domain`, live DNS + connection enforcement in cloud-functions.
- **No new npm dependency** — JSON-LD is parsed from `<script type="application/ld+json">` blocks with regex + `JSON.parse` + Zod validation, avoiding an issue-gated cheerio/jsdom dependency.
- **Reuses the existing `source` seam** (`{ type: 'url', url }`) — no schema shape change, backward-compatible on read.
- **Review-before-save** — imported drafts are not persisted until the member saves in the existing editor.

## Testing
- `pnpm typecheck`, `pnpm lint`, dependency-cruiser, and the full test suite pass.
- 134 cloud-functions tests (incl. 13 new JSON-LD tests) and 564 domain tests (incl. new SSRF tests) pass.

## Known follow-up
- The live SSRF fetch path (`ssrfFetch.ts`) has pure-helper unit tests but no integration/emulator coverage yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
