### PR TITLE
chore: add sonnet risk review on major dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-major-review.yml
+++ b/.github/workflows/dependabot-major-review.yml
@@ -107,16 +107,19 @@ jobs:
             **Effort if changes are needed:** <None / Small (a few edits) / Large
             (multi-file migration — warrants its own issue)>
 
-            **Recommendation:** <pick the ONE that fits:
+            **Recommendation:** Give the single clearest, most useful recommendation
+            for THIS specific situation, in your own words. The cases below are common
+            examples to orient you — NOT an exhaustive menu and NOT a constraint. If
+            the right call is something else, say that instead. Common examples:
             ✅ Safe to merge as-is — low risk, used safely /
             ⚠️ Merge, but watch <X> /
             🔧 Small code changes first (listed above) — fixable inline /
             🗺️ Large migration — do NOT merge as-is; open a dedicated issue + plan
-               (this is too big for a drive-by; consider /spec to scope it) /
-            🗑️ Remove instead of upgrade — this dependency appears unused or
-               trivially replaceable here (evidence above) /
-            ⛔ Hold — <reason, e.g. abandoned upstream, security concern, conflicts
-               with architecture>>
+               (too big for a drive-by; consider /spec to scope it) /
+            🗑️ Remove instead of upgrade — appears unused or trivially replaceable /
+            ⛔ Hold — <reason, e.g. abandoned upstream, security concern, architecture
+               conflict>
+            ...or any other recommendation that genuinely fits better.
 
             **Confidence:** <Low / Medium / High> — <one line on why, e.g. couldn't
             find a changelog>

--- a/.github/workflows/dependabot-major-review.yml
+++ b/.github/workflows/dependabot-major-review.yml
@@ -1,0 +1,114 @@
+name: Dependabot major-update review
+
+# Posts an automated risk/impact assessment + recommendation on MAJOR-version
+# Dependabot PRs. It NEVER approves or merges — it only comments, to help a
+# non-coder decide whether a major bump is safe to merge.
+#
+# Why pull_request_target: Dependabot-triggered runs can't read Actions secrets
+# (needed for CLAUDE_CODE_OAUTH_TOKEN). pull_request_target runs from the base
+# branch (main) with secret access. To stay safe we NEVER check out or execute
+# the updated dependency — the review only reads existing code, the PR diff via
+# `gh`, and public changelogs.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: dependabot-major-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  major-review:
+    runs-on: ubuntu-latest
+    # Any PR authored by Dependabot (regardless of who opened/reopened it).
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Check out base branch (main) — never the PR head
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sonnet risk/impact assessment (major bumps only)
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' }}
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: >-
+            --max-turns 30
+            --model claude-sonnet-4-6
+            --allowed-tools "Read,Grep,Glob,WebFetch,WebSearch,Bash(git log:*),Bash(git diff:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"
+          prompt: |
+            You are assessing a MAJOR-version Dependabot update for a NON-TECHNICAL
+            repository owner. Produce a risk/impact assessment and a clear
+            recommendation. You do NOT approve or merge — you only post one comment.
+
+            PR number: ${{ github.event.pull_request.number }}
+            PR title: ${{ github.event.pull_request.title }}
+            Package(s): ${{ steps.meta.outputs.dependency-names }}
+            Update: ${{ steps.meta.outputs.previous-version }} → ${{ steps.meta.outputs.new-version }}
+
+            ## Steps
+
+            1. Run `gh pr view ${{ github.event.pull_request.number }} --json title,body`
+               and `gh pr diff ${{ github.event.pull_request.number }}` to confirm
+               exactly which package(s) bump and the old → new versions. Dependabot's
+               PR body usually links release notes / changelogs — note them.
+            2. Use WebFetch / WebSearch to find the official changelog, release notes,
+               or migration guide for the NEW major version. Focus on documented
+               BREAKING CHANGES. If you can't find reliable notes, say so and lower
+               your confidence rather than guessing.
+            3. Determine how THIS repo actually uses the package: Grep/Glob/Read for
+               its import name and the specific APIs/exports the code relies on. A
+               breaking change only matters if it touches an API this repo uses.
+            4. Where relevant, cross-check repo conventions in CLAUDE.md (e.g. the
+               Firebase-only-in-firebase-sync rule, AI/Genkit conventions).
+            5. Decide a risk level and a recommendation.
+
+            ## Output
+
+            Post EXACTLY ONE comment with
+            `gh pr comment ${{ github.event.pull_request.number }} --body "..."`,
+            in plain English a non-coder can act on, using this structure:
+
+            ## 🤖 Automated major-update assessment (not an approval)
+
+            **Package:** <name> <old> → <new>
+            **Risk:** 🟢 Low / 🟡 Medium / 🔴 High
+
+            **What this update is:** <1–2 plain sentences>
+
+            **Breaking changes that matter here:** <bullets of the breaking changes
+            that actually touch how this repo uses the package — or "None found that
+            affect this repo's usage">
+
+            **What could break:** <plain language, or "Nothing obvious">
+
+            **Code changes needed before merging:** <"None" or a short list>
+
+            **Recommendation:** <pick one:
+            ✅ Safe to merge as-is /
+            ⚠️ Merge, but watch <X> /
+            🔧 Needs code changes first (summarised above) /
+            ⛔ Hold — <reason>>
+
+            **Confidence:** <Low / Medium / High> — <one line on why, e.g. couldn't
+            find a changelog>
+
+            ## Rules
+            - Do NOT edit any files. Do NOT approve or merge the PR.
+            - Keep it concise and concrete; no filler.
+            - Never execute or install the updated dependency; analyse from the diff,
+              the existing code, and public docs only.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-major-review.yml
+++ b/.github/workflows/dependabot-major-review.yml
@@ -71,9 +71,15 @@ jobs:
             3. Determine how THIS repo actually uses the package: Grep/Glob/Read for
                its import name and the specific APIs/exports the code relies on. A
                breaking change only matters if it touches an API this repo uses.
