### PR TITLE
ci: fix autofix push auth and skip husky hook

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -75,6 +75,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          # Do NOT persist the default GITHUB_TOKEN as an http.extraheader auth
+          # header: that header overrides the App-token credentials embedded in
+          # the push URL below, so the push would go out as the read-only
+          # github-actions[bot] and be denied (403). With this off, the push
+          # uses only the App token. (The clone itself still uses the default
+          # token; it just isn't left behind in .git/config.)
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
         with:
@@ -128,7 +135,14 @@ jobs:
           set -euo pipefail
           git config user.name "${APP_SLUG}[bot]"
           git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
-          git commit -am "style: apply prettier formatting"
+          # --no-verify: `pnpm install` installs husky's hooks, so a plain
+          # commit would fire the local pre-commit hook (lint-staged + typecheck
+          # + dependency-cruiser) inside CI. That is wasteful and, worse, would
+          # ABORT the formatting commit whenever the dependency bump breaks
+          # typecheck — exactly when we still want the format fix pushed so only
+          # the real failure remains. Autofix must never gate on those checks;
+          # ci.yml runs them as required status checks on the pushed commit.
+          git commit --no-verify -am "style: apply prettier formatting"
           # Push with the App token (re-triggers CI). No --force: if the branch
           # advanced meanwhile the push is rejected and the next synchronize
           # re-runs this workflow on the newer commit.


### PR DESCRIPTION
Follow-up to #295. The first live run (on the `prettier-plugin-svelte` 3→4 dependabot PR) formatted the 4 files correctly and committed, but **failed to push (403)**. Two bugs:

### 1. Push used the read-only default token, not the App token
`actions/checkout` persists the default `GITHUB_TOKEN` as an `http.<host>.extraheader` Authorization header. That header **overrides** the App-token credentials embedded in the push URL, so the push went out as `github-actions[bot]` (read-only under `pull_request_target` here) and was denied.

**Fix:** `persist-credentials: false` on checkout — the clone still uses the default token, but it isn't left in `.git/config`, so the push uses only the App token.

### 2. The autofix commit fired husky's pre-commit hook
`pnpm install` installs husky's hooks, so `git commit` ran the full local pre-commit hook (lint-staged + typecheck + dependency-cruiser) inside CI. It passed this time, but on a bump that breaks typecheck it would **abort the format commit** — exactly when we still want the format fix pushed so only the real failure remains.

**Fix:** `git commit --no-verify`. Autofix must never gate on those checks; `ci.yml` runs them as required status checks on the pushed commit anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)