### PR TITLE
chore: use opus 4.8 for the major-review assessment

### DIFF
--- a/.github/workflows/dependabot-major-review.yml
+++ b/.github/workflows/dependabot-major-review.yml
@@ -40,14 +40,14 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sonnet risk/impact assessment (major bumps only)
+      - name: Opus risk/impact assessment (major bumps only)
         if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' }}
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: >-
             --max-turns 30
-            --model claude-sonnet-4-6
+            --model claude-opus-4-8
             --allowed-tools "Read,Grep,Glob,WebFetch,WebSearch,Bash(git log:*),Bash(git diff:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"
           prompt: |
             You are assessing a MAJOR-version Dependabot update for a NON-TECHNICAL


### PR DESCRIPTION
## Summary

Switches the Dependabot major-review workflow from `claude-sonnet-4-6` to `claude-opus-4-8`.

The major-update review is a judgment-heavy task — read a changelog, map breaking changes onto how this repo actually uses the package, and give a non-coder a recommendation they can't independently verify. Opus 4.8 is stronger at exactly this (code review / real-bug finding / clear explanations), and it only runs on major bumps (low volume), so the cost difference is negligible. Runs on the Max subscription token, so there's no separate per-token bill either way.

Sonnet stays the right call for cheaper/mechanical jobs (e.g. the nightly doc review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)