### PR TITLE
fix(recipes): harden and trim the URL-import extraction pipeline

### DIFF
--- a/apps/cloud-functions/src/adapters/jsonLdRecipe.ts
+++ b/apps/cloud-functions/src/adapters/jsonLdRecipe.ts
@@ -170,7 +170,12 @@ function normalizeRecipeNode(raw: z.infer<typeof RawJsonLdRecipeSchema>): JsonLd
   const node = raw as Record<string, unknown>;
   const title = coerceText(node['name'] ?? node['headline']);
   const ingredients = coerceTextList(node['recipeIngredient'] ?? node['ingredients']);
-  if (title === null || ingredients.length === 0) return null;
+  const steps = coerceTextList(node['recipeInstructions']);
+  // Require a title, at least one ingredient, AND at least one step. An
+  // ingredient-only stub (some sites emit a Recipe node with no instructions)
+  // isn't a usable recipe — fall through so the HTML path or not-a-recipe can
+  // take over rather than feeding the model a recipe with no method.
+  if (title === null || ingredients.length === 0 || steps.length === 0) return null;
 
   return {
     title,
@@ -181,7 +186,7 @@ function normalizeRecipeNode(raw: z.infer<typeof RawJsonLdRecipeSchema>): JsonLd
     cookTimeMinutes: coerceDurationMinutes(node['cookTime']),
     tags: coerceTags(node),
     ingredients,
-    steps: coerceTextList(node['recipeInstructions']),
+    steps,
   };
 }
 

--- a/apps/cloud-functions/src/flows/extractRecipeFromUrl.ts
+++ b/apps/cloud-functions/src/flows/extractRecipeFromUrl.ts
@@ -216,12 +216,12 @@ function buildJsonLdPrompt(
 function stripHtmlNoise(html: string): string {
   return html
     .replace(/<!--[\s\S]*?-->/g, ' ')
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, ' ')
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, ' ')
-    .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript\s*>/gi, ' ')
-    .replace(/<template\b[^>]*>[\s\S]*?<\/template\s*>/gi, ' ')
-    .replace(/<svg\b[^>]*>[\s\S]*?<\/svg\s*>/gi, ' ')
-    .replace(/<head\b[^>]*>[\s\S]*?<\/head\s*>/gi, ' ')
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style[^>]*>/gi, ' ')
+    .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript[^>]*>/gi, ' ')
+    .replace(/<template\b[^>]*>[\s\S]*?<\/template[^>]*>/gi, ' ')
+    .replace(/<svg\b[^>]*>[\s\S]*?<\/svg[^>]*>/gi, ' ')
+    .replace(/<head\b[^>]*>[\s\S]*?<\/head[^>]*>/gi, ' ')
     .replace(/\bsrc\s*=\s*["']data:[^"']*["']/gi, 'src=""')
     .replace(/[ \t\f\v]{2,}/g, ' ')
     .replace(/(\s*\n\s*){2,}/g, '\n');

