### PR TITLE
fix(canon): bound and emulator-gate onCanonItemWritten AI side-effects

### DIFF
--- a/apps/cloud-functions/src/flows/embedText.ts
+++ b/apps/cloud-functions/src/flows/embedText.ts
@@ -4,6 +4,13 @@ import { EmbedTextInputSchema } from '@salt/domain/schemas';
 import { setActiveSpanName } from '@salt/ld-observability/server';
 import { ai } from '../genkit.js';
 import { resolveModel } from '../ai/resolveModel.js';
+import { aiFakeEnabled } from '../ai/fakeModel.js';
+
+// Deterministic stand-in returned under the e2e fake flag. Any length is
+// schema-valid (CanonItemSchema.embedding is z.array(number).nullable) and the
+// e2e suite never compares embeddings (it matches at stage-1 exact), so the
+// values only need to be present and stable.
+const FAKE_EMBEDDING = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8];
 
 export const embedTextFlow = ai.defineFlow(
   {
@@ -13,6 +20,15 @@ export const embedTextFlow = ai.defineFlow(
   },
   async ({ text }) => {
     setActiveSpanName(`embedText: ${text}`);
+    // E2E fake seam: the Genkit embedder has no flowModel-style fake (that seam
+    // swaps chat models only), so a real ai.embed() would run under
+    // FUNCTIONS_AI_FAKE, ECONNRESET against the fake key, and — called without
+    // withAiTimeout from onCanonItemWritten — hang the trigger. Return a canned
+    // vector so the embedding write-back path stays exercised, deterministically
+    // and offline. Unreachable in production (the flag is never set there).
+    if (aiFakeEnabled()) {
+      return { values: [...FAKE_EMBEDDING] };
+    }
     // The admin-configured model is free text (Phase 1), so it is wider than
     // the SDK's literal-union embedder param — launder it across the boundary.
     const embedder = googleAI.embedder(

--- a/apps/cloud-functions/src/triggers/onCanonItemWritten.ts
+++ b/apps/cloud-functions/src/triggers/onCanonItemWritten.ts
@@ -8,6 +8,8 @@ import { CanonItemSchema, DevSettingsSchema, type CanonItemDoc } from '@salt/dom
 import { embedTextFlow } from '../flows/embedText.js';
 import { generateCanonIconFlow } from '../flows/generateCanonIcon.js';
 import { removeFlatBackground } from '../imaging/removeFlatBackground.js';
+import { withAiTimeout } from '../adapters/withAiTimeout.js';
+import { aiFakeEnabled } from '../ai/fakeModel.js';
 
 // Defined here (not imported from index.ts) to avoid a circular import; the
 // Firebase CLI aggregates same-named defineSecret calls across files at deploy
@@ -28,7 +30,7 @@ async function maybeGenerateEmbedding(id: string, item: CanonItemDoc): Promise<v
   if (!normalised) return;
 
   try {
-    const { values } = await embedTextFlow({ text: normalised });
+    const { values } = await withAiTimeout('embedText', () => embedTextFlow({ text: normalised }));
     await getFirestore().collection('canonItems').doc(id).update({ embedding: values });
   } catch (err) {
     logger.error('onCanonItemWritten: embedding failed', { id, err });
@@ -47,6 +49,12 @@ async function maybeGenerateEmbedding(id: string, item: CanonItemDoc): Promise<v
 async function maybeGenerateIcon(id: string, item: CanonItemDoc): Promise<void> {
   if (item.thumbnail !== null) return; // real URL or "hidden" sentinel → skip
 
+  // E2E (FUNCTIONS_AI_FAKE): skip icon generation entirely. The real image model
+  // and the Storage upload (which authenticates via the GCE metadata server) are
+  // not emulator-safe and hang the trigger; no e2e spec asserts a generated icon.
+  // Unreachable in production (the flag is never set there).
+  if (aiFakeEnabled()) return;
+
   const name = item.name.trim();
   if (!name) return;
 
@@ -62,7 +70,9 @@ async function maybeGenerateIcon(id: string, item: CanonItemDoc): Promise<void> 
   const hint = item.iconHint?.trim();
 
   try {
-    const { imageBase64 } = await generateCanonIconFlow({ name, ...(hint ? { hint } : {}) });
+    const { imageBase64 } = await withAiTimeout('generateCanonIcon', () =>
+      generateCanonIconFlow({ name, ...(hint ? { hint } : {}) }),
+    );
     const raw = Buffer.from(imageBase64, 'base64');
     const webp = await removeFlatBackground(raw);
     const url = await uploadCanonIcon(id, webp);


### PR DESCRIPTION
## Summary

Fixes the **Cloud Functions root cause** of the intermittent canon e2e flake (#317), found while running #316's suite with `retain-on-failure` traces. The test (`canon-realtime-match`) was fine; the bug is in `onCanonItemWritten`.

## What was wrong

Seeding a canon item fires `onCanonItemWritten`, which runs two AI side-effects (`Promise.allSettled`), and **both**:
- make calls that aren't emulator-safe under `FUNCTIONS_AI_FAKE` — the **embedder** isn't covered by the chat-model fake seam (real `ai.embed()` → `ECONNRESET`), and the **icon** path's Storage upload authenticates against the **GCE metadata server** (`169.254.169.254`) → hangs;
- call their Genkit flow **bare**, with no `withAiTimeout` (violating the CLAUDE.md rule).

With `concurrency: 1` + `timeoutSeconds: 300`, a hung canon-write invocation **serializes/backs up and starves `onShoppingListItemWrite`** (normally ~1s) in the shared emulator runtime, pushing it past the test's 30s poll → `Received: null`. Hits canon-seeding specs intermittently.

## Fix

- **`embedText.ts`** — return a deterministic canned vector under `FUNCTIONS_AI_FAKE` (the Genkit *embedder* has no `flowModel`-style fake). Covers the trigger, the `serverEmbedding` query path, and the callable.
- **`onCanonItemWritten.ts`** — wrap both `embedTextFlow` and `generateCanonIconFlow` in `withAiTimeout` (prod correctness), and **skip the icon branch** under `FUNCTIONS_AI_FAKE` (real image model + Storage upload aren't emulator-safe and can't be cheaply faked).

## Safety

- **Off-flag (prod/staging) behaviour is unchanged** except the added timeouts, which only bound a stall — a healthy call is unaffected. `CanonItemSchema.embedding` is `z.array(z.number()).nullable()`, so the canned vector is schema-valid.
- **e2e:** no spec relies on canon embeddings (all deliberately stage-1 exact match, per #297) or on generated icons.

## Verification

- `pnpm typecheck`, `pnpm lint` (changed files), and the **full unit suite (1621 tests)** — green.
- The trigger's emulator test (`onCanonItemWritten.emulator.test.ts`) runs in CI / `pnpm test:emulator`.
- ⚠️ **The flake-elimination proof is an e2e `--repeat-each` against the Docker emulator on this branch** (globalSetup rebuilds the CF bundle, so the fix is in effect). Recommend running `pnpm --filter @salt/web-pwa e2e canon-realtime-match --repeat-each=10` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