-            4. Where relevant, cross-check repo conventions in CLAUDE.md (e.g. the
+            4. Assess NECESSITY. Is it a direct dependency (in a package.json) or only
+               transitive? Is it actually imported/used anywhere? If it appears unused
+               or trivially replaceable, removal may beat upgrading — say so.
+            5. Estimate EFFORT if changes are needed: a one-line tweak, a handful of
+               call-site edits, or a large multi-file/architectural migration. A large
+               migration should be tracked as its own issue + plan, NOT a drive-by fix.
+            6. Where relevant, cross-check repo conventions in CLAUDE.md (e.g. the
                Firebase-only-in-firebase-sync rule, AI/Genkit conventions).
-            5. Decide a risk level and a recommendation.
+            7. Decide a risk level, an effort estimate, and a recommendation.
 
             ## Output
 
@@ -94,13 +100,23 @@ jobs:
 
             **What could break:** <plain language, or "Nothing obvious">
 
-            **Code changes needed before merging:** <"None" or a short list>
+            **Is this dependency still needed?** <"Yes — used in <where>" / "Looks
+            unused or transitive — see recommendation" / "Direct dep, lightly used">
 
-            **Recommendation:** <pick one:
-            ✅ Safe to merge as-is /
+            **Code changes needed before merging:** <"None" or a short list>
+            **Effort if changes are needed:** <None / Small (a few edits) / Large
+            (multi-file migration — warrants its own issue)>
+
+            **Recommendation:** <pick the ONE that fits:
+            ✅ Safe to merge as-is — low risk, used safely /
             ⚠️ Merge, but watch <X> /
-            🔧 Needs code changes first (summarised above) /
-            ⛔ Hold — <reason>>
+            🔧 Small code changes first (listed above) — fixable inline /
+            🗺️ Large migration — do NOT merge as-is; open a dedicated issue + plan
+               (this is too big for a drive-by; consider /spec to scope it) /
+            🗑️ Remove instead of upgrade — this dependency appears unused or
+               trivially replaceable here (evidence above) /
+            ⛔ Hold — <reason, e.g. abandoned upstream, security concern, conflicts
+               with architecture>>
 
             **Confidence:** <Low / Medium / High> — <one line on why, e.g. couldn't
             find a changelog>


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependabot-major-review.yml` — an automated Sonnet **risk/impact assessment** on major-version Dependabot PRs, to help decide whether a major bump is safe to merge. It **never approves or merges** — comment only.

What it does on each major Dependabot PR:
- Reads the changelog / migration guide for the new major version (public docs).
- Greps how *this* repo actually uses the package, so it only flags breaking changes that touch our usage.
- Posts one plain-language comment: package + versions, a 🟢/🟡/🔴 risk level, what could break, any code changes needed, a clear recommendation (safe / caution / needs changes / hold), and a confidence level.
- Scoped to read-only tools — it cannot edit, approve, or merge.

## Safety note

Uses `pull_request_target` because Dependabot-triggered runs can't read Actions secrets (needed for `CLAUDE_CODE_OAUTH_TOKEN`). To avoid the usual `pull_request_target` risk, the job **checks out `main`, never the PR head, and never installs or runs the updated dependency** — it analyses only existing code, the PR diff via `gh`, and public changelogs.

## Scope

- Minor/patch bumps are untouched here (those auto-merge via the separate workflow).
- Only triggers on Dependabot-authored PRs; only proceeds when `fetch-metadata` reports a major bump.

## Onboarding the current backlog

The eight open major PRs (#272–#279) predate this workflow, so they won't be reviewed until a fresh open/reopen event. After merge, closing + reopening each one will trigger an assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