--- a/apps/cloud-functions/src/flows/extractRecipeFromUrl.ts
+++ b/apps/cloud-functions/src/flows/extractRecipeFromUrl.ts
@@ -100,29 +100,32 @@ export const extractRecipeFromUrlFlow = ai.defineFlow(
 
     let extracted: ExtractRecipeAIOutput;
     try {
-      const result = await withAiTimeout(
+      extracted = await withAiTimeout(
         'extractRecipeFromUrl',
-        () =>
-          ai.generate({
+        async () => {
+          const result = await ai.generate({
             model: EXTRACT_MODEL,
             system,
             prompt,
             output: { schema: ExtractRecipeAIOutputSchema },
             config: { temperature: 0 },
-          }),
-        { timeoutMs: 55_000, retries: 0 },
+          });
+          // Validate INSIDE the retried op: an empty/malformed structured
+          // response (Gemini occasionally returns one even at temperature:0, and
+          // structured-output coercion can fail transiently) then gets a fresh
+          // attempt rather than failing the whole import on a single flaky
+          // generation. Only a persistent failure surfaces as ai-failed.
+          const validated = ExtractRecipeAIOutputSchema.safeParse(result.output);
+          if (!validated.success) {
+            throw new Error(`extractor returned invalid structure: ${validated.error.message}`);
+          }
+          return validated.data;
+        },
+        { timeoutMs: 40_000, retries: 1 },
       );
-      const validated = ExtractRecipeAIOutputSchema.safeParse(result.output);
-      if (!validated.success) {
-        throw new UrlImportError(
-          'ai-failed',
-          `extractor returned invalid structure: ${validated.error.message}`,
-        );
-      }
-      extracted = validated.data;
     } catch (err) {
-      if (err instanceof UrlImportError) throw err;
-      // AI timeout / transport / model error all surface as ai-failed.
+      // AI timeout / transport / model error / invalid output all surface as
+      // ai-failed after the retry is exhausted.
       throw new UrlImportError('ai-failed', err instanceof Error ? err.message : 'ai error');
     }
 
@@ -150,6 +153,13 @@ export const extractRecipeFromUrlFlow = ai.defineFlow(
 //   a blog post shouldn't pass as a recipe). This keeps the failure taxonomy
 //   intact — it only fires not-a-recipe on a stronger combined signal.
 function hasUsableRecipe(extracted: ExtractRecipeAIOutput, hadJsonLd: boolean): boolean {
+  // A recipe with no title is a broken extraction — never assemble an untitled
+  // draft. Checked here (not at the schema) so an isRecipe=false response, which
+  // legitimately leaves the title empty, still maps to not-a-recipe rather than
+  // ai-failed.
+  if (extracted.title.trim().length === 0) {
+    return false;
+  }
   const ingredientCount = extracted.ingredientGroups.reduce(
     (sum, g) => sum + g.ingredients.length,
     0,
@@ -196,10 +206,33 @@ function buildJsonLdPrompt(
   };
 }
 
+// Strip the parts of a page that carry no recipe signal but burn tokens before
+// we forward HTML to the model: <script> (often hundreds of KB of bundles),
+// <style>, <head>, <noscript>, <template>, <svg> (icon paths), HTML comments,
+// and inline base64 `data:` URIs (which can each be tens of KB). A recipe page's
+// actual content survives intact. This runs on the fallback path only — most
+// mainstream sites carry JSON-LD and never reach here. Dependency-free regex,
+// consistent with jsonLdRecipe (no cheerio/jsdom — issue-gated).
+function stripHtmlNoise(html: string): string {
+  return html
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, ' ')
+    .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript\s*>/gi, ' ')
+    .replace(/<template\b[^>]*>[\s\S]*?<\/template\s*>/gi, ' ')
+    .replace(/<svg\b[^>]*>[\s\S]*?<\/svg\s*>/gi, ' ')
+    .replace(/<head\b[^>]*>[\s\S]*?<\/head\s*>/gi, ' ')
+    .replace(/\bsrc\s*=\s*["']data:[^"']*["']/gi, 'src=""')
+    .replace(/[ \t\f\v]{2,}/g, ' ')
+    .replace(/(\s*\n\s*){2,}/g, '\n');
+}
+
 // Build the prompt for the HTML fallback path (no JSON-LD found): the model both
-// finds the recipe in the page and converts it.
+// finds the recipe in the page and converts it. We strip script/style/svg noise
+// FIRST, then cap — so the budget is spent on real content, not bundles.
 function buildHtmlPrompt(html: string, sourceUrl: string): { system: string; prompt: string } {
-  const trimmedHtml = html.length > MAX_HTML_CHARS ? html.slice(0, MAX_HTML_CHARS) : html;
+  const cleaned = stripHtmlNoise(html);
+  const trimmedHtml = cleaned.length > MAX_HTML_CHARS ? cleaned.slice(0, MAX_HTML_CHARS) : cleaned;
   return {
     system: EXTRACT_SYSTEM,
     prompt: `Source URL: ${sourceUrl}\n\nPage HTML:\n${trimmedHtml}`,
@@ -301,12 +334,26 @@ async function assembleDraft(raw: ExtractRecipeAIOutput, sourceUrl: string): Pro
     steps,
     metadata: {
       servings: raw.servings,
-      totalTimeMinutes: raw.totalTimeMinutes,
+      // Derive a total from prep + cook when the source only gives the parts
+      // (common — e.g. the page states prep and cook but no explicit total), so
+      // the editor shows a total time instead of a blank.
+      totalTimeMinutes:
+        raw.totalTimeMinutes ??
+        (raw.prepTimeMinutes !== null && raw.cookTimeMinutes !== null
+          ? raw.prepTimeMinutes + raw.cookTimeMinutes
+          : null),
       prepTimeMinutes: raw.prepTimeMinutes,
       cookTimeMinutes: raw.cookTimeMinutes,
-      tags: raw.tags
-        .map((t) => t.toLowerCase().trim().replace(/\s+/g, '-'))
-        .filter((t) => t.length > 0),
+      // Split comma-joined tags ("vegetarian, quick" → two tags) before
+      // kebab-normalising, then dedupe.
+      tags: [
+        ...new Set(
+          raw.tags
+            .flatMap((t) => t.split(','))
+            .map((t) => t.toLowerCase().trim().replace(/\s+/g, '-'))
+            .filter((t) => t.length > 0),
+        ),
+      ],
     },
     source: { type: 'url', url: sourceUrl },
     notes: raw.notes,

--- a/apps/cloud-functions/tests/adapters/jsonLdRecipe.test.ts
+++ b/apps/cloud-functions/tests/adapters/jsonLdRecipe.test.ts
@@ -103,6 +103,16 @@ describe('extractRecipeJsonLd', () => {
     expect(extractRecipeJsonLd(page(JSON.stringify(thin)))).toBeNull();
   });
 
+  it('rejects a Recipe node with ingredients but no method steps', () => {
+    const noSteps = {
+      '@type': 'Recipe',
+      name: 'Stub',
+      recipeIngredient: ['200g flour', '2 eggs'],
+      recipeInstructions: [],
+    };
+    expect(extractRecipeJsonLd(page(JSON.stringify(noSteps)))).toBeNull();
+  });
+
   it('flattens HowToSection instructions into a flat list of steps', () => {
     const sectioned = {
       ...RECIPE,

--- a/apps/web-pwa/src/routes/recipes/RecipeListPage.svelte
+++ b/apps/web-pwa/src/routes/recipes/RecipeListPage.svelte
@@ -33,11 +33,17 @@
       addToast(urlImportMessage(result.error), 'destructive');
       return;
     }
-    // Hand the converted draft to the editor and route into it pre-filled.
+    // Hand the converted draft to the editor and route into it pre-filled. If
+    // navigation itself fails, surface it rather than silently closing the form
+    // and stranding the user with no editor and no error.
     stashImportedDraft(result.value);
-    showImport = false;
-    importUrl = '';
-    push('/recipes/new');
+    try {
+      push('/recipes/new');
+      showImport = false;
+      importUrl = '';
+    } catch {
+      addToast('Could not open the editor — please try again.', 'destructive');
+    }
   }
 </script>
 

--- a/packages/domain/src/schemas/extractRecipeFromUrl.ts
+++ b/packages/domain/src/schemas/extractRecipeFromUrl.ts
@@ -75,10 +75,14 @@ export const ExtractRecipeAIOutputSchema = z.object({
   isRecipe: z.boolean(),
   title: z.string(),
   description: z.string().nullable(),
-  servings: z.number().nullable(),
-  totalTimeMinutes: z.number().nullable(),
-  prepTimeMinutes: z.number().nullable(),
-  cookTimeMinutes: z.number().nullable(),
+  // Positive integers only — null is the "not stated" sentinel (also what an
+  // isRecipe=false response uses). This rejects nonsensical 0 / negative values
+  // a model glitch might emit (e.g. servings: 0) without breaking the
+  // not-a-recipe path, which leaves these null.
+  servings: z.number().int().positive().nullable(),
+  totalTimeMinutes: z.number().int().positive().nullable(),
+  prepTimeMinutes: z.number().int().positive().nullable(),
+  cookTimeMinutes: z.number().int().positive().nullable(),
   tags: z.array(z.string()),
   ingredientGroups: z.array(ExtractedIngredientGroupSchema),
   steps: z.array(ExtractedStepSchema),


### PR DESCRIPTION
## Summary

Follow-up tweaks to the merged recipe-URL-import feature (#262, Refs #260), grouped into reliability, cost, and extraction quality. No SSRF-enforcement or failure-taxonomy changes.

## Reliability
- **Retry the main Gemini call once** (the repo-wide `withAiTimeout` default) instead of `retries: 0`, and move the structured-output `safeParse` **inside** the retried op so a transient empty/malformed response gets a fresh attempt rather than failing the whole import. This is the fix for the `ai-failed` "the recipe reader had trouble with that page" reports — it was authored on the original branch but lost in the #262 squash, so it's re-applied here.

## Cost
- **Strip non-content HTML before the no-JSON-LD fallback prompt.** Removes `<script>` / `<style>` / `<head>` / `<svg>` / `<noscript>` / `<template>`, HTML comments, and inline base64 `data:` URIs, then caps. On a typical noisy page this is a **~79% reduction** (BBC: 437 KB → 90 KB, ~109k → ~22k tokens), so the token budget goes to real content and pages no longer truncate mid-recipe. JSON-LD path (most mainstream sites) is unaffected — it never reaches the fallback.

## Quality / correctness
- **Derive `totalTimeMinutes`** from prep + cook when the source omits the total (common — the BBC page hit this), so the editor shows a total instead of a blank.
- **Split comma-joined tags** before kebab-normalising, and dedupe.
- **Reject a JSON-LD Recipe with ingredients but no steps** — an ingredient-only stub isn't a usable recipe (falls through to the HTML path / not-a-recipe).
- **Require a non-empty title** for a draft to count as usable — checked in the flow, not the schema, so an `isRecipe=false` response still maps to `not-a-recipe` rather than `ai-failed`.
- **Schema hardening:** `servings` / `prep` / `cook` / `total` must be positive integers (`null` is the "not stated" sentinel), rejecting nonsensical `0`/negative values a model glitch might emit.
- **Editor-navigation fallback:** if routing into the editor throws after a successful import, show a toast instead of silently closing the form.

## Considered but skipped
- Capturing the recipe image from JSON-LD (deferred — needs safe-URL handling).
- Trimming the JSON-LD system prompt (marginal saving on the already-cheap path; risks conversion drift between the two prompts).

## Testing
- Added a JSON-LD test for the ingredients-but-no-steps rejection.
- `pnpm typecheck`, `pnpm lint`, dependency-cruiser, 135 cloud-functions tests, and 564 domain tests pass.
- Real-API smoke test on the BBC Lancashire hotpot URL: imports cleanly with `totalTimeMinutes: 90` (derived), servings 6, 14 ingredients, 7 steps, tags split correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
