### PR TITLE
ci: allow dependabot[bot] in major-review claude-code-action

### DIFF
--- a/.github/workflows/dependabot-major-review.yml
+++ b/.github/workflows/dependabot-major-review.yml
@@ -48,6 +48,11 @@ jobs:
           # Pass the workflow token explicitly so the action does NOT attempt the
           # GitHub App OIDC token exchange, which 401s under pull_request_target.
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # claude-code-action rejects bot-initiated runs by default ("Workflow
+          # initiated by non-human actor"). This workflow exists ONLY to review
+          # Dependabot PRs, and the job-level `if:` already gates on that exact
+          # author, so allow just dependabot[bot] (not '*') to clear the gate.
+          allowed_bots: "dependabot[bot]"
           claude_args: >-
             --max-turns 30
             --model claude-opus-4-8


### PR DESCRIPTION
## Problem

Every Dependabot **major-version** PR was failing the *Dependabot major-update review* workflow. The job ran (checkout + metadata), but the `anthropics/claude-code-action@v1` step aborted before Claude executed:

```
##[error]Workflow initiated by non-human actor: dependabot (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

A recent version of the action added a security gate that **rejects bot-initiated runs by default** (`allowed_bots` defaults to `""` = no bots). Since this workflow is always triggered by `dependabot[bot]`, the assessment never ran — producing a string of `failure` runs (commitlint, tailwindcss, jsdom, typescript, etc.).

## Fix

Add one input to the action step:

```yaml
allowed_bots: "dependabot[bot]"
```

Scoped to `dependabot[bot]` rather than `*` because:
- The job-level `if:` already gates on `github.event.pull_request.user.login == 'dependabot[bot]'`, so no other bot can reach the step.
- It runs under `pull_request_target` with secret access, so `*` is the riskier choice (the action's own docs warn external Apps could invoke it on public repos with `*`).

The other two workflows using the action are unaffected: `claude.yml` is gated to a human actor, and `nightly-doc-review.yml` runs on `schedule`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)