### PR TITLE
test(e2e): assert canonical names in recipe→shopping spec (#320)

### DIFF
--- a/apps/web-pwa/e2e/recipe-shopping-list.spec.ts
+++ b/apps/web-pwa/e2e/recipe-shopping-list.spec.ts
@@ -2,9 +2,11 @@
  * Recipe → shopping list E2E tests (issue #179, Phase 5).
  *
  * Exercises the "Add to shopping list" action from the recipe view against the
- * Firestore + Auth emulators. The AI parsing + canonicalisation CFs are not
- * required — ingredients are added as rawText items (matchState: pending),
- * which is the correct behaviour for uncanonicalised ingredients.
+ * Firestore + Auth + Functions emulators. Ingredients are written as raw entries
+ * (matchState: pending); the onShoppingListItemWrite trigger then canonicalises
+ * each one (clean name + structured amount/unit), so the rendered rows — and the
+ * assertions here — settle on the canonical name, not the raw recipe text. The
+ * 'recipe' SourceRef survives that rewrite untouched (issue #320).
  *
  * Covers:
  * - Items from all ingredient groups reach the shopping list.
@@ -64,8 +66,8 @@ test.describe('recipe → shopping list extraction', () => {
     expect(recipeId).toBeTruthy();
 
     // ── Open review sheet: default servings = 4, confirm ──────────────────────
-    // Unmatched ingredients (no AI CFs in e2e) default to add: true, so all
-    // three rows are included; the confirm button reads "Add 3 to list".
+    // Unmatched ingredients (no canon match in the client store) default to
+    // add: true, so all three rows are included; the button reads "Add 3 to list".
     await page.getByTestId('recipe-add-to-list-button').click();
     await expect(page.getByTestId('recipe-add-review-list')).toBeVisible();
     await expect(page.getByTestId('recipe-servings-value')).toContainText('4');
@@ -81,9 +83,17 @@ test.describe('recipe → shopping list extraction', () => {
     // ── Navigate to shopping list and verify all three items appear ───────────
     await page.goto('/#/shopping');
     await expect(page.getByTestId('shopping-list-page')).toBeVisible({ timeout: SYNC_TIMEOUT });
-    await expect(page.getByText('400g spaghetti')).toBeVisible({ timeout: SYNC_TIMEOUT });
-    await expect(page.getByText('2 cloves garlic')).toBeVisible({ timeout: SYNC_TIMEOUT });
-    await expect(page.getByText('100ml double cream')).toBeVisible({ timeout: SYNC_TIMEOUT });
+
+    // The onShoppingListItemWrite trigger canonicalises each entry asynchronously
+    // ("400g spaghetti" → name "spaghetti" + amount 400 / unit "g"), so the
+    // rendered row settles on the canonical name, not the raw recipe string.
+    // Assert the canonical name — which is also a substring of the raw entry, so
+    // the check holds whether or not it races the async rewrite. The old literal
+    // assertions only passed while the canon CF path was inert in e2e (before
+    // #297, which wired the fake-model seam + GEMINI_API_KEY); see issue #320.
+    await expect(page.getByText('spaghetti')).toBeVisible({ timeout: SYNC_TIMEOUT });
+    await expect(page.getByText('cloves garlic')).toBeVisible({ timeout: SYNC_TIMEOUT });
+    await expect(page.getByText('double cream')).toBeVisible({ timeout: SYNC_TIMEOUT });
 
     // ── Verify 'recipe' SourceRef on each item via the in-page store ──────────
     await page.waitForFunction(() => Boolean(window.__e2e), null, { timeout: 10_000 });


### PR DESCRIPTION
Closes #320

## Summary
The `recipe-shopping-list.spec.ts › adds all ingredients …` e2e test asserted the **literal raw ingredient text** (e.g. `400g spaghetti`), but the `onShoppingListItemWrite` Cloud Function trigger **canonicalises every entry on write** (`spaghetti` + structured amount/unit). The assertion was racing — and usually losing — that async rewrite, so the test flaked/failed.

This swaps the three literal-text DOM assertions for the **canonical names** (`spaghetti`, `cloves garlic`, `double cream`), which are also substrings of the raw entries — so the check holds regardless of when (or whether) the rewrite lands. No timeout bumps, no canon seeding, no production-code change.

## Root cause (this is **not** a convergence/contention flake)
- `commitRecipeAddPlan` writes unmatched recipe ingredients verbatim: `rawText:"400g spaghetti"`, `matchState:'pending'`, empty notes.
- `onShoppingListItemWrite` parses → `name "spaghetti", amount 400, unit "g"`; `matchOrCreate` creates a canon item (no AI needed on an empty store) and **rewrites `rawText → "spaghetti"`**.
- A polling probe confirmed the items are present the **entire time** (`count=3` throughout); only `rawText` flips to the canonical form within ~1.5s — so the literal `getByText('400g spaghetti')` finds nothing once the rewrite lands.
- **Why #297 is the exact boundary:** #297 added `GEMINI_API_KEY` + `FUNCTIONS_AI_FAKE=1` to the e2e Functions emulator, which let the trigger's canon-match path complete for the first time. The trigger / `genkit.ts` / e2e setup were untouched by #297, and its "Direct"-path changes (`recipeService`, `e2eHooks`, `seed`) were purely additive bridge helpers — so the "Direct" hypothesis is refuted.

## Verification
- **Reproduced** the failure with a temporary probe: `400g spaghetti` → `spaghetti` within ~0.5–1.5s.
- **Post-fix:** the full spec file passed **5/5 runs with no retries**.
- `pnpm typecheck`, eslint, dependency-cruiser, and the unit suite (1621 tests) all green via pre-commit / pre-push hooks.

## Scope / for reviewers
- Fix is **test-only** — the canonicalisation rewrite is correct production behavior (it's exactly what `canon-realtime-match.spec.ts` asserts).
- Scoped to the **first** test. The second test (`1 onion`) renders the same string post-canonicalisation (unitless count) and already passes — left untouched.
- Out of scope: the issue's "background load / contention" and AI-stub-bisection hypotheses — disproved by the probe, so no emulator/trigger changes were made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
