### PR TITLE
feat(ai): add a lite AI model role for cost-sensitive flows

### DIFF
--- a/apps/cloud-functions/src/ai/modelCapabilities.ts
+++ b/apps/cloud-functions/src/ai/modelCapabilities.ts
@@ -87,6 +87,7 @@ function isTextModel(model: CatalogModelLike): boolean {
 export const ROLE_CAPABILITY_PREDICATE: Record<AiModelRole, (model: CatalogModelLike) => boolean> =
   {
     fast: isTextModel,
+    lite: isTextModel,
     pro: isTextModel,
     embedding: isEmbeddingModel,
     image: isImageModel,

--- a/apps/cloud-functions/src/flows/arbitrateCanon.ts
+++ b/apps/cloud-functions/src/flows/arbitrateCanon.ts
@@ -42,7 +42,7 @@ export const arbitrateCanonFlow = ai.defineFlow(
     setActiveSpanName(`arbitrateCanon: ${req.normalisedName}`);
     const builtPrompt = buildPrompt(req);
     const result = await ai.generate({
-      model: googleAI.model(await resolveModel('fast', 'arbitrateCanon')),
+      model: googleAI.model(await resolveModel('lite', 'arbitrateCanon')),
       prompt: builtPrompt,
       output: { schema: CanonArbitrationAIOutputSchema },
       config: { temperature: 0 },

--- a/apps/cloud-functions/src/flows/generateChatTitle.ts
+++ b/apps/cloud-functions/src/flows/generateChatTitle.ts
@@ -24,7 +24,7 @@ export const generateChatTitleFlow = ai.defineFlow(
   async (input) => {
     const prompt = `User's message: "${input.userMessage}"\n\nChef's reply:\n${input.assistantResponse.slice(0, 500)}`;
 
-    const model = googleAI.model(await resolveModel('fast', 'generateChatTitle'));
+    const model = googleAI.model(await resolveModel('lite', 'generateChatTitle'));
     const result = await withAiTimeout(
       'generateChatTitle',
       () =>

--- a/apps/cloud-functions/src/flows/parseEntry.ts
+++ b/apps/cloud-functions/src/flows/parseEntry.ts
@@ -19,7 +19,7 @@ export const parseEntryFlow = ai.defineFlow(
     setActiveSpanName(`parseEntry: ${rawText}`);
     const prompt = buildPrompt(rawText);
     const result = await ai.generate({
-      model: googleAI.model(await resolveModel('fast', 'parseEntry')),
+      model: googleAI.model(await resolveModel('lite', 'parseEntry')),
       prompt,
       output: { schema: ParseEntryAIOutputSchema },
       config: { temperature: 0 },

--- a/apps/cloud-functions/src/flows/parseRecipeIngredients.ts
+++ b/apps/cloud-functions/src/flows/parseRecipeIngredients.ts
@@ -18,7 +18,7 @@ export const parseRecipeIngredientsFlow = ai.defineFlow(
     // Recipe lists are much larger prompts than single-entry calls, so Flash can
     // take 30–50s on a full ingredient list. Use a higher timeout with no retry:
     // retrying a large legitimate request just doubles the wait for no gain.
-    const model = googleAI.model(await resolveModel('fast', 'parseRecipeIngredients'));
+    const model = googleAI.model(await resolveModel('lite', 'parseRecipeIngredients'));
     const result = await withAiTimeout(
       'parseRecipeIngredients',
       () =>

--- a/apps/cloud-functions/src/flows/populateEquipmentEntry.ts
+++ b/apps/cloud-functions/src/flows/populateEquipmentEntry.ts
@@ -16,7 +16,7 @@ export const populateEquipmentEntryFlow = ai.defineFlow(
   async ({ confirmedName }) => {
     setActiveSpanName(`populateEquipmentEntry: ${confirmedName}`);
     const result = await ai.generate({
-      model: googleAI.model(await resolveModel('fast', 'populateEquipmentEntry')),
+      model: googleAI.model(await resolveModel('lite', 'populateEquipmentEntry')),
       system: SYSTEM_INSTRUCTIONS,
       prompt: `"${confirmedName}"`,
       output: { schema: PopulateEquipmentEntryAIOutputSchema },

--- a/apps/cloud-functions/tests/ai/modelCapabilities.test.ts
+++ b/apps/cloud-functions/tests/ai/modelCapabilities.test.ts
@@ -17,6 +17,11 @@ const textPro: CatalogModelLike = {
   name: 'gemini-pro-latest',
   supportedGenerationMethods: ['generateContent', 'countTokens'],
 };
+const textFlashLite: CatalogModelLike = {
+  name: 'gemini-flash-lite-latest',
+  displayName: 'Gemini Flash Lite',
+  supportedGenerationMethods: ['generateContent', 'countTokens'],
+};
 const embedder: CatalogModelLike = {
   name: 'gemini-embedding-001',
   supportedGenerationMethods: ['embedContent'],
@@ -37,6 +42,15 @@ describe('modelSupportsRole', () => {
     expect(modelSupportsRole('pro', textFlash)).toBe(true);
     expect(modelSupportsRole('fast', textPro)).toBe(true);
     expect(modelSupportsRole('pro', textPro)).toBe(true);
+  });
+
+  it('admits text models (incl. flash-lite) for the lite role and excludes embedding/image', () => {
+    expect(modelSupportsRole('lite', textFlashLite)).toBe(true);
+    expect(modelSupportsRole('lite', textFlash)).toBe(true);
+    expect(modelSupportsRole('lite', textPro)).toBe(true);
+    // The lite role reuses the text/reasoning predicate, so non-text models are out.
+    expect(modelSupportsRole('lite', embedder)).toBe(false);
+    expect(modelSupportsRole('lite', imageModel)).toBe(false);
   });
 
   it('keeps embedders and image models out of the reasoning roles', () => {

--- a/apps/cloud-functions/tests/ai/resolveModel.test.ts
+++ b/apps/cloud-functions/tests/ai/resolveModel.test.ts
@@ -30,9 +30,40 @@ describe('resolveModel', () => {
   it('falls back to defaults when the doc is absent', async () => {
     mockGet.mockResolvedValue({ exists: false });
     expect(await resolveModel('fast')).toBe(AI_MODEL_DEFAULTS.fast);
+    expect(await resolveModel('lite')).toBe(AI_MODEL_DEFAULTS.lite);
     expect(await resolveModel('pro')).toBe(AI_MODEL_DEFAULTS.pro);
     expect(await resolveModel('embedding')).toBe(AI_MODEL_DEFAULTS.embedding);
     expect(await resolveModel('image')).toBe(AI_MODEL_DEFAULTS.image);
+  });
+
+  // ─── Lite role (reassigned flows) ─────────────────────────────────────────
+  // parseRecipeIngredients (and its siblings) moved from `fast` to `lite`. The
+  // resolver is role-generic, so the contract is: a reassigned flow resolved on
+  // the `lite` role falls open to the lite default when the doc is absent or
+  // invalid, and honours a configured/overridden lite value.
+  describe('lite role', () => {
+    it('resolves the lite default for a reassigned flow when the doc is absent', async () => {
+      mockGet.mockResolvedValue({ exists: false });
+      expect(await resolveModel('lite', 'parseRecipeIngredients')).toBe(AI_MODEL_DEFAULTS.lite);
+    });
+
+    it('resolves the lite default for a reassigned flow when the doc is invalid', async () => {
+      mockGet.mockResolvedValue({ exists: true, data: () => ({ lite: 123 }) });
+      expect(await resolveModel('lite', 'parseRecipeIngredients')).toBe(AI_MODEL_DEFAULTS.lite);
+    });
+
+    it('honours a configured lite role value', async () => {
+      mockGet.mockResolvedValue({ exists: true, data: () => ({ lite: 'custom-lite-model' }) });
+      expect(await resolveModel('lite', 'parseRecipeIngredients')).toBe('custom-lite-model');
+    });
+
+    it('honours a per-flow override over the lite role value', async () => {
+      mockGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ lite: 'role-lite', perFlow: { parseRecipeIngredients: 'flow-lite' } }),
+      });
+      expect(await resolveModel('lite', 'parseRecipeIngredients')).toBe('flow-lite');
+    });
   });
 
   it('falls back to defaults when the doc is invalid (corrupt)', async () => {

--- a/apps/web-pwa/src/routes/admin/AppSettingsPage.svelte
+++ b/apps/web-pwa/src/routes/admin/AppSettingsPage.svelte
@@ -46,7 +46,13 @@
       role: 'fast',
       title: 'Fast model',
       description:
-        'Used by quick text flows: entry/recipe parsing, canon arbitration, equipment, chat titles, and URL recipe import.',
+        'Used by quick text flows that still want solid quality: recipe authoring, equipment identification, and URL recipe import.',
+    },
+    {
+      role: 'lite',
+      title: 'Lite model',
+      description:
+        'Cheap/fast tier for lightweight flows — entry/recipe-ingredient parsing, canon arbitration, equipment entry population, and chat titles — where a small quality trade-off is worth the cost and latency savings.',
     },
     {
       role: 'pro',
@@ -69,12 +75,14 @@
   // placeholder shows the default). Re-seeds whenever the saved doc changes.
   let drafts = $state<Record<AiModelRole, string>>({
     fast: '',
+    lite: '',
     pro: '',
     embedding: '',
     image: '',
   });
   let saving = $state<Record<AiModelRole, boolean>>({
     fast: false,
+    lite: false,
     pro: false,
     embedding: false,
     image: false,

--- a/packages/domain/src/schemas/appSettings.ts
+++ b/packages/domain/src/schemas/appSettings.ts
@@ -9,15 +9,16 @@ import { z } from 'zod';
 // empty, or never-configured doc resolves to the current behaviour — deleting
 // or corrupting the doc leaves AI fully working on defaults.
 
-// The four AI roles flows are bucketed into. Free-text model names per role for
+// The AI roles flows are bucketed into. Free-text model names per role for
 // now (no live catalog yet); a later phase adds validation against a catalog.
-export const AI_MODEL_ROLES = ['fast', 'pro', 'embedding', 'image'] as const;
+export const AI_MODEL_ROLES = ['fast', 'lite', 'pro', 'embedding', 'image'] as const;
 export type AiModelRole = (typeof AI_MODEL_ROLES)[number];
 
 // Today's exact production model literals — the fallback for every role. These
 // MUST stay in sync with the hardcoded literals the flows used before Phase 1.
 export const AI_MODEL_DEFAULTS = {
   fast: 'gemini-flash-latest',
+  lite: 'gemini-flash-lite-latest',
   pro: 'gemini-pro-latest',
   embedding: 'gemini-embedding-001',
   image: 'gemini-2.5-flash-image',
@@ -32,17 +33,17 @@ export const AI_MODEL_DEFAULTS = {
 // `perFlow` map of the production `appSettings` doc — renaming one orphans any
 // saved override. Add new flows here; do not rename existing ones.
 export const AI_FLOW_ROLES = {
-  arbitrateCanon: 'fast',
+  arbitrateCanon: 'lite',
   authorRecipe: 'fast',
   chefChat: 'pro',
   embedText: 'embedding',
   extractRecipeFromUrl: 'fast',
   generateCanonIcon: 'image',
-  generateChatTitle: 'fast',
+  generateChatTitle: 'lite',
   identifyEquipment: 'fast',
-  parseEntry: 'fast',
-  parseRecipeIngredients: 'fast',
-  populateEquipmentEntry: 'fast',
+  parseEntry: 'lite',
+  parseRecipeIngredients: 'lite',
+  populateEquipmentEntry: 'lite',
   serverEmbedding: 'embedding',
 } as const satisfies Record<string, AiModelRole>;
 
@@ -51,6 +52,7 @@ export const AI_FLOW_IDS = Object.keys(AI_FLOW_ROLES) as AiFlowId[];
 
 export const AppSettingsSchema = z.object({
   fast: z.string().min(1).default(AI_MODEL_DEFAULTS.fast),
+  lite: z.string().min(1).default(AI_MODEL_DEFAULTS.lite),
   pro: z.string().min(1).default(AI_MODEL_DEFAULTS.pro),
   embedding: z.string().min(1).default(AI_MODEL_DEFAULTS.embedding),
   image: z.string().min(1).default(AI_MODEL_DEFAULTS.image),

--- a/packages/domain/tests/appSettings.schema.test.ts
+++ b/packages/domain/tests/appSettings.schema.test.ts
@@ -9,6 +9,7 @@ describe('AppSettingsSchema', () => {
   it('defaults every role to today exact production literal for an empty doc', () => {
     expect(AppSettingsSchema.parse({})).toEqual({
       fast: 'gemini-flash-latest',
+      lite: 'gemini-flash-lite-latest',
       pro: 'gemini-pro-latest',
       embedding: 'gemini-embedding-001',
       image: 'gemini-2.5-flash-image',
@@ -19,14 +20,30 @@ describe('AppSettingsSchema', () => {
   it('AI_MODEL_DEFAULTS match the schema defaults', () => {
     const parsed = AppSettingsSchema.parse({});
     expect(parsed.fast).toBe(AI_MODEL_DEFAULTS.fast);
+    expect(parsed.lite).toBe(AI_MODEL_DEFAULTS.lite);
     expect(parsed.pro).toBe(AI_MODEL_DEFAULTS.pro);
     expect(parsed.embedding).toBe(AI_MODEL_DEFAULTS.embedding);
     expect(parsed.image).toBe(AI_MODEL_DEFAULTS.image);
   });
 
+  // Back-compat: a Phase 1/2 doc written before the `lite` role existed has no
+  // `lite` field; it MUST still parse and resolve `lite` to today's default so
+  // the reassigned flows keep working without a migration.
+  it('a doc without lite parses and yields the lite default (back-compat)', () => {
+    const parsed = AppSettingsSchema.parse({
+      fast: 'gemini-flash-latest',
+      pro: 'gemini-pro-latest',
+      embedding: 'gemini-embedding-001',
+      image: 'gemini-2.5-flash-image',
+    });
+    expect(parsed.lite).toBe('gemini-flash-lite-latest');
+    expect(parsed.lite).toBe(AI_MODEL_DEFAULTS.lite);
+  });
+
   it('fills only the unset roles with defaults (partial doc)', () => {
     const parsed = AppSettingsSchema.parse({ fast: 'custom-fast-model' });
     expect(parsed.fast).toBe('custom-fast-model');
+    expect(parsed.lite).toBe(AI_MODEL_DEFAULTS.lite);
     expect(parsed.pro).toBe(AI_MODEL_DEFAULTS.pro);
     expect(parsed.embedding).toBe(AI_MODEL_DEFAULTS.embedding);
     expect(parsed.image).toBe(AI_MODEL_DEFAULTS.image);
@@ -35,6 +52,7 @@ describe('AppSettingsSchema', () => {
   it('preserves explicit per-role overrides and audit metadata', () => {
     const parsed = AppSettingsSchema.parse({
       fast: 'a',
+      lite: 'a-lite',
       pro: 'b',
       embedding: 'c',
       image: 'd',
@@ -43,6 +61,7 @@ describe('AppSettingsSchema', () => {
     });
     expect(parsed).toEqual({
       fast: 'a',
+      lite: 'a-lite',
       pro: 'b',
       embedding: 'c',
       image: 'd',


### PR DESCRIPTION
Closes #281. Builds on #270 (admin-managed AI model selection), now merged to `main`.

## What changed
Registers a fifth semantic AI model role, **`lite`** — the cheap/fast tier for lightweight flows where a small quality trade-off is worth the cost and latency savings — and routes five cost-tolerant flows to it.

- **Schema** (`packages/domain/src/schemas/appSettings.ts`): `AI_MODEL_ROLES += 'lite'`; `AI_MODEL_DEFAULTS.lite = 'gemini-flash-lite-latest'`; `AppSettingsSchema += lite: z.string().min(1).default(...)`; `AI_FLOW_ROLES` reassigns the five flows to `lite`.
- **Flow reassignment** (`fast` → `lite`): `parseRecipeIngredients`, `parseEntry`, `generateChatTitle`, `populateEquipmentEntry`, `arbitrateCanon`. Changed both `AI_FLOW_ROLES` (admin grouping) **and** each flow's `resolveModel(...)` call-site literal, since the role is passed explicitly at each site.
- **Capability filter** (`apps/cloud-functions/src/ai/modelCapabilities.ts`): `lite: isTextModel` — reuses the existing `fast`/`pro` text/reasoning predicate. No new capability class.
- **Admin UI** (`apps/web-pwa/src/routes/admin/AppSettingsPage.svelte`): one `ROLE_META` entry for `lite` (card + effective readout + per-flow Advanced grouping render generically). Reworded the now-stale `fast` card copy. Embedding re-embed warning stays gated on `role === 'embedding'` only.
- **Tests**: schema back-compat (doc without `lite` yields the default); resolver returns the lite default for a reassigned flow when the doc is absent/invalid and honours configured/overridden values; classifier admits text models (incl. flash-lite) for `lite` and excludes embedding/image.

## Key decision
The five flows pass their role as an explicit literal to `resolveModel`, so the reassignment required editing the call sites too, not just `AI_FLOW_ROLES`. `resolveModel`'s own logic/cache/fallback are unchanged — it remains role-generic.

## Out of scope (do not suggest)
- Letting per-flow overrides reference a *role* instead of a literal model name (noted as a future follow-up in the issue).
- Any change to `resolveModel.ts` logic, `@salt/firebase-sync`, `firestore.rules`, the embedding warning, or non-Gemini provider seams.

## Verification
- Additive & back-compat: `.default()`ed field means existing `appSettings/singleton` docs parse unchanged — no migration. Fail-open preserved (missing/empty/corrupt doc → flows fall back to `gemini-flash-lite-latest`).
- `pnpm lint`, `pnpm typecheck`, `pnpm boundary:test` (17/17), and the full test suite (1621 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)