### PR TITLE
fix(canon): stop duplicate icon generation on canon-item create

### DIFF
--- a/apps/cloud-functions/src/triggers/onCanonItemWritten.ts
+++ b/apps/cloud-functions/src/triggers/onCanonItemWritten.ts
@@ -1,4 +1,4 @@
-import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { getFirestore, FieldValue, type DocumentSnapshot } from 'firebase-admin/firestore';
 import { getStorage } from 'firebase-admin/storage';
 import { onDocumentWritten } from 'firebase-functions/v2/firestore';
 import { defineSecret } from 'firebase-functions/params';
@@ -38,16 +38,51 @@ async function maybeGenerateEmbedding(id: string, item: CanonItemDoc): Promise<v
 }
 
 /**
- * Icon branch (issue #148): generate the Tier-1 pictogram if there is no valid
- * icon yet. Idempotency / opt-out guard: `thumbnail` must be exactly `null`.
- *   - a real URL  → already generated, skip
- *   - CANON_ICON_HIDDEN ("hidden") → user opted out, skip forever
- *   - null        → generate
- * Independent of the embedding guard, so each `.update()` only touches its own
- * field and the trigger self-terminates once both are set.
+ * Edge-trigger decision for the icon branch. The trigger fires on EVERY write to
+ * the doc, so generation must start only on the write that *transitions* the item
+ * into "needs an icon" — never merely because the thumbnail currently happens to
+ * be null. Otherwise an unrelated write landing while a generation is still in
+ * flight (most commonly the embedding `.update()` this same trigger issues on
+ * create) re-enters and starts a *duplicate* generation, because `thumbnail`
+ * stays null until the first one finishes.
+ *
+ * Generate when:
+ *   - create (no prior doc) with a null thumbnail
+ *   - thumbnail just went non-null → null (manual regenerate, or user cleared)
+ *   - the `iconRequestedAt` nonce changed — covers a forced regenerate of an item
+ *     whose thumbnail was *already* null (see regenerateCanonIcon)
+ * Skip when the thumbnail was already null before this write and stayed null: the
+ * write that first set it null already owns the in-flight generation.
+ *
+ * `thumbnail !== null` (a real URL, or the CANON_ICON_HIDDEN "hidden" sentinel)
+ * always skips: already generated, or the user opted out forever.
  */
-async function maybeGenerateIcon(id: string, item: CanonItemDoc): Promise<void> {
-  if (item.thumbnail !== null) return; // real URL or "hidden" sentinel → skip
+function iconNeedsGeneration(before: DocumentSnapshot | undefined, after: CanonItemDoc): boolean {
+  if (after.thumbnail !== null) return false; // real URL or "hidden" sentinel → skip
+  if (!before?.exists) return true; // create → generate
+  const prev = before.data();
+  if ((prev?.['thumbnail'] ?? null) !== null) return true; // just cleared → generate
+  // Already null and still null: only an explicit regenerate (nonce bump) re-fires;
+  // any other field change (embedding, rename, aisle…) must not start a duplicate.
+  return prev?.['iconRequestedAt'] !== after.iconRequestedAt;
+}
+
+/**
+ * Icon branch (issue #148): generate the Tier-1 pictogram when this write
+ * transitions the item into "needs an icon" (see iconNeedsGeneration). Independent
+ * of the embedding guard, so each `.update()` only touches its own field and the
+ * trigger self-terminates once both are set.
+ *
+ * Trade-off of edge-triggering: a generation that *fails* leaves `thumbnail` null
+ * but no longer self-heals on the next unrelated write — the regenerate callable
+ * (which bumps `iconRequestedAt`) is the retry path.
+ */
+async function maybeGenerateIcon(
+  id: string,
+  item: CanonItemDoc,
+  before: DocumentSnapshot | undefined,
+): Promise<void> {
+  if (!iconNeedsGeneration(before, item)) return;
 
   // E2E (FUNCTIONS_AI_FAKE): skip icon generation entirely. The real image model
   // and the Storage upload (which authenticates via the GCE metadata server) are
@@ -177,10 +212,11 @@ export const onCanonItemWritten = onDocumentWritten(
 
     const id = event.params.id;
     // Two independently-guarded side-effects. allSettled so a failure in one
-    // branch never rejects the handler (which would retry both).
+    // branch never rejects the handler (which would retry both). The icon branch
+    // is edge-triggered on before→after, so it needs the prior snapshot.
     await Promise.allSettled([
       maybeGenerateEmbedding(id, parsed.data),
-      maybeGenerateIcon(id, parsed.data),
+      maybeGenerateIcon(id, parsed.data, event.data?.before),
     ]);
   },
 );

--- a/apps/cloud-functions/tests/triggers/onCanonItemWritten.emulator.test.ts
+++ b/apps/cloud-functions/tests/triggers/onCanonItemWritten.emulator.test.ts
@@ -92,11 +92,13 @@ async function clearEmulator(): Promise<void> {
   }
 }
 
