### PR TITLE
fix: add id-token write permission to major-review workflow

### DIFF
--- a/.github/workflows/dependabot-major-review.yml
+++ b/.github/workflows/dependabot-major-review.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write # required by claude-code-action for OIDC token exchange
 
 concurrency:
   group: dependabot-major-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

The major-review workflow (#284) failed on every run with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

`anthropics/claude-code-action` needs `id-token: write` for its OIDC token exchange — the same permission `nightly-doc-review.yml` already declares. It was missing from `dependabot-major-review.yml`, so all four backlog review runs died before doing any analysis (no comments posted).

This adds the one missing permission. Once merged, re-triggering the major PRs (close+reopen) will post the assessments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)