### PR TITLE
chore(deps): ignore blocked major bumps (zod 4, OpenTelemetry 2.x, firebase-admin 14, Vite 8)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,15 @@ updates:
       # once firebase-functions peers firebase-admin ^14 and #303 lands.
       - dependency-name: "firebase-admin"
         update-types: ["version-update:semver-major"]
+      # @sveltejs/vite-plugin-svelte 7 peers Vite 8 (beta), while plugin 6 caps
+      # at Vite 7 — so the plugin and Vite majors are locked together and
+      # neither can move alone. Bumping the plugin to 7 against Vite 7 stops the
+      # app's Vite server from booting and times out E2E (#274). Both majors are
+      # ignored until the lockstep Vite 8 migration in #304 lands.
+      - dependency-name: "@sveltejs/vite-plugin-svelte"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,14 @@ updates:
       # migration in #298 lands. (Minor/patch within zod 3 still flow normally.)
       - dependency-name: "zod"
         update-types: ["version-update:semver-major"]
+      # OpenTelemetry SDK 2.x is a lockstep migration across every
+      # @opentelemetry/* package, plus 2.0 API breaks (NodeTracerProvider
+      # addSpanProcessor removed; Resource construction changed) in
+      # ld-observability/server and cloud-functions tracing. Bumping one otel
+      # package alone leaves incompatible 1.x/2.x copies in the tree. Suppress
+      # individual major PRs (currently #279) until the migration in #300 lands.
+      - dependency-name: "@opentelemetry/*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,14 @@ updates:
           - "patch"
     # Major updates match no group above, so Dependabot opens them as
     # individual PRs that warrant a closer look.
+    ignore:
+      # zod 4 is blocked: @genkit-ai/core (the sole zod source for the Genkit
+      # stack) pins zod ^3.23.8 up to its latest release (1.37.0), so zod 4's
+      # ZodObject fails Genkit's zod-3 ZodTypeAny constraint at every flow
+      # boundary. Re-enable once a Genkit release accepts zod 4 and the lockstep
+      # migration in #298 lands. (Minor/patch within zod 3 still flow normally.)
+      - dependency-name: "zod"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,13 @@ updates:
       # individual major PRs (currently #279) until the migration in #300 lands.
       - dependency-name: "@opentelemetry/*"
         update-types: ["version-update:semver-major"]
+      # firebase-admin 14 is blocked on firebase-functions: its latest release
+      # (7.2.5) peers firebase-admin ^11||^12||^13, excluding 14. pnpm only
+      # warns, but the CF deploy build's `npm install --prefix dist` enforces
+      # peers strictly and fails ERESOLVE, breaking E2E globalSetup. Re-enable
+      # once firebase-functions peers firebase-admin ^14 and #303 lands.
+      - dependency-name: "firebase-admin"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Stops Dependabot from re-opening major bumps that are blocked behind dedicated migrations, scoped to **major only** (minor/patch still flow).

### zod major — refs #298, #277
`@genkit-ai/core` pins `zod@^3.23.8` through its latest release (1.37.0). zod 4's restructured `ZodObject` fails Genkit's zod-3 `ZodTypeAny` at every `defineFlow`/`generate` boundary, so #277 fails typecheck across nearly every Cloud Function. Blocked upstream until a Genkit release accepts zod 4.

### @opentelemetry/* major — refs #300, #279
OpenTelemetry SDK 2.x is a lockstep migration across all `@opentelemetry/*` packages plus 2.0 API breaks (`NodeTracerProvider.addSpanProcessor` removed; `Resource` construction changed) in `ld-observability/server` and CF tracing. Bumping one package alone (#279) leaves incompatible 1.x/2.x copies. Not blocked upstream — a planned migration.

### firebase-admin major — refs #303, #278
`firebase-functions@7.2.5` (latest) peers `firebase-admin@^11||^12||^13`, excluding 14. The package manager only warns, but the CF deploy build's strict `npm install --prefix dist` → `ERESOLVE` → E2E `globalSetup` fails (#278). Blocked upstream until firebase-functions peers `firebase-admin@^14`.

### vite + @sveltejs/vite-plugin-svelte major — refs #304, #274
`@sveltejs/vite-plugin-svelte` 7 peers Vite 8 (beta); plugin 6 caps at Vite 7. The two majors are locked together — bumping the plugin to 7 against Vite 7 stops the app's Vite server from booting and times out E2E (#274). Blocked until Vite 8 is stable and the toolchain supports it; both majors ignored.

Remove each rule when its tracking issue lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
