### PR TITLE
feat(ops): one-click prod→staging Firestore refresh via Task Pilot

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,13 @@
     "chat.tools.terminal.autoApprove": {
         "pnpm": true
     },
+    "taskPilot.labels": [
+        "Firebase Emulators",
+        "Vite Dev Server",
+        "Genkit Admin UI",
+        "Export Prod Firestore",
+        "Restore Staging from Prod"
+    ],
     "terminal.integrated.enablePersistentSessions": true,
     "terminal.integrated.persistentSessionReviveProcess": "onExitAndWindowClose",
     "task.reconnection": true,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -103,6 +103,40 @@
         "showReuseMessage": true,
         "clear": false
       }
+    },
+    {
+      "label": "Export Prod Firestore",
+      "detail": "Read-only: export the PRODUCTION Firestore database to GCS. Safe half of the prod -> staging refresh; pair with 'Restore Staging from Prod'. No triggers fire; blocks until done.",
+      "type": "shell",
+      "command": "node",
+      "args": ["scripts/export-prod-firestore.mjs"],
+      "isBackground": false,
+      "problemMatcher": [],
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": true,
+        "clear": true
+      }
+    },
+    {
+      "label": "Restore Staging from Prod",
+      "detail": "DESTRUCTIVE: wipes staging Firestore and restores it from the newest prod export. Requires typing STAGING to confirm; refuses to target prod. Run 'Export Prod Firestore' first.",
+      "type": "shell",
+      "command": "node",
+      "args": ["scripts/restore-staging-from-prod.mjs"],
+      "isBackground": false,
+      "problemMatcher": [],
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": true,
+        "clear": true
+      }
     }
   ]
 }

