### PR TITLE
fix(ci): pin deploy CLI to Node 20 (real WIF auth fix; supersedes #336)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -44,9 +44,16 @@ jobs:
         with:
           version: '10.33.0'
 
+      # Node 20, NOT 22, for the deploy CLI: firebase-tools' bundled
+      # google-auth-library (gaxios/undici) throws "Premature close" on the
+      # sts.googleapis.com WIF token exchange under Node 22.23.0 (the patch
+      # ubuntu-latest picked up ~2026-06-25 — the exact break). gcloud's own
+      # exchange succeeds, proving WIF/IAM are fine; only the Node 22 HTTP
+      # client is affected. The deployed Functions runtime stays node22 (an
+      # esbuild --target, set in the CF build, independent of the CLI's Node).
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '20'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -63,18 +70,6 @@ jobs:
           project_id: s2-prod-e46bd
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
-
-      # firebase-tools authenticates in CI via Application Default Credentials,
-      # but ONLY "if gcloud is configured" — it does not consume the WIF
-      # external-account credential file directly (the GOOGLE_APPLICATION_
-      # CREDENTIALS path expects a service-account KEY). The auth step above
-      # exports CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE, so once the gcloud SDK is
-      # on PATH the CLI's ADC path resolves. ubuntu-latest stopped bundling
-      # gcloud (~2026-06-25), which silently broke deploys: the credential file
-      # is still created, but firebase deploy fails with "Failed to authenticate,
-      # have you run firebase login?". Installing gcloud restores the ADC path.
-      - name: Set up Cloud SDK (firebase-tools needs gcloud on PATH for ADC)
-        uses: google-github-actions/setup-gcloud@v2
 
       # Deploys hosting, functions, firestore rules + indexes, and storage rules
       # (canon icons, #148) to production. Storage rules deploy requires the

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -94,10 +94,17 @@ jobs:
         with:
           version: '10.33.0'
 
+      # Node 20, NOT 22, for the deploy CLI: firebase-tools' bundled
+      # google-auth-library (gaxios/undici) throws "Premature close" on the
+      # sts.googleapis.com WIF token exchange under Node 22.23.0 (the patch
+      # ubuntu-latest picked up ~2026-06-25 — the exact break). gcloud's own
+      # exchange succeeds, proving WIF/IAM are fine; only the Node 22 HTTP
+      # client is affected. The deployed Functions runtime stays node22 (an
+      # esbuild --target, set in the CF build, independent of the CLI's Node).
       - uses: actions/setup-node@v6
         if: ${{ steps.guard.outputs.should_deploy == 'true' }}
         with:
-          node-version: '22'
+          node-version: '20'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -118,19 +125,6 @@ jobs:
           project_id: s2-stage-ccb22
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
-
-      # firebase-tools authenticates in CI via Application Default Credentials,
-      # but ONLY "if gcloud is configured" — it does not consume the WIF
-      # external-account credential file directly (the GOOGLE_APPLICATION_
-      # CREDENTIALS path expects a service-account KEY). The auth step above
-      # exports CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE, so once the gcloud SDK is
-      # on PATH the CLI's ADC path resolves. ubuntu-latest stopped bundling
-      # gcloud (~2026-06-25), which silently broke deploys: the credential file
-      # is still created, but firebase deploy fails with "Failed to authenticate,
-      # have you run firebase login?". Installing gcloud restores the ADC path.
-      - name: Set up Cloud SDK (firebase-tools needs gcloud on PATH for ADC)
-        if: ${{ steps.guard.outputs.should_deploy == 'true' }}
-        uses: google-github-actions/setup-gcloud@v2
 
       # Deploys all targets in firebase.json: hosting, functions, firestore rules
       # + indexes, and storage rules (canon icons, #148). Storage rules deploy


### PR DESCRIPTION
## Why this exists

**#336 merged the wrong fix.** It landed my first attempt (Node 22 + `setup-gcloud`), which does **not** resolve the deploy failure — installing gcloud doesn't change firebase-tools' own HTTP client. `main` is therefore still broken. This PR lands the **actual** fix.

## Root cause (diagnosed with a `--debug` run + gcloud probe)

firebase-tools' bundled `google-auth-library` (undici) throws `Premature close` on the `https://sts.googleapis.com/v1/token` WIF exchange under **Node 22.23.0** — the patch `ubuntu-latest` started serving ~2026-06-25 (the exact break window). `gcloud auth print-access-token` completes the identical exchange (`gcloud WIF exchange: OK`), proving WIF/IAM are healthy and isolating it to the Node 22 HTTP client.

## Fix

- Pin the **deploy CLI** to **Node 20** in `deploy-staging.yml` + `deploy-production.yml`.
- Remove the no-op `setup-gcloud` step #336 added.
- Deployed **Functions runtime stays node22** (esbuild `--target`, independent of the CLI's Node).

## Validation

A Node 20 staging deploy (via `workflow_dispatch`) authenticated and ran a **full successful deploy** — all 17 functions + hosting + public-invoker grant — **twice**, including the final cleaned config. Net diff: `node-version '22' → '20'` and removal of the gcloud step in both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)