### PR TITLE
feat(ai): admin-managed AI model selection with capability-filtered picker

### DIFF
--- a/apps/cloud-functions/src/adapters/serverEmbedding.ts
+++ b/apps/cloud-functions/src/adapters/serverEmbedding.ts
@@ -5,8 +5,7 @@ import { failure, success, type DomainError, type ReadResult } from '@salt/share
 import { embedTextFlow } from '../flows/embedText.js';
 import { withAiTimeout } from './withAiTimeout.js';
 import { ai } from '../genkit.js';
-
-const EMBEDDING_MODEL = 'gemini-embedding-001';
+import { resolveModel } from '../ai/resolveModel.js';
 
 export function createServerEmbeddingAdapter(): EmbeddingPort {
   return {
@@ -23,12 +22,13 @@ export function createServerEmbeddingAdapter(): EmbeddingPort {
       texts: readonly string[],
     ): Promise<ReadResult<readonly (readonly number[])[], DomainError>> {
       try {
+        // Free-text admin model (Phase 1) is wider than the SDK's literal-union
+        // embedder param — launder it across the boundary.
+        const embedder = googleAI.embedder(
+          (await resolveModel('embedding')) as Parameters<typeof googleAI.embedder>[0],
+        );
         const allEmbeddings = await withAiTimeout('batchEmbedTexts', () =>
-          Promise.all(
-            texts.map((text) =>
-              ai.embed({ embedder: googleAI.embedder(EMBEDDING_MODEL), content: text }),
-            ),
-          ),
+          Promise.all(texts.map((text) => ai.embed({ embedder, content: text }))),
         );
         return success(allEmbeddings.map((e) => e[0]!.embedding));
       } catch (err) {

--- a/apps/cloud-functions/src/adapters/serverEmbedding.ts
+++ b/apps/cloud-functions/src/adapters/serverEmbedding.ts
@@ -25,7 +25,9 @@ export function createServerEmbeddingAdapter(): EmbeddingPort {
         // Free-text admin model (Phase 1) is wider than the SDK's literal-union
         // embedder param — launder it across the boundary.
         const embedder = googleAI.embedder(
-          (await resolveModel('embedding')) as Parameters<typeof googleAI.embedder>[0],
+          (await resolveModel('embedding', 'serverEmbedding')) as Parameters<
+            typeof googleAI.embedder
+          >[0],
         );
         const allEmbeddings = await withAiTimeout('batchEmbedTexts', () =>
           Promise.all(texts.map((text) => ai.embed({ embedder, content: text }))),

--- a/apps/cloud-functions/src/ai/listAiModels.ts
+++ b/apps/cloud-functions/src/ai/listAiModels.ts
@@ -1,0 +1,126 @@
+import { z } from 'genkit';
+import { HttpsError, type CallableRequest } from 'firebase-functions/https';
+import { logger } from 'firebase-functions';
+import { AI_MODEL_ROLES, type AiModelRole } from '@salt/domain/schemas';
+import { withAiTimeout } from '../adapters/withAiTimeout.js';
+import { requireAdmin } from './requireAdmin.js';
+import { modelSupportsRole, type CatalogModelLike } from './modelCapabilities.js';
+
+// Admin-only callable that serves a live, capability-filtered Gemini model
+// catalog to the admin UI (Phase 3). Fetches `GET /v1beta/models` server-side
+// with the API key (the key NEVER reaches the browser — only the filtered
+// catalog does), classifies each model, and returns one list per admin role.
+//
+// An in-process cache (~1h) keeps the external fetch cheap across warm
+// invocations; a `forceRefresh` request flag bypasses it so the operator's
+// "Refresh" control always pulls fresh data.
+//
+// onCall (NOT onCallGenkit): this is not a Genkit flow; it re-checks admin and
+// calls a plain REST endpoint. App Check enforcement + the AI secret are wired
+// at the export site in index.ts.
+
+const CATALOG_URL = 'https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000';
+const CACHE_TTL_MS = 60 * 60 * 1000; // ~1 hour
+
+// ─── REST response shape (type-laundering boundary → validate) ───────────────
+const CatalogModelSchema = z.object({
+  // The API returns `models/<id>`; we normalise to the bare id below.
+  name: z.string(),
+  displayName: z.string().optional(),
+  description: z.string().optional(),
+  supportedGenerationMethods: z.array(z.string()).optional(),
+});
+const CatalogResponseSchema = z.object({
+  models: z.array(z.unknown()).optional(),
+});
+
+// ─── Request / response contracts ────────────────────────────────────────────
+const ListAiModelsInputSchema = z
+  .object({ forceRefresh: z.boolean().optional() })
+  .optional()
+  .default({});
+
+export interface AiCatalogModel {
+  /** Bare model id, e.g. `gemini-flash-latest`. */
+  readonly name: string;
+  readonly displayName: string;
+}
+export interface ListAiModelsResult {
+  /** Filtered catalog per role; each role lists only models that qualify. */
+  readonly byRole: Record<AiModelRole, AiCatalogModel[]>;
+  /** When the underlying catalog was fetched (ms epoch). */
+  readonly fetchedAt: number;
+}
+
+type CacheEntry = { result: ListAiModelsResult; expiresAt: number };
+let cache: CacheEntry | null = null;
+
+/** Strip the `models/` prefix the API prepends to every id. */
+function bareId(name: string): string {
+  return name.startsWith('models/') ? name.slice('models/'.length) : name;
+}
+
+/** Fetches + parses the raw catalog, then builds the role-filtered result. */
+async function fetchCatalog(): Promise<ListAiModelsResult> {
+  const apiKey = process.env['GEMINI_API_KEY'] ?? process.env['GOOGLE_API_KEY'];
+  if (!apiKey) {
+    throw new HttpsError('failed-precondition', 'AI model catalog is unavailable.');
+  }
+
+  const res = await withAiTimeout('listAiModels.fetch', () =>
+    fetch(CATALOG_URL, { headers: { 'x-goog-api-key': apiKey } }),
+  );
+  if (!res.ok) {
+    logger.warn('listAiModels: catalog fetch returned non-OK', { status: res.status });
+    throw new HttpsError('unavailable', 'AI model catalog is unavailable.');
+  }
+
+  const json: unknown = await res.json();
+  const parsed = CatalogResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    logger.warn('listAiModels: catalog response failed validation');
+    throw new HttpsError('unavailable', 'AI model catalog is unavailable.');
+  }
+
+  // Per-model validation: skip any malformed entry rather than failing the
+  // whole catalog (one bad model must not blank the picker).
+  const models: CatalogModelLike[] = [];
+  for (const raw of parsed.data.models ?? []) {
+    const m = CatalogModelSchema.safeParse(raw);
+    if (!m.success) continue;
+    models.push({ ...m.data, name: bareId(m.data.name) });
+  }
+
+  const byRole = {} as Record<AiModelRole, AiCatalogModel[]>;
+  for (const role of AI_MODEL_ROLES) {
+    byRole[role] = models
+      .filter((m) => modelSupportsRole(role, m))
+      .map((m) => ({ name: m.name, displayName: m.displayName ?? m.name }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  return { byRole, fetchedAt: Date.now() };
+}
+
+/** Cache-aware accessor; `forceRefresh` bypasses + refills the cache. */
+async function loadCatalog(forceRefresh: boolean): Promise<ListAiModelsResult> {
+  const now = Date.now();
+  if (!forceRefresh && cache && cache.expiresAt > now) return cache.result;
+  const result = await fetchCatalog();
+  cache = { result, expiresAt: now + CACHE_TTL_MS };
+  return result;
+}
+
+export async function handleListAiModels(request: CallableRequest): Promise<ListAiModelsResult> {
+  await requireAdmin(request);
+  const input = ListAiModelsInputSchema.safeParse(request.data);
+  if (!input.success) {
+    throw new HttpsError('invalid-argument', 'Invalid request payload.');
+  }
+  return loadCatalog(input.data.forceRefresh ?? false);
+}
+
+// Test-only: clears the in-process catalog cache between cases.
+export function __resetListAiModelsCacheForTest(): void {
+  cache = null;
+}

--- a/apps/cloud-functions/src/ai/modelCapabilities.ts
+++ b/apps/cloud-functions/src/ai/modelCapabilities.ts
@@ -1,0 +1,110 @@
+import type { AiModelRole } from '@salt/domain/schemas';
+
+// Capability classifier for the live Gemini model catalog (Phase 3).
+//
+// The catalog's `GET /v1beta/models` entries expose `supportedGenerationMethods`
+// (e.g. `generateContent`, `embedContent`) plus name/description metadata. We map
+// each admin role to a MINIMUM-capability predicate: a model qualifies for a role
+// if it can do at least what the role needs. This is deliberately permissive for
+// the reasoning roles — cheaper models (e.g. `flash`) intentionally appear for
+// both `fast` and `pro`, because the operator picks the trade-off.
+//
+// The classifier is pure (no I/O) so it can be unit-tested in isolation and
+// reused by both the listAiModels callable (filtering) and testModel (picking the
+// right probe method).
+
+/** The catalog fields this classifier reads. A subset of the REST response. */
+export interface CatalogModelLike {
+  /** Bare model id, e.g. `gemini-flash-latest` (the API returns `models/<id>`). */
+  readonly name: string;
+  readonly displayName?: string | undefined;
+  readonly description?: string | undefined;
+  readonly supportedGenerationMethods?: readonly string[] | undefined;
+}
+
+function methods(model: CatalogModelLike): readonly string[] {
+  return model.supportedGenerationMethods ?? [];
+}
+
+function hasMethod(model: CatalogModelLike, method: string): boolean {
+  return methods(model).includes(method);
+}
+
+/** Lowercased haystack of every name/metadata field, for heuristic matching. */
+function metaHaystack(model: CatalogModelLike): string {
+  return [model.name, model.displayName ?? '', model.description ?? ''].join(' ').toLowerCase();
+}
+
+// ─── Image predicate ─────────────────────────────────────────────────────────
+// The catalog cannot cleanly flag *image generation* capability: image-capable
+// models advertise `generateContent` (or a `predict`-family method) just like
+// text models, and there is no `generateImage` method. So we gate on a
+// name/metadata heuristic IN ADDITION to a generation method:
+//   1. the model must expose `generateContent` or `predict`/`predictLongRunning`
+//      (i.e. it can be invoked to produce output at all); AND
+//   2. its name/metadata must look image-related — it contains the token `image`
+//      (e.g. `gemini-2.5-flash-image`, `imagen-3.0`) — while NOT being an
+//      embedding model (an `image-embedding`-style id is an embedder, not a
+//      generator, so it is excluded).
+// This matches today's default (`gemini-2.5-flash-image`) and the Imagen family,
+// and stays conservative: a plain text model never leaks into the image picker.
+function isImageModel(model: CatalogModelLike): boolean {
+  const canGenerate =
+    hasMethod(model, 'generateContent') ||
+    hasMethod(model, 'predict') ||
+    hasMethod(model, 'predictLongRunning');
+  if (!canGenerate) return false;
+  const hay = metaHaystack(model);
+  // `imagen` family or any id/description carrying the standalone `image` token.
+  const looksImage = hay.includes('imagen') || /\bimage\b/.test(hay) || hay.includes('-image');
+  if (!looksImage) return false;
+  // Never treat an embedder as an image generator.
+  if (isEmbeddingModel(model)) return false;
+  return true;
+}
+
+// ─── Embedding predicate ─────────────────────────────────────────────────────
+// An embedder advertises `embedContent` (and/or the batch `batchEmbedContents`).
+function isEmbeddingModel(model: CatalogModelLike): boolean {
+  return hasMethod(model, 'embedContent') || hasMethod(model, 'batchEmbedContents');
+}
+
+// ─── Text / reasoning predicate (fast + pro) ─────────────────────────────────
+// Any model that can `generateContent` and is NOT an image generator qualifies
+// for the reasoning roles. Embedders are excluded (they cannot generate text).
+// Both `fast` and `pro` share this predicate by design: the role is about which
+// flows use the model, not a hard capability ceiling, so a `flash` model is a
+// valid choice for `pro` and a `pro` model is a valid (if pricey) choice for
+// `fast`.
+function isTextModel(model: CatalogModelLike): boolean {
+  if (!hasMethod(model, 'generateContent')) return false;
+  if (isEmbeddingModel(model)) return false;
+  if (isImageModel(model)) return false;
+  return true;
+}
+
+/** Role → minimum-capability predicate over a catalog entry. */
+export const ROLE_CAPABILITY_PREDICATE: Record<AiModelRole, (model: CatalogModelLike) => boolean> =
+  {
+    fast: isTextModel,
+    pro: isTextModel,
+    embedding: isEmbeddingModel,
+    image: isImageModel,
+  };
+
+/** True if a model qualifies for the given role. */
+export function modelSupportsRole(role: AiModelRole, model: CatalogModelLike): boolean {
+  return ROLE_CAPABILITY_PREDICATE[role](model);
+}
+
+/**
+ * The cheapest correct probe method for a model: an embedder is pinged with
+ * `embedContent`; everything else (text/reasoning/image-capable) is pinged with
+ * `generateContent`. testModel uses this to pick the right ping.
+ */
+export function probeMethodFor(model: CatalogModelLike): 'embedContent' | 'generateContent' {
+  return isEmbeddingModel(model) ? 'embedContent' : 'generateContent';
+}
+
+// Exposed for tests / reuse.
+export { isImageModel, isEmbeddingModel, isTextModel };

--- a/apps/cloud-functions/src/ai/requireAdmin.ts
+++ b/apps/cloud-functions/src/ai/requireAdmin.ts
@@ -1,0 +1,46 @@
+import { getFirestore } from 'firebase-admin/firestore';
+import { HttpsError, type CallableRequest } from 'firebase-functions/https';
+import { logger } from 'firebase-functions';
+import { normaliseMemberEmail } from '@salt/domain';
+import { MemberSchema } from '@salt/domain/schemas';
+
+// Server-side admin re-check for operator-only callables (issue #155). The
+// client-side AdminGuard is UX-only — it merely hides screens — so every
+// admin-only Cloud Function MUST re-verify the caller server-side. There is no
+// shared helper yet, so this is it: read the caller's `members/{email}` doc
+// directly via the Admin SDK (CFs must NOT import @salt/firebase-sync) and
+// require `admin === true`.
+//
+// The members doc is keyed by the normalised email, matching how the browser
+// roster + AdminGuard look the caller up.
+
+/**
+ * Throws an HttpsError unless the request is from a signed-in member whose
+ * roster doc has `admin === true`. Returns the caller's normalised email on
+ * success (handy for audit metadata).
+ */
+export async function requireAdmin(request: CallableRequest): Promise<string> {
+  const email = request.auth?.token?.email;
+  if (!request.auth || !email) {
+    throw new HttpsError('unauthenticated', 'Sign in required.');
+  }
+  const normalised = normaliseMemberEmail(email);
+
+  let snap;
+  try {
+    snap = await getFirestore().collection('members').doc(normalised).get();
+  } catch (err) {
+    logger.error('requireAdmin: members read failed', { err });
+    // Fail closed: if we cannot confirm admin, deny.
+    throw new HttpsError('permission-denied', 'Admin access required.');
+  }
+
+  if (!snap.exists) {
+    throw new HttpsError('permission-denied', 'Admin access required.');
+  }
+  const parsed = MemberSchema.safeParse(snap.data());
+  if (!parsed.success || parsed.data.admin !== true) {
+    throw new HttpsError('permission-denied', 'Admin access required.');
+  }
+  return normalised;
+}

--- a/apps/cloud-functions/src/ai/resolveModel.ts
+++ b/apps/cloud-functions/src/ai/resolveModel.ts
@@ -1,0 +1,72 @@
+import { getFirestore } from 'firebase-admin/firestore';
+import { logger } from 'firebase-functions';
+import {
+  AppSettingsSchema,
+  AI_MODEL_DEFAULTS,
+  type AiModelRole,
+  type AppSettings,
+} from '@salt/domain/schemas';
+
+// CF-side AI model resolver (Phase 1). Reads the admin-managed
+// `appSettings/singleton` doc directly via the Admin SDK (Cloud Functions must
+// NOT import @salt/firebase-sync). Fails OPEN to today's defaults: a missing,
+// empty, invalid, or unreadable doc resolves every role to its hardcoded
+// production literal, so deleting/corrupting the doc leaves AI fully working.
+//
+// An in-process TTL cache (180s) keeps per-invocation Firestore reads cheap and
+// bounds propagation latency: an admin change takes effect within ~3 minutes as
+// warm instances expire their cache and cold starts read fresh.
+
+const COLLECTION = 'appSettings';
+const SINGLETON_DOC_ID = 'singleton';
+const CACHE_TTL_MS = 180_000;
+
+type CacheEntry = { settings: AppSettings; expiresAt: number };
+let cache: CacheEntry | null = null;
+
+// The defaulted doc — every role on its production literal. Used as the fallback
+// whenever the stored doc is absent or unusable.
+const DEFAULT_SETTINGS: AppSettings = AppSettingsSchema.parse({});
+
+async function loadSettings(): Promise<AppSettings> {
+  const now = Date.now();
+  if (cache && cache.expiresAt > now) return cache.settings;
+
+  let settings = DEFAULT_SETTINGS;
+  try {
+    const snap = await getFirestore().collection(COLLECTION).doc(SINGLETON_DOC_ID).get();
+    if (!snap.exists) {
+      logger.info('resolveModel: no appSettings doc, using model defaults');
+    } else {
+      const parsed = AppSettingsSchema.safeParse(snap.data());
+      if (parsed.success) {
+        settings = parsed.data;
+      } else {
+        logger.warn('resolveModel: invalid appSettings doc, using model defaults');
+      }
+    }
+  } catch (err) {
+    logger.warn('resolveModel: appSettings read failed, using model defaults', { err });
+  }
+
+  cache = { settings, expiresAt: now + CACHE_TTL_MS };
+  return settings;
+}
+
+/**
+ * Resolves the configured Gemini model name for an AI role, falling back to the
+ * production default for that role. Returns the bare model id (e.g.
+ * `gemini-flash-latest`) — callers wrap it in `googleAI.model(...)` /
+ * `googleAI.embedder(...)` as before.
+ */
+export async function resolveModel(role: AiModelRole): Promise<string> {
+  const settings = await loadSettings();
+  // Schema defaults guarantee a non-empty value, but belt-and-braces fall back
+  // to the literal if anything ever slips through.
+  return settings[role] || AI_MODEL_DEFAULTS[role];
+}
+
+// Test-only: clears the in-process cache between cases.
+export function __resetResolveModelCacheForTest(): void {
+  cache = null;
+}

--- a/apps/cloud-functions/src/ai/resolveModel.ts
+++ b/apps/cloud-functions/src/ai/resolveModel.ts
@@ -4,14 +4,19 @@ import {
   AppSettingsSchema,
   AI_MODEL_DEFAULTS,
   type AiModelRole,
+  type AiFlowId,
   type AppSettings,
 } from '@salt/domain/schemas';
 
-// CF-side AI model resolver (Phase 1). Reads the admin-managed
+// CF-side AI model resolver (Phase 1 + Phase 2). Reads the admin-managed
 // `appSettings/singleton` doc directly via the Admin SDK (Cloud Functions must
 // NOT import @salt/firebase-sync). Fails OPEN to today's defaults: a missing,
 // empty, invalid, or unreadable doc resolves every role to its hardcoded
 // production literal, so deleting/corrupting the doc leaves AI fully working.
+//
+// Phase 2 adds an optional per-flow override: when a caller passes its flowId,
+// a non-empty `perFlow[flowId]` entry wins over the role's model. Precedence is
+// per-flow override → role → code default.
 //
 // An in-process TTL cache (180s) keeps per-invocation Firestore reads cheap and
 // bounds propagation latency: an admin change takes effect within ~3 minutes as
@@ -54,15 +59,24 @@ async function loadSettings(): Promise<AppSettings> {
 }
 
 /**
- * Resolves the configured Gemini model name for an AI role, falling back to the
- * production default for that role. Returns the bare model id (e.g.
- * `gemini-flash-latest`) — callers wrap it in `googleAI.model(...)` /
- * `googleAI.embedder(...)` as before.
+ * Resolves the Gemini model name a flow should use. Precedence:
+ *   1. per-flow override — `perFlow[flowId]`, if `flowId` is given and that key
+ *      holds a non-empty value;
+ *   2. the role's configured model;
+ *   3. the role's production default.
+ * Returns the bare model id (e.g. `gemini-flash-latest`) — callers wrap it in
+ * `googleAI.model(...)` / `googleAI.embedder(...)` as before. Omitting `flowId`
+ * preserves the Phase 1 role-only behaviour.
  */
-export async function resolveModel(role: AiModelRole): Promise<string> {
+export async function resolveModel(role: AiModelRole, flowId?: AiFlowId): Promise<string> {
   const settings = await loadSettings();
-  // Schema defaults guarantee a non-empty value, but belt-and-braces fall back
-  // to the literal if anything ever slips through.
+  // Per-flow override wins when present and non-empty. The schema already
+  // rejects empty override values, but guard anyway so a hand-edited doc can
+  // never resolve to an empty model id.
+  const override = flowId ? settings.perFlow?.[flowId] : undefined;
+  if (override && override.trim()) return override;
+  // Schema defaults guarantee a non-empty role value, but belt-and-braces fall
+  // back to the literal if anything ever slips through.
   return settings[role] || AI_MODEL_DEFAULTS[role];
 }
 

--- a/apps/cloud-functions/src/ai/testModel.ts
+++ b/apps/cloud-functions/src/ai/testModel.ts
@@ -1,0 +1,67 @@
+import { z } from 'genkit';
+import { HttpsError, type CallableRequest } from 'firebase-functions/https';
+import { logger } from 'firebase-functions';
+import { googleAI } from '@genkit-ai/google-genai';
+import { AI_MODEL_ROLES, type AiModelRole } from '@salt/domain/schemas';
+import { ai } from '../genkit.js';
+import { withAiTimeout } from '../adapters/withAiTimeout.js';
+import { requireAdmin } from './requireAdmin.js';
+
+// Admin-only callable that probes a single model with the cheapest possible
+// request and reports whether it works (Phase 3). The operator clicks "Test"
+// next to a chosen/typed model; this fires one tiny `generateContent` (or
+// `embedContent` for the embedding role) ping against Gemini, wrapped in
+// withAiTimeout so a hung model surfaces as a clean failure rather than holding
+// the function open. The API key stays server-side; the browser only gets
+// `{ ok }` / `{ ok, error }`.
+//
+// onCall (NOT onCallGenkit): not a Genkit flow. App Check enforcement + the AI
+// secret are wired at the export site in index.ts.
+
+const TestModelInputSchema = z.object({
+  model: z.string().min(1),
+  // The role the model is being tested for — decides the probe method
+  // (embedding → embedContent, everything else → generateContent). Optional;
+  // defaults to a generate ping, which works for fast/pro/image-capable models.
+  role: z.enum(AI_MODEL_ROLES).optional(),
+});
+
+export interface TestModelResult {
+  readonly ok: boolean;
+  readonly error?: string;
+}
+
+async function probe(model: string, role: AiModelRole | undefined): Promise<void> {
+  if (role === 'embedding') {
+    const embedder = googleAI.embedder(model as Parameters<typeof googleAI.embedder>[0]);
+    await ai.embed({ embedder, content: 'ping' });
+    return;
+  }
+  // Cheap generate ping for fast/pro/image (and the unspecified case). A 1-token
+  // budget keeps it as cheap as the provider allows.
+  await ai.generate({
+    model: googleAI.model(model),
+    prompt: 'ping',
+    config: { maxOutputTokens: 1, temperature: 0 },
+  });
+}
+
+export async function handleTestModel(request: CallableRequest): Promise<TestModelResult> {
+  await requireAdmin(request);
+  const input = TestModelInputSchema.safeParse(request.data);
+  if (!input.success) {
+    throw new HttpsError('invalid-argument', 'Invalid request payload.');
+  }
+  const { model, role } = input.data;
+
+  try {
+    await withAiTimeout('testModel', () => probe(model, role));
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.info('testModel: probe failed', { model, role, message });
+    // A failed probe is an expected outcome, not a function error — return it so
+    // the UI can show "this model doesn't work" without a thrown HttpsError.
+    return { ok: false, error: message };
+  }
+}

--- a/apps/cloud-functions/src/flows/arbitrateCanon.ts
+++ b/apps/cloud-functions/src/flows/arbitrateCanon.ts
@@ -42,7 +42,7 @@ export const arbitrateCanonFlow = ai.defineFlow(
     setActiveSpanName(`arbitrateCanon: ${req.normalisedName}`);
     const builtPrompt = buildPrompt(req);
     const result = await ai.generate({
-      model: googleAI.model(await resolveModel('fast')),
+      model: googleAI.model(await resolveModel('fast', 'arbitrateCanon')),
       prompt: builtPrompt,
       output: { schema: CanonArbitrationAIOutputSchema },
       config: { temperature: 0 },

--- a/apps/cloud-functions/src/flows/arbitrateCanon.ts
+++ b/apps/cloud-functions/src/flows/arbitrateCanon.ts
@@ -3,8 +3,7 @@ import { googleAI } from '@genkit-ai/google-genai';
 import { ArbitrationRequestSchema, CanonArbitrationAIOutputSchema } from '@salt/domain/schemas';
 import { setActiveSpanName } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
-
-const GENERATION_MODEL = googleAI.model('gemini-flash-latest');
+import { resolveModel } from '../ai/resolveModel.js';
 
 // Flow output — discriminated union matching ArbitrationResult; includes prompt and rawResponse.
 const ArbitrationResultSchema = z.discriminatedUnion('kind', [
@@ -43,7 +42,7 @@ export const arbitrateCanonFlow = ai.defineFlow(
     setActiveSpanName(`arbitrateCanon: ${req.normalisedName}`);
     const builtPrompt = buildPrompt(req);
     const result = await ai.generate({
-      model: GENERATION_MODEL,
+      model: googleAI.model(await resolveModel('fast')),
       prompt: builtPrompt,
       output: { schema: CanonArbitrationAIOutputSchema },
       config: { temperature: 0 },

--- a/apps/cloud-functions/src/flows/authorRecipe.ts
+++ b/apps/cloud-functions/src/flows/authorRecipe.ts
@@ -7,9 +7,7 @@ import { withAiTimeout } from '../adapters/withAiTimeout.js';
 import { ai } from '../genkit.js';
 import { canonicaliseRecipeIngredientsFlow } from './canonicaliseRecipeIngredients.js';
 import { parseRecipeIngredientsFlow } from './parseRecipeIngredients.js';
-
-// Flash + temperature:0 for the librarian — accuracy over creativity (issue #206).
-const LIBRARIAN_MODEL = googleAI.model('gemini-flash-latest');
+import { resolveModel } from '../ai/resolveModel.js';
 
 const OutputSchema = z.custom<RecipeDoc>();
 
@@ -29,11 +27,13 @@ export const authorRecipeFlow = ai.defineFlow(
         ? `\n\nExisting tags in this recipe collection (prefer these where appropriate; add a new tag only if meaningfully different): ${input.existingTags.join(', ')}.`
         : '';
 
+    // Flash + temperature:0 for the librarian — accuracy over creativity (issue #206).
+    const model = googleAI.model(await resolveModel('fast'));
     const result = await withAiTimeout(
       'authorRecipe',
       () =>
         ai.generate({
-          model: LIBRARIAN_MODEL,
+          model,
           system: LIBRARIAN_SYSTEM + tagVocab,
           prompt: conversationText,
           output: { schema: LibrarianOutputSchema },

--- a/apps/cloud-functions/src/flows/authorRecipe.ts
+++ b/apps/cloud-functions/src/flows/authorRecipe.ts
@@ -28,7 +28,7 @@ export const authorRecipeFlow = ai.defineFlow(
         : '';
 
     // Flash + temperature:0 for the librarian — accuracy over creativity (issue #206).
-    const model = googleAI.model(await resolveModel('fast'));
+    const model = googleAI.model(await resolveModel('fast', 'authorRecipe'));
     const result = await withAiTimeout(
       'authorRecipe',
       () =>

--- a/apps/cloud-functions/src/flows/chefChat.ts
+++ b/apps/cloud-functions/src/flows/chefChat.ts
@@ -11,9 +11,7 @@ import {
 } from '@salt/domain/schemas';
 import { withAiTimeout } from '../adapters/withAiTimeout.js';
 import { ai } from '../genkit.js';
-
-// Pro-tier model for conversational quality (design principle #3, issue #206).
-const CHEF_MODEL = googleAI.model('gemini-pro-latest');
+import { resolveModel } from '../ai/resolveModel.js';
 
 async function readEquipmentContext(db: ReturnType<typeof getFirestore>): Promise<string> {
   try {
@@ -123,8 +121,9 @@ export const chefChatFlow = ai.defineFlow(
       content: [{ text: m.text }],
     }));
 
+    // Pro-tier model for conversational quality (design principle #3, issue #206).
     const { stream, response } = ai.generateStream({
-      model: CHEF_MODEL,
+      model: googleAI.model(await resolveModel('pro')),
       system: systemPrompt,
       messages: history,
       prompt: input.newMessage,

--- a/apps/cloud-functions/src/flows/chefChat.ts
+++ b/apps/cloud-functions/src/flows/chefChat.ts
@@ -123,7 +123,7 @@ export const chefChatFlow = ai.defineFlow(
 
     // Pro-tier model for conversational quality (design principle #3, issue #206).
     const { stream, response } = ai.generateStream({
-      model: googleAI.model(await resolveModel('pro')),
+      model: googleAI.model(await resolveModel('pro', 'chefChat')),
       system: systemPrompt,
       messages: history,
       prompt: input.newMessage,

--- a/apps/cloud-functions/src/flows/embedText.ts
+++ b/apps/cloud-functions/src/flows/embedText.ts
@@ -16,7 +16,7 @@ export const embedTextFlow = ai.defineFlow(
     // The admin-configured model is free text (Phase 1), so it is wider than
     // the SDK's literal-union embedder param — launder it across the boundary.
     const embedder = googleAI.embedder(
-      (await resolveModel('embedding')) as Parameters<typeof googleAI.embedder>[0],
+      (await resolveModel('embedding', 'embedText')) as Parameters<typeof googleAI.embedder>[0],
     );
     const embeddings = await ai.embed({ embedder, content: text });
     return { values: embeddings[0]!.embedding };

--- a/apps/cloud-functions/src/flows/embedText.ts
+++ b/apps/cloud-functions/src/flows/embedText.ts
@@ -3,8 +3,7 @@ import { googleAI } from '@genkit-ai/google-genai';
 import { EmbedTextInputSchema } from '@salt/domain/schemas';
 import { setActiveSpanName } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
-
-const EMBEDDING_MODEL = 'gemini-embedding-001';
+import { resolveModel } from '../ai/resolveModel.js';
 
 export const embedTextFlow = ai.defineFlow(
   {
@@ -14,10 +13,12 @@ export const embedTextFlow = ai.defineFlow(
   },
   async ({ text }) => {
     setActiveSpanName(`embedText: ${text}`);
-    const embeddings = await ai.embed({
-      embedder: googleAI.embedder(EMBEDDING_MODEL),
-      content: text,
-    });
+    // The admin-configured model is free text (Phase 1), so it is wider than
+    // the SDK's literal-union embedder param — launder it across the boundary.
+    const embedder = googleAI.embedder(
+      (await resolveModel('embedding')) as Parameters<typeof googleAI.embedder>[0],
+    );
+    const embeddings = await ai.embed({ embedder, content: text });
     return { values: embeddings[0]!.embedding };
   },
 );

--- a/apps/cloud-functions/src/flows/extractRecipeFromUrl.ts
+++ b/apps/cloud-functions/src/flows/extractRecipeFromUrl.ts
@@ -97,7 +97,7 @@ export const extractRecipeFromUrlFlow = ai.defineFlow(
       : buildHtmlPrompt(html, parsed.href);
 
     // Flash + temperature:0 — accuracy over creativity, mirrors the librarian flow.
-    const extractModel = googleAI.model(await resolveModel('fast'));
+    const extractModel = googleAI.model(await resolveModel('fast', 'extractRecipeFromUrl'));
     let extracted: ExtractRecipeAIOutput;
     try {
       extracted = await withAiTimeout(

--- a/apps/cloud-functions/src/flows/extractRecipeFromUrl.ts
+++ b/apps/cloud-functions/src/flows/extractRecipeFromUrl.ts
@@ -10,6 +10,7 @@ import { ssrfGuardedFetch, SsrfFetchError } from '../adapters/ssrfFetch.js';
 import { extractRecipeJsonLd, type JsonLdRecipe } from '../adapters/jsonLdRecipe.js';
 import { canonicaliseRecipeIngredientsFlow } from './canonicaliseRecipeIngredients.js';
 import { parseRecipeIngredientsFlow } from './parseRecipeIngredients.js';
+import { resolveModel } from '../ai/resolveModel.js';
 
 // SSRF-hardened URL import (recipe URL import epic, Phases 1 & 3).
 //
@@ -22,9 +23,6 @@ import { parseRecipeIngredientsFlow } from './parseRecipeIngredients.js';
 //
 // The flow throws a UrlImportError tagged with a failure code; the onCall
 // entrypoint maps each code to the right HttpsError + user-facing copy.
-
-// Flash + temperature:0 — accuracy over creativity, mirrors the librarian flow.
-const EXTRACT_MODEL = googleAI.model('gemini-flash-latest');
 
 // When no JSON-LD Recipe is present we forward the raw page HTML to the model.
 // Cap it so a huge page can't blow the prompt budget; recipes always appear well
@@ -98,13 +96,15 @@ export const extractRecipeFromUrlFlow = ai.defineFlow(
       ? buildJsonLdPrompt(jsonLd, parsed.href)
       : buildHtmlPrompt(html, parsed.href);
 
+    // Flash + temperature:0 — accuracy over creativity, mirrors the librarian flow.
+    const extractModel = googleAI.model(await resolveModel('fast'));
     let extracted: ExtractRecipeAIOutput;
     try {
       extracted = await withAiTimeout(
         'extractRecipeFromUrl',
         async () => {
           const result = await ai.generate({
-            model: EXTRACT_MODEL,
+            model: extractModel,
             system,
             prompt,
             output: { schema: ExtractRecipeAIOutputSchema },

--- a/apps/cloud-functions/src/flows/generateCanonIcon.ts
+++ b/apps/cloud-functions/src/flows/generateCanonIcon.ts
@@ -66,7 +66,7 @@ export const generateCanonIconFlow = ai.defineFlow(
     setActiveSpanName(`generateCanonIcon: ${name}`);
     const seed = loadCanonIconSeed();
 
-    const imageModel = googleAI.model(await resolveModel('image'));
+    const imageModel = googleAI.model(await resolveModel('image', 'generateCanonIcon'));
     const result = await withAiTimeout(
       'generateCanonIcon',
       () =>

--- a/apps/cloud-functions/src/flows/generateCanonIcon.ts
+++ b/apps/cloud-functions/src/flows/generateCanonIcon.ts
@@ -4,6 +4,7 @@ import { setActiveSpanName } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
 import { withAiTimeout } from '../adapters/withAiTimeout.js';
 import { loadCanonIconSeed } from './assets/canonIconSeed.js';
+import { resolveModel } from '../ai/resolveModel.js';
 
 // Tier-1 canon-item pictogram generation (issue #148).
 //
@@ -12,8 +13,6 @@ import { loadCanonIconSeed } from './assets/canonIconSeed.js';
 // VERBATIM from docs/canon-icons.md → "Proven prompt"; do NOT paraphrase —
 // wording changes drift the house style. The negative clauses are keyed to the
 // red-apple seed (see canonIconSeed.ts) — update them if the seed changes.
-
-const IMAGE_MODEL = googleAI.model('gemini-2.5-flash-image');
 
 // Image generation is far slower than text (~5–8s, occasionally more). Give it
 // a generous deadline; the trigger's function timeout is raised to match.
@@ -67,11 +66,12 @@ export const generateCanonIconFlow = ai.defineFlow(
     setActiveSpanName(`generateCanonIcon: ${name}`);
     const seed = loadCanonIconSeed();
 
+    const imageModel = googleAI.model(await resolveModel('image'));
     const result = await withAiTimeout(
       'generateCanonIcon',
       () =>
         ai.generate({
-          model: IMAGE_MODEL,
+          model: imageModel,
           prompt: [
             { media: { url: seed.url, contentType: seed.contentType } },
             { text: buildIconPrompt(name, hint) },

--- a/apps/cloud-functions/src/flows/generateChatTitle.ts
+++ b/apps/cloud-functions/src/flows/generateChatTitle.ts
@@ -24,7 +24,7 @@ export const generateChatTitleFlow = ai.defineFlow(
   async (input) => {
     const prompt = `User's message: "${input.userMessage}"\n\nChef's reply:\n${input.assistantResponse.slice(0, 500)}`;
 
-    const model = googleAI.model(await resolveModel('fast'));
+    const model = googleAI.model(await resolveModel('fast', 'generateChatTitle'));
     const result = await withAiTimeout(
       'generateChatTitle',
       () =>

--- a/apps/cloud-functions/src/flows/generateChatTitle.ts
+++ b/apps/cloud-functions/src/flows/generateChatTitle.ts
@@ -2,8 +2,7 @@ import { z } from 'genkit';
 import { googleAI } from '@genkit-ai/google-genai';
 import { withAiTimeout } from '../adapters/withAiTimeout.js';
 import { ai } from '../genkit.js';
-
-const FLASH_MODEL = googleAI.model('gemini-flash-latest');
+import { resolveModel } from '../ai/resolveModel.js';
 
 const InputSchema = z.object({
   userMessage: z.string(),
@@ -25,11 +24,12 @@ export const generateChatTitleFlow = ai.defineFlow(
   async (input) => {
     const prompt = `User's message: "${input.userMessage}"\n\nChef's reply:\n${input.assistantResponse.slice(0, 500)}`;
 
+    const model = googleAI.model(await resolveModel('fast'));
     const result = await withAiTimeout(
       'generateChatTitle',
       () =>
         ai.generate({
-          model: FLASH_MODEL,
+          model,
           system: SYSTEM_PROMPT,
           prompt,
           config: { temperature: 0.3 },

--- a/apps/cloud-functions/src/flows/identifyEquipment.ts
+++ b/apps/cloud-functions/src/flows/identifyEquipment.ts
@@ -5,8 +5,7 @@ import {
 } from '@salt/domain/schemas';
 import { setActiveSpanName } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
-
-const GENERATION_MODEL = googleAI.model('gemini-flash-latest');
+import { resolveModel } from '../ai/resolveModel.js';
 
 export const identifyEquipmentFlow = ai.defineFlow(
   {
@@ -17,7 +16,7 @@ export const identifyEquipmentFlow = ai.defineFlow(
   async ({ rawName }) => {
     setActiveSpanName(`identifyEquipment: ${rawName}`);
     const result = await ai.generate({
-      model: GENERATION_MODEL,
+      model: googleAI.model(await resolveModel('fast')),
       system: SYSTEM_INSTRUCTIONS,
       prompt: `"${rawName}"`,
       output: { schema: IdentifyEquipmentAIOutputSchema },

--- a/apps/cloud-functions/src/flows/identifyEquipment.ts
+++ b/apps/cloud-functions/src/flows/identifyEquipment.ts
@@ -16,7 +16,7 @@ export const identifyEquipmentFlow = ai.defineFlow(
   async ({ rawName }) => {
     setActiveSpanName(`identifyEquipment: ${rawName}`);
     const result = await ai.generate({
-      model: googleAI.model(await resolveModel('fast')),
+      model: googleAI.model(await resolveModel('fast', 'identifyEquipment')),
       system: SYSTEM_INSTRUCTIONS,
       prompt: `"${rawName}"`,
       output: { schema: IdentifyEquipmentAIOutputSchema },

--- a/apps/cloud-functions/src/flows/parseEntry.ts
+++ b/apps/cloud-functions/src/flows/parseEntry.ts
@@ -3,8 +3,7 @@ import { googleAI } from '@genkit-ai/google-genai';
 import { ParseEntryAIOutputSchema } from '@salt/domain/schemas';
 import { setActiveSpanName } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
-
-const GENERATION_MODEL = googleAI.model('gemini-flash-latest');
+import { resolveModel } from '../ai/resolveModel.js';
 
 const ParseEntryInputSchema = z.object({
   rawText: z.string(),
@@ -20,7 +19,7 @@ export const parseEntryFlow = ai.defineFlow(
     setActiveSpanName(`parseEntry: ${rawText}`);
     const prompt = buildPrompt(rawText);
     const result = await ai.generate({
-      model: GENERATION_MODEL,
+      model: googleAI.model(await resolveModel('fast')),
       prompt,
       output: { schema: ParseEntryAIOutputSchema },
       config: { temperature: 0 },

--- a/apps/cloud-functions/src/flows/parseEntry.ts
+++ b/apps/cloud-functions/src/flows/parseEntry.ts
@@ -19,7 +19,7 @@ export const parseEntryFlow = ai.defineFlow(
     setActiveSpanName(`parseEntry: ${rawText}`);
     const prompt = buildPrompt(rawText);
     const result = await ai.generate({
-      model: googleAI.model(await resolveModel('fast')),
+      model: googleAI.model(await resolveModel('fast', 'parseEntry')),
       prompt,
       output: { schema: ParseEntryAIOutputSchema },
       config: { temperature: 0 },

--- a/apps/cloud-functions/src/flows/parseRecipeIngredients.ts
+++ b/apps/cloud-functions/src/flows/parseRecipeIngredients.ts
@@ -6,8 +6,7 @@ import {
 } from '@salt/domain/schemas';
 import { withAiTimeout } from '../adapters/withAiTimeout.js';
 import { ai } from '../genkit.js';
-
-const GENERATION_MODEL = googleAI.model('gemini-flash-latest');
+import { resolveModel } from '../ai/resolveModel.js';
 
 export const parseRecipeIngredientsFlow = ai.defineFlow(
   {
@@ -19,11 +18,12 @@ export const parseRecipeIngredientsFlow = ai.defineFlow(
     // Recipe lists are much larger prompts than single-entry calls, so Flash can
     // take 30–50s on a full ingredient list. Use a higher timeout with no retry:
     // retrying a large legitimate request just doubles the wait for no gain.
+    const model = googleAI.model(await resolveModel('fast'));
     const result = await withAiTimeout(
       'parseRecipeIngredients',
       () =>
         ai.generate({
-          model: GENERATION_MODEL,
+          model,
           system: SYSTEM_INSTRUCTIONS,
           prompt: rawText,
           output: { schema: ParseRecipeIngredientsAIOutputSchema },

--- a/apps/cloud-functions/src/flows/parseRecipeIngredients.ts
+++ b/apps/cloud-functions/src/flows/parseRecipeIngredients.ts
@@ -18,7 +18,7 @@ export const parseRecipeIngredientsFlow = ai.defineFlow(
     // Recipe lists are much larger prompts than single-entry calls, so Flash can
     // take 30–50s on a full ingredient list. Use a higher timeout with no retry:
     // retrying a large legitimate request just doubles the wait for no gain.
-    const model = googleAI.model(await resolveModel('fast'));
+    const model = googleAI.model(await resolveModel('fast', 'parseRecipeIngredients'));
     const result = await withAiTimeout(
       'parseRecipeIngredients',
       () =>

--- a/apps/cloud-functions/src/flows/populateEquipmentEntry.ts
+++ b/apps/cloud-functions/src/flows/populateEquipmentEntry.ts
@@ -5,8 +5,7 @@ import {
 } from '@salt/domain/schemas';
 import { setActiveSpanName } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
-
-const GENERATION_MODEL = googleAI.model('gemini-flash-latest');
+import { resolveModel } from '../ai/resolveModel.js';
 
 export const populateEquipmentEntryFlow = ai.defineFlow(
   {
@@ -17,7 +16,7 @@ export const populateEquipmentEntryFlow = ai.defineFlow(
   async ({ confirmedName }) => {
     setActiveSpanName(`populateEquipmentEntry: ${confirmedName}`);
     const result = await ai.generate({
-      model: GENERATION_MODEL,
+      model: googleAI.model(await resolveModel('fast')),
       system: SYSTEM_INSTRUCTIONS,
       prompt: `"${confirmedName}"`,
       output: { schema: PopulateEquipmentEntryAIOutputSchema },

--- a/apps/cloud-functions/src/flows/populateEquipmentEntry.ts
+++ b/apps/cloud-functions/src/flows/populateEquipmentEntry.ts
@@ -16,7 +16,7 @@ export const populateEquipmentEntryFlow = ai.defineFlow(
   async ({ confirmedName }) => {
     setActiveSpanName(`populateEquipmentEntry: ${confirmedName}`);
     const result = await ai.generate({
-      model: googleAI.model(await resolveModel('fast')),
+      model: googleAI.model(await resolveModel('fast', 'populateEquipmentEntry')),
       system: SYSTEM_INSTRUCTIONS,
       prompt: `"${confirmedName}"`,
       output: { schema: PopulateEquipmentEntryAIOutputSchema },

--- a/apps/cloud-functions/src/index.ts
+++ b/apps/cloud-functions/src/index.ts
@@ -30,6 +30,8 @@ import {
 import { generateChatTitleFlow } from './flows/generateChatTitle.js';
 import { onShoppingListItemWrite } from './triggers/onShoppingListItemWrite.js';
 import { onCanonItemWritten } from './triggers/onCanonItemWritten.js';
+import { handleListAiModels } from './ai/listAiModels.js';
+import { handleTestModel } from './ai/testModel.js';
 
 initializeApp();
 
@@ -266,6 +268,26 @@ export const generateChatTitle = onCallGenkit(
     authPolicy: isSignedIn(),
   },
   generateChatTitleFlow,
+);
+
+// Admin-only AI model catalog + probe (Phase 3 — admin-managed model selection).
+// Both re-check admin server-side (issue #155) and declare the AI secret so the
+// catalog fetch / probe can read GEMINI_API_KEY from process.env. App Check
+// monitor-first like every other callable.
+export const listAiModels = onCall(
+  {
+    ...APP_CHECK_ENFORCEMENT,
+    secrets: [geminiApiKey],
+  },
+  handleListAiModels,
+);
+
+export const testModel = onCall(
+  {
+    ...APP_CHECK_ENFORCEMENT,
+    secrets: [geminiApiKey],
+  },
+  handleTestModel,
 );
 
 export { onShoppingListItemWrite };

--- a/apps/cloud-functions/tests/ai/listAiModels.test.ts
+++ b/apps/cloud-functions/tests/ai/listAiModels.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CallableRequest } from 'firebase-functions/https';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+class FakeHttpsError extends Error {
+  code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+vi.mock('firebase-functions/https', () => ({ HttpsError: FakeHttpsError }));
+vi.mock('firebase-functions', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// requireAdmin is exercised separately; here we stub it so list logic is the
+// unit under test (and toggle it to assert the admin gate is invoked).
+const mockRequireAdmin = vi.fn(async () => 'admin@example.com');
+vi.mock('../../src/ai/requireAdmin.js', () => ({ requireAdmin: mockRequireAdmin }));
+
+// withAiTimeout just runs the op in tests.
+vi.mock('../../src/adapters/withAiTimeout.js', () => ({
+  withAiTimeout: (_label: string, op: () => Promise<unknown>) => op(),
+}));
+
+const { handleListAiModels, __resetListAiModelsCacheForTest } =
+  await import('../../src/ai/listAiModels.js');
+
+const CATALOG = {
+  models: [
+    {
+      name: 'models/gemini-flash-latest',
+      displayName: 'Gemini Flash',
+      supportedGenerationMethods: ['generateContent'],
+    },
+    {
+      name: 'models/gemini-pro-latest',
+      supportedGenerationMethods: ['generateContent'],
+    },
+    {
+      name: 'models/gemini-embedding-001',
+      supportedGenerationMethods: ['embedContent'],
+    },
+    {
+      name: 'models/gemini-2.5-flash-image',
+      description: 'image generation',
+      supportedGenerationMethods: ['generateContent'],
+    },
+    // Malformed entry — must be skipped, not fail the whole catalog.
+    { displayName: 'no name field' },
+  ],
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function req(data: unknown): CallableRequest {
+  return { auth: { uid: 'u1' }, data } as unknown as CallableRequest;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetListAiModelsCacheForTest();
+  mockRequireAdmin.mockResolvedValue('admin@example.com');
+  process.env['GEMINI_API_KEY'] = 'test-key';
+  fetchMock = vi.fn(async () => ({
+    ok: true,
+    json: async () => CATALOG,
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+describe('handleListAiModels', () => {
+  it('re-checks admin', async () => {
+    await handleListAiModels(req({}));
+    expect(mockRequireAdmin).toHaveBeenCalledOnce();
+  });
+
+  it('filters the catalog per role', async () => {
+    const result = await handleListAiModels(req({}));
+    expect(result.byRole.fast.map((m) => m.name)).toEqual([
+      'gemini-flash-latest',
+      'gemini-pro-latest',
+    ]);
+    expect(result.byRole.pro.map((m) => m.name)).toEqual([
+      'gemini-flash-latest',
+      'gemini-pro-latest',
+    ]);
+    expect(result.byRole.embedding.map((m) => m.name)).toEqual(['gemini-embedding-001']);
+    expect(result.byRole.image.map((m) => m.name)).toEqual(['gemini-2.5-flash-image']);
+  });
+
+  it('caches across calls and forceRefresh bypasses the cache', async () => {
+    await handleListAiModels(req({}));
+    await handleListAiModels(req({}));
+    expect(fetchMock).toHaveBeenCalledTimes(1); // second served from cache
+
+    await handleListAiModels(req({ forceRefresh: true }));
+    expect(fetchMock).toHaveBeenCalledTimes(2); // bypassed
+  });
+
+  it('errors when the API key is missing', async () => {
+    delete process.env['GEMINI_API_KEY'];
+    delete process.env['GOOGLE_API_KEY'];
+    await expect(handleListAiModels(req({}))).rejects.toMatchObject({
+      code: 'failed-precondition',
+    });
+  });
+
+  it('errors when the catalog fetch is non-OK', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 503, json: async () => ({}) });
+    await expect(handleListAiModels(req({}))).rejects.toMatchObject({ code: 'unavailable' });
+  });
+});

--- a/apps/cloud-functions/tests/ai/modelCapabilities.test.ts
+++ b/apps/cloud-functions/tests/ai/modelCapabilities.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  modelSupportsRole,
+  probeMethodFor,
+  type CatalogModelLike,
+} from '../../src/ai/modelCapabilities.js';
+
+// Capability classifier (Phase 3). A minimum-capability gate: cheaper text
+// models (flash) intentionally qualify for both reasoning roles.
+
+const textFlash: CatalogModelLike = {
+  name: 'gemini-flash-latest',
+  displayName: 'Gemini Flash',
+  supportedGenerationMethods: ['generateContent', 'countTokens'],
+};
+const textPro: CatalogModelLike = {
+  name: 'gemini-pro-latest',
+  supportedGenerationMethods: ['generateContent', 'countTokens'],
+};
+const embedder: CatalogModelLike = {
+  name: 'gemini-embedding-001',
+  supportedGenerationMethods: ['embedContent'],
+};
+const imageModel: CatalogModelLike = {
+  name: 'gemini-2.5-flash-image',
+  description: 'Image generation model',
+  supportedGenerationMethods: ['generateContent'],
+};
+const imagen: CatalogModelLike = {
+  name: 'imagen-3.0-generate-002',
+  supportedGenerationMethods: ['predict'],
+};
+
+describe('modelSupportsRole', () => {
+  it('lets text models (incl. flash) qualify for both fast and pro', () => {
+    expect(modelSupportsRole('fast', textFlash)).toBe(true);
+    expect(modelSupportsRole('pro', textFlash)).toBe(true);
+    expect(modelSupportsRole('fast', textPro)).toBe(true);
+    expect(modelSupportsRole('pro', textPro)).toBe(true);
+  });
+
+  it('keeps embedders and image models out of the reasoning roles', () => {
+    expect(modelSupportsRole('fast', embedder)).toBe(false);
+    expect(modelSupportsRole('pro', embedder)).toBe(false);
+    expect(modelSupportsRole('fast', imageModel)).toBe(false);
+    expect(modelSupportsRole('pro', imageModel)).toBe(false);
+  });
+
+  it('matches only embedders for the embedding role', () => {
+    expect(modelSupportsRole('embedding', embedder)).toBe(true);
+    expect(modelSupportsRole('embedding', textFlash)).toBe(false);
+    expect(modelSupportsRole('embedding', imageModel)).toBe(false);
+  });
+
+  it('matches image-generation models for the image role (name + method heuristic)', () => {
+    expect(modelSupportsRole('image', imageModel)).toBe(true);
+    expect(modelSupportsRole('image', imagen)).toBe(true);
+    // Plain text/embedder never leak into the image picker.
+    expect(modelSupportsRole('image', textFlash)).toBe(false);
+    expect(modelSupportsRole('image', textPro)).toBe(false);
+    expect(modelSupportsRole('image', embedder)).toBe(false);
+  });
+
+  it('excludes a model with no usable generation method from every role', () => {
+    const inert: CatalogModelLike = { name: 'gemini-legacy', supportedGenerationMethods: [] };
+    expect(modelSupportsRole('fast', inert)).toBe(false);
+    expect(modelSupportsRole('pro', inert)).toBe(false);
+    expect(modelSupportsRole('embedding', inert)).toBe(false);
+    expect(modelSupportsRole('image', inert)).toBe(false);
+  });
+});
+
+describe('probeMethodFor', () => {
+  it('pings embedders with embedContent and everything else with generateContent', () => {
+    expect(probeMethodFor(embedder)).toBe('embedContent');
+    expect(probeMethodFor(textFlash)).toBe('generateContent');
+    expect(probeMethodFor(imageModel)).toBe('generateContent');
+  });
+});

--- a/apps/cloud-functions/tests/ai/resolveModel.test.ts
+++ b/apps/cloud-functions/tests/ai/resolveModel.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AI_MODEL_DEFAULTS } from '@salt/domain/schemas';
+
+// ─── Mock firebase-functions logger ──────────────────────────────────────────
+vi.mock('firebase-functions', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Mock firebase-admin/firestore ───────────────────────────────────────────
+// A single mutable handle the tests reconfigure per-case; the resolver always
+// reads appSettings/singleton.
+const mockGet = vi.fn();
+vi.mock('firebase-admin/firestore', () => ({
+  getFirestore: () => ({
+    collection: (_name: string) => ({
+      doc: (_id: string) => ({ get: mockGet }),
+    }),
+  }),
+}));
+
+const { resolveModel, __resetResolveModelCacheForTest } =
+  await import('../../src/ai/resolveModel.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetResolveModelCacheForTest();
+});
+
+describe('resolveModel', () => {
+  it('falls back to defaults when the doc is absent', async () => {
+    mockGet.mockResolvedValue({ exists: false });
+    expect(await resolveModel('fast')).toBe(AI_MODEL_DEFAULTS.fast);
+    expect(await resolveModel('pro')).toBe(AI_MODEL_DEFAULTS.pro);
+    expect(await resolveModel('embedding')).toBe(AI_MODEL_DEFAULTS.embedding);
+    expect(await resolveModel('image')).toBe(AI_MODEL_DEFAULTS.image);
+  });
+
+  it('falls back to defaults when the doc is invalid (corrupt)', async () => {
+    mockGet.mockResolvedValue({ exists: true, data: () => ({ fast: 123 }) });
+    expect(await resolveModel('fast')).toBe(AI_MODEL_DEFAULTS.fast);
+  });
+
+  it('falls back to defaults when the doc is empty', async () => {
+    mockGet.mockResolvedValue({ exists: true, data: () => ({}) });
+    expect(await resolveModel('fast')).toBe(AI_MODEL_DEFAULTS.fast);
+    expect(await resolveModel('image')).toBe(AI_MODEL_DEFAULTS.image);
+  });
+
+  it('falls back to defaults when the read throws', async () => {
+    mockGet.mockRejectedValue(new Error('unavailable'));
+    expect(await resolveModel('embedding')).toBe(AI_MODEL_DEFAULTS.embedding);
+  });
+
+  it('returns the configured model for a role', async () => {
+    mockGet.mockResolvedValue({ exists: true, data: () => ({ fast: 'custom-fast-model' }) });
+    expect(await resolveModel('fast')).toBe('custom-fast-model');
+    // Unset roles still fall back to their defaults.
+    expect(await resolveModel('pro')).toBe(AI_MODEL_DEFAULTS.pro);
+  });
+
+  it('caches reads within the TTL (one Firestore read across roles)', async () => {
+    mockGet.mockResolvedValue({ exists: true, data: () => ({ fast: 'cached-fast' }) });
+    await resolveModel('fast');
+    await resolveModel('pro');
+    await resolveModel('image');
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/cloud-functions/tests/ai/resolveModel.test.ts
+++ b/apps/cloud-functions/tests/ai/resolveModel.test.ts
@@ -65,4 +65,74 @@ describe('resolveModel', () => {
     await resolveModel('image');
     expect(mockGet).toHaveBeenCalledTimes(1);
   });
+
+  // ─── Phase 2: per-flow override precedence ────────────────────────────────
+  describe('per-flow overrides', () => {
+    it('a per-flow override beats the role model', async () => {
+      mockGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ fast: 'role-fast', perFlow: { authorRecipe: 'flow-specific' } }),
+      });
+      expect(await resolveModel('fast', 'authorRecipe')).toBe('flow-specific');
+    });
+
+    it('a per-flow override only affects its own flow, not siblings on the role', async () => {
+      mockGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ fast: 'role-fast', perFlow: { authorRecipe: 'flow-specific' } }),
+      });
+      // The overridden flow gets its override...
+      expect(await resolveModel('fast', 'authorRecipe')).toBe('flow-specific');
+      // ...every other flow on the same role still gets the role model.
+      expect(await resolveModel('fast', 'parseEntry')).toBe('role-fast');
+      expect(await resolveModel('fast', 'arbitrateCanon')).toBe('role-fast');
+    });
+
+    it('a per-flow override beats the role default when the role is unset', async () => {
+      mockGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ perFlow: { chefChat: 'flow-pro' } }),
+      });
+      expect(await resolveModel('pro', 'chefChat')).toBe('flow-pro');
+    });
+
+    it('falls through to the role model when the flow has no override', async () => {
+      mockGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ fast: 'role-fast', perFlow: { chefChat: 'flow-pro' } }),
+      });
+      expect(await resolveModel('fast', 'authorRecipe')).toBe('role-fast');
+    });
+
+    it('falls through to the role default when neither override nor role is set', async () => {
+      mockGet.mockResolvedValue({ exists: true, data: () => ({}) });
+      expect(await resolveModel('fast', 'authorRecipe')).toBe(AI_MODEL_DEFAULTS.fast);
+    });
+
+    it('falls through to role/default when perFlow is absent entirely', async () => {
+      mockGet.mockResolvedValue({ exists: true, data: () => ({ fast: 'role-fast' }) });
+      expect(await resolveModel('fast', 'authorRecipe')).toBe('role-fast');
+      expect(await resolveModel('image', 'generateCanonIcon')).toBe(AI_MODEL_DEFAULTS.image);
+    });
+
+    it('ignores an empty override and fails open to defaults (empty value rejects the doc)', async () => {
+      // An empty-string override fails the schema, so the whole doc is rejected
+      // and the resolver fails open to defaults — exercising both the empty-value
+      // guard and the fail-open path.
+      mockGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ fast: 'role-fast', perFlow: { authorRecipe: '' } }),
+      });
+      expect(await resolveModel('fast', 'authorRecipe')).toBe(AI_MODEL_DEFAULTS.fast);
+    });
+
+    it('with no flowId, behaves exactly like role-only resolution (Phase 1 compat)', async () => {
+      mockGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ fast: 'role-fast', perFlow: { authorRecipe: 'flow-specific' } }),
+      });
+      // No flowId → the override is never consulted; the role model wins.
+      expect(await resolveModel('fast')).toBe('role-fast');
+    });
+  });
 });

--- a/apps/cloud-functions/tests/ai/testModel.test.ts
+++ b/apps/cloud-functions/tests/ai/testModel.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CallableRequest } from 'firebase-functions/https';
+
+class FakeHttpsError extends Error {
+  code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+vi.mock('firebase-functions/https', () => ({ HttpsError: FakeHttpsError }));
+vi.mock('firebase-functions', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const mockRequireAdmin = vi.fn(async () => 'admin@example.com');
+vi.mock('../../src/ai/requireAdmin.js', () => ({ requireAdmin: mockRequireAdmin }));
+
+vi.mock('../../src/adapters/withAiTimeout.js', () => ({
+  withAiTimeout: (_label: string, op: () => Promise<unknown>) => op(),
+}));
+
+const mockGenerate = vi.fn();
+const mockEmbed = vi.fn();
+vi.mock('../../src/genkit.js', () => ({
+  ai: {
+    generate: (...a: unknown[]) => mockGenerate(...a),
+    embed: (...a: unknown[]) => mockEmbed(...a),
+  },
+}));
+vi.mock('@genkit-ai/google-genai', () => ({
+  googleAI: { model: (n: string) => `model:${n}`, embedder: (n: string) => `embedder:${n}` },
+}));
+
+const { handleTestModel } = await import('../../src/ai/testModel.js');
+
+function req(data: unknown): CallableRequest {
+  return { auth: { uid: 'u1' }, data } as unknown as CallableRequest;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue('admin@example.com');
+  mockGenerate.mockResolvedValue({ text: 'ok' });
+  mockEmbed.mockResolvedValue([{ embedding: [0.1] }]);
+});
+
+describe('handleTestModel', () => {
+  it('re-checks admin', async () => {
+    await handleTestModel(req({ model: 'gemini-flash-latest' }));
+    expect(mockRequireAdmin).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an invalid payload', async () => {
+    await expect(handleTestModel(req({ model: '' }))).rejects.toMatchObject({
+      code: 'invalid-argument',
+    });
+  });
+
+  it('returns ok for a successful generate ping', async () => {
+    const result = await handleTestModel(req({ model: 'gemini-flash-latest', role: 'fast' }));
+    expect(result).toEqual({ ok: true });
+    expect(mockGenerate).toHaveBeenCalledOnce();
+    expect(mockEmbed).not.toHaveBeenCalled();
+  });
+
+  it('uses an embed ping for the embedding role', async () => {
+    const result = await handleTestModel(req({ model: 'gemini-embedding-001', role: 'embedding' }));
+    expect(result).toEqual({ ok: true });
+    expect(mockEmbed).toHaveBeenCalledOnce();
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('returns ok:false with the error message when the probe throws', async () => {
+    mockGenerate.mockRejectedValueOnce(new Error('model not found'));
+    const result = await handleTestModel(req({ model: 'bogus-model', role: 'fast' }));
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('model not found');
+  });
+});

--- a/apps/cloud-functions/tests/flows/parseEntry.test.ts
+++ b/apps/cloud-functions/tests/flows/parseEntry.test.ts
@@ -16,7 +16,7 @@ vi.mock('@genkit-ai/google-genai', () => ({
 }));
 
 vi.mock('firebase-functions', () => ({
-  logger: { error: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
 // Import after mocks so defineFlow returns the handler directly.

--- a/apps/web-pwa/src/App.svelte
+++ b/apps/web-pwa/src/App.svelte
@@ -23,6 +23,7 @@
   import { initRecipeSync } from './lib/recipeService.js';
   import { initChatSync } from './lib/chatService.js';
   import { initDevSettingsSync } from './lib/devSettingsService.js';
+  import { initAppSettingsSync } from './lib/appSettingsService.js';
   import { normaliseMemberEmail } from '@salt/domain';
   import SessionOverlay from './lib/dev/SessionOverlay.svelte';
 
@@ -37,6 +38,7 @@
     const unsubRecipes = initRecipeSync();
     const unsubChat = initChatSync(auth.user.uid);
     const unsubDevSettings = initDevSettingsSync();
+    const unsubAppSettings = initAppSettingsSync();
     return () => {
       unsubCanon();
       unsubEquipment();
@@ -46,6 +48,7 @@
       unsubRecipes();
       unsubChat();
       unsubDevSettings();
+      unsubAppSettings();
     };
   });
 

--- a/apps/web-pwa/src/lib/aiModelCatalogService.ts
+++ b/apps/web-pwa/src/lib/aiModelCatalogService.ts
@@ -1,0 +1,97 @@
+import { writable, derived, get } from 'svelte/store';
+import type { Readable } from 'svelte/store';
+import {
+  callListAiModels,
+  callTestModel,
+  type AiCatalogModel,
+  type AiModelCatalog,
+} from '@salt/firebase-sync';
+import { AI_MODEL_ROLES, type AiModelRole } from '@salt/domain/schemas';
+
+// Live Gemini model catalog for the admin AI-settings page (Phase 3). Calls the
+// firebase-sync wrappers (which own the Firebase SDK) and holds the
+// capability-filtered, per-role lists in a store. Exposes a `refresh()` that
+// force-re-fetches the catalog and a `testModel()` that probes one model.
+//
+// The catalog is best-effort: if it is unavailable (offline, non-admin, AI key
+// missing server-side), the store stays empty and the UI falls back to free-text
+// entry — the combobox keeps working with `allowCustom`, just without
+// suggestions.
+
+const emptyByRole = (): Record<AiModelRole, AiCatalogModel[]> => {
+  const out = {} as Record<AiModelRole, AiCatalogModel[]>;
+  for (const role of AI_MODEL_ROLES) out[role] = [];
+  return out;
+};
+
+const _byRole = writable<Record<AiModelRole, AiCatalogModel[]>>(emptyByRole());
+const _isLoading = writable(false);
+// True when the last fetch failed (or never ran). Drives the "fell back to
+// free-text" UX without blocking the page.
+const _isUnavailable = writable(true);
+const _fetchedAt = writable<number | null>(null);
+
+// Per-role filtered model lists. Empty when the catalog is unavailable.
+export const catalogByRole: Readable<Record<AiModelRole, AiCatalogModel[]>> = _byRole;
+export const isCatalogLoading: Readable<boolean> = _isLoading;
+export const isCatalogUnavailable: Readable<boolean> = _isUnavailable;
+export const catalogFetchedAt: Readable<number | null> = _fetchedAt;
+
+// True once at least one role has models — i.e. the combobox can show
+// suggestions. When false, fields fall back to plain free-text.
+export const hasCatalog: Readable<boolean> = derived(_byRole, ($byRole) =>
+  AI_MODEL_ROLES.some((role) => $byRole[role].length > 0),
+);
+
+function applyCatalog(catalog: AiModelCatalog): void {
+  // Defensive: ensure every role key exists even if the server omits one.
+  const next = emptyByRole();
+  for (const role of AI_MODEL_ROLES) {
+    next[role] = catalog.byRole[role] ?? [];
+  }
+  _byRole.set(next);
+  _fetchedAt.set(catalog.fetchedAt);
+  _isUnavailable.set(false);
+}
+
+async function load(forceRefresh: boolean): Promise<void> {
+  _isLoading.set(true);
+  const result = await callListAiModels(forceRefresh);
+  _isLoading.set(false);
+  if (result.kind === 'ok') {
+    applyCatalog(result.value);
+  } else {
+    // Leave any previously-loaded catalog in place on a transient refresh
+    // failure, but flag unavailability so the UI can hint at free-text fallback.
+    _isUnavailable.set(get(hasCatalog) ? false : true);
+  }
+}
+
+// Lazily loads the catalog once (no-op if already loaded). Safe to call on mount.
+export async function ensureCatalog(): Promise<void> {
+  if (!get(_isUnavailable)) return;
+  await load(false);
+}
+
+// Force a fresh fetch (the "Refresh" control), bypassing the CF cache.
+export async function refreshCatalog(): Promise<void> {
+  await load(true);
+}
+
+// Probes a model server-side; returns the ok/error outcome for the UI to surface.
+export async function testModel(
+  model: string,
+  role?: AiModelRole,
+): Promise<{ ok: boolean; error?: string }> {
+  const result = await callTestModel(model, role);
+  if (result.kind === 'ok') return result.value;
+  // A wrapper-level failure (auth/network) — present it as a failed probe.
+  return { ok: false, error: 'Could not reach the model test service.' };
+}
+
+export function __resetAiModelCatalogServiceForTest(): void {
+  _byRole.set(emptyByRole());
+  _isLoading.set(false);
+  _isUnavailable.set(true);
+  _fetchedAt.set(null);
+}

--- a/apps/web-pwa/src/lib/appSettingsService.ts
+++ b/apps/web-pwa/src/lib/appSettingsService.ts
@@ -2,18 +2,23 @@ import { subscribeAppSettings, saveAppSettings } from '@salt/firebase-sync';
 import {
   AI_MODEL_DEFAULTS,
   AI_MODEL_ROLES,
+  AI_FLOW_ROLES,
+  AI_FLOW_IDS,
   type AppSettings,
   type AiModelRole,
+  type AiFlowId,
 } from '@salt/domain/schemas';
 import type { DomainError, ReadResult } from '@salt/shared-types';
 import { writable, derived, get } from 'svelte/store';
 import type { Readable } from 'svelte/store';
 import { auth } from './auth.svelte.js';
 
-// Admin-managed AI model settings (Phase 1). Subscribes to the per-environment
-// `appSettings/singleton` doc. Each role defaults to today's exact production
-// model literal, so the effective config matches current behaviour even before
-// the doc loads and when no doc exists — and a deleted/corrupt doc is harmless.
+// Admin-managed AI model settings (Phase 1 + Phase 2). Subscribes to the
+// per-environment `appSettings/singleton` doc. Each role defaults to today's
+// exact production model literal, so the effective config matches current
+// behaviour even before the doc loads and when no doc exists — and a
+// deleted/corrupt doc is harmless. Phase 2 adds optional per-flow overrides that
+// take precedence over the flow's role.
 
 const _settings = writable<AppSettings | null>(null);
 const _isLoading = writable(true);
@@ -32,6 +37,19 @@ export const effectiveModels: Readable<Record<AiModelRole, string>> = derived(_s
   const out = {} as Record<AiModelRole, string>;
   for (const role of AI_MODEL_ROLES) {
     out[role] = $s?.[role] ?? AI_MODEL_DEFAULTS[role];
+  }
+  return out;
+});
+
+// The model each flow actually resolves to, mirroring the CF resolver's
+// precedence: per-flow override → role's model → role's default. The admin UI
+// uses this for each flow's "effective model" readout so it matches the flows.
+export const effectiveFlowModels: Readable<Record<AiFlowId, string>> = derived(_settings, ($s) => {
+  const out = {} as Record<AiFlowId, string>;
+  for (const flowId of AI_FLOW_IDS) {
+    const role = AI_FLOW_ROLES[flowId];
+    const override = $s?.perFlow?.[flowId];
+    out[flowId] = override?.trim() ? override : ($s?.[role] ?? AI_MODEL_DEFAULTS[role]);
   }
   return out;
 });
@@ -59,23 +77,43 @@ export function initAppSettingsSync(): () => void {
   };
 }
 
-// Builds the next full doc from the current store (or defaults), applying the
-// per-role override and refreshing the audit metadata. The whole doc is written
-// (last-write-wins) so unset fields fall back to schema defaults.
-function buildNext(role: AiModelRole, model: string | undefined): AppSettings {
-  const current: AppSettings = get(_settings) ?? {
-    ...AI_MODEL_DEFAULTS,
-    schemaVersion: 1,
-  };
+// The current doc (or a defaults skeleton if none has loaded), the base every
+// mutation merges onto. The whole doc is written (last-write-wins), so unset
+// role fields fall back to schema defaults.
+function currentDoc(): AppSettings {
+  return (
+    get(_settings) ?? {
+      ...AI_MODEL_DEFAULTS,
+      schemaVersion: 1,
+    }
+  );
+}
+
+// Stamps audit metadata onto a built doc and bumps schemaVersion.
+function withAudit(doc: AppSettings): AppSettings {
   return {
-    ...current,
-    // Clearing a field (undefined) means "use the default": persist the default
-    // literal so the saved doc is self-describing and the readout is stable.
-    [role]: model && model.trim() ? model.trim() : AI_MODEL_DEFAULTS[role],
+    ...doc,
     schemaVersion: 1,
     updatedAt: Date.now(),
     updatedBy: auth.user?.email ?? 'unknown',
   };
+}
+
+// Persists a built doc: optimistically updates the store, then writes through.
+function persist(next: AppSettings): Promise<ReadResult<void, DomainError>> {
+  _settings.set(next);
+  return saveAppSettings(next);
+}
+
+// Builds the next full doc applying a per-role override. Per-flow overrides on
+// the current doc are preserved untouched (they sit on a sibling field).
+function buildNext(role: AiModelRole, model: string | undefined): AppSettings {
+  return withAudit({
+    ...currentDoc(),
+    // Clearing a field (undefined) means "use the default": persist the default
+    // literal so the saved doc is self-describing and the readout is stable.
+    [role]: model && model.trim() ? model.trim() : AI_MODEL_DEFAULTS[role],
+  });
 }
 
 // Sets a role's model to a free-text value. An empty/blank value resets the
@@ -84,16 +122,48 @@ export function setModelRole(
   role: AiModelRole,
   model: string,
 ): Promise<ReadResult<void, DomainError>> {
-  const next = buildNext(role, model);
-  _settings.set(next);
-  return saveAppSettings(next);
+  return persist(buildNext(role, model));
 }
 
 // Resets a single role back to today's default model.
 export function resetModelRole(role: AiModelRole): Promise<ReadResult<void, DomainError>> {
-  const next = buildNext(role, undefined);
-  _settings.set(next);
-  return saveAppSettings(next);
+  return persist(buildNext(role, undefined));
+}
+
+// Builds the next full doc applying a per-flow override. A blank value clears
+// the override (delete the key) so the flow falls back to its role; a non-empty
+// value sets the override. An empty `perFlow` map is dropped entirely to keep
+// the saved doc clean and match the "absent = no overrides" back-compat shape.
+function buildNextFlow(flowId: AiFlowId, model: string | undefined): AppSettings {
+  const doc = currentDoc();
+  const perFlow: Record<string, string> = { ...(doc.perFlow ?? {}) };
+  const trimmed = model?.trim();
+  if (trimmed) {
+    perFlow[flowId] = trimmed;
+  } else {
+    delete perFlow[flowId];
+  }
+  const next: AppSettings = { ...doc };
+  if (Object.keys(perFlow).length > 0) {
+    next.perFlow = perFlow;
+  } else {
+    delete next.perFlow;
+  }
+  return withAudit(next);
+}
+
+// Sets a flow's override to a free-text value. An empty/blank value clears the
+// override (same as resetFlowOverride), so the flow inherits its role's model.
+export function setFlowOverride(
+  flowId: AiFlowId,
+  model: string,
+): Promise<ReadResult<void, DomainError>> {
+  return persist(buildNextFlow(flowId, model));
+}
+
+// Clears a single flow's override, falling it back to its role's model.
+export function resetFlowOverride(flowId: AiFlowId): Promise<ReadResult<void, DomainError>> {
+  return persist(buildNextFlow(flowId, undefined));
 }
 
 export function __resetAppSettingsServiceForTest(): void {

--- a/apps/web-pwa/src/lib/appSettingsService.ts
+++ b/apps/web-pwa/src/lib/appSettingsService.ts
@@ -1,0 +1,105 @@
+import { subscribeAppSettings, saveAppSettings } from '@salt/firebase-sync';
+import {
+  AI_MODEL_DEFAULTS,
+  AI_MODEL_ROLES,
+  type AppSettings,
+  type AiModelRole,
+} from '@salt/domain/schemas';
+import type { DomainError, ReadResult } from '@salt/shared-types';
+import { writable, derived, get } from 'svelte/store';
+import type { Readable } from 'svelte/store';
+import { auth } from './auth.svelte.js';
+
+// Admin-managed AI model settings (Phase 1). Subscribes to the per-environment
+// `appSettings/singleton` doc. Each role defaults to today's exact production
+// model literal, so the effective config matches current behaviour even before
+// the doc loads and when no doc exists — and a deleted/corrupt doc is harmless.
+
+const _settings = writable<AppSettings | null>(null);
+const _isLoading = writable(true);
+const _isCorrupt = writable(false);
+
+export const appSettings: Readable<AppSettings | null> = _settings;
+export const isLoadingAppSettings: Readable<boolean> = _isLoading;
+// True when the doc exists but failed validation. The UI surfaces a warning;
+// the effective config still falls back to defaults so AI keeps working.
+export const isAppSettingsCorrupt: Readable<boolean> = _isCorrupt;
+
+// The model that each role actually resolves to right now: the saved value if
+// present, otherwise today's default. Mirrors the CF resolver's fallback so the
+// admin UI's "effective model" readout matches what the flows really use.
+export const effectiveModels: Readable<Record<AiModelRole, string>> = derived(_settings, ($s) => {
+  const out = {} as Record<AiModelRole, string>;
+  for (const role of AI_MODEL_ROLES) {
+    out[role] = $s?.[role] ?? AI_MODEL_DEFAULTS[role];
+  }
+  return out;
+});
+
+let unsub: (() => void) | null = null;
+
+export function initAppSettingsSync(): () => void {
+  _isLoading.set(true);
+  unsub = subscribeAppSettings(
+    (s) => {
+      _settings.set(s);
+      _isCorrupt.set(false);
+      _isLoading.set(false);
+    },
+    (err) => {
+      // A corrupt doc surfaces here; keep the store null so effective config
+      // falls back to defaults, and flag corruption for the UI.
+      _isCorrupt.set(err.kind === 'StorageError' && err.reason === 'corruption');
+      _isLoading.set(false);
+    },
+  );
+  return () => {
+    unsub?.();
+    unsub = null;
+  };
+}
+
+// Builds the next full doc from the current store (or defaults), applying the
+// per-role override and refreshing the audit metadata. The whole doc is written
+// (last-write-wins) so unset fields fall back to schema defaults.
+function buildNext(role: AiModelRole, model: string | undefined): AppSettings {
+  const current: AppSettings = get(_settings) ?? {
+    ...AI_MODEL_DEFAULTS,
+    schemaVersion: 1,
+  };
+  return {
+    ...current,
+    // Clearing a field (undefined) means "use the default": persist the default
+    // literal so the saved doc is self-describing and the readout is stable.
+    [role]: model && model.trim() ? model.trim() : AI_MODEL_DEFAULTS[role],
+    schemaVersion: 1,
+    updatedAt: Date.now(),
+    updatedBy: auth.user?.email ?? 'unknown',
+  };
+}
+
+// Sets a role's model to a free-text value. An empty/blank value resets the
+// role to its default (same as resetModelRole).
+export function setModelRole(
+  role: AiModelRole,
+  model: string,
+): Promise<ReadResult<void, DomainError>> {
+  const next = buildNext(role, model);
+  _settings.set(next);
+  return saveAppSettings(next);
+}
+
+// Resets a single role back to today's default model.
+export function resetModelRole(role: AiModelRole): Promise<ReadResult<void, DomainError>> {
+  const next = buildNext(role, undefined);
+  _settings.set(next);
+  return saveAppSettings(next);
+}
+
+export function __resetAppSettingsServiceForTest(): void {
+  unsub?.();
+  unsub = null;
+  _settings.set(null);
+  _isLoading.set(true);
+  _isCorrupt.set(false);
+}

--- a/apps/web-pwa/src/routes/admin/AdminHomePage.svelte
+++ b/apps/web-pwa/src/routes/admin/AdminHomePage.svelte
@@ -42,6 +42,12 @@
       description: 'Per-environment operator switches, e.g. canon icon generation.',
       href: '/admin/dev-settings',
     },
+    {
+      id: 'app-settings',
+      title: 'AI model settings',
+      description: 'Choose the Gemini model used for each AI role in this environment.',
+      href: '/admin/app-settings',
+    },
   ];
 </script>
 

--- a/apps/web-pwa/src/routes/admin/AppSettingsPage.svelte
+++ b/apps/web-pwa/src/routes/admin/AppSettingsPage.svelte
@@ -1,15 +1,25 @@
 <script lang="ts">
   import { Button, TextField } from '@salt/ui-components';
   import { push } from 'svelte-spa-router';
-  import { AI_MODEL_DEFAULTS, AI_MODEL_ROLES, type AiModelRole } from '@salt/domain/schemas';
+  import {
+    AI_MODEL_DEFAULTS,
+    AI_MODEL_ROLES,
+    AI_FLOW_ROLES,
+    AI_FLOW_IDS,
+    type AiModelRole,
+    type AiFlowId,
+  } from '@salt/domain/schemas';
   import AdminGuard from './AdminGuard.svelte';
   import {
     appSettings,
     effectiveModels,
+    effectiveFlowModels,
     isLoadingAppSettings,
     isAppSettingsCorrupt,
     setModelRole,
     resetModelRole,
+    setFlowOverride,
+    resetFlowOverride,
   } from '../../lib/appSettingsService.js';
   import { addToast } from '../../lib/toastStore.js';
 
@@ -17,6 +27,10 @@
   // defaults to today's exact production model literal, so clearing a field (or
   // a missing/corrupt doc) falls back to the default. Changes take up to ~3
   // minutes to propagate (the CF resolver caches for 180s).
+  //
+  // Phase 2 adds an "Advanced: per-flow overrides" section: an optional override
+  // for a single flow that takes precedence over its role's model. Same
+  // field/save/reset pattern as the role cards.
 
   type RoleMeta = { role: AiModelRole; title: string; description: string };
   const ROLE_META: RoleMeta[] = [
@@ -91,6 +105,86 @@
       addToast('Reset to default.', 'success');
     }
   }
+
+  // ─── Phase 2: per-flow overrides ────────────────────────────────────────────
+  // Human-readable label per flow id; the role is derived from AI_FLOW_ROLES.
+  const FLOW_LABELS: Record<AiFlowId, string> = {
+    arbitrateCanon: 'Canon arbitration',
+    authorRecipe: 'Recipe author (librarian)',
+    chefChat: 'Chef Chat',
+    embedText: 'Embed text (callable)',
+    extractRecipeFromUrl: 'Recipe import from URL',
+    generateCanonIcon: 'Canon icon generation',
+    generateChatTitle: 'Chat title generation',
+    identifyEquipment: 'Equipment identification',
+    parseEntry: 'Entry parsing',
+    parseRecipeIngredients: 'Recipe ingredient parsing',
+    populateEquipmentEntry: 'Equipment entry population',
+    serverEmbedding: 'Server embedding (canon/recipe vectors)',
+  };
+
+  // Flow ids grouped by role, so the Advanced section mirrors the role cards.
+  const FLOWS_BY_ROLE: { role: AiModelRole; flows: AiFlowId[] }[] = AI_MODEL_ROLES.map((role) => ({
+    role,
+    flows: AI_FLOW_IDS.filter((flowId) => AI_FLOW_ROLES[flowId] === role),
+  })).filter((g) => g.flows.length > 0);
+
+  const initialFlowDrafts = (): Record<AiFlowId, string> =>
+    Object.fromEntries(AI_FLOW_IDS.map((id) => [id, ''])) as Record<AiFlowId, string>;
+  const initialFlowSaving = (): Record<AiFlowId, boolean> =>
+    Object.fromEntries(AI_FLOW_IDS.map((id) => [id, false])) as Record<AiFlowId, boolean>;
+
+  let flowDrafts = $state<Record<AiFlowId, string>>(initialFlowDrafts());
+  let flowSaving = $state<Record<AiFlowId, boolean>>(initialFlowSaving());
+  // Whether the Advanced section is expanded. Auto-opens when any override is
+  // already set so an admin lands on existing config.
+  let showAdvanced = $state(false);
+
+  $effect(() => {
+    const s = $appSettings;
+    let anyOverride = false;
+    for (const flowId of AI_FLOW_IDS) {
+      // Mirror only an explicitly-set override into the field; leave it blank
+      // (placeholder shows the inherited role model) when no override exists.
+      const saved = s?.perFlow?.[flowId];
+      flowDrafts[flowId] = saved ?? '';
+      if (saved) anyOverride = true;
+    }
+    if (anyOverride) showAdvanced = true;
+  });
+
+  async function onSaveFlow(flowId: AiFlowId): Promise<void> {
+    flowSaving[flowId] = true;
+    const result = await setFlowOverride(flowId, flowDrafts[flowId]);
+    flowSaving[flowId] = false;
+    if (result.kind !== 'ok') {
+      addToast('Failed to save the flow override.', 'error');
+    } else {
+      addToast('Flow override saved. It may take up to ~3 minutes to take effect.', 'success');
+    }
+  }
+
+  async function onResetFlow(flowId: AiFlowId): Promise<void> {
+    flowSaving[flowId] = true;
+    flowDrafts[flowId] = '';
+    const result = await resetFlowOverride(flowId);
+    flowSaving[flowId] = false;
+    if (result.kind !== 'ok') {
+      addToast('Failed to clear the flow override.', 'error');
+    } else {
+      addToast('Override cleared — flow now follows its role.', 'success');
+    }
+  }
+
+  // True when a flow currently has an explicit override in the saved doc.
+  const flowHasOverride = $derived.by(() => {
+    const perFlow = $appSettings?.perFlow;
+    const out = {} as Record<AiFlowId, boolean>;
+    for (const flowId of AI_FLOW_IDS) {
+      out[flowId] = Boolean(perFlow?.[flowId]);
+    }
+    return out;
+  });
 
   const lastUpdatedLabel = $derived.by(() => {
     const s = $appSettings;
@@ -193,6 +287,87 @@
           </div>
         </div>
       {/each}
+    </div>
+
+    <div class="rounded-lg border" data-testid="app-settings-advanced">
+      <button
+        type="button"
+        class="flex w-full items-center justify-between gap-3 p-4 text-left"
+        onclick={() => (showAdvanced = !showAdvanced)}
+        aria-expanded={showAdvanced}
+        data-testid="app-settings-advanced-toggle"
+      >
+        <span>
+          <span class="text-base font-medium">Advanced: per-flow overrides</span>
+          <span class="mt-0.5 block text-sm text-muted-foreground">
+            Override the model for a single flow. An override takes precedence over the flow's role;
+            leave it blank to follow the role. For one-off experiments — most flows should follow
+            their role.
+          </span>
+        </span>
+        <span class="text-sm text-muted-foreground">{showAdvanced ? 'Hide' : 'Show'}</span>
+      </button>
+
+      {#if showAdvanced}
+        <div class="flex flex-col gap-4 border-t p-4">
+          {#each FLOWS_BY_ROLE as group (group.role)}
+            <div data-testid="app-settings-flow-group-{group.role}">
+              <h3 class="text-sm font-semibold text-muted-foreground uppercase">
+                {group.role} role
+              </h3>
+              <div class="mt-2 flex flex-col gap-4">
+                {#each group.flows as flowId (flowId)}
+                  <div class="rounded-md border p-3" data-testid="app-settings-flow-{flowId}">
+                    <p class="text-sm font-medium">{FLOW_LABELS[flowId]}</p>
+                    <p class="mt-1 text-sm" data-testid="app-settings-flow-effective-{flowId}">
+                      Effective model:
+                      <code class="rounded bg-muted px-1 py-0.5 text-xs"
+                        >{$effectiveFlowModels[flowId]}</code
+                      >
+                      {#if flowHasOverride[flowId]}
+                        <span class="text-muted-foreground">(override)</span>
+                      {:else}
+                        <span class="text-muted-foreground">(follows {group.role} role)</span>
+                      {/if}
+                    </p>
+
+                    <div class="mt-2 flex items-end gap-2">
+                      <div class="flex-1">
+                        <TextField
+                          label="Model override"
+                          placeholder={`Follows ${group.role} role: ${$effectiveModels[group.role]}`}
+                          bind:value={flowDrafts[flowId]}
+                          disabled={$isLoadingAppSettings || flowSaving[flowId]}
+                          data-testid="app-settings-flow-input-{flowId}"
+                        />
+                      </div>
+                      <Button
+                        size="sm"
+                        onclick={() => void onSaveFlow(flowId)}
+                        disabled={$isLoadingAppSettings || flowSaving[flowId]}
+                        data-testid="app-settings-flow-save-{flowId}"
+                      >
+                        Save
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onclick={() => void onResetFlow(flowId)}
+                        disabled={$isLoadingAppSettings ||
+                          flowSaving[flowId] ||
+                          !flowHasOverride[flowId]}
+                        data-testid="app-settings-flow-reset-{flowId}"
+                      >
+                        Reset to role
+                      </Button>
+                    </div>
+                  </div>
+                {/each}
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
     </div>
   </div>
 </AdminGuard>

--- a/apps/web-pwa/src/routes/admin/AppSettingsPage.svelte
+++ b/apps/web-pwa/src/routes/admin/AppSettingsPage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button, TextField } from '@salt/ui-components';
+  import { Button } from '@salt/ui-components';
   import { push } from 'svelte-spa-router';
   import {
     AI_MODEL_DEFAULTS,
@@ -10,6 +10,14 @@
     type AiFlowId,
   } from '@salt/domain/schemas';
   import AdminGuard from './AdminGuard.svelte';
+  import ModelComboField from './ModelComboField.svelte';
+  import {
+    catalogByRole,
+    isCatalogLoading,
+    isCatalogUnavailable,
+    ensureCatalog,
+    refreshCatalog,
+  } from '../../lib/aiModelCatalogService.js';
   import {
     appSettings,
     effectiveModels,
@@ -192,6 +200,23 @@
     const when = new Date(s.updatedAt).toLocaleString();
     return s.updatedBy ? `Last changed by ${s.updatedBy} on ${when}` : `Last changed on ${when}`;
   });
+
+  // ─── Phase 3: live model catalog ────────────────────────────────────────────
+  // Lazily load the capability-filtered Gemini catalog so each field's combobox
+  // can suggest currently-available models. Best-effort: if it fails the
+  // comboboxes degrade to free-text (allowCustom), so the page never blocks.
+  $effect(() => {
+    void ensureCatalog();
+  });
+
+  async function onRefreshCatalog(): Promise<void> {
+    await refreshCatalog();
+    if ($isCatalogUnavailable) {
+      addToast('Could not refresh the model catalog — free-text entry still works.', 'error');
+    } else {
+      addToast('Model catalog refreshed.', 'success');
+    }
+  }
 </script>
 
 <AdminGuard>
@@ -204,8 +229,29 @@
           and production each have their own).
         </p>
       </div>
-      <Button size="sm" onclick={() => push('/admin')}>Back to admin</Button>
+      <div class="flex shrink-0 items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onclick={() => void onRefreshCatalog()}
+          disabled={$isCatalogLoading}
+          data-testid="app-settings-refresh-catalog"
+        >
+          {$isCatalogLoading ? 'Refreshing…' : 'Refresh models'}
+        </Button>
+        <Button size="sm" onclick={() => push('/admin')}>Back to admin</Button>
+      </div>
     </div>
+
+    {#if $isCatalogUnavailable && !$isCatalogLoading}
+      <div
+        class="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900"
+        data-testid="app-settings-catalog-unavailable"
+      >
+        The live model catalog is unavailable, so the dropdowns are empty — you can still type a
+        model name by hand. Use "Refresh models" to try again.
+      </div>
+    {/if}
 
     <div
       class="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900"
@@ -257,33 +303,35 @@
             </div>
           {/if}
 
-          <div class="mt-3 flex items-end gap-2">
-            <div class="flex-1">
-              <TextField
-                label={meta.title}
-                placeholder={`Default: ${AI_MODEL_DEFAULTS[meta.role]}`}
-                bind:value={drafts[meta.role]}
+          <div class="mt-3 flex flex-col gap-2">
+            <ModelComboField
+              label={meta.title}
+              placeholder={`Default: ${AI_MODEL_DEFAULTS[meta.role]}`}
+              bind:value={drafts[meta.role]}
+              models={$catalogByRole[meta.role]}
+              role={meta.role}
+              disabled={$isLoadingAppSettings || saving[meta.role]}
+              testId={meta.role}
+            />
+            <div class="flex gap-2">
+              <Button
+                size="sm"
+                onclick={() => void onSave(meta.role)}
                 disabled={$isLoadingAppSettings || saving[meta.role]}
-                data-testid="app-settings-input-{meta.role}"
-              />
+                data-testid="app-settings-save-{meta.role}"
+              >
+                Save
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onclick={() => void onReset(meta.role)}
+                disabled={$isLoadingAppSettings || saving[meta.role]}
+                data-testid="app-settings-reset-{meta.role}"
+              >
+                Reset to default
+              </Button>
             </div>
-            <Button
-              size="sm"
-              onclick={() => void onSave(meta.role)}
-              disabled={$isLoadingAppSettings || saving[meta.role]}
-              data-testid="app-settings-save-{meta.role}"
-            >
-              Save
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onclick={() => void onReset(meta.role)}
-              disabled={$isLoadingAppSettings || saving[meta.role]}
-              data-testid="app-settings-reset-{meta.role}"
-            >
-              Reset to default
-            </Button>
           </div>
         </div>
       {/each}
@@ -331,35 +379,37 @@
                       {/if}
                     </p>
 
-                    <div class="mt-2 flex items-end gap-2">
-                      <div class="flex-1">
-                        <TextField
-                          label="Model override"
-                          placeholder={`Follows ${group.role} role: ${$effectiveModels[group.role]}`}
-                          bind:value={flowDrafts[flowId]}
-                          disabled={$isLoadingAppSettings || flowSaving[flowId]}
-                          data-testid="app-settings-flow-input-{flowId}"
-                        />
-                      </div>
-                      <Button
-                        size="sm"
-                        onclick={() => void onSaveFlow(flowId)}
+                    <div class="mt-2 flex flex-col gap-2">
+                      <ModelComboField
+                        label="Model override"
+                        placeholder={`Follows ${group.role} role: ${$effectiveModels[group.role]}`}
+                        bind:value={flowDrafts[flowId]}
+                        models={$catalogByRole[group.role]}
+                        role={group.role}
                         disabled={$isLoadingAppSettings || flowSaving[flowId]}
-                        data-testid="app-settings-flow-save-{flowId}"
-                      >
-                        Save
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onclick={() => void onResetFlow(flowId)}
-                        disabled={$isLoadingAppSettings ||
-                          flowSaving[flowId] ||
-                          !flowHasOverride[flowId]}
-                        data-testid="app-settings-flow-reset-{flowId}"
-                      >
-                        Reset to role
-                      </Button>
+                        testId="flow-{flowId}"
+                      />
+                      <div class="flex gap-2">
+                        <Button
+                          size="sm"
+                          onclick={() => void onSaveFlow(flowId)}
+                          disabled={$isLoadingAppSettings || flowSaving[flowId]}
+                          data-testid="app-settings-flow-save-{flowId}"
+                        >
+                          Save
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onclick={() => void onResetFlow(flowId)}
+                          disabled={$isLoadingAppSettings ||
+                            flowSaving[flowId] ||
+                            !flowHasOverride[flowId]}
+                          data-testid="app-settings-flow-reset-{flowId}"
+                        >
+                          Reset to role
+                        </Button>
+                      </div>
                     </div>
                   </div>
                 {/each}

--- a/apps/web-pwa/src/routes/admin/AppSettingsPage.svelte
+++ b/apps/web-pwa/src/routes/admin/AppSettingsPage.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+  import { Button, TextField } from '@salt/ui-components';
+  import { push } from 'svelte-spa-router';
+  import { AI_MODEL_DEFAULTS, AI_MODEL_ROLES, type AiModelRole } from '@salt/domain/schemas';
+  import AdminGuard from './AdminGuard.svelte';
+  import {
+    appSettings,
+    effectiveModels,
+    isLoadingAppSettings,
+    isAppSettingsCorrupt,
+    setModelRole,
+    resetModelRole,
+  } from '../../lib/appSettingsService.js';
+  import { addToast } from '../../lib/toastStore.js';
+
+  // Admin AI model settings (Phase 1). One free-text field per role; each
+  // defaults to today's exact production model literal, so clearing a field (or
+  // a missing/corrupt doc) falls back to the default. Changes take up to ~3
+  // minutes to propagate (the CF resolver caches for 180s).
+
+  type RoleMeta = { role: AiModelRole; title: string; description: string };
+  const ROLE_META: RoleMeta[] = [
+    {
+      role: 'fast',
+      title: 'Fast model',
+      description:
+        'Used by quick text flows: entry/recipe parsing, canon arbitration, equipment, chat titles, and URL recipe import.',
+    },
+    {
+      role: 'pro',
+      title: 'Pro model',
+      description: 'Used by Chef Chat, where answer quality matters more than latency.',
+    },
+    {
+      role: 'embedding',
+      title: 'Embedding model',
+      description: 'Used to embed text for canon matching and recipe ingredient canonicalisation.',
+    },
+    {
+      role: 'image',
+      title: 'Image model',
+      description: 'Used to generate canon-item icons.',
+    },
+  ];
+
+  // Local edit buffer per role, seeded from the saved value (or empty so the
+  // placeholder shows the default). Re-seeds whenever the saved doc changes.
+  let drafts = $state<Record<AiModelRole, string>>({
+    fast: '',
+    pro: '',
+    embedding: '',
+    image: '',
+  });
+  let saving = $state<Record<AiModelRole, boolean>>({
+    fast: false,
+    pro: false,
+    embedding: false,
+    image: false,
+  });
+
+  $effect(() => {
+    const s = $appSettings;
+    for (const role of AI_MODEL_ROLES) {
+      // Only mirror an explicit, non-default saved value into the field; leave
+      // it blank when it equals the default so the placeholder communicates
+      // "defaulting to X".
+      const saved = s?.[role];
+      drafts[role] = saved && saved !== AI_MODEL_DEFAULTS[role] ? saved : '';
+    }
+  });
+
+  async function onSave(role: AiModelRole): Promise<void> {
+    saving[role] = true;
+    const result = await setModelRole(role, drafts[role]);
+    saving[role] = false;
+    if (result.kind !== 'ok') {
+      addToast('Failed to save the model setting.', 'error');
+    } else {
+      addToast('Model setting saved. It may take up to ~3 minutes to take effect.', 'success');
+    }
+  }
+
+  async function onReset(role: AiModelRole): Promise<void> {
+    saving[role] = true;
+    drafts[role] = '';
+    const result = await resetModelRole(role);
+    saving[role] = false;
+    if (result.kind !== 'ok') {
+      addToast('Failed to reset the model setting.', 'error');
+    } else {
+      addToast('Reset to default.', 'success');
+    }
+  }
+
+  const lastUpdatedLabel = $derived.by(() => {
+    const s = $appSettings;
+    if (!s?.updatedAt) return null;
+    const when = new Date(s.updatedAt).toLocaleString();
+    return s.updatedBy ? `Last changed by ${s.updatedBy} on ${when}` : `Last changed on ${when}`;
+  });
+</script>
+
+<AdminGuard>
+  <div class="flex flex-col gap-4 p-4 sm:p-6" data-testid="admin-app-settings">
+    <div class="flex items-start justify-between gap-3">
+      <div>
+        <h1 class="text-xl font-semibold">AI model settings</h1>
+        <p class="text-sm text-muted-foreground">
+          Choose the Gemini model for each AI role in <strong>this environment only</strong> (dev, staging
+          and production each have their own).
+        </p>
+      </div>
+      <Button size="sm" onclick={() => push('/admin')}>Back to admin</Button>
+    </div>
+
+    <div
+      class="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900"
+      data-testid="app-settings-propagation-note"
+    >
+      Changes take up to ~3 minutes to propagate to running flows (each function caches the selected
+      model for up to 180 seconds). Leave a field blank to use the default shown.
+    </div>
+
+    {#if $isAppSettingsCorrupt}
+      <div
+        class="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-900"
+        data-testid="app-settings-corrupt-warning"
+      >
+        The saved settings document is invalid and is being ignored — all roles are running on their
+        defaults. Saving any field below will replace it with a valid document.
+      </div>
+    {/if}
+
+    {#if lastUpdatedLabel}
+      <p class="text-xs text-muted-foreground" data-testid="app-settings-audit">
+        {lastUpdatedLabel}
+      </p>
+    {/if}
+
+    <div class="flex flex-col gap-4">
+      {#each ROLE_META as meta (meta.role)}
+        <div class="rounded-lg border p-4" data-testid="app-settings-role-{meta.role}">
+          <h2 class="text-base font-medium">{meta.title}</h2>
+          <p class="mt-0.5 text-sm text-muted-foreground">{meta.description}</p>
+
+          <p class="mt-2 text-sm" data-testid="app-settings-effective-{meta.role}">
+            Effective model:
+            <code class="rounded bg-muted px-1 py-0.5 text-xs">{$effectiveModels[meta.role]}</code>
+            {#if $effectiveModels[meta.role] === AI_MODEL_DEFAULTS[meta.role]}
+              <span class="text-muted-foreground">(default)</span>
+            {/if}
+          </p>
+
+          {#if meta.role === 'embedding'}
+            <div
+              class="mt-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900"
+              data-testid="app-settings-embedding-warning"
+            >
+              <strong>Changing the embedding model requires a re-embed migration.</strong> Existing canon
+              and recipe vectors were produced by the current model; a different model's vectors are not
+              comparable, so matching quality will degrade until everything is re-embedded. Do not change
+              this without a planned migration.
+            </div>
+          {/if}
+
+          <div class="mt-3 flex items-end gap-2">
+            <div class="flex-1">
+              <TextField
+                label={meta.title}
+                placeholder={`Default: ${AI_MODEL_DEFAULTS[meta.role]}`}
+                bind:value={drafts[meta.role]}
+                disabled={$isLoadingAppSettings || saving[meta.role]}
+                data-testid="app-settings-input-{meta.role}"
+              />
+            </div>
+            <Button
+              size="sm"
+              onclick={() => void onSave(meta.role)}
+              disabled={$isLoadingAppSettings || saving[meta.role]}
+              data-testid="app-settings-save-{meta.role}"
+            >
+              Save
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onclick={() => void onReset(meta.role)}
+              disabled={$isLoadingAppSettings || saving[meta.role]}
+              data-testid="app-settings-reset-{meta.role}"
+            >
+              Reset to default
+            </Button>
+          </div>
+        </div>
+      {/each}
+    </div>
+  </div>
+</AdminGuard>

--- a/apps/web-pwa/src/routes/admin/ModelComboField.svelte
+++ b/apps/web-pwa/src/routes/admin/ModelComboField.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import {
+    Button,
+    Combobox,
+    ComboboxContent,
+    ComboboxCreate,
+    ComboboxEmpty,
+    ComboboxField,
+    ComboboxInput,
+    ComboboxItem,
+    type ComboboxItemType,
+  } from '@salt/ui-components';
+  import type { AiModelRole } from '@salt/domain/schemas';
+  import type { AiCatalogModel } from '@salt/firebase-sync';
+  import { testModel as probeModel } from '../../lib/aiModelCatalogService.js';
+
+  // One model field: a capability-filtered combobox (free-text retained via
+  // allowCustom) plus a per-field "Test" probe. Used by both the role cards and
+  // the Advanced per-flow rows on AppSettingsPage. When the catalog is
+  // unavailable (`models` empty) it degrades to a plain free-text combobox.
+
+  let {
+    label,
+    placeholder,
+    value = $bindable(),
+    models,
+    role,
+    disabled = false,
+    testId,
+  }: {
+    label: string;
+    placeholder: string;
+    value: string;
+    models: AiCatalogModel[];
+    // Role decides the probe method server-side (embedding vs generate).
+    role: AiModelRole;
+    disabled?: boolean;
+    testId: string;
+  } = $props();
+
+  const items = $derived<ComboboxItemType[]>(
+    models.map((m) => ({
+      value: m.name,
+      label: m.displayName && m.displayName !== m.name ? `${m.name} — ${m.displayName}` : m.name,
+    })),
+  );
+
+  function filterFn(input: string, item: ComboboxItemType): boolean {
+    const q = input.trim().toLowerCase();
+    if (!q) return true;
+    return item.value.toLowerCase().includes(q) || item.label.toLowerCase().includes(q);
+  }
+
+  // The combobox emits the selected item's *value* (the model id). Custom typed
+  // text also arrives via onValueChange / onCreate as the raw string.
+  function onValueChange(v: string): void {
+    value = v;
+  }
+  function onCreate(v: string): void {
+    value = v;
+  }
+
+  type TestState =
+    | { status: 'idle' }
+    | { status: 'testing' }
+    | { status: 'ok' }
+    | { status: 'error'; message: string };
+  let test = $state<TestState>({ status: 'idle' });
+
+  // The model to probe: the typed/selected value, or the placeholder default
+  // when the field is blank (blank = "use the default", so test that).
+  const effectiveValue = $derived(value.trim());
+
+  async function onTest(): Promise<void> {
+    const model = effectiveValue;
+    if (!model) {
+      test = { status: 'error', message: 'Enter or choose a model first.' };
+      return;
+    }
+    test = { status: 'testing' };
+    const result = await probeModel(model, role);
+    test = result.ok
+      ? { status: 'ok' }
+      : { status: 'error', message: result.error ?? 'Model test failed.' };
+  }
+
+  // Reset the test result whenever the value changes so a stale OK/error never
+  // lingers against a different model.
+  $effect(() => {
+    void value;
+    if (test.status === 'ok' || test.status === 'error') test = { status: 'idle' };
+  });
+</script>
+
+<div class="flex items-end gap-2" data-testid="model-combo-{testId}">
+  <div class="flex-1">
+    <span class="mb-1 block text-sm font-medium">{label}</span>
+    <Combobox
+      {items}
+      value={value || undefined}
+      allowCustom={true}
+      {filterFn}
+      {onValueChange}
+      {onCreate}
+      {placeholder}
+    >
+      <ComboboxField>
+        <ComboboxInput data-testid="model-combo-input-{testId}" />
+      </ComboboxField>
+      <ComboboxContent>
+        {#snippet children({ filteredItems, showCreate })}
+          {#each filteredItems as item, i (item.value)}
+            <ComboboxItem {item} index={i} />
+          {/each}
+          {#if showCreate}
+            <ComboboxCreate />
+          {/if}
+          {#if filteredItems.length === 0 && !showCreate}
+            <ComboboxEmpty>No matching models — type a custom name.</ComboboxEmpty>
+          {/if}
+        {/snippet}
+      </ComboboxContent>
+    </Combobox>
+  </div>
+  <Button
+    variant="outline"
+    size="sm"
+    onclick={() => void onTest()}
+    disabled={disabled || test.status === 'testing'}
+    data-testid="model-combo-test-{testId}"
+  >
+    {test.status === 'testing' ? 'Testing…' : 'Test'}
+  </Button>
+</div>
+
+{#if test.status === 'ok'}
+  <p class="mt-1 text-xs text-green-700" data-testid="model-combo-test-ok-{testId}">
+    Model responded successfully.
+  </p>
+{:else if test.status === 'error'}
+  <p class="mt-1 text-xs text-red-700" data-testid="model-combo-test-error-{testId}">
+    Test failed: {test.message}
+  </p>
+{/if}

--- a/apps/web-pwa/src/routes/index.ts
+++ b/apps/web-pwa/src/routes/index.ts
@@ -21,6 +21,7 @@ import AdminHomePage from './admin/AdminHomePage.svelte';
 import AdminMembersPage from './admin/AdminMembersPage.svelte';
 import AdminMealPlanPage from './admin/AdminMealPlanPage.svelte';
 import DevSettingsPage from './admin/DevSettingsPage.svelte';
+import AppSettingsPage from './admin/AppSettingsPage.svelte';
 import NotFound from './NotFound.svelte';
 
 // More-specific static routes must precede parameterised ones when using a Map.
@@ -53,6 +54,7 @@ export const routes: RouteDefinition = new Map([
   ['/admin/members', AdminMembersPage],
   ['/admin/mealplan', AdminMealPlanPage],
   ['/admin/dev-settings', DevSettingsPage],
+  ['/admin/app-settings', AppSettingsPage],
   ['/admin/aisles', AisleManagementPage],
   ['/admin/canon', CanonListPage],
   ['/admin/canon/new', CanonCreatePage],

--- a/apps/web-pwa/tests/aiModelCatalogService.test.ts
+++ b/apps/web-pwa/tests/aiModelCatalogService.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi, type Mocked } from 'vitest';
+import { get } from 'svelte/store';
+
+vi.mock('@salt/firebase-sync', () => ({
+  callListAiModels: vi.fn(),
+  callTestModel: vi.fn(),
+}));
+
+import * as firebaseSync from '@salt/firebase-sync';
+import {
+  catalogByRole,
+  hasCatalog,
+  isCatalogUnavailable,
+  ensureCatalog,
+  refreshCatalog,
+  testModel,
+  __resetAiModelCatalogServiceForTest,
+} from '../src/lib/aiModelCatalogService.js';
+
+const fs = firebaseSync as unknown as Mocked<typeof firebaseSync>;
+
+const CATALOG = {
+  byRole: {
+    fast: [{ name: 'gemini-flash-latest', displayName: 'Gemini Flash' }],
+    pro: [{ name: 'gemini-pro-latest', displayName: 'Gemini Pro' }],
+    embedding: [{ name: 'gemini-embedding-001', displayName: 'Embedding' }],
+    image: [{ name: 'gemini-2.5-flash-image', displayName: 'Image' }],
+  },
+  fetchedAt: 1_700_000_000_000,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetAiModelCatalogServiceForTest();
+});
+
+describe('aiModelCatalogService', () => {
+  it('loads the per-role catalog on ensureCatalog', async () => {
+    fs.callListAiModels.mockResolvedValue({ kind: 'ok', value: CATALOG });
+    await ensureCatalog();
+    expect(get(hasCatalog)).toBe(true);
+    expect(get(isCatalogUnavailable)).toBe(false);
+    expect(get(catalogByRole).fast.map((m) => m.name)).toEqual(['gemini-flash-latest']);
+  });
+
+  it('falls back to empty (free-text) when the catalog is unavailable', async () => {
+    fs.callListAiModels.mockResolvedValue({
+      kind: 'err',
+      error: { kind: 'NetworkError', reason: 'transient' },
+    });
+    await ensureCatalog();
+    expect(get(hasCatalog)).toBe(false);
+    expect(get(isCatalogUnavailable)).toBe(true);
+    for (const role of ['fast', 'pro', 'embedding', 'image'] as const) {
+      expect(get(catalogByRole)[role]).toEqual([]);
+    }
+  });
+
+  it('forces a fresh fetch on refresh', async () => {
+    fs.callListAiModels.mockResolvedValue({ kind: 'ok', value: CATALOG });
+    await refreshCatalog();
+    expect(fs.callListAiModels).toHaveBeenCalledWith(true);
+  });
+
+  it('surfaces a test-model failure as ok:false', async () => {
+    fs.callTestModel.mockResolvedValue({
+      kind: 'err',
+      error: { kind: 'NetworkError', reason: 'transient' },
+    });
+    const result = await testModel('gemini-flash-latest', 'fast');
+    expect(result.ok).toBe(false);
+  });
+
+  it('passes through a successful probe result', async () => {
+    fs.callTestModel.mockResolvedValue({ kind: 'ok', value: { ok: true } });
+    const result = await testModel('gemini-flash-latest', 'fast');
+    expect(result.ok).toBe(true);
+  });
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -77,6 +77,14 @@ service cloud.firestore {
       allow read: if request.auth != null;
       allow write: if isAdmin();
     }
+    // AI model settings (admin-managed model selection) — per-environment
+    // singleton naming the Gemini model for each AI role. The CF model resolver
+    // reads it via the Admin SDK (bypasses rules); any signed-in user may read
+    // (the admin UI shows the effective config); only admins may change it.
+    match /appSettings/{document} {
+      allow read: if request.auth != null;
+      allow write: if isAdmin();
+    }
     // Chat sessions (issue #206) — the first per-user-scoped data in Salt.
     // A session may only be read or written by the user who owns it.
     // On create, the client must set ownerUid to their own uid.

--- a/packages/adapters/firebase-sync/src/aiModelCallables.ts
+++ b/packages/adapters/firebase-sync/src/aiModelCallables.ts
@@ -1,0 +1,65 @@
+import { getFunctions, httpsCallable } from 'firebase/functions';
+import { failure, type DomainError, type ReadResult } from '@salt/shared-types';
+import type { AiModelRole } from '@salt/domain/schemas';
+
+// Browser → admin-only Phase 3 callables. CLAUDE.md rule #2: the Firebase SDK is
+// only touched here. The web service consumes these wrappers, never
+// `firebase/functions` directly. Mirrors equipmentCallables.ts: map the callable
+// error codes to DomainError and return a ReadResult.
+
+export interface AiCatalogModel {
+  readonly name: string;
+  readonly displayName: string;
+}
+export interface AiModelCatalog {
+  readonly byRole: Record<AiModelRole, AiCatalogModel[]>;
+  readonly fetchedAt: number;
+}
+export interface TestModelOutcome {
+  readonly ok: boolean;
+  readonly error?: string;
+}
+
+function mapCallableError(err: unknown): DomainError {
+  const code = (err as { code?: string }).code ?? '';
+  if (code === 'functions/unauthenticated') {
+    return { kind: 'AuthError', reason: 'unauthenticated' };
+  }
+  if (code === 'functions/permission-denied') {
+    return { kind: 'AuthError', reason: 'forbidden' };
+  }
+  return { kind: 'NetworkError', reason: 'transient' };
+}
+
+/** Fetches the capability-filtered model catalog. `forceRefresh` bypasses the CF cache. */
+export async function callListAiModels(
+  forceRefresh = false,
+): Promise<ReadResult<AiModelCatalog, DomainError>> {
+  try {
+    const fn = httpsCallable<{ forceRefresh: boolean }, AiModelCatalog>(
+      getFunctions(undefined, 'europe-west2'),
+      'listAiModels',
+    );
+    const res = await fn({ forceRefresh });
+    return { kind: 'ok', value: res.data };
+  } catch (err) {
+    return failure(mapCallableError(err));
+  }
+}
+
+/** Probes a single model (server-side); resolves to ok/error rather than throwing for a failed probe. */
+export async function callTestModel(
+  model: string,
+  role?: AiModelRole,
+): Promise<ReadResult<TestModelOutcome, DomainError>> {
+  try {
+    const fn = httpsCallable<{ model: string; role?: AiModelRole }, TestModelOutcome>(
+      getFunctions(undefined, 'europe-west2'),
+      'testModel',
+    );
+    const res = await fn(role ? { model, role } : { model });
+    return { kind: 'ok', value: res.data };
+  } catch (err) {
+    return failure(mapCallableError(err));
+  }
+}

--- a/packages/adapters/firebase-sync/src/appSettingsSync.ts
+++ b/packages/adapters/firebase-sync/src/appSettingsSync.ts
@@ -1,0 +1,49 @@
+import { getFirestore, doc, setDoc, onSnapshot } from 'firebase/firestore';
+import { getApp } from 'firebase/app';
+import type { DomainError, ReadResult } from '@salt/shared-types';
+import { success, failure } from '@salt/shared-types';
+import { AppSettingsSchema, type AppSettings } from '@salt/domain/schemas';
+import { classifyFirestoreError } from './firestoreErrors.js';
+
+// Admin-managed AI model settings (Phase 1). A single Firestore singleton doc,
+// read here for the admin UI and (independently, via the Admin SDK) by the CF
+// model resolver. A corrupt doc surfaces a Failure via onError (single-doc read
+// contract); a missing doc yields null (the UI/resolver apply schema defaults).
+
+const COLLECTION = 'appSettings';
+const SINGLETON_DOC_ID = 'singleton';
+
+export function subscribeAppSettings(
+  onSettings: (settings: AppSettings | null) => void,
+  onError: (err: DomainError) => void,
+): () => void {
+  const db = getFirestore(getApp());
+  return onSnapshot(
+    doc(db, COLLECTION, SINGLETON_DOC_ID),
+    (snap) => {
+      if (!snap.exists()) {
+        onSettings(null);
+        return;
+      }
+      const result = AppSettingsSchema.safeParse(snap.data());
+      if (!result.success) {
+        onError({ kind: 'StorageError', reason: 'corruption' });
+        return;
+      }
+      onSettings(result.data);
+    },
+    (err) => onError(classifyFirestoreError(err)),
+  );
+}
+
+export async function saveAppSettings(
+  settings: AppSettings,
+): Promise<ReadResult<void, DomainError>> {
+  try {
+    const db = getFirestore(getApp());
+    await setDoc(doc(db, COLLECTION, SINGLETON_DOC_ID), { ...settings });
+    return success(undefined);
+  } catch (err) {
+    return failure(classifyFirestoreError(err));
+  }
+}

--- a/packages/adapters/firebase-sync/src/index.ts
+++ b/packages/adapters/firebase-sync/src/index.ts
@@ -55,6 +55,8 @@ export {
 } from './mealPlanSync.js';
 export { subscribeDevSettings, saveDevSettings } from './devSettingsSync.js';
 export { subscribeAppSettings, saveAppSettings } from './appSettingsSync.js';
+export { callListAiModels, callTestModel } from './aiModelCallables.js';
+export type { AiCatalogModel, AiModelCatalog, TestModelOutcome } from './aiModelCallables.js';
 export type {
   IdentifyEquipmentCandidate,
   IdentifyEquipmentResult,

--- a/packages/adapters/firebase-sync/src/index.ts
+++ b/packages/adapters/firebase-sync/src/index.ts
@@ -54,6 +54,7 @@ export {
   saveMealPlanWeek,
 } from './mealPlanSync.js';
 export { subscribeDevSettings, saveDevSettings } from './devSettingsSync.js';
+export { subscribeAppSettings, saveAppSettings } from './appSettingsSync.js';
 export type {
   IdentifyEquipmentCandidate,
   IdentifyEquipmentResult,

--- a/packages/adapters/firebase-sync/tests/appSettingsSync.test.ts
+++ b/packages/adapters/firebase-sync/tests/appSettingsSync.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockUnsubscribe, mockOnSnapshot, mockSetDoc, mockDoc, mockGetFirestore } = vi.hoisted(
+  () => ({
+    mockUnsubscribe: vi.fn(),
+    mockOnSnapshot: vi.fn(),
+    mockSetDoc: vi.fn(),
+    mockDoc: vi.fn(() => 'mock-doc-ref'),
+    mockGetFirestore: vi.fn(() => 'mock-db'),
+  }),
+);
+
+vi.mock('firebase/app', () => ({
+  getApp: vi.fn(() => ({})),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  getFirestore: mockGetFirestore,
+  doc: mockDoc,
+  onSnapshot: mockOnSnapshot,
+  setDoc: mockSetDoc,
+}));
+
+import { subscribeAppSettings, saveAppSettings } from '../src/appSettingsSync.js';
+import { AI_MODEL_DEFAULTS, type AppSettings } from '@salt/domain/schemas';
+
+type SnapCallback = (snap: { exists: () => boolean; data: () => unknown }) => void;
+type ErrorCallback = (err: Error & { code?: string }) => void;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockOnSnapshot.mockReturnValue(mockUnsubscribe);
+  mockSetDoc.mockResolvedValue(undefined);
+  vi.stubGlobal('navigator', { onLine: true });
+});
+
+describe('subscribeAppSettings', () => {
+  it('targets appSettings/singleton and returns the unsubscribe', () => {
+    const unsub = subscribeAppSettings(
+      () => {},
+      () => {},
+    );
+    expect(mockDoc).toHaveBeenCalledWith('mock-db', 'appSettings', 'singleton');
+    expect(unsub).toBe(mockUnsubscribe);
+  });
+
+  it('calls onSettings(null) when the doc does not exist', () => {
+    const onSettings = vi.fn();
+    subscribeAppSettings(onSettings, () => {});
+    (mockOnSnapshot.mock.calls[0][1] as SnapCallback)({
+      exists: () => false,
+      data: () => undefined,
+    });
+    expect(onSettings).toHaveBeenCalledWith(null);
+  });
+
+  it('maps a valid doc, defaulting unset roles', () => {
+    const onSettings = vi.fn();
+    subscribeAppSettings(onSettings, () => {});
+    (mockOnSnapshot.mock.calls[0][1] as SnapCallback)({
+      exists: () => true,
+      data: () => ({ fast: 'custom-fast' }),
+    });
+    expect(onSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fast: 'custom-fast',
+        pro: AI_MODEL_DEFAULTS.pro,
+        embedding: AI_MODEL_DEFAULTS.embedding,
+        image: AI_MODEL_DEFAULTS.image,
+        schemaVersion: 1,
+      }),
+    );
+  });
+
+  it('surfaces a corrupt doc as a StorageError/corruption Failure (does not throw)', () => {
+    const onSettings = vi.fn();
+    const onError = vi.fn();
+    subscribeAppSettings(onSettings, onError);
+    (mockOnSnapshot.mock.calls[0][1] as SnapCallback)({
+      exists: () => true,
+      data: () => ({ fast: 123 }), // wrong type
+    });
+    expect(onSettings).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith({ kind: 'StorageError', reason: 'corruption' });
+  });
+
+  it('classifies a stream-level error via onError', () => {
+    const onError = vi.fn();
+    subscribeAppSettings(() => {}, onError);
+    const err = Object.assign(new Error('permission denied'), { code: 'permission-denied' });
+    (mockOnSnapshot.mock.calls[0][2] as ErrorCallback)(err);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('saveAppSettings', () => {
+  it('writes the full doc to appSettings/singleton and returns ok', async () => {
+    const settings: AppSettings = {
+      fast: 'a',
+      pro: 'b',
+      embedding: 'c',
+      image: 'd',
+      schemaVersion: 1,
+    };
+    const result = await saveAppSettings(settings);
+    expect(mockDoc).toHaveBeenCalledWith('mock-db', 'appSettings', 'singleton');
+    expect(mockSetDoc).toHaveBeenCalledWith('mock-doc-ref', { ...settings });
+    expect(result.kind).toBe('ok');
+  });
+
+  it('returns a Failure when setDoc rejects (never throws across the seam)', async () => {
+    mockSetDoc.mockRejectedValueOnce(Object.assign(new Error('nope'), { code: 'unavailable' }));
+    const result = await saveAppSettings({
+      fast: 'a',
+      pro: 'b',
+      embedding: 'c',
+      image: 'd',
+      schemaVersion: 1,
+    });
+    expect(result.kind).toBe('err');
+  });
+});

--- a/packages/domain/src/schemas/appSettings.ts
+++ b/packages/domain/src/schemas/appSettings.ts
@@ -23,12 +23,46 @@ export const AI_MODEL_DEFAULTS = {
   image: 'gemini-2.5-flash-image',
 } as const satisfies Record<AiModelRole, string>;
 
+// Phase 2: per-flow model overrides. Every AI flow (and the server embedding
+// adapter) maps to exactly one role; this is the single source of truth for that
+// mapping, shared by the CF resolver and the admin UI. A flow inherits its
+// role's model unless an admin sets an explicit override in `perFlow`.
+//
+// IMPORTANT: these flow-id keys are stable identifiers persisted in the
+// `perFlow` map of the production `appSettings` doc — renaming one orphans any
+// saved override. Add new flows here; do not rename existing ones.
+export const AI_FLOW_ROLES = {
+  arbitrateCanon: 'fast',
+  authorRecipe: 'fast',
+  chefChat: 'pro',
+  embedText: 'embedding',
+  extractRecipeFromUrl: 'fast',
+  generateCanonIcon: 'image',
+  generateChatTitle: 'fast',
+  identifyEquipment: 'fast',
+  parseEntry: 'fast',
+  parseRecipeIngredients: 'fast',
+  populateEquipmentEntry: 'fast',
+  serverEmbedding: 'embedding',
+} as const satisfies Record<string, AiModelRole>;
+
+export type AiFlowId = keyof typeof AI_FLOW_ROLES;
+export const AI_FLOW_IDS = Object.keys(AI_FLOW_ROLES) as AiFlowId[];
+
 export const AppSettingsSchema = z.object({
   fast: z.string().min(1).default(AI_MODEL_DEFAULTS.fast),
   pro: z.string().min(1).default(AI_MODEL_DEFAULTS.pro),
   embedding: z.string().min(1).default(AI_MODEL_DEFAULTS.embedding),
   image: z.string().min(1).default(AI_MODEL_DEFAULTS.image),
   schemaVersion: z.literal(1).default(1),
+  // Phase 2: optional per-flow overrides (flow-id → model name). Absent means
+  // "no overrides" — every flow inherits its role's model — so a Phase 1 doc
+  // with no `perFlow` field parses unchanged (back-compat on read). Keys are
+  // free-form strings so an unknown/retired flow-id in a stored doc never fails
+  // the parse; the resolver only reads the key for the flow it asks about. Each
+  // value is a non-empty model name — clearing an override drops the key
+  // entirely rather than storing an empty string.
+  perFlow: z.record(z.string(), z.string().min(1)).optional(),
   // Audit metadata: who last changed the doc and when (ms epoch). Optional so a
   // never-configured / defaulted doc still parses; the UI shows them when set.
   updatedAt: z.number().optional(),

--- a/packages/domain/src/schemas/appSettings.ts
+++ b/packages/domain/src/schemas/appSettings.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+// Admin-managed AI model selection (Phase 1). A single Firestore singleton doc
+// (`appSettings/singleton`); Firestore is per-project, so this is automatically
+// scoped to the environment it lives in.
+//
+// Each role field names the Gemini model used by a class of AI flows. Every
+// field `.default()`s to today's exact production literal, so a missing,
+// empty, or never-configured doc resolves to the current behaviour — deleting
+// or corrupting the doc leaves AI fully working on defaults.
+
+// The four AI roles flows are bucketed into. Free-text model names per role for
+// now (no live catalog yet); a later phase adds validation against a catalog.
+export const AI_MODEL_ROLES = ['fast', 'pro', 'embedding', 'image'] as const;
+export type AiModelRole = (typeof AI_MODEL_ROLES)[number];
+
+// Today's exact production model literals — the fallback for every role. These
+// MUST stay in sync with the hardcoded literals the flows used before Phase 1.
+export const AI_MODEL_DEFAULTS = {
+  fast: 'gemini-flash-latest',
+  pro: 'gemini-pro-latest',
+  embedding: 'gemini-embedding-001',
+  image: 'gemini-2.5-flash-image',
+} as const satisfies Record<AiModelRole, string>;
+
+export const AppSettingsSchema = z.object({
+  fast: z.string().min(1).default(AI_MODEL_DEFAULTS.fast),
+  pro: z.string().min(1).default(AI_MODEL_DEFAULTS.pro),
+  embedding: z.string().min(1).default(AI_MODEL_DEFAULTS.embedding),
+  image: z.string().min(1).default(AI_MODEL_DEFAULTS.image),
+  schemaVersion: z.literal(1).default(1),
+  // Audit metadata: who last changed the doc and when (ms epoch). Optional so a
+  // never-configured / defaulted doc still parses; the UI shows them when set.
+  updatedAt: z.number().optional(),
+  updatedBy: z.string().optional(),
+});
+
+export type AppSettings = z.infer<typeof AppSettingsSchema>;

--- a/packages/domain/src/schemas/index.ts
+++ b/packages/domain/src/schemas/index.ts
@@ -71,8 +71,14 @@ export type { ShoppingListsConfigDoc } from './shoppingListsConfig.js';
 export { DevSettingsSchema } from './devSettings.js';
 export type { DevSettingsDoc } from './devSettings.js';
 
-export { AppSettingsSchema, AI_MODEL_DEFAULTS, AI_MODEL_ROLES } from './appSettings.js';
-export type { AppSettings, AiModelRole } from './appSettings.js';
+export {
+  AppSettingsSchema,
+  AI_MODEL_DEFAULTS,
+  AI_MODEL_ROLES,
+  AI_FLOW_ROLES,
+  AI_FLOW_IDS,
+} from './appSettings.js';
+export type { AppSettings, AiModelRole, AiFlowId } from './appSettings.js';
 
 export { MemberSchema } from './member.js';
 export type { MemberDoc } from './member.js';

--- a/packages/domain/src/schemas/index.ts
+++ b/packages/domain/src/schemas/index.ts
@@ -71,6 +71,9 @@ export type { ShoppingListsConfigDoc } from './shoppingListsConfig.js';
 export { DevSettingsSchema } from './devSettings.js';
 export type { DevSettingsDoc } from './devSettings.js';
 
+export { AppSettingsSchema, AI_MODEL_DEFAULTS, AI_MODEL_ROLES } from './appSettings.js';
+export type { AppSettings, AiModelRole } from './appSettings.js';
+
 export { MemberSchema } from './member.js';
 export type { MemberDoc } from './member.js';
 

--- a/packages/domain/tests/appSettings.schema.test.ts
+++ b/packages/domain/tests/appSettings.schema.test.ts
@@ -59,4 +59,37 @@ describe('AppSettingsSchema', () => {
   it('rejects a non-string model name', () => {
     expect(AppSettingsSchema.safeParse({ fast: 123 }).success).toBe(false);
   });
+
+  // ─── Phase 2: optional per-flow overrides ─────────────────────────────────
+  it('a Phase 1 doc with no perFlow parses and yields no overrides (back-compat)', () => {
+    const parsed = AppSettingsSchema.parse({
+      fast: 'a',
+      pro: 'b',
+      embedding: 'c',
+      image: 'd',
+    });
+    // Absent field stays absent — "no overrides", never an empty object.
+    expect(parsed.perFlow).toBeUndefined();
+  });
+
+  it('preserves an explicit perFlow override map', () => {
+    const parsed = AppSettingsSchema.parse({
+      fast: 'role-fast',
+      perFlow: { authorRecipe: 'flow-specific', chefChat: 'flow-pro' },
+    });
+    expect(parsed.perFlow).toEqual({ authorRecipe: 'flow-specific', chefChat: 'flow-pro' });
+  });
+
+  it('accepts an empty perFlow map (degenerate but valid)', () => {
+    const parsed = AppSettingsSchema.parse({ perFlow: {} });
+    expect(parsed.perFlow).toEqual({});
+  });
+
+  it('rejects an empty-string override value', () => {
+    expect(AppSettingsSchema.safeParse({ perFlow: { authorRecipe: '' } }).success).toBe(false);
+  });
+
+  it('rejects a non-string override value', () => {
+    expect(AppSettingsSchema.safeParse({ perFlow: { authorRecipe: 123 } }).success).toBe(false);
+  });
 });

--- a/packages/domain/tests/appSettings.schema.test.ts
+++ b/packages/domain/tests/appSettings.schema.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { AppSettingsSchema, AI_MODEL_DEFAULTS } from '@salt/domain/schemas';
+
+// Admin-managed AI model settings (Phase 1). The per-role defaults are the
+// load-bearing safety property: a missing, empty, or partial doc MUST resolve
+// every role to today's exact production literal, so deleting/corrupting the doc
+// leaves AI fully working.
+describe('AppSettingsSchema', () => {
+  it('defaults every role to today exact production literal for an empty doc', () => {
+    expect(AppSettingsSchema.parse({})).toEqual({
+      fast: 'gemini-flash-latest',
+      pro: 'gemini-pro-latest',
+      embedding: 'gemini-embedding-001',
+      image: 'gemini-2.5-flash-image',
+      schemaVersion: 1,
+    });
+  });
+
+  it('AI_MODEL_DEFAULTS match the schema defaults', () => {
+    const parsed = AppSettingsSchema.parse({});
+    expect(parsed.fast).toBe(AI_MODEL_DEFAULTS.fast);
+    expect(parsed.pro).toBe(AI_MODEL_DEFAULTS.pro);
+    expect(parsed.embedding).toBe(AI_MODEL_DEFAULTS.embedding);
+    expect(parsed.image).toBe(AI_MODEL_DEFAULTS.image);
+  });
+
+  it('fills only the unset roles with defaults (partial doc)', () => {
+    const parsed = AppSettingsSchema.parse({ fast: 'custom-fast-model' });
+    expect(parsed.fast).toBe('custom-fast-model');
+    expect(parsed.pro).toBe(AI_MODEL_DEFAULTS.pro);
+    expect(parsed.embedding).toBe(AI_MODEL_DEFAULTS.embedding);
+    expect(parsed.image).toBe(AI_MODEL_DEFAULTS.image);
+  });
+
+  it('preserves explicit per-role overrides and audit metadata', () => {
+    const parsed = AppSettingsSchema.parse({
+      fast: 'a',
+      pro: 'b',
+      embedding: 'c',
+      image: 'd',
+      updatedAt: 1234,
+      updatedBy: 'admin@example.com',
+    });
+    expect(parsed).toEqual({
+      fast: 'a',
+      pro: 'b',
+      embedding: 'c',
+      image: 'd',
+      schemaVersion: 1,
+      updatedAt: 1234,
+      updatedBy: 'admin@example.com',
+    });
+  });
+
+  it('rejects an empty-string model name (falls back via safeParse failure)', () => {
+    expect(AppSettingsSchema.safeParse({ fast: '' }).success).toBe(false);
+  });
+
+  it('rejects a non-string model name', () => {
+    expect(AppSettingsSchema.safeParse({ fast: 123 }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements #265 — admin-managed AI model selection with a capability-filtered live picker. Built in three phases (one commit each).

## What this delivers
An operator opens **Admin → AI Model Settings** and manages the models Salt uses, grouped by semantic role (`fast`, `pro`, `embedding`, `image`). Each field offers a **live, capability-filtered dropdown** of currently-available Gemini models (image-only for `image`, embedding-only for `embedding`, text/reasoning incl. `flash` for `fast`/`pro`), still accepts a **typed custom value**, and has a **"Test"** probe and catalog **"Refresh"**. An **Advanced: per-flow overrides** section lets a single flow diverge from its role. The page shows the **effective model** (override → role → default), a **per-field reset**, **who changed it and when**, a **~3-min propagation note**, and an **embedding re-embed-migration warning**. If the config doc is missing/empty/corrupt, **AI keeps working** on the built-in defaults — externalising the models can never brick AI.

## Phases
- **Phase 1 — role-based config + CF resolver** (`976eb1c`): `@salt/domain` `AppSettingsSchema` (per-role fields defaulting to today's literals), `firebase-sync` subscribe/save, web `appSettingsService` + `AppSettingsPage` behind `AdminGuard`, and a CF `resolveModel(role)` reading `/appSettings/singleton` via `firebase-admin` with a 180s TTL cache and code-default fallback. Replaces 12 hardcoded model literals.
- **Phase 2 — per-flow overrides** (`471eaa4`): optional back-compat `perFlow` map; `resolveModel(role, flowId?)` precedence override → role → default; Advanced override UI.
- **Phase 3 — live picker + test probe** (`dc2b424`): admin-only `listAiModels` (server-side `GET /v1beta/models` + code-side capability classifier, ~1h cache + force-refresh) and `testModel` callables; firebase-sync callable wrappers; web catalog service; `Combobox` swap (free-text retained) with per-field Test + Refresh.

## Key decisions
- `updatedAt` stored as ms-epoch `number` to keep the schema free of Firebase types (`@salt/domain` stays pure).
- `perFlow` keys are free-form strings (not a zod enum) so a retired/unknown flow id never fails the whole-doc parse; `AI_FLOW_ROLES` is the canonical flow→role map.
- `image` capability predicate = exposes a generation method **and** name/displayName/description matches an image heuristic (`imagen`, standalone `image`, or `-image` suffix) **and** is not an embedder (the API can't mark image generation by method alone).
- Reasoning roles share one `generateContent`-and-not-(embedder/image) gate, so cheaper `flash` tiers intentionally appear for `fast`/`pro` (minimum-capability gate, not a ceiling).

## Safety / boundaries
- No AI key reaches the browser — catalog fetch and probe run server-side in admin-only callables (server-side admin re-check per #155); the browser only gets the filtered catalog / probe result.
- CF never imports `@salt/firebase-sync` (the only `firebase/functions` touchpoint is the wrappers in `@salt/firebase-sync`); CF logging stays on `firebase-functions/logger`.
- Schema is backward-compatible on read (absent doc = current behaviour); fail-open guaranteed.

## Verification
`pnpm typecheck`, `pnpm lint`, `pnpm boundary:test` (17/17), and the full suite (**133 files, 1615 tests**) all pass; `@salt/web-pwa` builds.

## Follow-ups (noted, out of scope)
- App Check stays monitor-first (`enforceAppCheck: false`) to match every other callable — flip alongside the rest at the enforcement step.
- The Test probe spends a real (tiny) Gemini call per click — admin-only and time-boxed, but a small cost surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
