### PR TITLE
fix: pass github_token to major-review to skip OIDC app exchange

### DIFF
--- a/.github/workflows/dependabot-major-review.yml
+++ b/.github/workflows/dependabot-major-review.yml
@@ -45,6 +45,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Pass the workflow token explicitly so the action does NOT attempt the
+          # GitHub App OIDC token exchange, which 401s under pull_request_target.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: >-
             --max-turns 30
             --model claude-sonnet-4-6


### PR DESCRIPTION
## Summary

Follow-up to #286. With `id-token: write` added, the action now obtains an OIDC token, but the next step fails:

> Exchanging OIDC token for app token... App token exchange failed: 401 Unauthorized - Invalid OIDC token

The action attempts a GitHub **App** token exchange via OIDC, which the Claude app endpoint rejects under `pull_request_target` (the OIDC claims differ from a trusted `schedule`/default-branch context like the nightly workflow).

Passing `github_token: ${{ secrets.GITHUB_TOKEN }}` makes the action use the workflow token for GitHub operations and **skip the App-token exchange** altogether. Claude model auth is unaffected — it still uses `CLAUDE_CODE_OAUTH_TOKEN`.

Once merged, re-triggering the four major PRs will post the assessments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)