### PR TITLE
test(firebase-sync): isolate emulator Firestore connection per test (#319)

### DIFF
--- a/packages/adapters/firebase-sync/src/auth.ts
+++ b/packages/adapters/firebase-sync/src/auth.ts
@@ -13,16 +13,19 @@ import { getApp } from 'firebase/app';
 import { failure, success, type DomainError, type ReadResult } from '@salt/shared-types';
 import type { AuthProvider, User, ErrorReportingPort } from '@salt/domain';
 
-let authEmulatorConnected = false;
+// Keyed to the Auth instance (not a module-global boolean) so a re-created
+// default app — as the emulator integration suite does per test, #319 — gets
+// its fresh Auth wired to the emulator rather than skipped by a stale flag.
+const authEmulatorConnected = new WeakSet<Auth>();
 
 // Composition helper: connect the Auth emulator. Called from initFirebase
-// when useEmulators=true. Idempotent.
+// when useEmulators=true. Idempotent per Auth instance.
 export function connectAuthEmulatorOnce(auth: Auth): void {
-  if (authEmulatorConnected) return;
+  if (authEmulatorConnected.has(auth)) return;
   const _env = (import.meta as { env?: Record<string, string | undefined> }).env ?? {};
   const authPort = _env['VITE_EMULATOR_AUTH_PORT'] ?? '9099';
   connectAuthEmulator(auth, `http://127.0.0.1:${authPort}`, { disableWarnings: true });
-  authEmulatorConnected = true;
+  authEmulatorConnected.add(auth);
 }
 
 function toUser(fb: FirebaseUser): User {

--- a/packages/adapters/firebase-sync/src/init.ts
+++ b/packages/adapters/firebase-sync/src/init.ts
@@ -1,5 +1,5 @@
 import { initializeApp, getApps, getApp } from 'firebase/app';
-import type { FirebaseOptions } from 'firebase/app';
+import type { FirebaseApp, FirebaseOptions } from 'firebase/app';
 import {
   getFirestore,
   initializeFirestore,
@@ -13,7 +13,14 @@ import { getAuth } from 'firebase/auth';
 import { initializeAppCheck, ReCaptchaEnterpriseProvider } from 'firebase/app-check';
 import { connectAuthEmulatorOnce } from './auth.js';
 
-let emulatorsConnected = false;
+// Tracks which app instances have had their emulator transports wired up.
+// Keyed to the app instance (not a module-global boolean) so that a torn-down
+// and re-created default app — as the emulator integration suite now does per
+// test to isolate a poisoned Listen channel (#319) — re-establishes its
+// emulator connection instead of being skipped by a stale "already connected"
+// flag. Still idempotent per app: connectFirestoreEmulator throws if called
+// twice on the same Firestore instance, and a live app is only ever wired once.
+const emulatorConnectedApps = new WeakSet<FirebaseApp>();
 
 export interface AppCheckConfig {
   /** reCAPTCHA Enterprise site key. Public — it ships in the client bundle. */
@@ -64,7 +71,7 @@ export function initFirebase(
     });
   }
 
-  if (useEmulators && !emulatorsConnected) {
+  if (useEmulators && !emulatorConnectedApps.has(app)) {
     const _env = (import.meta as { env?: Record<string, string | undefined> }).env ?? {};
     const firestorePort = Number(_env['VITE_EMULATOR_FIRESTORE_PORT'] ?? 8080);
     const functionsPort = Number(_env['VITE_EMULATOR_FUNCTIONS_PORT'] ?? 5001);
@@ -82,7 +89,7 @@ export function initFirebase(
     connectFirestoreEmulator(db, '127.0.0.1', firestorePort);
     connectFunctionsEmulator(getFunctions(app, 'europe-west2'), '127.0.0.1', functionsPort);
     connectAuthEmulatorOnce(getAuth(app));
-    emulatorsConnected = true;
+    emulatorConnectedApps.add(app);
   }
 }
 

--- a/packages/adapters/firebase-sync/tests/emulatorHelpers.ts
+++ b/packages/adapters/firebase-sync/tests/emulatorHelpers.ts
@@ -2,8 +2,11 @@
 // These run against the Firestore + Auth emulators (started by firebase emulators:exec).
 
 import { getAuth, signInAnonymously } from 'firebase/auth';
-import { getApp } from 'firebase/app';
+import { getApp, getApps, deleteApp } from 'firebase/app';
 import { initFirebase } from '../src/init.js';
+
+// Firebase's default (unnamed) app is registered under this reserved name.
+const DEFAULT_APP_NAME = '[DEFAULT]';
 
 const PROJECT_ID = 'demo-salt';
 // Firestore port for the REST clear endpoint. Read from import.meta.env (fed
@@ -23,6 +26,29 @@ const EMULATOR_HOST = `127.0.0.1:${FIRESTORE_PORT}`;
 export async function initFirebaseEmulator(): Promise<void> {
   initFirebase({ projectId: PROJECT_ID, apiKey: 'demo-api-key' }, true);
   await signInAnonymously(getAuth(getApp()));
+}
+
+/**
+ * Tears down and re-creates the default Firebase app so the next test gets a
+ * brand-new Firestore client (and anonymous session). The emulator's long-poll
+ * Listen channel intermittently corrupts mid-suite — a bogus multi-GB
+ * `RESOURCE_EXHAUSTED: Received message larger than max` framing error — which
+ * pushes the client into maximum backoff and poisons the connection for its
+ * whole lifetime. `clearFirestoreEmulator` resets data but not that client
+ * state, and `retry` reuses the same poisoned client, so a single hiccup used
+ * to cascade into a `subscribeAisles` convergence timeout. Re-creating the app
+ * per test contains the corruption to the one test that hit it (#319 / #122).
+ *
+ * `deleteApp` terminates the old Firestore client; `initFirebaseEmulator` then
+ * re-wires a fresh app (the WeakSet-keyed guards in init.ts/auth.ts re-connect
+ * the new instance) and re-authenticates. Call in beforeEach.
+ */
+export async function resetDefaultApp(): Promise<void> {
+  const existing = getApps().find((app) => app.name === DEFAULT_APP_NAME);
+  if (existing) {
+    await deleteApp(existing);
+  }
+  await initFirebaseEmulator();
 }
 
 /**

--- a/packages/adapters/firebase-sync/tests/realtimeSubscriptions.emulator.test.ts
+++ b/packages/adapters/firebase-sync/tests/realtimeSubscriptions.emulator.test.ts
@@ -9,8 +9,8 @@
  * (8080/9099) as the ad-hoc fallback.
  * Run via: pnpm test:emulator
  */
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { initializeApp, deleteApp, type FirebaseApp } from 'firebase/app';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { initializeApp, deleteApp, getApps, type FirebaseApp } from 'firebase/app';
 import { initializeFirestore, connectFirestoreEmulator, doc, setDoc } from 'firebase/firestore';
 import type { Firestore } from 'firebase/firestore';
 import { getAuth, connectAuthEmulator, signInAnonymously } from 'firebase/auth';
@@ -29,7 +29,7 @@ import {
   subscribeShoppingListsConfig,
   saveShoppingListsConfig,
 } from '../src/shoppingListsConfigSubscription.js';
-import { clearFirestoreEmulator, initFirebaseEmulator, PROJECT_ID } from './emulatorHelpers.js';
+import { clearFirestoreEmulator, resetDefaultApp, PROJECT_ID } from './emulatorHelpers.js';
 import type {
   CanonItem,
   Aisle,
@@ -57,6 +57,7 @@ const CONVERGENCE_MS = 15_000;
 const _env = (import.meta as { env?: Record<string, string | undefined> }).env ?? {};
 const WRITER_FIRESTORE_PORT = Number(_env['VITE_EMULATOR_FIRESTORE_PORT'] ?? 8080);
 const WRITER_AUTH_PORT = _env['VITE_EMULATOR_AUTH_PORT'] ?? '9099';
+const WRITER_APP_NAME = 'rt-writer';
 
 let writerApp: FirebaseApp;
 let writerDb: Firestore;
@@ -80,10 +81,18 @@ function makeAisle(id: string, name: string): Aisle {
   return { id, name, order: 0 };
 }
 
-beforeAll(async () => {
-  await initFirebaseEmulator();
-
-  writerApp = initializeApp({ projectId: PROJECT_ID, apiKey: 'demo-api-key' }, 'rt-writer');
+// Both apps are re-created per test (not once in beforeAll) so a Listen channel
+// poisoned by a prior test's emulator gRPC corruption cannot bleed into the next
+// — that cross-test connection-state bleed is what turned a single transient
+// hiccup into a hard `subscribeAisles` convergence timeout (#319). resetDefaultApp
+// rebuilds the default app the subscribe* functions read through; createWriterApp
+// rebuilds the cross-client "writer" app.
+async function createWriterApp(): Promise<void> {
+  const stale = getApps().find((app) => app.name === WRITER_APP_NAME);
+  if (stale) {
+    await deleteApp(stale);
+  }
+  writerApp = initializeApp({ projectId: PROJECT_ID, apiKey: 'demo-api-key' }, WRITER_APP_NAME);
   // Force long-polling for the same reason as the default app (see init.ts): the
   // emulator's gRPC streaming transport intermittently corrupts the Listen
   // channel and poisons the writer's connection. (#122)
@@ -94,14 +103,16 @@ beforeAll(async () => {
     disableWarnings: true,
   });
   await signInAnonymously(writerAuth);
-});
-
-afterAll(async () => {
-  await deleteApp(writerApp);
-});
+}
 
 beforeEach(async () => {
   await clearFirestoreEmulator();
+  await resetDefaultApp();
+  await createWriterApp();
+});
+
+afterEach(async () => {
+  await deleteApp(writerApp);
 });
 
 describe('realtimeSubscriptions — Firestore emulator', () => {

--- a/packages/adapters/firebase-sync/vitest.emulator.config.ts
+++ b/packages/adapters/firebase-sync/vitest.emulator.config.ts
@@ -33,10 +33,14 @@ export default defineConfig({
     // Residual insurance for the flaky Firestore realtime Listen stream (#122).
     // Root cause: the default gRPC streaming transport intermittently breaks the
     // emulator Listen stream with a bogus multi-GB RESOURCE_EXHAUSTED, poisoning
-    // the channel for the client's lifetime — and since the clients live in
-    // beforeAll, retries reused the dead channel, so retry alone never cleared
-    // it. The landed root fix forces long-polling on the emulator transport
-    // (init.ts + the writer app here), which removes the streaming framing bug.
+    // the channel for the client's lifetime. Two landed fixes attack it: (1)
+    // long-polling on the emulator transport (init.ts + the writer app), which
+    // removes the streaming framing bug; (2) the realtime suite now re-creates
+    // the default + writer apps per test (#319), so a poisoned channel is
+    // contained to the one test that hit it instead of cascading into a later
+    // subscribeAisles convergence timeout — and because Vitest re-runs beforeEach
+    // on retry, each retry now gets a fresh client (previously the apps lived in
+    // beforeAll, so retries reused the dead channel and never cleared it).
     // retry:2 stays as cheap insurance; drop it once main stays green for a
     // stretch without it.
     retry: 2,


### PR DESCRIPTION
## Summary

Structurally fixes the chronic **`Vitest integration (emulator)`** flake (#319, recurrence of #122): `subscribeAisles > delivers a cross-client write within the convergence window` intermittently fails with `waitFor timed out after 15000ms`, burning all retries and reding `main` CI (which also gates staging auto-deploy).

**Root cause:** the emulator's long-poll `Listen` channel intermittently corrupts — a bogus multi-GB `RESOURCE_EXHAUSTED: Received message larger than max` framing error — pushing the Firestore client into maximum backoff and poisoning the connection for its lifetime. Because the default + writer apps lived in `beforeAll`, that poison bled across the **whole file**, and `retry` reused the dead channel, so one transient hiccup cascaded into a hard `subscribeAisles` timeout. `clearFirestoreEmulator` resets data but not client state.

**Fix:** re-create both Firebase apps **per test** instead of once per file, so a corrupted channel is contained to the single test that hit it — exactly the per-test isolation route the issue prefers over more retry/timeout band-aids.

## Changes

- **`src/init.ts` / `src/auth.ts`** — key the emulator-connection guards to the app/auth *instance* (`WeakSet`) instead of a module-global boolean, so a torn-down default app re-wires its emulator connection on rebuild. **Production behavior is unchanged** — the emulator branch only runs under `useEmulators`.
- **`tests/emulatorHelpers.ts`** — add `resetDefaultApp()` (`deleteApp` → `initFirebaseEmulator`), which terminates the old Firestore client and rebuilds a fresh, re-authenticated app.
- **`tests/realtimeSubscriptions.emulator.test.ts`** — rebuild the default app (`resetDefaultApp`) and the writer app (`createWriterApp`) in `beforeEach`; tear the writer down in `afterEach`. Since Vitest re-runs `beforeEach` on retry, each retry now also gets a fresh client (previously retries reused the dead channel).
- **`vitest.emulator.config.ts`** — `retry: 2` kept as insurance per the issue's DoD; comment updated to describe the structural fix.

## Verification

- `pnpm test:emulator` — full emulator suite green (**34 passed**), cloud-functions suite green (11 passed).
- Realtime suite run **8× against a live stack** — **16 passed each, 0 failures**, no `app already exists` / resource leaks from the per-test teardown.
- `pnpm typecheck`, `pnpm lint`, dependency-cruiser all clean (via pre-commit).

Final validation is sustained CI green — per the issue, once `main` stays green for a stretch the `retry: 2` insurance can be dropped.

Closes #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)