### PR TITLE
ci: skip e2e + integration suites for non-app changes

### DIFF
--- a/.claude/commands/defect.md
+++ b/.claude/commands/defect.md
@@ -63,7 +63,7 @@ remediation require? What is the risk of NOT fixing.]
 ## Architecture Notes & Constraints
 [Layer map references, packages touched, constraints from CLAUDE.md (purity, schema/back-compat).
 **Behavior that must be preserved**, and the tests that encode it. What must NOT be done.
-Written for a fresh Sonnet agent.]
+Written for a fresh agent with no prior context.]
 
 ## Open Questions / Decisions
 [Every fork raised in Step 3, each as:

--- a/.claude/commands/refactor-spec.md
+++ b/.claude/commands/refactor-spec.md
@@ -47,7 +47,7 @@ red flag, not a phase.]
 ## Architecture Notes
 [Target-state layer map. Packages touched. Migration approach: in-place / parallel-implementation
 behind a flag / strangler (incremental call-site migration). Existing patterns to reuse.
-Constraints from CLAUDE.md. Written for a fresh Sonnet agent.]
+Constraints from CLAUDE.md. Written for a fresh agent with no prior context.]
 
 ## Open Questions / Decisions
 [Every cut-point or risk raised in Step 2, each as:

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -24,7 +24,7 @@ No implementation detail. Written for a non-coder deciding if this is right.]
 
 ## Architecture Notes
 [Layer map references. Packages touched. Key decisions made. Constraints from CLAUDE.md.
-What must NOT be done. Existing patterns to reuse. Written for a fresh Sonnet agent.]
+What must NOT be done. Existing patterns to reuse. Written for a fresh agent with no prior context.]
 
 ## Open Questions / Decisions
 [Every architecture risk or fork raised in Step 2 goes here, each as:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ permissions:
   actions: read
 
 jobs:
-  # Decide whether a PR touches anything other than documentation. The heavy
-  # emulator + Playwright suites are skipped for docs-only PRs, but this
-  # workflow still TRIGGERS on every PR so the required status checks report
+  # Decide whether a PR touches app code. The heavy emulator + Playwright
+  # suites are skipped for non-app PRs (docs / CI / tooling — see the allowlist
+  # below), but this workflow still TRIGGERS on every PR so the required status checks report
   # (a skipped required job passes; an un-triggered one would block merge
   # forever waiting on a context that never appears).
   changes:
@@ -49,16 +49,31 @@ jobs:
           echo "Changed files:"
           echo "$changed"
 
-          # Documentation-only allowlist. Anything NOT matched here counts as
-          # code and triggers the full suite, so a mixed code+docs PR runs
-          # everything. Conservative by design.
-          non_doc=$(echo "$changed" | grep -vE '^(docs/|.*\.md$|LICENSE$)' || true)
+          # Non-app allowlist. These paths cannot change the runtime behaviour
+          # of the app, so the heavy emulator + Playwright suites (which only
+          # exercise app behaviour) are pure waste for them:
+          #   - docs/, *.md, LICENSE        — documentation
+          #   - .github/                    — CI / dependabot config
+          #   - .claude/                    — AI-agent tooling (commands, settings)
+          #   - .vscode/, .editorconfig,
+          #     .nvmrc, .gitignore,
+          #     .vexpignore                 — editor / meta dotfiles
+          # Anything NOT matched here counts as code and triggers the full
+          # suite, so a mixed code+non-app PR runs everything. Conservative by
+          # design. Lint/typecheck/unit/boundary (the `ci` job) always run
+          # regardless — only the heavy suites are gated.
+          #
+          # Caveat: a change to the e2e / vitest-integration job setup *inside*
+          # .github/workflows/ci.yml will itself skip those suites, so such a
+          # change cannot be validated green by this run — verify it on a
+          # follow-up PR that also touches app code.
+          non_app=$(echo "$changed" | grep -vE '^(docs/|.*\.md$|LICENSE$|\.github/|\.claude/|\.vscode/|\.editorconfig$|\.nvmrc$|\.gitignore$|\.vexpignore$)' || true)
 
-          if [ -n "$non_doc" ]; then
-            echo "Non-documentation changes detected — running full CI."
+          if [ -n "$non_app" ]; then
+            echo "App-impacting changes detected — running full CI."
             code=true
           else
-            echo "Documentation-only change — skipping emulator + e2e suites."
+            echo "Non-app change (docs / CI / tooling) — skipping emulator + e2e suites."
             code=false
           fi
           echo "code=$code" >> "$GITHUB_OUTPUT"
@@ -140,8 +155,8 @@ jobs:
   # the structural isolation (distinct project + ports 8082/9101 vs 8081/9100)
   # is belt-and-suspenders here. They stay non-concurrent for LOCAL runs only.
   #
-  # Skipped (→ passes as a required check) for documentation-only PRs and for
-  # branches behind origin/main (strict ruleset forces a rebase that
+  # Skipped (→ passes as a required check) for non-app PRs (docs / CI / tooling)
+  # and for branches behind origin/main (strict ruleset forces a rebase that
   # re-triggers CI — see the `changes` job's uptodate gate).
   vitest-integration:
     name: Vitest integration (emulator)
@@ -180,8 +195,8 @@ jobs:
     # test-emulators, 8081/9100/5002) never collides with the Vitest stack
     # (8082/9101) — the #84 non-concurrency rule is a single-host constraint
     # that does not apply across GitHub Actions jobs (see vitest-integration).
-    # Skipped (→ passes as a required check) for documentation-only PRs and for
-    # branches behind origin/main (see the `changes` job's uptodate gate).
+    # Skipped (→ passes as a required check) for non-app PRs (docs / CI / tooling)
+    # and for branches behind origin/main (see the `changes` job's uptodate gate).
     needs: [changes, ci]
     if: ${{ needs.changes.outputs.code == 'true' && needs.changes.outputs.uptodate == 'true' }}
 


### PR DESCRIPTION
## What

Widen the `changes`-detection allowlist in `.github/workflows/ci.yml` from **docs-only** to **non-app**. The heavy **Vitest integration (emulator)** and **E2E (Playwright)** suites now skip for paths that cannot change runtime app behaviour:

- `docs/`, `*.md`, `LICENSE` (existing)
- `.github/` — CI & dependabot config
- `.claude/` — agent tooling
- `.vscode/`, `.editorconfig`, `.nvmrc`, `.gitignore`, `.vexpignore` — editor/meta dotfiles

## Why

These suites only exercise app behaviour, so running them on CI/tooling/docs changes is pure waste — slow feedback and wasted compute. Skipped jobs report as passed required checks, so merge isn't blocked.

## Safety

- **Lint/typecheck/unit/boundary** (the `ci` job) still run on everything — no gate.
- **Mixed** app+non-app PRs run the full suite (conservative allowlist).
- **Pushes to `main`** always run everything (deploy source).

## Caveat (documented inline)

Because `ci.yml` is itself in the skip list, a change to the e2e/vitest-integration **job setup** inside it will also skip those suites — so validate such structural test-job changes on a follow-up PR that also touches app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)