### PR TITLE
chore: auto-merge low-risk Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,38 @@
+name: Dependabot auto-merge
+
+# Auto-enables merge for low-risk Dependabot PRs (patch + minor bumps only).
+# Major bumps are never auto-merged — Dependabot opens those as individual PRs
+# (see .github/dependabot.yml) so they get a human review.
+#
+# Prerequisites (one-time, in repo settings):
+#   1. Settings → General → Pull Requests → enable "Allow auto-merge".
+#   2. Branch protection on `main` requiring the CI status checks, so auto-merge
+#      waits for green before merging instead of merging immediately.
+# This workflow only flips on auto-merge; CI still gates the actual merge.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Only act on PRs opened by Dependabot.
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependabot-auto-merge.yml` so low-risk dependency bumps land without manual clicks, complementing the grouped Dependabot config in #266.

- Triggers on Dependabot PRs only (`github.actor == 'dependabot[bot]'`).
- Reads the update type via `dependabot/fetch-metadata` and **enables auto-merge only for patch and minor** bumps.
- **Major bumps are never auto-merged** — they keep arriving as individual PRs for human review.
- Uses `gh pr merge --auto --squash`, so the merge still waits for required CI checks to pass.

## Required one-time repo settings

Auto-merge won't take effect until these are enabled (they can't be set from a workflow file):

1. **Settings → General → Pull Requests → "Allow auto-merge"** must be ON.
2. **Branch protection on `main` requiring the CI status checks** — otherwise `--auto` has no gate to wait on and could merge immediately.

With both in place, a patch/minor bump auto-merges as soon as CI is green; everything else waits for you.

> Note: if `main` branch protection also **requires approvals**, Dependabot PRs will sit until approved — tell me and I'll add an auto-approve step (or you can exempt Dependabot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