-function makeEvent(id: string, after: CanonItemDoc | null) {
+function makeEvent(id: string, after: CanonItemDoc | null, before?: CanonItemDoc | null) {
   return {
     params: { id },
     data: {
-      before: { exists: false, data: () => undefined },
+      before: before
+        ? { exists: true, data: () => before }
+        : { exists: false, data: () => undefined },
       after: after ? { exists: true, data: () => after } : { exists: false, data: () => undefined },
     },
   };
@@ -225,5 +227,50 @@ describe('onCanonItemWritten — Firestore emulator', () => {
     await (onCanonItemWritten as Function)(makeEvent('canon-4', item));
 
     expect(mockEmbed).not.toHaveBeenCalled();
+  });
+
+  // Edge-trigger regression: the trigger fires on every write, but icon
+  // generation must start only on the write that transitions the item into
+  // "needs an icon". The duplicate-generation bug came from the embedding
+  // `.update()` re-firing the trigger while the create-fire's generation was
+  // still in flight (thumbnail still null), starting a second generation.
+  it('does not regenerate the icon when an unrelated field changes while thumbnail stays null', async () => {
+    const before = makeCanonItem('canon-reentry', { thumbnail: null, embedding: null });
+    // Same write the embedding branch issues on create: embedding added, thumbnail untouched.
+    const after = makeCanonItem('canon-reentry', { thumbnail: null, embedding: [0.1, 0.2, 0.3] });
+
+    await (onCanonItemWritten as Function)(makeEvent('canon-reentry', after, before));
+
+    expect(mockGenerateIcon).not.toHaveBeenCalled();
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+
+  it('regenerates when thumbnail transitions from a URL to null', async () => {
+    const db = getFirestore(adminApp);
+    const before = makeCanonItem('canon-regen', {
+      thumbnail: 'https://firebasestorage.googleapis.com/v0/b/demo-salt.appspot.com/o/old.webp?alt=media',
+      embedding: [1],
+    });
+    const after = makeCanonItem('canon-regen', { thumbnail: null, embedding: [1] });
+    await db.collection('canonItems').doc('canon-regen').set(after);
+
+    await (onCanonItemWritten as Function)(makeEvent('canon-regen', after, before));
+
+    expect(mockGenerateIcon).toHaveBeenCalledOnce();
+  });
+
+  it('regenerates when iconRequestedAt is bumped even though thumbnail was already null', async () => {
+    const db = getFirestore(adminApp);
+    const before = makeCanonItem('canon-nonce', { thumbnail: null, embedding: [1] });
+    const after = makeCanonItem('canon-nonce', {
+      thumbnail: null,
+      embedding: [1],
+      iconRequestedAt: 1234,
+    });
+    await db.collection('canonItems').doc('canon-nonce').set(after);
+
+    await (onCanonItemWritten as Function)(makeEvent('canon-nonce', after, before));
+
+    expect(mockGenerateIcon).toHaveBeenCalledOnce();
   });
 });

--- a/apps/cloud-functions/tests/triggers/onCanonItemWritten.emulator.test.ts
+++ b/apps/cloud-functions/tests/triggers/onCanonItemWritten.emulator.test.ts
@@ -248,7 +248,8 @@ describe('onCanonItemWritten — Firestore emulator', () => {
   it('regenerates when thumbnail transitions from a URL to null', async () => {
     const db = getFirestore(adminApp);
     const before = makeCanonItem('canon-regen', {
-      thumbnail: 'https://firebasestorage.googleapis.com/v0/b/demo-salt.appspot.com/o/old.webp?alt=media',
+      thumbnail:
+        'https://firebasestorage.googleapis.com/v0/b/demo-salt.appspot.com/o/old.webp?alt=media',
       embedding: [1],
     });
     const after = makeCanonItem('canon-regen', { thumbnail: null, embedding: [1] });


### PR DESCRIPTION
## Problem

Prod Genkit traces showed `generateCanonIcon` running **twice** for many newly-created canon items, with the second call starting before the first finished.

Root cause is trigger re-entrancy. [`onCanonItemWritten`](apps/cloud-functions/src/triggers/onCanonItemWritten.ts) fires on every write to a `canonItems/{id}` doc, and the icon branch was **level-triggered** — its only guard was `thumbnail !== null`, which reflects *committed* state and can't tell that a generation is already in flight. On a brand-new item:

1. **create** → trigger invocation **A**: the embedding branch writes `embedding` back (~fast); the icon branch starts a ~5–8s image generation.
2. The embedding `.update()` re-fires the trigger → invocation **B**. Embedding is now present so that branch skips, but `thumbnail` is **still null** (A's image gen hasn't finished) → **B starts a second generation.**

Both eventually write `thumbnail`; the second overwrites the first. Net waste: an extra image-model call + Storage upload + trigger fires on every new item. Any *other* write landing during the generation window (rename, aisle change, synonym append) would trigger the same duplication.

## Fix

Make the icon branch **edge-triggered**: compare `event.data.before` → `after` and generate only when the write *transitions* the item into "needs an icon":

- create with a null thumbnail
- thumbnail just went non-null → null (manual regenerate / user cleared)
- the `iconRequestedAt` nonce changed — forced regen of an item whose thumbnail was *already* null (what [`regenerateCanonIcon`](apps/cloud-functions/src/callables/regenerateCanonIcon.ts) bumps)

When thumbnail was already null and stays null (the embedding write, or any unrelated edit during the gen window) → **skip**; the write that first set it null already owns the in-flight generation. This closes the whole re-entrancy class, and makes `iconRequestedAt` the *proper* regen signal rather than just a trick to force a doc mutation.

**Trade-off:** a generation that *fails* no longer self-heals on the next unrelated write — manual regenerate (the `iconRequestedAt` path) is the retry route. This is intentional and acceptable.

## Tests

- `tsc --noEmit` clean, eslint clean (boundaries OK).
- Emulator suite green — **14/14** cloud-functions tests (added 3 regressions):
  - unrelated-field write while thumbnail stays null (the embedding re-fire) → **no** second generation
  - thumbnail URL → null → regenerates
  - `iconRequestedAt` bumped with already-null thumbnail → regenerates
  - existing create / hidden / URL / kill-switch cases unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
