### PR TITLE
chore: approve native build scripts via pnpm onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,13 @@
     ]
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "@firebase/util",
+      "esbuild",
+      "protobufjs",
+      "re2",
+      "sharp"
+    ],
     "overrides": {
       "@opentelemetry/api": "1.9.0",
       "@tootallnate/once": "^2.0.1",


### PR DESCRIPTION
## Summary

pnpm 10 gates package lifecycle scripts behind an approval list. Without it, a clean `pnpm install` skips the build/install scripts for `re2` (native addon), `esbuild`, `protobufjs`, `sharp`, and `@firebase/util` — printing an "Ignored build scripts" warning and leaving re2's native binary uncompiled.

This pins the trusted set in `package.json` (`pnpm.onlyBuiltDependencies`) so installs run them automatically and reproducibly across checkouts/worktrees, with no interactive `pnpm approve-builds` step.

## Changes
- `package.json`: add `pnpm.onlyBuiltDependencies` = `[@firebase/util, esbuild, protobufjs, re2, sharp]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)