### PR TITLE
fix(shopping): label rows by parsed name, strip quantity at display time

### DIFF
--- a/apps/web-pwa/e2e/recipe-shopping-list.spec.ts
+++ b/apps/web-pwa/e2e/recipe-shopping-list.spec.ts
@@ -4,9 +4,11 @@
  * Exercises the "Add to shopping list" action from the recipe view against the
  * Firestore + Auth + Functions emulators. Ingredients are written as raw entries
  * (matchState: pending); the onShoppingListItemWrite trigger then canonicalises
- * each one (clean name + structured amount/unit), so the rendered rows — and the
- * assertions here — settle on the canonical name, not the raw recipe text. The
- * 'recipe' SourceRef survives that rewrite untouched (issue #320).
+ * each one (clean name + structured amount/unit). The shopping row labels by the
+ * parsed name — resolveItemDisplayName strips the leading amount/unit at display
+ * time — so rows read "Spaghetti" / "Onion", not "400g spaghetti" / "1 onion",
+ * regardless of whether the async trigger has run. The 'recipe' SourceRef
+ * survives the trigger's rewrite untouched (issue #320).
  *
  * Covers:
  * - Items from all ingredient groups reach the shopping list.
@@ -83,13 +85,12 @@ test.describe('recipe → shopping list extraction', () => {
     await page.goto('/#/shopping');
     await expect(page.getByTestId('shopping-list-page')).toBeVisible({ timeout: SYNC_TIMEOUT });
 
-    // The onShoppingListItemWrite trigger canonicalises each entry asynchronously
-    // ("400g spaghetti" → name "spaghetti" + amount 400 / unit "g"), so the
-    // rendered row settles on the canonical name, not the raw recipe string.
-    // Assert the canonical name — which is also a substring of the raw entry, so
-    // the check holds whether or not it races the async rewrite. The old literal
-    // assertions only passed while the canon CF path was inert in e2e (before
-    // #297, which wired the fake-model seam + GEMINI_API_KEY); see issue #320.
+    // The shopping row labels by the parsed name (resolveItemDisplayName strips
+    // the leading amount/unit at display time), so "400g spaghetti" renders as
+    // "Spaghetti". The parsed name is a substring of the raw entry, so these
+    // checks hold immediately on the pending row and continue to hold after the
+    // async trigger writes the structured amount/unit; they never depend on the
+    // canon match resolving (relevant since #297 wired the fake-model seam).
     await expect(page.getByText('spaghetti')).toBeVisible({ timeout: SYNC_TIMEOUT });
     await expect(page.getByText('cloves garlic')).toBeVisible({ timeout: SYNC_TIMEOUT });
     await expect(page.getByText('double cream')).toBeVisible({ timeout: SYNC_TIMEOUT });
@@ -167,7 +168,9 @@ test.describe('recipe → shopping list extraction', () => {
     // Verify SourceRef.servings = 6 via the shopping list store.
     await page.goto('/#/shopping');
     await expect(page.getByTestId('shopping-list-page')).toBeVisible({ timeout: SYNC_TIMEOUT });
-    await expect(page.getByText('1 onion')).toBeVisible({ timeout: SYNC_TIMEOUT });
+    // Row labels by the parsed name — "1 onion" renders as "Onion" (the "1" is
+    // lifted into the separate amount field), so assert the parsed name.
+    await expect(page.getByText('onion')).toBeVisible({ timeout: SYNC_TIMEOUT });
 
     await waitForBridge(page);
     const storeItems = await page.evaluate<ShoppingListItem[]>(

--- a/apps/web-pwa/src/routes/shopping/ShoppingListPage.svelte
+++ b/apps/web-pwa/src/routes/shopping/ShoppingListPage.svelte
@@ -83,10 +83,6 @@
     ),
   );
 
-  // Live canon ids — same set semantics groupItemsByAisle uses, so a row's
-  // display name and its aisle grouping never disagree about what's matched.
-  const liveCanonIds = $derived(new Set(canonMap.keys()));
-
   // Tri-state icon thumbnail for a row, looked up by its matched canon id.
   // Returns null (→ bare tile) for unmatched/pending rows.
   function thumbnailFor(canonId: string | null): string | null {
@@ -400,12 +396,13 @@
     return text.charAt(0).toUpperCase() + text.slice(1);
   }
 
-  // Label a row by the user's own wording (rawText), title-cased — the amount,
-  // unit and notes the parser lifted out are rendered separately, so the label
-  // stays close to what was entered without duplicating those fields.
+  // Label a single row, title-cased: the user's / recipe's wording with the
+  // amount, unit and context the parser lifts out removed ("1 whole chicken" →
+  // "Whole Chicken"), so it reads as the item without the quantity that's shown
+  // separately, and without collapsing to the leaner canon name ("Chicken").
+  // Combined aggregate rows label by canon name instead — see rowLabel.
   function displayLabel(item: ShoppingListItem): string {
-    const resolved = resolveItemDisplayName(item, liveCanonIds);
-    return titleCase(resolved.text);
+    return titleCase(resolveItemDisplayName(item));
   }
 
   function sourceLabel(item: ShoppingListItem): string {

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -146,7 +146,6 @@ export type {
   RecipeGroup,
   ManualBucket,
   GroupedByRecipe,
-  ItemDisplayName,
   RecipeItemAddDefault,
   ParsedEntry,
   EntryParsePort,

--- a/packages/domain/src/shoppingList/index.ts
+++ b/packages/domain/src/shoppingList/index.ts
@@ -58,7 +58,6 @@ export { groupItemsByRecipe } from './queries/groupItemsByRecipe.js';
 export type { RecipeGroup, ManualBucket, GroupedByRecipe } from './queries/groupItemsByRecipe.js';
 
 export { resolveItemDisplayName } from './queries/resolveItemDisplayName.js';
-export type { ItemDisplayName } from './queries/resolveItemDisplayName.js';
 
 export { recipeItemAddDefault } from './queries/recipeItemAddDefault.js';
 export type { RecipeItemAddDefault } from './queries/recipeItemAddDefault.js';

--- a/packages/domain/src/shoppingList/queries/resolveItemDisplayName.ts
+++ b/packages/domain/src/shoppingList/queries/resolveItemDisplayName.ts
@@ -1,27 +1,22 @@
 import type { ShoppingListItem } from '../entities/ShoppingListItem.js';
-import { hasLiveCanonMatch } from '../../canon/index.js';
+import { parseShoppingListEntry } from './parseEntry.js';
 
-// Where a shopping-list row's display label comes from. The `text` is always the
-// user/recipe-supplied `rawText` so a row reads as it was entered (minus the bits
-// the parser lifts out into amount/unit/notes, which the row renders separately).
-// `source` only signals whether a live canon match backs the row — `canon` rows
-// still own the icon/thumbnail via the matched canon item — it no longer changes
-// the text. The caller applies presentation casing.
-export interface ItemDisplayName {
-  readonly text: string;
-  readonly source: 'canon' | 'raw';
-}
-
-// Resolve the label a shopping-list item should display by. The text is always
-// `rawText` (the user's wording); a live canon match (matched / needs_approval,
-// with the canon item still present) is reported via `source: 'canon'` so the
-// caller can still source the icon from canon, but it does not rename the row.
-// Pure — the caller supplies the set of live canon ids (same set fed to
-// groupItemsByAisle, so display name and grouping never disagree).
-export function resolveItemDisplayName(
-  item: ShoppingListItem,
-  liveCanonIds: ReadonlySet<string>,
-): ItemDisplayName {
-  const source = hasLiveCanonMatch(item, liveCanonIds) ? 'canon' : 'raw';
-  return { text: item.rawText, source };
+// The label a single shopping-list row displays by: the user's (or recipe's)
+// wording with the amount / unit / context the parser lifts out removed, so the
+// row reads as the item itself ("whole chicken") without the quantity that's
+// already rendered separately, and without collapsing to the leaner canon name
+// ("chicken"). Manual and recipe rows are labelled identically — recipe wording
+// is clean by construction, so the same parse applies cleanly to both.
+//
+// Parsing at display time (rather than trusting `item.rawText` to have been
+// rewritten) keeps the label correct before the async match trigger runs, and for
+// the items it never rewrites — pending / failed / notes-bearing rows still carry
+// the raw "2 whole chickens" in `rawText`, and stripping it here drops the leading
+// "2" that's otherwise duplicated by the separate amount field.
+//
+// The combined aggregate row is the one place a canon name is shown instead; that
+// lives in the page's `rowLabel`, not here. Pure and I/O-free — the caller applies
+// presentation casing.
+export function resolveItemDisplayName(item: ShoppingListItem): string {
+  return parseShoppingListEntry(item.rawText).name;
 }

--- a/packages/domain/tests/shoppingList/resolveItemDisplayName.test.ts
+++ b/packages/domain/tests/shoppingList/resolveItemDisplayName.test.ts
@@ -21,43 +21,41 @@ function makeItem(overrides: Partial<ShoppingListItem> = {}): ShoppingListItem {
   };
 }
 
-const liveCanonIds = new Set(['c1']);
-
 describe('resolveItemDisplayName', () => {
-  it("labels a live-matched item by the user's rawText, flagged as canon-backed", () => {
-    const item = makeItem({ matchState: 'matched', canonId: 'c1' });
-    expect(resolveItemDisplayName(item, liveCanonIds)).toEqual({
-      text: 'mature cheddar cheese',
-      source: 'canon',
-    });
+  it('keeps the descriptive wording when there is nothing to strip', () => {
+    expect(resolveItemDisplayName(makeItem({ rawText: 'mature cheddar cheese' }))).toBe(
+      'mature cheddar cheese',
+    );
   });
 
-  it('treats needs_approval as a live match (still canon-backed)', () => {
-    const item = makeItem({ matchState: 'needs_approval', canonId: 'c1' });
-    expect(resolveItemDisplayName(item, liveCanonIds)).toEqual({
-      text: 'mature cheddar cheese',
-      source: 'canon',
-    });
+  it('strips a leading quantity but keeps descriptive words ("whole")', () => {
+    expect(resolveItemDisplayName(makeItem({ rawText: '2 whole chickens' }))).toBe(
+      'whole chickens',
+    );
   });
 
-  it('reports source raw for pending items', () => {
-    const item = makeItem({ matchState: 'pending' });
-    expect(resolveItemDisplayName(item, liveCanonIds)).toEqual({
-      text: 'mature cheddar cheese',
-      source: 'raw',
-    });
+  it('strips a number-attached unit', () => {
+    expect(resolveItemDisplayName(makeItem({ rawText: '400g spaghetti' }))).toBe('spaghetti');
   });
 
-  it('reports source raw when the matched canon has been deleted', () => {
-    const item = makeItem({ matchState: 'matched', canonId: 'deleted-canon' });
-    expect(resolveItemDisplayName(item, liveCanonIds)).toEqual({
-      text: 'mature cheddar cheese',
-      source: 'raw',
-    });
+  it('strips a trailing "for …" context', () => {
+    expect(resolveItemDisplayName(makeItem({ rawText: 'flour for the cake' }))).toBe('flour');
   });
 
-  it('reports source raw for failed items', () => {
-    const item = makeItem({ matchState: 'failed' });
-    expect(resolveItemDisplayName(item, liveCanonIds).source).toBe('raw');
+  it('labels recipe rows exactly like manual rows (parsed name, not canon name)', () => {
+    const recipe = makeItem({
+      rawText: '100ml double cream',
+      sources: [{ kind: 'recipe', recipeId: 'r1', servings: 4 }],
+    });
+    expect(resolveItemDisplayName(recipe)).toBe('double cream');
+  });
+
+  it('parses regardless of match state — a pending/failed row still drops the quantity', () => {
+    expect(resolveItemDisplayName(makeItem({ rawText: '1 onion', matchState: 'pending' }))).toBe(
+      'onion',
+    );
+    expect(resolveItemDisplayName(makeItem({ rawText: '1 onion', matchState: 'failed' }))).toBe(
+      'onion',
+    );
   });
 });


### PR DESCRIPTION
## What & why

On the shopping list, manually-added rows were showing **raw text** — including a leading quantity — instead of the *parsed* name. #333 made every row label by `rawText`, which only reads cleanly once the async match trigger has rewritten `rawText`. For rows the trigger hasn't rewritten (pending / failed / notes-bearing), the quantity stayed in the name, so a manual `2 whole chickens` read **"2 Whole Chickens (2)"** — the amount duplicated.

## The change (display only)

`resolveItemDisplayName` now derives a single row's label by **parsing `rawText` at display time** (`parseShoppingListEntry`): it strips the amount / unit / context that the row already renders separately, while keeping descriptive words — `1 whole chicken` → **"Whole Chicken"**, not the leaner canon "Chicken".

| Display context | Text shown |
| --- | --- |
| Manual single row | parsed name |
| Recipe single row | parsed name (identical treatment) |
| Expanded breakdown rows | parsed name |
| Combined aggregate row header | canon item name (unchanged — `rowLabel`) |

Manual and recipe rows are labelled identically; the combined aggregate row stays the one place a canon name is shown. The query no longer needs the canon map or the vestigial `source` flag, so both are dropped along with the now-unused `ItemDisplayName` export.

## Scope

- **Matching pipeline untouched** — no changes to the `onShoppingListItemWrite` trigger, `parseEntry`, or `matchOrCreate`.
- Parsing at display time is what makes the label robust to trigger timing, and it fixes the duplicated-quantity case on pending/failed rows.

## Tests

- Rewrote `resolveItemDisplayName` unit tests to assert the parsing contract (quantity/unit/context stripped, descriptive words kept, manual == recipe).
- `recipe-shopping-list` e2e: its `"1 onion"` assertion encoded the **old** unparsed display; the row now reads "Onion" with a separate "(1)", so it's retargeted to the parsed name. Audited every other shopping/recipe e2e text assertion ("heinz baked beans" ← "heinz baked beans 4 tins", "whole milk" ← "whole milk 2L", "cheddar cheese" ← "cheddar cheese 2 tins", …) — all match the parsed portion and still hold.

Verified locally: `pnpm typecheck` ✓, domain suite 577/577 ✓, ESLint + dependency-cruiser ✓ (pre-commit). e2e impact reasoned through, not run (needs emulators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)