### PR TITLE
fix(cloud-functions): stop shopping items getting stuck at matchState 'pending'

### DIFF
--- a/apps/cloud-functions/scripts/recategorise-stuck-items.mjs
+++ b/apps/cloud-functions/scripts/recategorise-stuck-items.mjs
@@ -1,0 +1,125 @@
+// One-off operator script: recover shopping-list items stuck at
+// matchState 'pending' (the perpetual "OTHER" spinner).
+//
+// WHY THIS EXISTS — before the onShoppingListItemWrite fix, the match trigger
+// could be SIGKILLed mid-flight (60s timeout / 256MiB OOM) before writing a
+// terminal matchState, stranding the item at 'pending' forever: triggers don't
+// auto-retry and the item gets no further write to re-fire on. The deployed fix
+// (raised timeout + memory + a catch) prevents new strandings, but items
+// already stuck won't self-heal — nothing ever re-fires their match.
+//
+// WHAT IT DOES — mimics the manual "delete and re-add" fix, batched: each stuck
+// item is re-created under a fresh doc id (atomically, via a batched set+delete),
+// which the now-fixed trigger sees as a new creation and re-matches. The new
+// doc preserves every field (createdAt kept for stable ordering), with canonId
+// reset to null and matchState reset to 'pending'. Atomic per item — a crash
+// can never lose or duplicate data.
+//
+// USAGE
+//   Dry run (default — lists what would change, writes nothing):
+//     GOOGLE_CLOUD_PROJECT=<projectId> \
+//       node apps/cloud-functions/scripts/recategorise-stuck-items.mjs
+//   Apply:
+//     GOOGLE_CLOUD_PROJECT=<projectId> \
+//       node apps/cloud-functions/scripts/recategorise-stuck-items.mjs --apply
+//   Against the Firestore emulator:
+//     FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GOOGLE_CLOUD_PROJECT=demo-salt \
+//       node apps/cloud-functions/scripts/recategorise-stuck-items.mjs --apply
+//
+// FLAGS
+//   --apply                 Perform the writes (omit for a dry run).
+//   --max-age-minutes=N     Only touch items pending and untouched for at least
+//                           N minutes (default 10), so in-flight matches — which
+//                           now resolve within ~180s — are never disrupted.
+//
+// Re-runnable: once the trigger matches a re-created item it leaves 'pending',
+// so a second run won't pick it up again.
+
+import { initializeApp, applicationDefault } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const apply = process.argv.includes('--apply');
+const maxAgeArg = process.argv.find((a) => a.startsWith('--max-age-minutes='));
+const maxAgeMinutes = maxAgeArg ? Number(maxAgeArg.split('=')[1]) : 10;
+
+if (!Number.isFinite(maxAgeMinutes) || maxAgeMinutes < 0) {
+  console.error(`Invalid --max-age-minutes value: ${maxAgeArg}`);
+  process.exit(1);
+}
+
+const projectId = process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCLOUD_PROJECT;
+if (!projectId) {
+  console.error('Set GOOGLE_CLOUD_PROJECT to the target Firebase project id.');
+  process.exit(1);
+}
+
+// Against the emulator, FIRESTORE_EMULATOR_HOST short-circuits credentials.
+// Against a real project, ADC (gcloud auth application-default login, or a
+// service account on CI) provides them.
+const useEmulator = Boolean(process.env.FIRESTORE_EMULATOR_HOST);
+initializeApp(useEmulator ? { projectId } : { projectId, credential: applicationDefault() });
+
+const db = getFirestore();
+const cutoffIso = new Date(Date.now() - maxAgeMinutes * 60_000).toISOString();
+
+console.log(
+  `${apply ? 'APPLYING' : 'DRY RUN'} — recategorise items stuck at matchState 'pending' ` +
+    `older than ${maxAgeMinutes}m (updatedAt < ${cutoffIso}) in project ${projectId}` +
+    (useEmulator ? ' [emulator]' : ''),
+);
+
+const lists = await db.collection('shoppingLists').get();
+
+let stuck = 0;
+let recreated = 0;
+
+for (const listDoc of lists.docs) {
+  const itemsRef = listDoc.ref.collection('items');
+  // Read the whole subcollection and filter in memory — shopping lists are
+  // family-shared and small, so this avoids needing a collection-group index.
+  const items = await itemsRef.get();
+
+  for (const itemDoc of items.docs) {
+    const data = itemDoc.data();
+    const isStuck =
+      data.matchState === 'pending' &&
+      data.canonId == null &&
+      data.checked !== true &&
+      // Items written before this field existed sort as '' < cutoff → eligible.
+      (typeof data.updatedAt === 'string' ? data.updatedAt : '') < cutoffIso;
+
+    if (!isStuck) continue;
+    stuck++;
+
+    const newRef = itemsRef.doc();
+    const newData = {
+      ...data,
+      id: newRef.id,
+      canonId: null,
+      matchState: 'pending',
+      updatedAt: new Date().toISOString(),
+    };
+
+    console.log(
+      `  ${apply ? 'recreate' : 'would recreate'} "${data.rawText ?? ''}" ` +
+        `(${listDoc.id}/${itemDoc.id} → ${newRef.id})`,
+    );
+
+    if (apply) {
+      // Atomic: the new creation and the old deletion commit together, so a
+      // crash can never strand a half-migrated item.
+      const batch = db.batch();
+      batch.set(newRef, newData);
+      batch.delete(itemDoc.ref);
+      await batch.commit();
+      recreated++;
+    }
+  }
+}
+
+console.log(
+  apply
+    ? `Done — recreated ${recreated}/${stuck} stuck item(s). The trigger will now re-match them.`
+    : `Found ${stuck} stuck item(s). Re-run with --apply to recreate them.`,
+);
+process.exit(0);

