### PR TITLE
ci: run integration + e2e concurrently, skip when rebase needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.detect.outputs.code }}
+      uptodate: ${{ steps.detect.outputs.uptodate }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,10 +36,12 @@ jobs:
           set -euo pipefail
 
           # Non-PR events (push to main) always run the full suite — main is the
-          # deploy source and must stay genuinely green.
+          # deploy source and must stay genuinely green. Nothing to rebase
+          # against, so uptodate is trivially true.
           if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "Event '$EVENT_NAME' is not a pull_request — running full CI."
             echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "uptodate=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -53,11 +56,34 @@ jobs:
 
           if [ -n "$non_doc" ]; then
             echo "Non-documentation changes detected — running full CI."
-            echo "code=true" >> "$GITHUB_OUTPUT"
+            code=true
           else
             echo "Documentation-only change — skipping emulator + e2e suites."
-            echo "code=false" >> "$GITHUB_OUTPUT"
+            code=false
           fi
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+
+          # Up-to-date gate. The "Main" ruleset uses
+          # strict_required_status_checks_policy (= "require branches to be up
+          # to date before merging"), so a branch behind origin/main CANNOT
+          # merge until it is rebased — and that rebase re-triggers this whole
+          # workflow. Running the heavy emulator + Playwright suites on a branch
+          # that is already behind is therefore pure waste: the result is thrown
+          # away at rebase. When behind, mark uptodate=false so the heavy jobs
+          # skip (a skipped required check passes; strict mode still blocks the
+          # merge until the branch is updated, at which point CI runs for real).
+          # Only meaningful when code=true (the heavy suites would otherwise run).
+          uptodate=true
+          if [ "$code" = "true" ]; then
+            git fetch --no-tags origin main
+            if git merge-base --is-ancestor FETCH_HEAD "$HEAD_SHA"; then
+              echo "Branch is up to date with origin/main — heavy suites will run."
+            else
+              echo "Branch is behind origin/main — rebase required before merge; skipping heavy suites this run."
+              uptodate=false
+            fi
+          fi
+          echo "uptodate=$uptodate" >> "$GITHUB_OUTPUT"
 
   ci:
     name: Lint, typecheck, test, boundary
@@ -104,15 +130,24 @@ jobs:
   # (docker-compose.vitest.yml, project salt-vitest-emulators, 8082/9101).
   # scripts/test-emulator.mjs owns the full lifecycle: down -v -> up --wait
   # (healthcheck-gated) -> run suites -> always down -v in a finally. No Java,
-  # no CF prebuild, no Playwright. Sequenced before e2e (e2e `needs:` this job)
-  # so the two composed stacks are never concurrent — non-concurrent by design
-  # per #84; this is also the cheaper suite, so it fails fast ahead of e2e.
+  # no CF prebuild, no Playwright.
+  #
+  # Gated behind `ci` (lint/typecheck/unit/boundary) so the heavy emulator
+  # suites only start once the cheap checks pass. Runs CONCURRENTLY with e2e:
+  # the #84 "never concurrent" rule is a SINGLE-HOST constraint (local dev runs
+  # both stacks on one machine). In CI each job gets its own ubuntu-latest
+  # runner, so the two composed stacks never share ports/volumes/Docker state —
+  # the structural isolation (distinct project + ports 8082/9101 vs 8081/9100)
+  # is belt-and-suspenders here. They stay non-concurrent for LOCAL runs only.
+  #
+  # Skipped (→ passes as a required check) for documentation-only PRs and for
+  # branches behind origin/main (strict ruleset forces a rebase that
+  # re-triggers CI — see the `changes` job's uptodate gate).
   vitest-integration:
     name: Vitest integration (emulator)
     runs-on: ubuntu-latest
-    # Skipped (→ passes as a required check) for documentation-only PRs.
-    needs: changes
-    if: ${{ needs.changes.outputs.code == 'true' }}
+    needs: [changes, ci]
+    if: ${{ needs.changes.outputs.code == 'true' && needs.changes.outputs.uptodate == 'true' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -140,12 +175,15 @@ jobs:
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest
-    # Sequenced after the Vitest integration stack so the e2e composed stack
-    # (docker-compose.test.yml, project test-emulators, 8081/9100/5002) is
-    # never concurrent with the Vitest one — non-concurrent by design (#84).
-    # Skipped (→ passes as a required check) for documentation-only PRs.
-    needs: [changes, vitest-integration]
-    if: ${{ needs.changes.outputs.code == 'true' }}
+    # Gated behind `ci`; runs CONCURRENTLY with vitest-integration. Separate
+    # runners mean the e2e composed stack (docker-compose.test.yml, project
+    # test-emulators, 8081/9100/5002) never collides with the Vitest stack
+    # (8082/9101) — the #84 non-concurrency rule is a single-host constraint
+    # that does not apply across GitHub Actions jobs (see vitest-integration).
+    # Skipped (→ passes as a required check) for documentation-only PRs and for
+    # branches behind origin/main (see the `changes` job's uptodate gate).
+    needs: [changes, ci]
+    if: ${{ needs.changes.outputs.code == 'true' && needs.changes.outputs.uptodate == 'true' }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What

Two CI changes to the heavy emulator suites in `.github/workflows/ci.yml`:

1. **Run `Vitest integration (emulator)` and `E2E (Playwright)` concurrently.** They were sequenced (`e2e needs: vitest-integration`) under the #84 "never concurrent" rule. That rule is a **single-host** constraint (local dev runs both stacks on one machine). In CI each job gets its own `ubuntu-latest` runner, so the two emulator stacks — Vitest on `8082/9101`, e2e on `8081/9100/5002` — never share ports, volumes, or Docker state. Both now gate behind the cheap `ci` job (lint/typecheck/unit/boundary) and overlap.

2. **Skip the heavy suites when the branch is behind `origin/main`.** The "Main" ruleset uses `strict_required_status_checks_policy` ("require branches up to date before merging"), so a behind branch can't merge until rebased — and rebasing re-triggers CI. Running the emulator/e2e suites on an already-behind branch is wasted work. The `changes` job now emits an `uptodate` output (`git merge-base --is-ancestor`); when `false`, the heavy jobs skip.

## Why it's safe

- A **skipped required check counts as passing**, so skips don't wedge the merge gate.
- When a branch is behind, strict mode blocks the merge regardless until it's updated — and that update re-triggers CI, running the heavy suites for real on the up-to-date SHA.
- Required check **contexts are unchanged** (`Lint, typecheck, test, boundary`, `Vitest integration (emulator)`, `E2E (Playwright)`), so the ruleset stays satisfied.

## Wall-clock

Critical path becomes roughly `changes → ci → max(vitest, e2e)` instead of `changes → vitest → e2e` — the two long suites overlap instead of running back-to-back.

## Caveat

With the up-to-date skip, bypass-merging a behind branch (only the repo admin can) would merge a state where the heavy suites were skipped. The normal non-bypass path can't hit this — strict mode forces the rebase + real run first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)