--- a/docs/data-refresh.md
+++ b/docs/data-refresh.md
@@ -27,10 +27,12 @@ The export bucket must exist, and staging's Firestore service agent must be able
 to read it. The scripts print these commands if something's missing.
 
 ```bash
-# Create the export bucket in the same location as prod's database.
-LOC=$(gcloud firestore databases describe --project=s2-prod-e46bd --format='value(locationId)')
+# Create the export bucket co-located with prod's database. Firestore reports a
+# multi-region database as nam5 / eur3, but `buckets create --location` wants the
+# GCS multi-region name instead: nam5 -> US, eur3 -> EU. A regional database
+# (e.g. europe-west2) uses that region directly. Prod (and staging) are nam5 -> US.
 gcloud storage buckets create gs://s2-prod-e46bd-firestore-exports \
-  --project=s2-prod-e46bd --location="$LOC"
+  --project=s2-prod-e46bd --location=US
 
 # Let staging read the bucket (needed by the import step).
 NUM=$(gcloud projects describe s2-stage-ccb22 --format='value(projectNumber)')

--- a/docs/data-refresh.md
+++ b/docs/data-refresh.md
@@ -34,11 +34,17 @@ to read it. The scripts print these commands if something's missing.
 gcloud storage buckets create gs://s2-prod-e46bd-firestore-exports \
   --project=s2-prod-e46bd --location=US
 
-# Let staging read the bucket (needed by the import step).
+# Let staging read the bucket (needed by the import step). Cross-project import
+# requires BOTH storage.buckets.get and storage.objects.get on the bucket, so the
+# staging service agent needs objectViewer AND legacyBucketReader — objectViewer
+# alone is NOT enough (it omits storage.buckets.get, which import checks against
+# the bucket root and fails with PERMISSION_DENIED on the bucket path).
 NUM=$(gcloud projects describe s2-stage-ccb22 --format='value(projectNumber)')
-gcloud storage buckets add-iam-policy-binding gs://s2-prod-e46bd-firestore-exports \
-  --member="serviceAccount:service-$NUM@gcp-sa-firestore.iam.gserviceaccount.com" \
-  --role=roles/storage.objectViewer
+for ROLE in roles/storage.objectViewer roles/storage.legacyBucketReader; do
+  gcloud storage buckets add-iam-policy-binding gs://s2-prod-e46bd-firestore-exports \
+    --member="serviceAccount:service-$NUM@gcp-sa-firestore.iam.gserviceaccount.com" \
+    --role="$ROLE"
+done
 
 # (optional) auto-delete old exports after 7 days
 gcloud storage buckets update gs://s2-prod-e46bd-firestore-exports \

--- a/docs/data-refresh.md
+++ b/docs/data-refresh.md
@@ -1,0 +1,84 @@
+# Refreshing staging with prod data
+
+To test a migration or bug fix against real data, you can replace **staging's**
+Firestore with a faithful copy of **prod**. This is a two-step, two-click flow in
+the **Task Pilot** sidebar:
+
+1. **Export Prod Firestore** — read-only managed export of prod to a GCS bucket.
+2. **Restore Staging from Prod** — wipes staging, then imports the newest export.
+
+Both are one-shot tasks ([.vscode/tasks.json](../.vscode/tasks.json)); the
+scripts live in [scripts/](../scripts/).
+
+## Why managed export/import (and not a copy script)
+
+Managed import **does not fire Cloud Functions triggers**. A hand-rolled
+Admin-SDK copy would re-fire `onShoppingListItemWrite` (Gemini) and
+`onCanonItemWritten` (icon generation) in the target project — burning cost and
+mutating the very data you just copied. Managed export/import also doesn't bill
+document reads, handles subcollections, and runs on your local CLI credentials.
+It's also why this is **developer tooling, not an in-app admin button**: Cloud
+Functions deploy from one codebase to both envs, so a wipe-and-restore callable
+would also exist in prod.
+
+## One-time setup
+
+The export bucket must exist, and staging's Firestore service agent must be able
+to read it. The scripts print these commands if something's missing.
+
+```bash
+# Create the export bucket in the same location as prod's database.
+LOC=$(gcloud firestore databases describe --project=s2-prod-e46bd --format='value(locationId)')
+gcloud storage buckets create gs://s2-prod-e46bd-firestore-exports \
+  --project=s2-prod-e46bd --location="$LOC"
+
+# Let staging read the bucket (needed by the import step).
+NUM=$(gcloud projects describe s2-stage-ccb22 --format='value(projectNumber)')
+gcloud storage buckets add-iam-policy-binding gs://s2-prod-e46bd-firestore-exports \
+  --member="serviceAccount:service-$NUM@gcp-sa-firestore.iam.gserviceaccount.com" \
+  --role=roles/storage.objectViewer
+
+# (optional) auto-delete old exports after 7 days
+gcloud storage buckets update gs://s2-prod-e46bd-firestore-exports \
+  --lifecycle-file=/dev/stdin <<'JSON'
+{ "rule": [ { "action": {"type": "Delete"}, "condition": {"age": 7} } ] }
+JSON
+```
+
+You authenticate with your own `gcloud auth login` and `firebase login`; both
+already grant you access to prod and staging via the deploy roles.
+
+## Usage
+
+1. Click **Export Prod Firestore**. It blocks until the export completes and
+   prints the GCS path on success.
+2. Click **Restore Staging from Prod**. It selects the newest export, prints the
+   plan, and asks you to type `STAGING` before it wipes and restores.
+
+## Safety
+
+- The restore **hard-refuses** any target that isn't staging (it bails if the
+  project equals prod or matches `/prod/i`).
+- It requires typing `STAGING` to confirm before the destructive wipe.
+- The export is read-only on prod.
+
+## After a restore — re-apply staging-only config
+
+A restore is a **full mirror**, so these come across from prod and may need
+attention:
+
+- **`appSettings` / `devSettings`** — env-specific config (Gemini model per role,
+  kill-switches like canon-icon generation). Staging now holds prod's values;
+  re-apply any staging overrides.
+- **`chatSessions`** — real users' chat history (per-user, TTL'd) is now in
+  staging. Fine for most testing, but be aware of it.
+- **`members`** — staging's login allowlist is now prod's, so your real account
+  can sign in. Note the export carries the `members` allowlist docs only —
+  Firebase **Auth** accounts are separate, so you just re-authenticate and the
+  `beforeMemberCreated` blocking function admits you.
+
+## Scope
+
+This refreshes **prod → staging** only. Local **dev** uses the Firestore
+emulator with its own export-on-exit data ([pnpm dev:emulators](../package.json));
+it is intentionally not a target of this flow.

--- a/scripts/export-prod-firestore.mjs
+++ b/scripts/export-prod-firestore.mjs
@@ -51,10 +51,11 @@ try {
 }
 if (!bucketOk) {
   console.error(`✖ Export bucket ${BUCKET} not found (or no access). One-time setup:`);
+  console.error(`    gcloud storage buckets create ${BUCKET} --project=${PROD_PROJECT} --location=US`);
   console.error(
-    `    LOC=$(gcloud firestore databases describe --project=${PROD_PROJECT} --format='value(locationId)')`,
+    '    # --location must match the DB location: multi-region nam5 -> US, eur3 -> EU;',
   );
-  console.error(`    gcloud storage buckets create ${BUCKET} --project=${PROD_PROJECT} --location=$LOC`);
+  console.error('    # a regional DB (e.g. europe-west2) uses that region. See docs/data-refresh.md.');
   console.error('  (The restore step also needs staging granted read on this bucket — see docs/data-refresh.md.)');
   process.exit(1);
 }

--- a/scripts/export-prod-firestore.mjs
+++ b/scripts/export-prod-firestore.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Task Pilot one-shot: export the PRODUCTION Firestore database to a GCS bucket.
+//
+// This is the SAFE half of the prod→staging refresh — it is read-only against
+// prod. Pair it with scripts/restore-staging-from-prod.mjs, which wipes staging
+// and imports the newest export this produces.
+//
+// Why managed export: it does NOT bill document reads and does NOT fire Cloud
+// Functions triggers, so it is cheap and side-effect-free on prod. `gcloud
+// firestore export` blocks until the operation completes, so a Task Pilot click
+// that returns success means the export is on GCS and ready to restore.
+//
+// Auth: your local `gcloud` active account (`gcloud auth login`). Needs the
+// Firestore "Import Export Admin" role on prod and write access to the bucket.
+//
+// One-time setup (this script prints it if the bucket is missing):
+//   LOC=$(gcloud firestore databases describe --project=<PROD> --format='value(locationId)')
+//   gcloud storage buckets create gs://<PROD>-firestore-exports --project=<PROD> --location=$LOC
+
+import { execFileSync } from 'node:child_process';
+
+const PROD_PROJECT = process.env.SALT_PROD_PROJECT ?? 's2-prod-e46bd';
+const BUCKET = process.env.SALT_FS_EXPORT_BUCKET ?? `gs://${PROD_PROJECT}-firestore-exports`;
+
+function run(cmd, args) {
+  execFileSync(cmd, args, { stdio: 'inherit' });
+}
+
+function commandExists(cmd) {
+  try {
+    execFileSync(cmd, ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (!commandExists('gcloud')) {
+  console.error('✖ gcloud CLI not found. Install the Google Cloud SDK, then `gcloud auth login`.');
+  process.exit(1);
+}
+
+// Preflight: the export bucket must already exist (one-time setup).
+let bucketOk = true;
+try {
+  execFileSync('gcloud', ['storage', 'buckets', 'describe', BUCKET, '--format=value(name)'], {
+    stdio: 'ignore',
+  });
+} catch {
+  bucketOk = false;
+}
+if (!bucketOk) {
+  console.error(`✖ Export bucket ${BUCKET} not found (or no access). One-time setup:`);
+  console.error(
+    `    LOC=$(gcloud firestore databases describe --project=${PROD_PROJECT} --format='value(locationId)')`,
+  );
+  console.error(`    gcloud storage buckets create ${BUCKET} --project=${PROD_PROJECT} --location=$LOC`);
+  console.error('  (The restore step also needs staging granted read on this bucket — see docs/data-refresh.md.)');
+  process.exit(1);
+}
+
+// Timestamped, lexically-sortable, GCS-safe prefix (no ':' or '.'). The restore
+// script picks the newest such prefix, so naming order == recency order.
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const dest = `${BUCKET}/${stamp}`;
+
+console.log(`Exporting Firestore: project=${PROD_PROJECT} → ${dest}`);
+console.log('(read-only on prod; no Cloud Functions triggers fire; blocks until complete)\n');
+
+try {
+  run('gcloud', ['firestore', 'export', dest, `--project=${PROD_PROJECT}`]);
+} catch {
+  console.error('\n✖ Export failed. Check `gcloud auth login` and your Firestore export IAM role on prod.');
+  process.exit(1);
+}
+
+console.log(`\n✔ Export complete: ${dest}`);
+console.log('  Next: run the "Restore Staging from Prod" task to load it into staging.');

--- a/scripts/restore-staging-from-prod.mjs
+++ b/scripts/restore-staging-from-prod.mjs
@@ -109,11 +109,16 @@ console.log(`\n› Importing ${exportPath} into ${STAGING_PROJECT} … (blocks u
 try {
   run('gcloud', ['firestore', 'import', exportPath, `--project=${STAGING_PROJECT}`]);
 } catch {
-  console.error('\n✖ Import failed. If this is a permission error, grant staging read on the bucket:');
+  console.error('\n✖ Import failed. If this is a permission error, grant staging read on the bucket.');
+  console.error('  Cross-project import needs BOTH storage.buckets.get and storage.objects.get,');
+  console.error('  so grant objectViewer AND legacyBucketReader (objectViewer alone is NOT enough —');
+  console.error('  it lacks storage.buckets.get, which the import checks against the bucket root):');
   console.error(`    NUM=$(gcloud projects describe ${STAGING_PROJECT} --format='value(projectNumber)')`);
-  console.error(`    gcloud storage buckets add-iam-policy-binding ${BUCKET} \\`);
-  console.error(`      --member="serviceAccount:service-$NUM@gcp-sa-firestore.iam.gserviceaccount.com" \\`);
-  console.error('      --role=roles/storage.objectViewer');
+  console.error('    for ROLE in roles/storage.objectViewer roles/storage.legacyBucketReader; do');
+  console.error(`      gcloud storage buckets add-iam-policy-binding ${BUCKET} \\`);
+  console.error('        --member="serviceAccount:service-$NUM@gcp-sa-firestore.iam.gserviceaccount.com" \\');
+  console.error('        --role="$ROLE"');
+  console.error('    done');
   process.exit(1);
 }
 

--- a/scripts/restore-staging-from-prod.mjs
+++ b/scripts/restore-staging-from-prod.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// Task Pilot one-shot: WIPE staging Firestore and restore it from the newest
+// prod export (produced by scripts/export-prod-firestore.mjs).
+//
+// DESTRUCTIVE — deletes ALL staging collections, then imports a full copy of
+// prod. The point is a faithful mirror for testing a migration or bug fix
+// against real data. It refuses to target anything but staging and makes you
+// type STAGING to confirm before the wipe.
+//
+// Why managed import: it does NOT fire Cloud Functions triggers, so the
+// canon-match / icon-gen pipelines do not storm staging on the way in — they
+// only run when you later exercise the migration/fix.
+//
+// After the restore, staging's `appSettings` / `devSettings` singletons hold
+// PROD's values (model selection, kill-switches) and `chatSessions` holds real
+// users' history. Re-apply any staging-specific config you need.
+//
+// Auth: local `gcloud` (firestore import) + `firebase` (firestore:delete), both
+// already used for deploys. Staging's Firestore service agent must have read on
+// the export bucket — the script prints the grant command if the import is denied.
+
+import { execFileSync } from 'node:child_process';
+import { createInterface } from 'node:readline';
+
+const PROD_PROJECT = process.env.SALT_PROD_PROJECT ?? 's2-prod-e46bd';
+const STAGING_PROJECT = process.env.SALT_STAGING_PROJECT ?? 's2-stage-ccb22';
+const BUCKET = process.env.SALT_FS_EXPORT_BUCKET ?? `gs://${PROD_PROJECT}-firestore-exports`;
+
+// ── Hard safety guard: this task wipes its target, so it must NEVER hit prod ──
+if (STAGING_PROJECT === PROD_PROJECT || /prod/i.test(STAGING_PROJECT)) {
+  console.error(`✖ Refusing to run: target "${STAGING_PROJECT}" looks like production.`);
+  console.error('  This task wipes its target; it is only ever allowed to hit staging.');
+  process.exit(1);
+}
+
+function run(cmd, args) {
+  execFileSync(cmd, args, { stdio: 'inherit' });
+}
+
+function commandExists(cmd) {
+  try {
+    execFileSync(cmd, ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ask(question) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => rl.question(question, (answer) => (rl.close(), resolve(answer))));
+}
+
+for (const cmd of ['gcloud', 'firebase']) {
+  if (!commandExists(cmd)) {
+    console.error(`✖ ${cmd} CLI not found. Install it and authenticate (gcloud auth login / firebase login).`);
+    process.exit(1);
+  }
+}
+
+// Find the newest export prefix in the bucket. Export prefixes are timestamped
+// subdirectories, so the lexically-greatest one is the most recent.
+let listing;
+try {
+  listing = execFileSync('gcloud', ['storage', 'ls', `${BUCKET}/`], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).toString();
+} catch {
+  console.error(`✖ Could not list ${BUCKET}. Run "Export Prod Firestore" first.`);
+  process.exit(1);
+}
+const exportPath = listing
+  .split('\n')
+  .map((line) => line.trim())
+  .filter((line) => line.startsWith(`${BUCKET}/`) && line.endsWith('/'))
+  .sort()
+  .at(-1)
+  ?.replace(/\/$/, '');
+if (!exportPath) {
+  console.error(`✖ No exports found in ${BUCKET}. Run "Export Prod Firestore" first.`);
+  process.exit(1);
+}
+
+console.log('────────────────────────────────────────────────────────────');
+console.log(' Restore staging Firestore from a prod export');
+console.log('────────────────────────────────────────────────────────────');
+console.log(`  Target (WIPED, then restored): ${STAGING_PROJECT}`);
+console.log(`  Source export:                 ${exportPath}`);
+console.log('');
+console.log('  This DELETES every collection in staging, then imports the export.');
+console.log('  Managed import does not fire Cloud Functions triggers.');
+console.log('');
+
+const answer = await ask('  Type STAGING to proceed (anything else aborts): ');
+if (answer.trim() !== 'STAGING') {
+  console.log('Aborted. Nothing was changed.');
+  process.exit(0);
+}
+
+console.log(`\n› Wiping all collections in ${STAGING_PROJECT} …`);
+try {
+  run('firebase', ['firestore:delete', '--all-collections', '--project', STAGING_PROJECT, '--force']);
+} catch {
+  console.error('✖ Wipe failed. Check `firebase login` and your access to staging.');
+  process.exit(1);
+}
+
+console.log(`\n› Importing ${exportPath} into ${STAGING_PROJECT} … (blocks until complete)`);
+try {
+  run('gcloud', ['firestore', 'import', exportPath, `--project=${STAGING_PROJECT}`]);
+} catch {
+  console.error('\n✖ Import failed. If this is a permission error, grant staging read on the bucket:');
+  console.error(`    NUM=$(gcloud projects describe ${STAGING_PROJECT} --format='value(projectNumber)')`);
+  console.error(`    gcloud storage buckets add-iam-policy-binding ${BUCKET} \\`);
+  console.error(`      --member="serviceAccount:service-$NUM@gcp-sa-firestore.iam.gserviceaccount.com" \\`);
+  console.error('      --role=roles/storage.objectViewer');
+  process.exit(1);
+}
+
+console.log(`\n✔ Staging restored from ${exportPath}.`);
+console.log('  Reminder: appSettings/devSettings now hold PROD values, and chatSessions holds');
+console.log('  real user history — re-apply staging-specific config if needed.');


### PR DESCRIPTION
Closes #343.

## What

Two one-shot **Task Pilot** buttons to replace **staging's** Firestore with a faithful copy of **prod**, for testing migrations / bug fixes against real data:

1. **Export Prod Firestore** ([scripts/export-prod-firestore.mjs](../blob/feat/prod-staging-firestore-refresh/scripts/export-prod-firestore.mjs)) — read-only managed export of prod to a GCS bucket. `gcloud firestore export` blocks until done, so a green run means it's ready.
2. **Restore Staging from Prod** ([scripts/restore-staging-from-prod.mjs](../blob/feat/prod-staging-firestore-refresh/scripts/restore-staging-from-prod.mjs)) — picks the newest export, wipes staging, imports it.

Surfaced by adding entries to [.vscode/tasks.json](.vscode/tasks.json) and the labels to `taskPilot.labels` in [.vscode/settings.json](.vscode/settings.json). No extension/`.vsix` change — Task Pilot reads both at runtime.

## Why managed export/import (not an Admin-SDK copy, not in-app admin)

- **Managed import does not fire Cloud Functions triggers** — an Admin-SDK write of `shoppingLists/items` / `canonItems` into staging would re-fire `onShoppingListItemWrite` (Gemini) and `onCanonItemWritten` (icon-gen) there: cost + mutating the copy. It also doesn't bill reads and handles subcollections.
- **Developer tooling, not an in-app admin button:** functions deploy from one codebase to *both* envs, so a wipe-and-restore callable would also land in prod. Nothing destructive is deployed; the scripts run on your local `gcloud`/`firebase` auth.

## Safety

- Restore **hard-refuses** any target that isn't staging (`!== prod`, no `/prod/i`).
- Restore requires typing `STAGING` before the wipe; export is read-only on prod.
- It's a **full mirror** — `docs/data-refresh.md` documents the post-restore caveat that `appSettings`/`devSettings` (env config) and `chatSessions` (real history) come across and may need re-applying.

## One-time setup

Create the export bucket in prod and grant staging's Firestore service agent read on it — exact commands in [docs/data-refresh.md](docs/data-refresh.md), and the scripts print them if the bucket is missing / import is denied.

## Testing notes

Scripts are syntax-checked (`node --check`) and both JSON files validate; pre-commit (typecheck + dependency-cruiser) is green. I did **not** run the export/import end-to-end — it needs prod credentials and the restore is destructive to staging — but the flow fails safe (preflight checks, hard prod guard, typed confirm). First real run also exercises the one-time bucket/IAM setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)