--- a/apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts
+++ b/apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts
@@ -27,7 +27,23 @@ function looksCompound(text: string): boolean {
 }
 
 export const onShoppingListItemWrite = onDocumentWritten(
-  { document: TRIGGER_PATH, region: 'europe-west2', secrets: [geminiApiKey, ldSdkKey] },
+  {
+    document: TRIGGER_PATH,
+    region: 'europe-west2',
+    secrets: [geminiApiKey, ldSdkKey],
+    // The match pipeline makes up to three sequential AI calls — entry parse
+    // (compound items only), embedding, then arbitration — each bounded at ~40s
+    // by withAiTimeout (20s + 1 retry), so ~120s worst case. The default 60s
+    // function timeout SIGKILLs the invocation mid-flight before the matchState
+    // write-back runs, stranding the item at 'pending' forever: triggers don't
+    // auto-retry and the item gets no further write to re-fire on. 180s leaves
+    // headroom over the bounded AI budget so a terminal state is always written.
+    // 512MiB mirrors canonicaliseRecipeIngredients — the same list() over the
+    // whole canon collection + embeddings OOM-kills the default 256MiB instance,
+    // another mid-flight death that leaves the item stuck 'pending'.
+    timeoutSeconds: 180,
+    memory: '512MiB',
+  },
   async (event) => {
     const after = event.data?.after;
     const before = event.data?.before;
@@ -69,6 +85,8 @@ export const onShoppingListItemWrite = onDocumentWritten(
     const currentNotes = typeof afterData['notes'] === 'string' ? afterData['notes'] : '';
 
     const { listId, itemId } = event.params;
+    const db = getFirestore();
+    const docRef = db.collection('shoppingLists').doc(listId).collection('items').doc(itemId);
 
     await whenServerObservabilityReady();
     const span = startSpan(`shoppingList.matchItem: ${rawText}`);
@@ -82,9 +100,6 @@ export const onShoppingListItemWrite = onDocumentWritten(
         { rawName: cleanName, ...(rawText ? { rawText } : {}) },
         buildMatchOrCreatePorts(span),
       );
-
-      const db = getFirestore();
-      const docRef = db.collection('shoppingLists').doc(listId).collection('items').doc(itemId);
 
       if (result.kind === 'err') {
         errorCategory = result.error.kind;
@@ -113,6 +128,24 @@ export const onShoppingListItemWrite = onDocumentWritten(
         ...(parsedAmount !== undefined ? { amount: parsedAmount } : undefined),
         ...(parsedUnit !== undefined ? { unit: parsedUnit } : undefined),
       });
+    } catch (err) {
+      // matchOrCreate and the AI adapters convert operational failures into a
+      // Result (handled as 'failed' above), so reaching here means an unexpected
+      // throw — a Firestore write blip, an OOM survivor, or a bug. Write a
+      // terminal 'failed' so the item never sits in limbo: the user sees it
+      // uncategorised under OTHER (checkable, re-addable) instead of a spinner
+      // that never resolves. A hard timeout/OOM SIGKILL can't run this catch —
+      // that path is prevented by the timeoutSeconds/memory headroom above.
+      errorCategory = 'exception';
+      logger.error('onShoppingListItemWrite: unexpected error', { err, docId: itemId });
+      await docRef
+        .update({ matchState: 'failed', updatedAt: new Date().toISOString() })
+        .catch((writeErr) => {
+          logger.error('onShoppingListItemWrite: failed to write terminal state', {
+            writeErr,
+            docId: itemId,
+          });
+        });
     } finally {
       // DORMANT: trace propagation — trigger boundary; mark per convention.
       // When re-enabled, extract trace context from a header injected at write

--- a/apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts
+++ b/apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts
@@ -300,6 +300,49 @@ describe('onShoppingListItemWrite', () => {
     });
   });
 
+  describe('unexpected exception → failed matchState (never limbo)', () => {
+    it('writes matchState: failed when matchOrCreate throws', async () => {
+      mockMatchOrCreate.mockRejectedValue(new Error('arbitrateCanon timed out after 20000ms'));
+
+      await (onShoppingListItemWrite as Function)(makeEvent({ before: null, after: PENDING_ITEM }));
+
+      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ matchState: 'failed' }));
+      // A thrown error must not write a canonId — the item is terminal-uncategorised.
+      expect(mockUpdate).not.toHaveBeenCalledWith(
+        expect.objectContaining({ canonId: expect.anything() }),
+      );
+    });
+
+    it('does not rethrow — the handler resolves so the trigger is not retried into limbo', async () => {
+      mockMatchOrCreate.mockRejectedValue(new Error('boom'));
+
+      await expect(
+        (onShoppingListItemWrite as Function)(makeEvent({ before: null, after: PENDING_ITEM })),
+      ).resolves.toBeUndefined();
+    });
+
+    it('still ends the span and flushes when an exception is thrown', async () => {
+      mockMatchOrCreate.mockRejectedValue(new Error('boom'));
+
+      await (onShoppingListItemWrite as Function)(makeEvent({ before: null, after: PENDING_ITEM }));
+
+      expect(mockSpan.end).toHaveBeenCalled();
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        'onShoppingListItemWrite',
+        expect.objectContaining({ scope: 'shoppingListItem', errorCategory: 'exception' }),
+      );
+    });
+
+    it('swallows a failed terminal-state write so the handler still resolves', async () => {
+      mockMatchOrCreate.mockRejectedValue(new Error('boom'));
+      mockUpdate.mockRejectedValueOnce(new Error('firestore unavailable'));
+
+      await expect(
+        (onShoppingListItemWrite as Function)(makeEvent({ before: null, after: PENDING_ITEM })),
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe('entry parsing', () => {
     it('feeds the clean parsed name to matchOrCreate for "for" entries', async () => {
       mockMatchOrCreate.mockResolvedValue({


### PR DESCRIPTION
## Problem

Adding a shopping-list item sometimes (~1 in 3) leaves it stuck under **OTHER** with a perpetual spinner that never resolves — even after 30 minutes. Deleting and re-adding the identical item fixes it in seconds.

## Root cause

`onShoppingListItemWrite` runs the canon-match pipeline — up to **three sequential AI calls** (entry-parse for compound items, embedding, arbitration), each hard-bounded at ~40s by `withAiTimeout` (20s + 1 retry) → ~120s worst case. But the trigger set **no `timeoutSeconds`**, inheriting the default **60s** (`setGlobalOptions` only sets the region).

When the documented [bimodal AI stall](https://github.com/eggman0131/saltV2/blob/main/apps/cloud-functions/src/adapters/withAiTimeout.ts) hits, cumulative latency crosses 60s and the runtime **SIGKILLs the invocation before the `matchState` write-back runs**. The item is stranded at `matchState: 'pending'` forever — triggers don't auto-retry, and a stuck item gets no further write to re-fire on. (The default 256MiB instance OOM-killing on the whole-canon `list()` + embeddings is a second mid-flight-death path.)

This matches every symptom: **~1 in 3** = the runs that stall; **never resolves** = no retry/sweep; **delete + re-add works** = a fresh trigger that hits a healthy connection or a now-existing canon (deterministic match, zero AI). The sibling callable doing the identical `matchOrCreate` work already uses `timeoutSeconds: 120` + `512MiB` for exactly this reason.

## Fix

- **`timeoutSeconds: 180` + `memory: '512MiB'`** on the trigger — 180s strictly exceeds the ~120s bounded AI budget, so the write-back always runs; 512MiB removes the OOM path (mirrors `canonicaliseRecipeIngredients`).
- **`catch` → write `matchState: 'failed'`** for any unexpected throw, so the item ends in a terminal, usable state (uncategorised under OTHER, checkable, re-addable) instead of limbo. `db`/`docRef` hoisted so the catch can reach the doc.
- **`scripts/recategorise-stuck-items.mjs`** — one-off operator script to recover items *already* stranded (they won't self-heal). Re-creates each stuck item under a fresh doc id via an **atomic batched set+delete** so the fixed trigger re-matches it — the manual delete-and-re-add, batched, with zero data-loss risk. **Dry-run by default**; `--apply` to execute; `--max-age-minutes=N` (default 10) so in-flight matches are never disrupted.

Net result: every invocation now reaches a terminal state — **work, or fail, never limbo.**

## Testing

- `pnpm --filter @salt/cloud-functions test` — all pass, incl. 4 new tests covering the catch path (throw → `failed`, no rethrow, span still ends, terminal-write failure swallowed).
- `typecheck`, `eslint`, `dependency-cruiser` all clean (pre-commit + pre-push hooks).

## Deploy / follow-up

- ⚠️ Requires a deploy to take effect: `firebase deploy --only functions:onShoppingListItemWrite`.
- After deploy, run the cleanup script (dry-run first) to clear items already stuck in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)