### PR TITLE
chore: add grouped weekly Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Dependabot configuration for the Salt pnpm monorepo.
+# A single npm entry covers every workspace package via the root pnpm-lock.yaml.
+# Routine minor/patch bumps are grouped into a couple of weekly PRs; majors stay
+# individual so breaking upgrades get reviewed on their own.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      # Non-breaking production dependency bumps → one PR.
+      production-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      # Non-breaking dev/tooling bumps → one PR.
+      dev-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    # Major updates match no group above, so Dependabot opens them as
+    # individual PRs that warrant a closer look.
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to batch dependency-update noise into a predictable weekly cadence, instead of the current ungrouped one-PR-per-bump default.

- **npm (whole workspace via the root lockfile):** minor/patch **production** bumps grouped into one PR, minor/patch **development** bumps into another — roughly 2 PRs per week.
- **Major bumps stay individual** so breaking upgrades get reviewed on their own.
- **GitHub Actions** bumps grouped into one weekly PR.
- Scheduled Mondays; `open-pull-requests-limit: 10`; labelled `dependencies`.

Docs automation is untouched — `nightly-doc-review.yml` already handles that separately.

## Follow-up (not in this PR)

Optional auto-merge workflow for patch/minor bumps on green CI, so the routine batch lands without manual clicks. Say the word and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
