### PR TITLE
feat(observability): category-gated caught-error reporting (client + server)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,15 @@ cloud-functions            →  shared-types, domain, observability/server
   - **Firestore triggers** → log and return; there is no caller to surface a `Failure` to.
 - **Production schema changes need a back-compat check.** Pre-launch (greenfield) schema-shape changes are free. Once production holds real data, a schema-shape change must not break documents already written — keep it backward-compatible on read or run a one-off migration. See [docs/salt-architecture.md §1.1](docs/salt-architecture.md).
 
+## Observability / error-reporting conventions
+
+- **Report the unexpected, suppress the expected.** Caught errors reach PostHog error tracking only via `ErrorReportingPort`, gated on the `DomainError` category — not by which call site happens to have a `catch`/`onError`. Reporting exists to surface failures the friendly-message path would otherwise hide; it is not a mirror of every `Failure`. Full policy: [docs/salt-architecture.md §7.6](docs/salt-architecture.md).
+- **Report:** `StorageError`, `SyncError`, uncategorised/unknown errors, and (server-side) unhandled CF exceptions + AI/Genkit flow failures. `AuthError` is reported **except** the sign-out / token-refresh `permission-denied` race on in-flight listeners.
+- **Do not report:** `NetworkError`/offline, `ValidationError`, `NotFound`, `ConflictError`, and the sign-out auth race.
+- **Coverage is uniform** across write/command failures, realtime `onError`, and server CF — gated by category, not by call-site shape.
+- **Best-effort, never throws** (Rule 10). Scrub raw user input (e.g. canon match text) from reported context — data is family-shared, but free-form user content must not be attached. Server PostHog reporting is additive to `firebase-functions/logger`.
+- **Not lint-enforceable.** This is a runtime convention checked by review + the gating helper + unit tests, not `eslint-plugin-boundaries`.
+
 ## Enforcement
 
 - `pnpm lint` — ESLint with `eslint-plugin-boundaries` checks the import graph.

--- a/apps/cloud-functions/src/callables/regenerateCanonIcon.ts
+++ b/apps/cloud-functions/src/callables/regenerateCanonIcon.ts
@@ -1,6 +1,12 @@
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { onCall, HttpsError } from 'firebase-functions/https';
+import { defineSecret } from 'firebase-functions/params';
 import { RegenerateCanonIconInputSchema } from '@salt/domain/schemas';
+import { reportFlowError } from '../observability/reportServerError.js';
+
+// Bound so an unexpected Firestore write failure here can be reported
+// (posthog-node). Optional like elsewhere — reporting no-ops when unset.
+const posthogApiKey = defineSecret('POSTHOG_API_KEY');
 
 // Manual regenerate / un-hide escape hatch (issue #148). Setting `thumbnail`
 // (→ null) and stamping the `iconRequestedAt` nonce re-fires onCanonItemWritten,
@@ -19,7 +25,7 @@ import { RegenerateCanonIconInputSchema } from '@salt/domain/schemas';
 // alongside the index.ts callables at the enforcement step (this also fires AI
 // image generation, so it is part of the cost surface App Check protects).
 export const regenerateCanonIcon = onCall(
-  { region: 'europe-west2', enforceAppCheck: false },
+  { region: 'europe-west2', enforceAppCheck: false, secrets: [posthogApiKey] },
   async (request) => {
     if (!request.auth) {
       throw new HttpsError('unauthenticated', 'Sign in required.');
@@ -33,14 +39,22 @@ export const regenerateCanonIcon = onCall(
     // No hint clears any stale hint so the regeneration is plain. iconRequestedAt
     // forces the write to mutate the doc so the trigger fires even when the item
     // had no icon (thumbnail already null) — see the header note.
-    await getFirestore()
-      .collection('canonItems')
-      .doc(canonId)
-      .update({
-        thumbnail: null,
-        iconHint: hint ? hint : FieldValue.delete(),
-        iconRequestedAt: Date.now(),
-      });
+    try {
+      await getFirestore()
+        .collection('canonItems')
+        .doc(canonId)
+        .update({
+          thumbnail: null,
+          iconHint: hint ? hint : FieldValue.delete(),
+          iconRequestedAt: Date.now(),
+        });
+    } catch (err) {
+      // An unexpected Firestore write failure (StorageError-class) — report it
+      // additively, flush, then re-throw so the callable's error path is
+      // unchanged. The auth/validation guards above throw HttpsError before this.
+      await reportFlowError(err);
+      throw err;
+    }
     return { ok: true } as const;
   },
 );

--- a/apps/cloud-functions/src/flows/chefChat.ts
+++ b/apps/cloud-functions/src/flows/chefChat.ts
@@ -12,6 +12,7 @@ import { withAiTimeout } from '../adapters/withAiTimeout.js';
 import { ai } from '../genkit.js';
 import { flowModel, aiModelLabel } from '../ai/fakeModel.js';
 import { tracedGenerate } from '../ai/aiGenerationTelemetry.js';
+import { reportFlowError } from '../observability/reportServerError.js';
 
 async function readEquipmentContext(db: ReturnType<typeof getFirestore>): Promise<string> {
   try {
@@ -103,52 +104,60 @@ export const chefChatFlow = ai.defineFlow(
     streamSchema: z.string(),
   },
   async (input, streamingCallback) => {
-    const db = getFirestore();
-    const [equipmentContext, recipeContext] = await Promise.all([
-      readEquipmentContext(db),
-      input.recipeId ? readRecipeContext(db, input.recipeId) : Promise.resolve(''),
-    ]);
+    try {
+      const db = getFirestore();
+      const [equipmentContext, recipeContext] = await Promise.all([
+        readEquipmentContext(db),
+        input.recipeId ? readRecipeContext(db, input.recipeId) : Promise.resolve(''),
+      ]);
 
-    const systemPrompt = buildSystemPrompt(equipmentContext, recipeContext);
+      const systemPrompt = buildSystemPrompt(equipmentContext, recipeContext);
 
-    // Convert Message[] history to Genkit MessageData format. Our domain role is
-    // 'user' | 'assistant'; Genkit/Gemini uses 'user' | 'model', so the assistant
-    // turns must be remapped (a bare cast leaves 'assistant' at runtime, which
-    // Genkit rejects with "messages.N.role: must be equal to one of the allowed
-    // values").
-    const history = input.messages.map((m) => ({
-      role: (m.role === 'assistant' ? 'model' : 'user') as 'user' | 'model',
-      content: [{ text: m.text }],
-    }));
+      // Convert Message[] history to Genkit MessageData format. Our domain role is
+      // 'user' | 'assistant'; Genkit/Gemini uses 'user' | 'model', so the assistant
+      // turns must be remapped (a bare cast leaves 'assistant' at runtime, which
+      // Genkit rejects with "messages.N.role: must be equal to one of the allowed
+      // values").
+      const history = input.messages.map((m) => ({
+        role: (m.role === 'assistant' ? 'model' : 'user') as 'user' | 'model',
+        content: [{ text: m.text }],
+      }));
 
-    // Pro-tier model for conversational quality (design principle #3, issue #206).
-    const chatModel = await flowModel('pro', 'chefChat');
-    const modelLabel = await aiModelLabel('pro', 'chefChat');
-    const { stream, response } = ai.generateStream({
-      model: chatModel,
-      system: systemPrompt,
-      messages: history,
-      prompt: input.newMessage,
-    });
+      // Pro-tier model for conversational quality (design principle #3, issue #206).
+      const chatModel = await flowModel('pro', 'chefChat');
+      const modelLabel = await aiModelLabel('pro', 'chefChat');
+      const { stream, response } = ai.generateStream({
+        model: chatModel,
+        system: systemPrompt,
+        messages: history,
+        prompt: input.newMessage,
+      });
 
-    for await (const chunk of stream) {
-      const text = chunk.text;
-      if (text) streamingCallback(text);
+      for await (const chunk of stream) {
+        const text = chunk.text;
+        if (text) streamingCallback(text);
+      }
+
+      // Emit $ai_generation off the final aggregated response (carries usage). The
+      // stream itself is already draining above; tracedGenerate just awaits the
+      // resolved response under the existing timeout and records model/tokens/latency.
+      const finalResponse = await withAiTimeout(
+        'chefChat',
+        () => tracedGenerate('chefChat', modelLabel, () => response),
+        {
+          timeoutMs: 55_000,
+          retries: 0,
+        },
+      );
+
+      return finalResponse.text;
+    } catch (err) {
+      // onCallGenkit owns this callable's error path; report the AI/Genkit
+      // failure (incl. AiTimeoutError, or a mid-stream model error) here, flush,
+      // then re-throw unchanged. Best-effort; never throws.
+      await reportFlowError(err);
+      throw err;
     }
-
-    // Emit $ai_generation off the final aggregated response (carries usage). The
-    // stream itself is already draining above; tracedGenerate just awaits the
-    // resolved response under the existing timeout and records model/tokens/latency.
-    const finalResponse = await withAiTimeout(
-      'chefChat',
-      () => tracedGenerate('chefChat', modelLabel, () => response),
-      {
-        timeoutMs: 55_000,
-        retries: 0,
-      },
-    );
-
-    return finalResponse.text;
   },
 );
 

--- a/apps/cloud-functions/src/flows/generateChatTitle.ts
+++ b/apps/cloud-functions/src/flows/generateChatTitle.ts
@@ -3,6 +3,7 @@ import { withAiTimeout } from '../adapters/withAiTimeout.js';
 import { ai } from '../genkit.js';
 import { flowModel, aiModelLabel } from '../ai/fakeModel.js';
 import { tracedGenerate } from '../ai/aiGenerationTelemetry.js';
+import { reportFlowError } from '../observability/reportServerError.js';
 
 const InputSchema = z.object({
   userMessage: z.string(),
@@ -24,22 +25,30 @@ export const generateChatTitleFlow = ai.defineFlow(
   async (input) => {
     const prompt = `User's message: "${input.userMessage}"\n\nChef's reply:\n${input.assistantResponse.slice(0, 500)}`;
 
-    const model = await flowModel('lite', 'generateChatTitle');
-    const modelLabel = await aiModelLabel('lite', 'generateChatTitle');
-    const result = await withAiTimeout(
-      'generateChatTitle',
-      () =>
-        tracedGenerate('generateChatTitle', modelLabel, () =>
-          ai.generate({
-            model,
-            system: SYSTEM_PROMPT,
-            prompt,
-            config: { temperature: 0.3 },
-          }),
-        ),
-      { timeoutMs: 15_000, retries: 0 },
-    );
+    try {
+      const model = await flowModel('lite', 'generateChatTitle');
+      const modelLabel = await aiModelLabel('lite', 'generateChatTitle');
+      const result = await withAiTimeout(
+        'generateChatTitle',
+        () =>
+          tracedGenerate('generateChatTitle', modelLabel, () =>
+            ai.generate({
+              model,
+              system: SYSTEM_PROMPT,
+              prompt,
+              config: { temperature: 0.3 },
+            }),
+          ),
+        { timeoutMs: 15_000, retries: 0 },
+      );
 
-    return (result.text ?? '').trim().slice(0, 60) || 'New chat';
+      return (result.text ?? '').trim().slice(0, 60) || 'New chat';
+    } catch (err) {
+      // onCallGenkit owns this callable's error path; report the AI/Genkit
+      // failure (incl. AiTimeoutError) here, flush, then re-throw unchanged.
+      // Best-effort; never throws.
+      await reportFlowError(err);
+      throw err;
+    }
   },
 );

--- a/apps/cloud-functions/src/flows/identifyEquipment.ts
+++ b/apps/cloud-functions/src/flows/identifyEquipment.ts
@@ -6,6 +6,7 @@ import { setActiveSpanName } from '@salt/observability/server';
 import { ai } from '../genkit.js';
 import { flowModel, aiModelLabel } from '../ai/fakeModel.js';
 import { tracedGenerate } from '../ai/aiGenerationTelemetry.js';
+import { reportFlowError } from '../observability/reportServerError.js';
 
 export const identifyEquipmentFlow = ai.defineFlow(
   {
@@ -15,20 +16,29 @@ export const identifyEquipmentFlow = ai.defineFlow(
   },
   async ({ rawName }) => {
     setActiveSpanName(`identifyEquipment: ${rawName}`);
-    const model = await flowModel('fast', 'identifyEquipment');
-    const result = await tracedGenerate(
-      'identifyEquipment',
-      await aiModelLabel('fast', 'identifyEquipment'),
-      () =>
-        ai.generate({
-          model,
-          system: SYSTEM_INSTRUCTIONS,
-          prompt: `"${rawName}"`,
-          output: { schema: IdentifyEquipmentAIOutputSchema },
-          config: { temperature: 0 },
-        }),
-    );
-    return { candidates: result.output!.candidates };
+    try {
+      const model = await flowModel('fast', 'identifyEquipment');
+      const result = await tracedGenerate(
+        'identifyEquipment',
+        await aiModelLabel('fast', 'identifyEquipment'),
+        () =>
+          ai.generate({
+            model,
+            system: SYSTEM_INSTRUCTIONS,
+            prompt: `"${rawName}"`,
+            output: { schema: IdentifyEquipmentAIOutputSchema },
+            config: { temperature: 0 },
+          }),
+      );
+      return { candidates: result.output!.candidates };
+    } catch (err) {
+      // onCallGenkit owns the error path for this callable, so the AI/Genkit
+      // failure (incl. AiTimeoutError) is reported here at the flow boundary —
+      // the only path that reaches this flow. Report + flush, then re-throw so
+      // Genkit's behaviour is unchanged. Best-effort; never throws.
+      await reportFlowError(err);
+      throw err;
+    }
   },
 );
 

--- a/apps/cloud-functions/src/flows/populateEquipmentEntry.ts
+++ b/apps/cloud-functions/src/flows/populateEquipmentEntry.ts
@@ -6,6 +6,7 @@ import { setActiveSpanName } from '@salt/observability/server';
 import { ai } from '../genkit.js';
 import { flowModel, aiModelLabel } from '../ai/fakeModel.js';
 import { tracedGenerate } from '../ai/aiGenerationTelemetry.js';
+import { reportFlowError } from '../observability/reportServerError.js';
 
 export const populateEquipmentEntryFlow = ai.defineFlow(
   {
@@ -15,25 +16,33 @@ export const populateEquipmentEntryFlow = ai.defineFlow(
   },
   async ({ confirmedName }) => {
     setActiveSpanName(`populateEquipmentEntry: ${confirmedName}`);
-    // Production: googleAI.model(resolveModel('lite', 'populateEquipmentEntry')).
-    // Under FUNCTIONS_AI_FAKE=1 (emulator e2e only) flowModel returns the
-    // deterministic fake model instead; byte-identical otherwise. See
-    // ../ai/fakeModel.ts for the cross-process stub contract.
-    const model = await flowModel('lite', 'populateEquipmentEntry');
-    const result = await tracedGenerate(
-      'populateEquipmentEntry',
-      await aiModelLabel('lite', 'populateEquipmentEntry'),
-      () =>
-        ai.generate({
-          model,
-          system: SYSTEM_INSTRUCTIONS,
-          prompt: `"${confirmedName}"`,
-          output: { schema: PopulateEquipmentEntryAIOutputSchema },
-          config: { temperature: 0 },
-        }),
-    );
-    const output = result.output!;
-    return { name: output.name, accessories: output.accessories };
+    try {
+      // Production: googleAI.model(resolveModel('lite', 'populateEquipmentEntry')).
+      // Under FUNCTIONS_AI_FAKE=1 (emulator e2e only) flowModel returns the
+      // deterministic fake model instead; byte-identical otherwise. See
+      // ../ai/fakeModel.ts for the cross-process stub contract.
+      const model = await flowModel('lite', 'populateEquipmentEntry');
+      const result = await tracedGenerate(
+        'populateEquipmentEntry',
+        await aiModelLabel('lite', 'populateEquipmentEntry'),
+        () =>
+          ai.generate({
+            model,
+            system: SYSTEM_INSTRUCTIONS,
+            prompt: `"${confirmedName}"`,
+            output: { schema: PopulateEquipmentEntryAIOutputSchema },
+            config: { temperature: 0 },
+          }),
+      );
+      const output = result.output!;
+      return { name: output.name, accessories: output.accessories };
+    } catch (err) {
+      // onCallGenkit owns this callable's error path; report the AI/Genkit
+      // failure here (the only path to this flow), flush, then re-throw
+      // unchanged. Best-effort; never throws.
+      await reportFlowError(err);
+      throw err;
+    }
   },
 );
 

--- a/apps/cloud-functions/src/index.ts
+++ b/apps/cloud-functions/src/index.ts
@@ -15,6 +15,7 @@ import {
   runWithExtractedTraceContext,
 } from '@salt/observability/server';
 import { registerGenkitDevTracing } from './genkitTracing.js';
+import { reportFlowError } from './observability/reportServerError.js';
 import { embedTextFlow } from './flows/embedText.js';
 import { arbitrateCanonFlow } from './flows/arbitrateCanon.js';
 import { matchOrCreateCanonFlow } from './flows/matchOrCreateCanon.js';
@@ -126,14 +127,25 @@ export const matchOrCreateCanon = onCall(
 
     await whenServerObservabilityReady();
 
-    // Suppress propagation locally so flows stay root-listed in the Dev UI.
-    if (process.env['GENKIT_TELEMETRY_SERVER']) {
-      return matchOrCreateCanonFlow(request.data);
+    try {
+      // Suppress propagation locally so flows stay root-listed in the Dev UI.
+      if (process.env['GENKIT_TELEMETRY_SERVER']) {
+        return await matchOrCreateCanonFlow(request.data);
+      }
+      // Production: nest the flow span under the inbound request trace. The
+      // trace flow (env-gate + runWithExtractedTraceContext) is unchanged — the
+      // report() lives in the catch and never touches the active context.
+      return await runWithExtractedTraceContext(request.rawRequest?.headers, () =>
+        matchOrCreateCanonFlow(request.data),
+      );
+    } catch (err) {
+      // AI/Genkit flow failure (incl. AiTimeoutError). Report the genuine cause
+      // additively, flush, then re-throw so the callable's error path is
+      // unchanged. matchOrCreateCanonFlow's own finally also flushes; flush is
+      // idempotent + non-throwing.
+      await reportFlowError(err);
+      throw err;
     }
-    // Production: nest the flow span under the inbound request trace.
-    return runWithExtractedTraceContext(request.rawRequest?.headers, () =>
-      matchOrCreateCanonFlow(request.data),
-    );
   },
 );
 
@@ -160,14 +172,23 @@ export const canonicaliseRecipeIngredients = onCall(
       throw new HttpsError('invalid-argument', 'Invalid request payload.');
     }
     await whenServerObservabilityReady();
-    return canonicaliseRecipeIngredientsFlow(parsed.data);
+    try {
+      return await canonicaliseRecipeIngredientsFlow(parsed.data);
+    } catch (err) {
+      // AI/Genkit batch flow failure — report the cause additively, flush, then
+      // re-throw unchanged. The flow's finally also flushes (idempotent).
+      await reportFlowError(err);
+      throw err;
+    }
   },
 );
 
 export const identifyEquipment = onCallGenkit(
   {
     ...APP_CHECK_ENFORCEMENT,
-    secrets: [geminiApiKey],
+    // posthogApiKey bound so the flow's onCallGenkit-boundary error reporting
+    // (reportFlowError in the flow body) can read POSTHOG_API_KEY at runtime.
+    secrets: [geminiApiKey, posthogApiKey],
     authPolicy: isSignedIn(),
   },
   identifyEquipmentFlow,
@@ -176,7 +197,7 @@ export const identifyEquipment = onCallGenkit(
 export const populateEquipmentEntry = onCallGenkit(
   {
     ...APP_CHECK_ENFORCEMENT,
-    secrets: [geminiApiKey],
+    secrets: [geminiApiKey, posthogApiKey],
     authPolicy: isSignedIn(),
   },
   populateEquipmentEntryFlow,
@@ -213,7 +234,14 @@ export const authorRecipe = onCall(
       throw new HttpsError('invalid-argument', 'Invalid request payload.');
     }
     await whenServerObservabilityReady();
-    return authorRecipeFlow(parsed.data);
+    try {
+      return await authorRecipeFlow(parsed.data);
+    } catch (err) {
+      // Librarian flow failure (AI + batch canonicalise) — report the cause
+      // additively, flush, then re-throw unchanged.
+      await reportFlowError(err);
+      throw err;
+    }
   },
 );
 
@@ -264,7 +292,17 @@ export const extractRecipeFromUrl = onCall(
     try {
       return await extractRecipeFromUrlFlow(parsed.data);
     } catch (err) {
-      if (err instanceof UrlImportError) throw mapUrlImportFailure(err.code);
+      // Report the GENUINE cause before mapping to a user-facing HttpsError —
+      // the raw error/stack, never the HttpsError envelope. The UrlImportError
+      // taxonomy encodes EXPECTED user outcomes (bad/blocked URL, unreachable
+      // page, not-a-recipe) which are suppressed per policy; only `ai-failed`
+      // (the recipe-reader model itself failing) is the unexpected one worth
+      // surfacing. A non-UrlImportError throw is an unexpected bug → report.
+      if (err instanceof UrlImportError) {
+        if (err.code === 'ai-failed') await reportFlowError(err);
+        throw mapUrlImportFailure(err.code);
+      }
+      await reportFlowError(err);
       throw new HttpsError(
         'internal',
         'The recipe reader had trouble with that page — try again, or add it manually.',
@@ -276,7 +314,7 @@ export const extractRecipeFromUrl = onCall(
 export const chefChat = onCallGenkit(
   {
     ...APP_CHECK_ENFORCEMENT,
-    secrets: [geminiApiKey],
+    secrets: [geminiApiKey, posthogApiKey],
     authPolicy: isSignedIn(),
     timeoutSeconds: 120,
   },
@@ -286,7 +324,7 @@ export const chefChat = onCallGenkit(
 export const generateChatTitle = onCallGenkit(
   {
     ...APP_CHECK_ENFORCEMENT,
-    secrets: [geminiApiKey],
+    secrets: [geminiApiKey, posthogApiKey],
     authPolicy: isSignedIn(),
   },
   generateChatTitleFlow,
@@ -295,21 +333,38 @@ export const generateChatTitle = onCallGenkit(
 // Admin-only AI model catalog + probe (Phase 3 — admin-managed model selection).
 // Both re-check admin server-side (issue #155) and declare the AI secret so the
 // catalog fetch / probe can read GEMINI_API_KEY from process.env. App Check
-// monitor-first like every other callable.
+// monitor-first like every other callable. POSTHOG_API_KEY is bound so an
+// unexpected throw can be reported (the handlers map every EXPECTED operational
+// outcome to an HttpsError / a `{ ok:false }` result, so only a non-HttpsError
+// escaping is reported — see reportUnexpected).
+//
+// reportUnexpected: report a genuine bug (a non-HttpsError throw) before it
+// propagates, then re-throw unchanged. An HttpsError is an outcome the handler /
+// requireAdmin deliberately classified (auth, permission, unavailable catalog) —
+// expected, so suppressed. Flush before return so the report is not stranded.
+async function reportUnexpected<T>(op: () => Promise<T>): Promise<T> {
+  try {
+    return await op();
+  } catch (err) {
+    if (!(err instanceof HttpsError)) await reportFlowError(err);
+    throw err;
+  }
+}
+
 export const listAiModels = onCall(
   {
     ...APP_CHECK_ENFORCEMENT,
-    secrets: [geminiApiKey],
+    secrets: [geminiApiKey, posthogApiKey],
   },
-  handleListAiModels,
+  (request) => reportUnexpected(() => handleListAiModels(request)),
 );
 
 export const testModel = onCall(
   {
     ...APP_CHECK_ENFORCEMENT,
-    secrets: [geminiApiKey],
+    secrets: [geminiApiKey, posthogApiKey],
   },
-  handleTestModel,
+  (request) => reportUnexpected(() => handleTestModel(request)),
 );
 
 export { onShoppingListItemWrite };

--- a/apps/cloud-functions/src/observability/reportServerError.ts
+++ b/apps/cloud-functions/src/observability/reportServerError.ts
@@ -1,0 +1,46 @@
+import type { DomainError } from '@salt/shared-types';
+import {
+  createServerObservabilityErrorReportingAdapter,
+  flushServerObservability,
+} from '@salt/observability/server';
+
+// Single server-side error-reporting entrypoint for cloud-functions, mirroring
+// the web-pwa `getErrorReporter()` singleton pattern. The adapter is created once
+// at module load and reused across invocations so every CF catch site routes
+// through the SAME category-gated, never-throwing port (CLAUDE.md Rule 10,
+// §Observability). Sourced from @salt/observability/server ONLY — never the
+// default subpath, which wraps the browser-only PostHog SDK (CLAUDE.md Rule 5).
+//
+// Reporting is ADDITIVE: every existing firebase-functions/logger call stays.
+// This sends the same failure to PostHog error tracking so server exceptions
+// surface alongside browser-side ones under the synthetic server person.
+const reporter = createServerObservabilityErrorReportingAdapter();
+
+// Report a caught server error, best-effort. `category` is optional: server
+// failures are usually RAW uncategorised exceptions (there is no server
+// classifyFirestoreError), so omitting it gates as reportable ("report the
+// unexpected"). Pass a DomainError kind when one is genuinely known (e.g. a
+// classified Result envelope) so a suppressed category is honoured exactly like
+// the client. Never throws — the adapter swallows any SDK failure.
+export function reportServerError(error: unknown, category?: DomainError['kind']): void {
+  reporter.report(error, category);
+}
+
+// Report a caught error and flush before the function freezes, best-effort. Use
+// inside a flow / callable catch when the surrounding code does NOT already flush
+// in a finally (posthog-node batches; an un-flushed event is lost when the Node
+// process is paused between invocations). flush is non-throwing and no-ops when
+// uninitialised, so this is always safe to call. Never throws.
+//
+// This is the AI/Genkit flow-failure reporting hook: a flow throwing (incl.
+// AiTimeoutError from withAiTimeout) calls this in its catch, then re-throws so
+// the flow's failure behaviour and the onCallGenkit/onCall error path are
+// unchanged. Reporting at the flow body (vs wrapping the handler) keeps the
+// handler's exact `ai.defineFlow` type inference intact.
+export async function reportFlowError(
+  error: unknown,
+  category?: DomainError['kind'],
+): Promise<void> {
+  reportServerError(error, category);
+  await flushServerObservability();
+}

--- a/apps/cloud-functions/src/triggers/onCanonItemWritten.ts
+++ b/apps/cloud-functions/src/triggers/onCanonItemWritten.ts
@@ -5,17 +5,24 @@ import { defineSecret } from 'firebase-functions/params';
 import { logger } from 'firebase-functions';
 import { normaliseName } from '@salt/domain';
 import { CanonItemSchema, DevSettingsSchema, type CanonItemDoc } from '@salt/domain/schemas';
+import { flushServerObservability } from '@salt/observability/server';
 import { embedTextFlow } from '../flows/embedText.js';
 import { generateCanonIconFlow } from '../flows/generateCanonIcon.js';
 import { removeFlatBackground } from '../imaging/removeFlatBackground.js';
 import { withAiTimeout } from '../adapters/withAiTimeout.js';
 import { aiFakeEnabled } from '../ai/fakeModel.js';
+import { reportServerError } from '../observability/reportServerError.js';
 
 // Defined here (not imported from index.ts) to avoid a circular import; the
 // Firebase CLI aggregates same-named defineSecret calls across files at deploy
 // time. The trigger reaches Gemini for both the embedding and the icon, so the
 // key must be bound to its runtime.
 const geminiApiKey = defineSecret('GEMINI_API_KEY');
+// Bound so server error reporting (posthog-node) can read POSTHOG_API_KEY at
+// runtime — this trigger now reports embedding/icon/devSettings-read failures.
+// Optional like elsewhere: when unset, reporting no-ops and the logger still
+// emits.
+const posthogApiKey = defineSecret('POSTHOG_API_KEY');
 
 const ICON_STORAGE_PREFIX = 'canon-icons';
 
@@ -34,6 +41,10 @@ async function maybeGenerateEmbedding(id: string, item: CanonItemDoc): Promise<v
     await getFirestore().collection('canonItems').doc(id).update({ embedding: values });
   } catch (err) {
     logger.error('onCanonItemWritten: embedding failed', { id, err });
+    // Additive: an embedding flow failure (AI/Genkit) is unexpected → report it
+    // to PostHog alongside the logger. Best-effort, never throws. The handler's
+    // finally flushes before the function returns.
+    reportServerError(err);
   }
 }
 
@@ -119,6 +130,10 @@ async function maybeGenerateIcon(
   } catch (err) {
     // Leave thumbnail null so a later write retries; never block the trigger.
     logger.error('onCanonItemWritten: icon generation failed', { id, err });
+    // Additive: icon generation chains an AI flow, image processing and a Storage
+    // upload — a throw here is unexpected. Report it to PostHog alongside the
+    // logger. Best-effort, never throws; the handler's finally flushes.
+    reportServerError(err);
   }
 }
 
@@ -135,12 +150,20 @@ async function isCanonIconGenerationEnabled(): Promise<boolean> {
     if (!snap.exists) return true;
     const parsed = DevSettingsSchema.safeParse(snap.data());
     if (!parsed.success) {
+      // Expected validation fallback (a doc that doesn't match the schema, e.g.
+      // a partially-written settings doc): NOT reported — this is a
+      // ValidationError-class "expected" outcome, suppressed per policy. The
+      // fail-open default + the warn log are the contract.
       logger.warn('onCanonItemWritten: invalid devSettings doc, defaulting to enabled');
       return true;
     }
     return parsed.data.canonIconGenerationEnabled;
   } catch (err) {
     logger.warn('onCanonItemWritten: devSettings read failed, defaulting to enabled', { err });
+    // A read THROW (vs a shape mismatch above) is a StorageError-class failure.
+    // Non-critical (we fail open), but genuinely unexpected, so report it
+    // additively — best-effort, never throws.
+    reportServerError(err, 'StorageError');
     return true;
   }
 }
@@ -183,7 +206,7 @@ export const onCanonItemWritten = onDocumentWritten(
   {
     document: 'canonItems/{id}',
     region: 'europe-west2',
-    secrets: [geminiApiKey],
+    secrets: [geminiApiKey, posthogApiKey],
     // Image generation (~5–8s+) plus sharp processing need more headroom than
     // the default text-only triggers.
     timeoutSeconds: 300,
@@ -211,12 +234,19 @@ export const onCanonItemWritten = onDocumentWritten(
     }
 
     const id = event.params.id;
-    // Two independently-guarded side-effects. allSettled so a failure in one
-    // branch never rejects the handler (which would retry both). The icon branch
-    // is edge-triggered on before→after, so it needs the prior snapshot.
-    await Promise.allSettled([
-      maybeGenerateEmbedding(id, parsed.data),
-      maybeGenerateIcon(id, parsed.data, event.data?.before),
-    ]);
+    try {
+      // Two independently-guarded side-effects. allSettled so a failure in one
+      // branch never rejects the handler (which would retry both). The icon branch
+      // is edge-triggered on before→after, so it needs the prior snapshot.
+      await Promise.allSettled([
+        maybeGenerateEmbedding(id, parsed.data),
+        maybeGenerateIcon(id, parsed.data, event.data?.before),
+      ]);
+    } finally {
+      // The branch catches above report best-effort to posthog-node, which
+      // batches; flush before the function freezes so a report is not stranded.
+      // Non-throwing + no-op when uninitialised, so it is always safe to call.
+      await flushServerObservability();
+    }
   },
 );

--- a/apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts
+++ b/apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts
@@ -10,6 +10,7 @@ import {
 } from '@salt/observability/server';
 import { buildMatchOrCreatePorts } from '../flows/matchOrCreateCanon.js';
 import { createServerEntryParseAdapter } from '../adapters/serverEntryParse.js';
+import { reportServerError } from '../observability/reportServerError.js';
 
 const TRIGGER_PATH = 'shoppingLists/{listId}/items/{itemId}';
 
@@ -138,6 +139,10 @@ export const onShoppingListItemWrite = onDocumentWritten(
       // that path is prevented by the timeoutSeconds/memory headroom above.
       errorCategory = 'exception';
       logger.error('onShoppingListItemWrite: unexpected error', { err, docId: itemId });
+      // Additive to the logger: surface this unexpected throw to PostHog error
+      // tracking. Uncategorised → reported. Best-effort (never throws). The
+      // finally block flushes before the function returns.
+      reportServerError(err);
       await docRef
         .update({ matchState: 'failed', updatedAt: new Date().toISOString() })
         .catch((writeErr) => {
@@ -145,6 +150,9 @@ export const onShoppingListItemWrite = onDocumentWritten(
             writeErr,
             docId: itemId,
           });
+          // A failed terminal-state write is a StorageError-class failure that
+          // leaves the item stuck; report it additively too.
+          reportServerError(writeErr);
         });
     } finally {
       // DORMANT: trace propagation — trigger boundary; mark per convention.

--- a/apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts
+++ b/apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Phase 3: the extractRecipeFromUrl onCall callable reports the GENUINE cause of
+// a failure (raw error/stack, never the HttpsError envelope) before mapping to a
+// user-facing HttpsError — but only for the UNEXPECTED failures:
+//   • a non-UrlImportError throw (a bug)            → REPORT
+//   • UrlImportError code 'ai-failed' (model failed)→ REPORT
+//   • every other UrlImportError code (invalid/blocked/unreachable/not-a-recipe)
+//     is an EXPECTED user outcome                    → SUPPRESS (do not report)
+// The user-facing HttpsError mapping is unchanged in all cases.
+
+// ─── Spy on the server error reporter + flush ─────────────────────────────────
+const mockReport = vi.fn();
+const mockFlush = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@salt/observability/server', () => ({
+  initServerObservability: vi.fn(),
+  whenServerObservabilityReady: vi.fn(async () => {}),
+  runWithExtractedTraceContext: vi.fn((_h: unknown, fn: () => unknown) => fn()),
+  createServerObservabilityErrorReportingAdapter: vi.fn(() => ({ report: mockReport })),
+  flushServerObservability: mockFlush,
+}));
+
+// ─── Stub everything index.ts imports so module load is cheap & inert ─────────
+class FakeHttpsError extends Error {
+  code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+vi.mock('firebase-functions/https', () => ({
+  onCall: (_opts: unknown, handler: unknown) => handler,
+  onCallGenkit: (_opts: unknown, _flow: unknown) => () => undefined,
+  isSignedIn: () => ({}),
+  HttpsError: FakeHttpsError,
+}));
+vi.mock('firebase-admin/app', () => ({ initializeApp: vi.fn() }));
+vi.mock('firebase-functions/v2', () => ({ setGlobalOptions: vi.fn() }));
+vi.mock('firebase-functions/params', () => ({ defineSecret: (name: string) => ({ name }) }));
+vi.mock('@genkit-ai/firebase', () => ({ enableFirebaseTelemetry: vi.fn(async () => {}) }));
+vi.mock('../../src/genkitTracing.js', () => ({ registerGenkitDevTracing: vi.fn() }));
+
+// The flow under test — stubbed so we drive its outcome from the test.
+const extractRecipeFromUrlFlow = vi.fn();
+// Real UrlImportError shape (code + name) so the index.ts `instanceof` branch works.
+class UrlImportError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'UrlImportError';
+  }
+}
+vi.mock('../../src/flows/extractRecipeFromUrl.js', () => ({
+  extractRecipeFromUrlFlow,
+  UrlImportError,
+}));
+
+// Remaining modules index.ts pulls in only to register functions.
+vi.mock('../../src/flows/embedText.js', () => ({ embedTextFlow: vi.fn() }));
+vi.mock('../../src/flows/arbitrateCanon.js', () => ({ arbitrateCanonFlow: vi.fn() }));
+vi.mock('../../src/flows/matchOrCreateCanon.js', () => ({ matchOrCreateCanonFlow: vi.fn() }));
+vi.mock('../../src/flows/canonicaliseRecipeIngredients.js', () => ({
+  canonicaliseRecipeIngredientsFlow: vi.fn(),
+}));
+vi.mock('../../src/flows/identifyEquipment.js', () => ({ identifyEquipmentFlow: vi.fn() }));
+vi.mock('../../src/flows/populateEquipmentEntry.js', () => ({
+  populateEquipmentEntryFlow: vi.fn(),
+}));
+vi.mock('../../src/flows/parseRecipeIngredients.js', () => ({
+  parseRecipeIngredientsFlow: vi.fn(),
+}));
+vi.mock('../../src/flows/chefChat.js', () => ({ chefChatFlow: vi.fn() }));
+vi.mock('../../src/flows/authorRecipe.js', () => ({ authorRecipeFlow: vi.fn() }));
+vi.mock('../../src/flows/generateChatTitle.js', () => ({ generateChatTitleFlow: vi.fn() }));
+vi.mock('../../src/triggers/onShoppingListItemWrite.js', () => ({
+  onShoppingListItemWrite: vi.fn(),
+}));
+vi.mock('../../src/triggers/onCanonItemWritten.js', () => ({ onCanonItemWritten: vi.fn() }));
+vi.mock('../../src/ai/listAiModels.js', () => ({ handleListAiModels: vi.fn() }));
+vi.mock('../../src/ai/testModel.js', () => ({ handleTestModel: vi.fn() }));
+vi.mock('../../src/callables/regenerateCanonIcon.js', () => ({ regenerateCanonIcon: vi.fn() }));
+vi.mock('../../src/auth/beforeMemberCreated.js', () => ({ beforeMemberCreated: vi.fn() }));
+
+const { extractRecipeFromUrl } = await import('../../src/index.js');
+
+const invoke = (data: Record<string, unknown>) =>
+  (extractRecipeFromUrl as unknown as Function)({ auth: { uid: 'u1' }, data });
+
+const VALID = { url: 'https://example.com/recipe' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFlush.mockResolvedValue(undefined);
+});
+
+describe('extractRecipeFromUrl callable — selective failure reporting', () => {
+  it('reports an UNEXPECTED (non-UrlImportError) cause, then maps to HttpsError', async () => {
+    const bug = new Error('unexpected null deref in assembleDraft');
+    extractRecipeFromUrlFlow.mockRejectedValue(bug);
+
+    await expect(invoke(VALID)).rejects.toBeInstanceOf(FakeHttpsError);
+
+    // The raw cause is reported (uncategorised), not the HttpsError envelope.
+    expect(mockReport).toHaveBeenCalledWith(bug, undefined);
+    expect(mockFlush).toHaveBeenCalled();
+    // The reported arg is the genuine cause, not a FakeHttpsError.
+    expect(mockReport.mock.calls[0]![0]).toBe(bug);
+    expect(mockReport.mock.calls[0]![0]).not.toBeInstanceOf(FakeHttpsError);
+  });
+
+  it("reports a UrlImportError with code 'ai-failed' (the model itself failed)", async () => {
+    const aiFail = new UrlImportError('ai-failed', 'model could not read the page');
+    extractRecipeFromUrlFlow.mockRejectedValue(aiFail);
+
+    await expect(invoke(VALID)).rejects.toBeInstanceOf(FakeHttpsError);
+
+    expect(mockReport).toHaveBeenCalledWith(aiFail, undefined);
+  });
+
+  it.each(['invalid-url', 'blocked-url', 'fetch-failed', 'not-a-recipe'])(
+    "does NOT report the EXPECTED UrlImportError code '%s' (suppressed)",
+    async (code) => {
+      extractRecipeFromUrlFlow.mockRejectedValue(new UrlImportError(code, 'expected outcome'));
+
+      await expect(invoke(VALID)).rejects.toBeInstanceOf(FakeHttpsError);
+
+      // Expected user outcomes are suppressed — only the mapped HttpsError
+      // reaches the client; nothing is sent to PostHog error tracking.
+      expect(mockReport).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not report on the success path', async () => {
+    extractRecipeFromUrlFlow.mockResolvedValue({ id: 'r1', title: 'Soup' });
+
+    await invoke(VALID);
+
+    expect(mockReport).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts
+++ b/apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Phase 3: an onCallGenkit flow throwing (incl. AiTimeoutError) must be reported
+// to PostHog at the flow boundary it controls, flushed, then re-thrown unchanged
+// so Genkit's error path / the flow's success behaviour are untouched.
+//
+// generateChatTitle is reached ONLY via its onCallGenkit callable, so the flow
+// body's try/catch is the single reporting site for it (no double-report risk).
+
+// ─── Spy on the server error reporter + flush ─────────────────────────────────
+const mockReport = vi.fn();
+const mockFlush = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@salt/observability/server', () => ({
+  createServerObservabilityErrorReportingAdapter: vi.fn(() => ({ report: mockReport })),
+  flushServerObservability: mockFlush,
+}));
+
+// ─── Mock Genkit so defineFlow returns the handler directly ───────────────────
+const mockGenerate = vi.fn();
+vi.mock('../../src/genkit.js', () => ({
+  ai: {
+    defineFlow: (_config: unknown, handler: unknown) => handler,
+    generate: mockGenerate,
+  },
+}));
+
+// ─── Mock model resolution + AI-generation telemetry passthrough ──────────────
+vi.mock('../../src/ai/fakeModel.js', () => ({
+  flowModel: vi.fn(async () => 'fake-model'),
+  aiModelLabel: vi.fn(async () => 'fake-model-label'),
+}));
+// tracedGenerate just invokes the op; its telemetry is out of scope here.
+vi.mock('../../src/ai/aiGenerationTelemetry.js', () => ({
+  tracedGenerate: vi.fn((_flow: string, _model: string, op: () => unknown) => op()),
+}));
+
+// Import after mocks so defineFlow returns the handler directly.
+const { generateChatTitleFlow } = await import('../../src/flows/generateChatTitle.js');
+
+const INPUT = { userMessage: 'how do I make pasta', assistantResponse: 'boil water, add pasta' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFlush.mockResolvedValue(undefined);
+});
+
+describe('generateChatTitle flow — failure reporting', () => {
+  it('reports the AI failure (uncategorised), flushes, and re-throws unchanged', async () => {
+    const boom = new Error('generateChatTitle timed out after 15000ms');
+    mockGenerate.mockRejectedValue(boom);
+
+    await expect((generateChatTitleFlow as Function)(INPUT)).rejects.toThrow(boom);
+
+    // Uncategorised server exception → reportable (undefined category).
+    expect(mockReport).toHaveBeenCalledWith(boom, undefined);
+    // Flushed so the event is not stranded when the function freezes.
+    expect(mockFlush).toHaveBeenCalled();
+  });
+
+  it('does not report on the success path', async () => {
+    mockGenerate.mockResolvedValue({ text: 'Pasta Basics' });
+
+    const title = await (generateChatTitleFlow as Function)(INPUT);
+
+    expect(title).toBe('Pasta Basics');
+    expect(mockReport).not.toHaveBeenCalled();
+  });
+
+  it('does not attach the raw chat text to the report payload', async () => {
+    mockGenerate.mockRejectedValue(new Error('boom'));
+
+    await expect(
+      (generateChatTitleFlow as Function)({
+        userMessage: 'a very specific secret family recipe for lasagne',
+        assistantResponse: 'here is the secret',
+      }),
+    ).rejects.toThrow();
+
+    // report() receives only (error, category) — never the user message.
+    const args = mockReport.mock.calls[0]!;
+    expect(JSON.stringify(args)).not.toContain('secret family recipe');
+  });
+});

--- a/apps/cloud-functions/tests/flows/matchOrCreateCanon.tracePropagation.test.ts
+++ b/apps/cloud-functions/tests/flows/matchOrCreateCanon.tracePropagation.test.ts
@@ -36,6 +36,10 @@ vi.mock('@salt/observability/server', () => ({
   initServerObservability: vi.fn(),
   whenServerObservabilityReady: vi.fn(async () => {}),
   runWithExtractedTraceContext,
+  // index.ts now imports ../observability/reportServerError.js, which constructs
+  // the server error reporter at module load and flushes on the report path.
+  createServerObservabilityErrorReportingAdapter: vi.fn(() => ({ report: vi.fn() })),
+  flushServerObservability: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../src/flows/matchOrCreateCanon.js', () => ({ matchOrCreateCanonFlow }));

--- a/apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts
+++ b/apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts
@@ -40,15 +40,21 @@ const mockSpan = {
   end: vi.fn(),
 };
 
+// Spy on the server error reporter the trigger now wires through
+// ../observability/reportServerError.js (constructed at module load).
+const mockReport = vi.fn();
+const mockFlush = vi.fn().mockResolvedValue(undefined);
+
 vi.mock('@salt/observability/server', () => ({
   startSpan: vi.fn(() => mockSpan),
-  flushServerObservability: vi.fn().mockResolvedValue(undefined),
+  flushServerObservability: mockFlush,
   whenServerObservabilityReady: vi.fn().mockResolvedValue(undefined),
   initServerObservability: vi.fn(),
   isServerObservabilityInitialised: vi.fn(() => false),
   createServerObservabilityMatchLoggingAdapter: vi.fn(() => ({
     write: vi.fn().mockResolvedValue(undefined),
   })),
+  createServerObservabilityErrorReportingAdapter: vi.fn(() => ({ report: mockReport })),
   captureAiGeneration: vi.fn(),
 }));
 
@@ -339,6 +345,44 @@ describe('onShoppingListItemWrite', () => {
       );
     });
 
+    it('reports the unexpected error to PostHog and flushes before returning', async () => {
+      const boom = new Error('arbitrateCanon timed out after 20000ms');
+      mockMatchOrCreate.mockRejectedValue(boom);
+
+      await (onShoppingListItemWrite as Function)(makeEvent({ before: null, after: PENDING_ITEM }));
+
+      // Additive to the logger: the raw error is reported, uncategorised
+      // (undefined category → reportable). The terminal-state write succeeds, so
+      // only the matchOrCreate throw is reported.
+      expect(mockReport).toHaveBeenCalledWith(boom, undefined);
+      // The flush in the finally runs after the report so the event is not
+      // stranded when the function freezes.
+      expect(mockFlush).toHaveBeenCalled();
+    });
+
+    it('does not attach the raw shopping-list text to the report payload', async () => {
+      mockMatchOrCreate.mockRejectedValue(new Error('boom'));
+
+      await (onShoppingListItemWrite as Function)(
+        makeEvent({
+          before: null,
+          after: {
+            rawText: 'two pounds of organic heirloom tomatoes',
+            canonId: null,
+            matchState: 'pending',
+          },
+        }),
+      );
+
+      // report() is called with only (error, category) — never the rawText. The
+      // adapter forwards just the error/stack; free-form user content must not
+      // ride along (CLAUDE.md §Observability).
+      expect(mockReport).toHaveBeenCalledTimes(1);
+      const reportArgs = mockReport.mock.calls[0]!;
+      expect(reportArgs).toHaveLength(2);
+      expect(JSON.stringify(reportArgs)).not.toContain('organic heirloom tomatoes');
+    });
+
     it('swallows a failed terminal-state write so the handler still resolves', async () => {
       mockMatchOrCreate.mockRejectedValue(new Error('boom'));
       mockUpdate.mockRejectedValueOnce(new Error('firestore unavailable'));
@@ -346,6 +390,20 @@ describe('onShoppingListItemWrite', () => {
       await expect(
         (onShoppingListItemWrite as Function)(makeEvent({ before: null, after: PENDING_ITEM })),
       ).resolves.toBeUndefined();
+    });
+
+    it('reports BOTH the unexpected error and the failed terminal-state write', async () => {
+      const boom = new Error('boom');
+      const writeErr = new Error('firestore unavailable');
+      mockMatchOrCreate.mockRejectedValue(boom);
+      mockUpdate.mockRejectedValueOnce(writeErr);
+
+      await (onShoppingListItemWrite as Function)(makeEvent({ before: null, after: PENDING_ITEM }));
+
+      // The unexpected throw AND the StorageError-class terminal-write failure
+      // each report — the item is stuck either way, so both are surfaced.
+      expect(mockReport).toHaveBeenCalledWith(boom, undefined);
+      expect(mockReport).toHaveBeenCalledWith(writeErr, undefined);
     });
   });
 

--- a/apps/web-pwa/src/lib/canonService.ts
+++ b/apps/web-pwa/src/lib/canonService.ts
@@ -39,7 +39,7 @@ import type {
 import { ErrorCode, failure, success, type DomainError, type Result } from '@salt/shared-types';
 import { writable, get } from 'svelte/store';
 import type { Readable } from 'svelte/store';
-import { reportSubscriptionError } from './errorReporting.js';
+import { reportIfFailed, reportSubscriptionError, reportWriteError } from './errorReporting.js';
 
 export type { MatchOrCreateResult };
 
@@ -221,6 +221,9 @@ export async function addCanonItem(
       span.setAttribute('canon.result', result.value.item.name);
     } else {
       span.setAttribute('canon.error', result.error.kind);
+      // AI-callable (matchOrCreateCanon) failure: report the unexpected
+      // (StorageError/SyncError/Auth/unknown); the gate drops NetworkError etc.
+      reportWriteError(getErrorReporter(), result.error);
     }
     return result;
   } finally {
@@ -319,7 +322,7 @@ export async function splitMostRecentSynonym(
 }
 
 export async function deleteCanonItem(id: string): Promise<Result<void, DomainError>> {
-  return deleteCanonItemDoc(id);
+  return reportIfFailed(getErrorReporter(), await deleteCanonItemDoc(id));
 }
 
 // ─── Icon (Tier-1 pictogram) escape hatch (issue #148) ───────────────────────────
@@ -333,7 +336,7 @@ export async function regenerateCanonIcon(
   id: string,
   hint?: string,
 ): Promise<Result<void, DomainError>> {
-  return callRegenerateCanonIcon(id, hint);
+  return reportIfFailed(getErrorReporter(), await callRegenerateCanonIcon(id, hint));
 }
 
 /** Hide a canon item's icon: sets `thumbnail` to the "hidden" sentinel so the
@@ -347,7 +350,7 @@ export async function hideCanonIcon(item: CanonItem): Promise<Result<CanonItem, 
 /** Un-hide a canon item's icon: clears the "hidden" sentinel (→ null) via the
  *  regenerate callable, which re-triggers generation. */
 export async function unhideCanonIcon(id: string): Promise<Result<void, DomainError>> {
-  return callRegenerateCanonIcon(id);
+  return reportIfFailed(getErrorReporter(), await callRegenerateCanonIcon(id));
 }
 
 // ─── Test helpers ────────────────────────────────────────────────────────────────

--- a/apps/web-pwa/src/lib/canonService.ts
+++ b/apps/web-pwa/src/lib/canonService.ts
@@ -39,6 +39,7 @@ import type {
 import { ErrorCode, failure, success, type DomainError, type Result } from '@salt/shared-types';
 import { writable, get } from 'svelte/store';
 import type { Readable } from 'svelte/store';
+import { reportSubscriptionError } from './errorReporting.js';
 
 export type { MatchOrCreateResult };
 
@@ -155,7 +156,7 @@ export function initCanonSync(): () => void {
       recomputeAisleUsage();
       markLoaded('items');
     },
-    (err) => errors.report(err),
+    (err, rawError) => reportSubscriptionError(errors, err, rawError),
   );
 
   const unsubAisles = subscribeAisles(
@@ -164,7 +165,7 @@ export function initCanonSync(): () => void {
       recomputeAisleUsage();
       markLoaded('aisles');
     },
-    (err) => errors.report(err),
+    (err, rawError) => reportSubscriptionError(errors, err, rawError),
   );
 
   return () => {

--- a/apps/web-pwa/src/lib/chatService.ts
+++ b/apps/web-pwa/src/lib/chatService.ts
@@ -6,6 +6,7 @@ import {
   callGenerateChatTitle,
 } from '@salt/firebase-sync';
 import { createObservabilityErrorReportingAdapter } from '@salt/observability';
+import { reportSubscriptionError } from './errorReporting.js';
 import type { ChatSessionDoc } from '@salt/domain/schemas';
 import type { DomainError, ReadResult } from '@salt/shared-types';
 import { success } from '@salt/shared-types';
@@ -69,8 +70,8 @@ export function initChatSync(ownerUid: string): () => void {
       applySnapshot(incoming);
       _isLoadingSessions.set(false);
     },
-    (err) => {
-      errors.report(err);
+    (err, rawError) => {
+      reportSubscriptionError(errors, err, rawError);
       _isLoadingSessions.set(false);
     },
   );

--- a/apps/web-pwa/src/lib/chatService.ts
+++ b/apps/web-pwa/src/lib/chatService.ts
@@ -6,7 +6,7 @@ import {
   callGenerateChatTitle,
 } from '@salt/firebase-sync';
 import { createObservabilityErrorReportingAdapter } from '@salt/observability';
-import { reportSubscriptionError } from './errorReporting.js';
+import { reportIfFailed, reportSubscriptionError, reportWriteError } from './errorReporting.js';
 import type { ChatSessionDoc } from '@salt/domain/schemas';
 import type { DomainError, ReadResult } from '@salt/shared-types';
 import { success } from '@salt/shared-types';
@@ -106,7 +106,10 @@ export async function createChatSession(
   latestLocalEdit.set(stamped.id, stamped.updatedAt);
   _sessions.set([...get(_sessions), stamped]);
   const result = await saveChatSession(stamped);
-  if (result.kind === 'err') return result;
+  if (result.kind === 'err') {
+    reportWriteError(getErrorReporter(), result.error);
+    return result;
+  }
   return success(stamped);
 }
 
@@ -117,13 +120,13 @@ export async function persistSession(
   latestLocalEdit.set(stamped.id, stamped.updatedAt);
   const others = get(_sessions).filter((s) => s.id !== stamped.id);
   _sessions.set([...others, stamped]);
-  return saveChatSession(stamped);
+  return reportIfFailed(getErrorReporter(), await saveChatSession(stamped));
 }
 
 export async function removeSession(id: string): Promise<ReadResult<void, DomainError>> {
   latestLocalEdit.set(id, now());
   _sessions.set(get(_sessions).filter((s) => s.id !== id));
-  return deleteChatSession(id);
+  return reportIfFailed(getErrorReporter(), await deleteChatSession(id));
 }
 
 // Send a user message: appends the user turn, streams the assistant reply,
@@ -165,6 +168,8 @@ export async function sendMessage(
 
   if (streamResult.kind === 'err') {
     _sessions.set(prevSessions);
+    // Report the chefChat AI-callable failure (gate drops NetworkError/offline).
+    reportWriteError(getErrorReporter(), streamResult.error);
     return streamResult;
   }
 

--- a/apps/web-pwa/src/lib/errorReporting.ts
+++ b/apps/web-pwa/src/lib/errorReporting.ts
@@ -1,5 +1,5 @@
 import type { ErrorReportingPort } from '@salt/domain';
-import type { DomainError } from '@salt/shared-types';
+import type { DomainError, ReadResult, Result } from '@salt/shared-types';
 import { isAuthTransitioning } from '@salt/firebase-sync';
 
 // Shared report path for realtime-subscription onError sites across the service
@@ -23,4 +23,39 @@ export function reportSubscriptionError(
 ): void {
   if (err.kind === 'AuthError' && isAuthTransitioning()) return;
   errors.report(rawError ?? err, err.kind);
+}
+
+// Shared report path for WRITE/COMMAND failures across the service layer
+// (canon/chat/recipe/shopping). Unlike reportSubscriptionError, this is for
+// caller-initiated writes, NOT in-flight listeners — so it does NOT consult
+// isAuthTransitioning(). A write that fails with AuthError is a genuine
+// authorisation failure the user just triggered (not the sign-out teardown
+// race, which only affects subscription listeners), so write-path AuthError IS
+// reportable per policy.
+//
+// The category gate ("report the unexpected, suppress the expected") still
+// lives inside the injected port's report(): suppressed categories
+// (NetworkError/ValidationError/NotFound/ConflictError) no-op there, so callers
+// just always call this on the err branch without branching on category.
+//
+// The RAW error is forwarded when the adapter supplies it (it carries the real
+// stack); the synthetic DomainError is the fallback when there is none.
+export function reportWriteError(
+  errors: ErrorReportingPort,
+  error: DomainError,
+  rawError?: unknown,
+): void {
+  errors.report(rawError ?? error, error.kind);
+}
+
+// Ergonomic wrapper for the common one-line write site
+// `return reportIfFailed(getErrorReporter(), await saveX(...))`. No-ops on
+// `kind: 'ok'`, reports via reportWriteError on `kind: 'err'`, and returns the
+// result UNCHANGED so it can be returned directly — reporting stays a pure
+// side-effect that never alters control flow, return values, or toasts.
+export function reportIfFailed<
+  R extends Result<unknown, DomainError> | ReadResult<unknown, DomainError>,
+>(errors: ErrorReportingPort, result: R, rawError?: unknown): R {
+  if (result.kind === 'err') reportWriteError(errors, result.error, rawError);
+  return result;
 }

--- a/apps/web-pwa/src/lib/errorReporting.ts
+++ b/apps/web-pwa/src/lib/errorReporting.ts
@@ -1,0 +1,26 @@
+import type { ErrorReportingPort } from '@salt/domain';
+import type { DomainError } from '@salt/shared-types';
+import { isAuthTransitioning } from '@salt/firebase-sync';
+
+// Shared report path for realtime-subscription onError sites across the service
+// layer (canon/chat/recipe/shopping). The category gate ("report the unexpected,
+// suppress the expected") lives inside the injected port's report(); here we add
+// the ONE extra suppression the category gate cannot make on its own: the
+// sign-out / token-refresh teardown race.
+//
+// An in-flight Firestore listener fires `permission-denied` (→ AuthError) as the
+// session tears down. AuthError is reportable by category, so without this check
+// the teardown race would spam PostHog. While a transition is in flight we drop
+// AuthError; a genuine rules-misconfig AuthError (no transition) still reports.
+// Every other category passes straight to the port and is gated there.
+//
+// The RAW error is forwarded when the subscription supplies it (it carries the
+// real stack); the synthetic DomainError is the fallback when there is none.
+export function reportSubscriptionError(
+  errors: ErrorReportingPort,
+  err: DomainError,
+  rawError?: unknown,
+): void {
+  if (err.kind === 'AuthError' && isAuthTransitioning()) return;
+  errors.report(rawError ?? err, err.kind);
+}

--- a/apps/web-pwa/src/lib/recipeService.ts
+++ b/apps/web-pwa/src/lib/recipeService.ts
@@ -8,7 +8,7 @@ import {
   saveShoppingListItem,
 } from '@salt/firebase-sync';
 import { createObservabilityErrorReportingAdapter } from '@salt/observability';
-import { reportSubscriptionError } from './errorReporting.js';
+import { reportIfFailed, reportSubscriptionError } from './errorReporting.js';
 import { addItem, recipeItemAddDefault } from '@salt/domain';
 import type {
   Recipe,
@@ -111,7 +111,7 @@ export async function persistRecipe(recipe: Recipe): Promise<ReadResult<void, Do
   latestLocalEdit.set(stamped.id, stamped.updatedAt);
   const others = get(_recipes).filter((r) => r.id !== stamped.id);
   _recipes.set([...others, stamped]);
-  return saveRecipeDoc(stamped);
+  return reportIfFailed(getErrorReporter(), await saveRecipeDoc(stamped));
 }
 
 export async function parseIngredients(
@@ -194,7 +194,11 @@ export async function canonicaliseIngredients(
   const batchResult = await callCanonicaliseRecipeIngredients({
     items: toProcess.map(({ rawName, rawText }) => ({ rawName, rawText })),
   });
-  if (batchResult.kind === 'err') return batchResult;
+  // Report the batch CF transport failure (the whole canonicalise call failed).
+  // Per-row `settled[i]` slots below are per-ingredient match OUTCOMES folded
+  // into matchState:'failed' — expected results, not I/O failures — so they are
+  // intentionally not reported.
+  if (batchResult.kind === 'err') return reportIfFailed(getErrorReporter(), batchResult);
   const settled = batchResult.value;
 
   // Map ingredientId → matchOrCreate result for O(1) lookup.
@@ -231,7 +235,7 @@ export async function matchIngredient(
   ing: Ingredient,
 ): Promise<ReadResult<Ingredient, DomainError>> {
   const parseResult = await callParseRecipeIngredients(ing.rawText);
-  if (parseResult.kind === 'err') return parseResult;
+  if (parseResult.kind === 'err') return reportIfFailed(getErrorReporter(), parseResult);
 
   const firstItem = parseResult.value[0]?.items[0];
   if (!firstItem?.parsed) {
@@ -242,7 +246,7 @@ export async function matchIngredient(
   const canonResult = await callCanonicaliseRecipeIngredients({
     items: [{ rawName: parsed.item, rawText: ing.rawText }],
   });
-  if (canonResult.kind === 'err') return canonResult;
+  if (canonResult.kind === 'err') return reportIfFailed(getErrorReporter(), canonResult);
 
   const slot = canonResult.value[0]!;
   if (slot.kind === 'err') {
@@ -260,7 +264,7 @@ export async function removeRecipe(id: string): Promise<ReadResult<void, DomainE
   // Record the delete as a local edit so a stale echo can't resurrect the doc.
   latestLocalEdit.set(id, new Date().toISOString());
   _recipes.set(get(_recipes).filter((r) => r.id !== id));
-  return deleteRecipeDoc(id);
+  return reportIfFailed(getErrorReporter(), await deleteRecipeDoc(id));
 }
 
 // ─── Shopping-list extraction ─────────────────────────────────────────────────
@@ -384,5 +388,9 @@ export async function commitRecipeAddPlan(
   if (saves.length === 0) return success(undefined);
 
   const results = await Promise.all(saves);
-  return results.find((r) => r.kind !== 'ok') ?? success(undefined);
+  const firstFailure = results.find((r) => r.kind !== 'ok');
+  // Report the first shopping-list write failure (StorageError/SyncError/etc.);
+  // the addItem domain ValidationError above short-circuits before any write and
+  // is a suppressed category regardless, so it is intentionally not reported.
+  return firstFailure ? reportIfFailed(getErrorReporter(), firstFailure) : success(undefined);
 }

--- a/apps/web-pwa/src/lib/recipeService.ts
+++ b/apps/web-pwa/src/lib/recipeService.ts
@@ -8,6 +8,7 @@ import {
   saveShoppingListItem,
 } from '@salt/firebase-sync';
 import { createObservabilityErrorReportingAdapter } from '@salt/observability';
+import { reportSubscriptionError } from './errorReporting.js';
 import { addItem, recipeItemAddDefault } from '@salt/domain';
 import type {
   Recipe,
@@ -94,8 +95,8 @@ export function initRecipeSync(): () => void {
       applySnapshot(incoming);
       _isLoadingRecipes.set(false);
     },
-    (err) => {
-      errors.report(err);
+    (err, rawError) => {
+      reportSubscriptionError(errors, err, rawError);
       _isLoadingRecipes.set(false);
     },
   );

--- a/apps/web-pwa/src/lib/shoppingListService.svelte.ts
+++ b/apps/web-pwa/src/lib/shoppingListService.svelte.ts
@@ -35,6 +35,7 @@ import { writable, get } from 'svelte/store';
 import type { Readable } from 'svelte/store';
 import { auth } from './auth.svelte.js';
 import { findMemberByEmail } from './membersService.js';
+import { reportSubscriptionError } from './errorReporting.js';
 
 // ─── ID generators ───────────────────────────────────────────────────────────
 
@@ -97,7 +98,7 @@ export function setActiveListId(listId: string): void {
       _itemsForActiveList.set(items);
       markLoaded('items');
     },
-    (err) => errors.report(err),
+    (err, rawError) => reportSubscriptionError(errors, err, rawError),
   );
 }
 
@@ -119,7 +120,7 @@ export function initShoppingListSync(): () => void {
       _lists.set(incoming);
       markLoaded('lists');
     },
-    (err) => errors.report(err),
+    (err, rawError) => reportSubscriptionError(errors, err, rawError),
   );
 
   const unsubConfig = subscribeShoppingListsConfig(
@@ -127,7 +128,7 @@ export function initShoppingListSync(): () => void {
       _defaultListId.set(config?.defaultListId ?? null);
       markLoaded('config');
     },
-    (err) => errors.report(err),
+    (err, rawError) => reportSubscriptionError(errors, err, rawError),
   );
 
   return () => {

--- a/apps/web-pwa/src/lib/shoppingListService.svelte.ts
+++ b/apps/web-pwa/src/lib/shoppingListService.svelte.ts
@@ -35,7 +35,7 @@ import { writable, get } from 'svelte/store';
 import type { Readable } from 'svelte/store';
 import { auth } from './auth.svelte.js';
 import { findMemberByEmail } from './membersService.js';
-import { reportSubscriptionError } from './errorReporting.js';
+import { reportIfFailed, reportSubscriptionError, reportWriteError } from './errorReporting.js';
 
 // ─── ID generators ───────────────────────────────────────────────────────────
 
@@ -68,6 +68,17 @@ let _errorReporter: ReturnType<typeof createObservabilityErrorReportingAdapter> 
 function getErrorReporter() {
   if (!_errorReporter) _errorReporter = createObservabilityErrorReportingAdapter();
   return _errorReporter;
+}
+
+// Bulk write helper: the multi-item commands (checkItems/uncheckItems/
+// confirmItemsNeeded) fan out N saveShoppingListItem writes and return void.
+// Report the FIRST failing write among them (the gate drops suppressed
+// categories); a single failed write in a batch is enough signal.
+function reportFirstWriteFailure(results: readonly ReadResult<void, DomainError>[]): void {
+  const firstFailure = results.find((r) => r.kind === 'err');
+  if (firstFailure && firstFailure.kind === 'err') {
+    reportWriteError(getErrorReporter(), firstFailure.error);
+  }
 }
 
 // ─── Loading state tracking ──────────────────────────────────────────────────
@@ -147,10 +158,14 @@ export async function addList(name: string): Promise<ReadResult<ShoppingList, Do
   if (result.kind !== 'ok') return result;
   const list = result.value;
   const saveResult = await createShoppingList(list);
-  if (saveResult.kind !== 'ok') return saveResult;
+  if (saveResult.kind !== 'ok') {
+    if (saveResult.kind === 'err') reportWriteError(getErrorReporter(), saveResult.error);
+    return saveResult;
+  }
   if (!get(_defaultListId)) {
     const config: ShoppingListsConfig = { defaultListId: list.id, schemaVersion: 1 };
-    await saveShoppingListsConfig(config);
+    const configResult = await saveShoppingListsConfig(config);
+    if (configResult.kind === 'err') reportWriteError(getErrorReporter(), configResult.error);
   }
   return result;
 }
@@ -163,7 +178,10 @@ export async function renameListById(
   const domainResult = renameList(get(_lists), { id, name, now });
   if (domainResult.kind !== 'ok') return domainResult;
   const updated = domainResult.value.find((l) => l.id === id)!;
-  return renameShoppingList(id, updated.name, updated.updatedAt);
+  return reportIfFailed(
+    getErrorReporter(),
+    await renameShoppingList(id, updated.name, updated.updatedAt),
+  );
 }
 
 export async function removeList(id: string): Promise<ReadResult<void, DomainError>> {
@@ -171,7 +189,7 @@ export async function removeList(id: string): Promise<ReadResult<void, DomainErr
   const config: ShoppingListsConfig = { defaultListId: defaultId, schemaVersion: 1 };
   const domainResult = deleteList(get(_lists), config, { id });
   if (domainResult.kind !== 'ok') return domainResult;
-  return deleteShoppingList(id);
+  return reportIfFailed(getErrorReporter(), await deleteShoppingList(id));
 }
 
 export async function changeDefaultList(listId: string): Promise<ReadResult<void, DomainError>> {
@@ -179,7 +197,7 @@ export async function changeDefaultList(listId: string): Promise<ReadResult<void
   const config: ShoppingListsConfig = { defaultListId: defaultId, schemaVersion: 1 };
   const domainResult = setDefaultList(get(_lists), config, { listId });
   if (domainResult.kind !== 'ok') return domainResult;
-  return saveShoppingListsConfig(domainResult.value);
+  return reportIfFailed(getErrorReporter(), await saveShoppingListsConfig(domainResult.value));
 }
 
 // ─── Item commands ────────────────────────────────────────────────────────────
@@ -198,7 +216,7 @@ export async function addItemToList(
   const result = addItem(items, { rawText, source, now }, ids);
   if (result.kind !== 'ok') return result;
   const newItem = result.value[result.value.length - 1]!;
-  return saveShoppingListItem(listId, newItem);
+  return reportIfFailed(getErrorReporter(), await saveShoppingListItem(listId, newItem));
 }
 
 export async function updateItemRawText(
@@ -211,7 +229,7 @@ export async function updateItemRawText(
   const result = editItemRawText(items, { id: itemId, rawText, now });
   if (result.kind !== 'ok') return result;
   const updated = result.value.find((i) => i.id === itemId)!;
-  return saveShoppingListItem(listId, updated);
+  return reportIfFailed(getErrorReporter(), await saveShoppingListItem(listId, updated));
 }
 
 export async function updateItemAmountUnit(
@@ -225,7 +243,7 @@ export async function updateItemAmountUnit(
   const result = editItemAmountUnit(items, { id: itemId, amount, unit, now });
   if (result.kind !== 'ok') return result;
   const updated = result.value.find((i) => i.id === itemId)!;
-  return saveShoppingListItem(listId, updated);
+  return reportIfFailed(getErrorReporter(), await saveShoppingListItem(listId, updated));
 }
 
 export async function updateItemNotes(
@@ -238,7 +256,7 @@ export async function updateItemNotes(
   const result = editItemNotes(items, { id: itemId, notes, now });
   if (result.kind !== 'ok') return result;
   const updated = result.value.find((i) => i.id === itemId)!;
-  return saveShoppingListItem(listId, updated);
+  return reportIfFailed(getErrorReporter(), await saveShoppingListItem(listId, updated));
 }
 
 export async function toggleItemChecked(
@@ -252,7 +270,7 @@ export async function toggleItemChecked(
     : checkItem(items, { id: item.id, now });
   if (result.kind !== 'ok') return result;
   const updated = result.value.find((i) => i.id === item.id)!;
-  return saveShoppingListItem(listId, updated);
+  return reportIfFailed(getErrorReporter(), await saveShoppingListItem(listId, updated));
 }
 
 // Clear an item's verification flag — the shopper confirmed they need it (issue
@@ -266,7 +284,7 @@ export async function confirmItemNeeded(
   const result = domainConfirmItemNeeded(items, { id: itemId, now });
   if (result.kind !== 'ok') return result;
   const updated = result.value.find((i) => i.id === itemId)!;
-  return saveShoppingListItem(listId, updated);
+  return reportIfFailed(getErrorReporter(), await saveShoppingListItem(listId, updated));
 }
 
 // Clear the verification flag on several items at once — confirming a combined
@@ -283,7 +301,8 @@ export async function confirmItemsNeeded(
     if (result.kind === 'ok') working = result.value;
   }
   const toSave = working.filter((i) => itemIds.includes(i.id));
-  await Promise.all(toSave.map((item) => saveShoppingListItem(listId, item)));
+  const results = await Promise.all(toSave.map((item) => saveShoppingListItem(listId, item)));
+  reportFirstWriteFailure(results);
 }
 
 export async function checkItems(listId: string, itemIds: readonly string[]): Promise<void> {
@@ -295,7 +314,8 @@ export async function checkItems(listId: string, itemIds: readonly string[]): Pr
     if (result.kind === 'ok') working = result.value;
   }
   const toSave = working.filter((i) => itemIds.includes(i.id));
-  await Promise.all(toSave.map((item) => saveShoppingListItem(listId, item)));
+  const results = await Promise.all(toSave.map((item) => saveShoppingListItem(listId, item)));
+  reportFirstWriteFailure(results);
 }
 
 export async function uncheckItems(listId: string, itemIds: readonly string[]): Promise<void> {
@@ -307,7 +327,8 @@ export async function uncheckItems(listId: string, itemIds: readonly string[]): 
     if (result.kind === 'ok') working = result.value;
   }
   const toSave = working.filter((i) => itemIds.includes(i.id));
-  await Promise.all(toSave.map((item) => saveShoppingListItem(listId, item)));
+  const results = await Promise.all(toSave.map((item) => saveShoppingListItem(listId, item)));
+  reportFirstWriteFailure(results);
 }
 
 export async function removeItem(
@@ -317,21 +338,21 @@ export async function removeItem(
   const items = get(_itemsForActiveList);
   const result = deleteItem(items, { id: itemId });
   if (result.kind !== 'ok') return result;
-  return deleteShoppingListItem(listId, itemId);
+  return reportIfFailed(getErrorReporter(), await deleteShoppingListItem(listId, itemId));
 }
 
 export async function removeItems(
   listId: string,
   itemIds: readonly string[],
 ): Promise<ReadResult<void, DomainError>> {
-  return deleteShoppingListItems(listId, itemIds);
+  return reportIfFailed(getErrorReporter(), await deleteShoppingListItems(listId, itemIds));
 }
 
 export async function clearChecked(listId: string): Promise<ReadResult<void, DomainError>> {
   const items = get(_itemsForActiveList);
   const checkedIds = items.filter((i) => i.checked).map((i) => i.id);
   if (checkedIds.length === 0) return { kind: 'ok', value: undefined };
-  return deleteShoppingListItems(listId, checkedIds);
+  return reportIfFailed(getErrorReporter(), await deleteShoppingListItems(listId, checkedIds));
 }
 
 export async function moveSelectedItems(
@@ -343,7 +364,10 @@ export async function moveSelectedItems(
   const now = new Date().toISOString();
   const result = moveItems(items, [], { itemIds, now });
   if (result.kind !== 'ok') return result;
-  return moveShoppingListItems(sourceListId, targetListId, result.value.targetItems);
+  return reportIfFailed(
+    getErrorReporter(),
+    await moveShoppingListItems(sourceListId, targetListId, result.value.targetItems),
+  );
 }
 
 // ─── Snapshots ────────────────────────────────────────────────────────────────

--- a/apps/web-pwa/tests/canonService.errorReporting.test.ts
+++ b/apps/web-pwa/tests/canonService.errorReporting.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mocked } from 'vitest';
+import type { DomainError } from '@salt/shared-types';
+
+// ─── Shared report() spy (Phase 2 write-path reporting) ─────────────────────────
+// The service caches getErrorReporter(); the adapter mock must return a STABLE
+// report so we can assert on it across calls. We delegate to the REAL category
+// gate (isReportableCategory) so "suppressed write failure does NOT surface"
+// exercises the actual report/suppress boundary — not a forked predicate.
+const { reportSpy, gatedReport } = vi.hoisted(() => {
+  const reportSpy = vi.fn();
+  return { reportSpy, gatedReport: reportSpy };
+});
+
+vi.mock('@salt/observability', async () => {
+  const actual = await vi.importActual<typeof import('@salt/observability')>('@salt/observability');
+  return {
+    isReportableCategory: actual.isReportableCategory,
+    createObservabilityErrorReportingAdapter: vi.fn(() => ({
+      // Mirror the real adapter: gate by category, then forward. This keeps the
+      // suppression behaviour under test instead of stubbing it away.
+      report: (error: unknown, category: DomainError['kind']) => {
+        if (!actual.isReportableCategory(category)) return;
+        gatedReport(error, category);
+      },
+    })),
+    createObservabilityMatchLoggingAdapter: vi.fn(() => ({
+      write: vi.fn().mockResolvedValue(undefined),
+    })),
+    startSpan: vi.fn(() => ({ setAttribute: vi.fn(), end: vi.fn() })),
+  };
+});
+
+vi.mock('@salt/firebase-sync', () => ({
+  subscribeCanonItems: vi.fn(() => vi.fn()),
+  subscribeAisles: vi.fn(() => vi.fn()),
+  upsertCanonItem: vi.fn().mockResolvedValue(undefined),
+  deleteCanonItem: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  callMatchOrCreate: vi.fn(),
+  callRegenerateCanonIcon: vi.fn(),
+  isAuthTransitioning: vi.fn(() => false),
+}));
+
+import * as firebaseSync from '@salt/firebase-sync';
+import {
+  addCanonItem,
+  deleteCanonItem,
+  regenerateCanonIcon,
+  unhideCanonIcon,
+  __resetCanonServiceForTest,
+} from '../src/lib/canonService.js';
+
+const fs = firebaseSync as Mocked<typeof firebaseSync>;
+
+const STORAGE_ERR: DomainError = { kind: 'StorageError', reason: 'unavailable' };
+const SYNC_ERR: DomainError = { kind: 'SyncError', reason: 'push-failed' };
+const NETWORK_ERR: DomainError = { kind: 'NetworkError', reason: 'offline' };
+const NOTFOUND_ERR: DomainError = { kind: 'NotFound', resource: 'canon', id: 'x' };
+
+describe('canonService — write/command failure reporting (Phase 2)', () => {
+  beforeEach(() => {
+    __resetCanonServiceForTest();
+    vi.clearAllMocks();
+    reportSpy.mockReset();
+  });
+
+  afterEach(() => {
+    __resetCanonServiceForTest();
+  });
+
+  describe('addCanonItem (matchOrCreateCanon AI callable)', () => {
+    it('reports a StorageError callable failure', async () => {
+      fs.callMatchOrCreate.mockResolvedValueOnce({ kind: 'err', error: STORAGE_ERR });
+      await addCanonItem('milk', null, true);
+      expect(reportSpy).toHaveBeenCalledWith(STORAGE_ERR, 'StorageError');
+    });
+
+    it('does NOT surface a NetworkError callable failure (gate suppresses)', async () => {
+      fs.callMatchOrCreate.mockResolvedValueOnce({ kind: 'err', error: NETWORK_ERR });
+      await addCanonItem('milk', null, true);
+      expect(reportSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteCanonItem (firebase-sync adapter)', () => {
+    it('reports a StorageError adapter failure', async () => {
+      fs.deleteCanonItem.mockResolvedValueOnce({ kind: 'err', error: STORAGE_ERR });
+      await deleteCanonItem('id');
+      expect(reportSpy).toHaveBeenCalledWith(STORAGE_ERR, 'StorageError');
+    });
+
+    it('does NOT surface a NotFound adapter failure (gate suppresses)', async () => {
+      fs.deleteCanonItem.mockResolvedValueOnce({ kind: 'err', error: NOTFOUND_ERR });
+      await deleteCanonItem('id');
+      expect(reportSpy).not.toHaveBeenCalled();
+    });
+
+    it('does NOT report on success', async () => {
+      fs.deleteCanonItem.mockResolvedValueOnce({ kind: 'ok', value: undefined });
+      await deleteCanonItem('id');
+      expect(reportSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('regenerateCanonIcon / unhideCanonIcon (regenerate AI callable)', () => {
+    it('reports a SyncError regenerate failure', async () => {
+      fs.callRegenerateCanonIcon.mockResolvedValueOnce({ kind: 'err', error: SYNC_ERR });
+      await regenerateCanonIcon('id');
+      expect(reportSpy).toHaveBeenCalledWith(SYNC_ERR, 'SyncError');
+    });
+
+    it('reports a StorageError unhide failure', async () => {
+      fs.callRegenerateCanonIcon.mockResolvedValueOnce({ kind: 'err', error: STORAGE_ERR });
+      await unhideCanonIcon('id');
+      expect(reportSpy).toHaveBeenCalledWith(STORAGE_ERR, 'StorageError');
+    });
+  });
+});

--- a/apps/web-pwa/tests/canonService.icon.test.ts
+++ b/apps/web-pwa/tests/canonService.icon.test.ts
@@ -8,6 +8,7 @@ vi.mock('@salt/firebase-sync', () => ({
   deleteCanonItem: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   callMatchOrCreate: vi.fn(),
   callRegenerateCanonIcon: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  isAuthTransitioning: vi.fn(() => false),
 }));
 
 vi.mock('@salt/observability', () => ({

--- a/apps/web-pwa/tests/canonService.sync.test.ts
+++ b/apps/web-pwa/tests/canonService.sync.test.ts
@@ -10,6 +10,7 @@ vi.mock('@salt/firebase-sync', () => ({
   upsertCanonItem: vi.fn().mockResolvedValue(undefined),
   deleteCanonItem: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   callMatchOrCreate: vi.fn(),
+  isAuthTransitioning: vi.fn(() => false),
 }));
 
 vi.mock('@salt/observability', () => ({

--- a/apps/web-pwa/tests/chatService.errorReporting.test.ts
+++ b/apps/web-pwa/tests/chatService.errorReporting.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi, type Mocked } from 'vitest';
+import type { DomainError } from '@salt/shared-types';
+import type { ChatSessionDoc } from '@salt/domain/schemas';
+
+// Stable, gated report() spy — delegates to the REAL category gate so suppressed
+// write failures genuinely no-op (see canonService.errorReporting.test.ts).
+const { reportSpy } = vi.hoisted(() => ({ reportSpy: vi.fn() }));
+
+vi.mock('@salt/observability', async () => {
+  const actual = await vi.importActual<typeof import('@salt/observability')>('@salt/observability');
+  return {
+    isReportableCategory: actual.isReportableCategory,
+    createObservabilityErrorReportingAdapter: vi.fn(() => ({
+      report: (error: unknown, category: DomainError['kind']) => {
+        if (!actual.isReportableCategory(category)) return;
+        reportSpy(error, category);
+      },
+    })),
+  };
+});
+
+vi.mock('@salt/firebase-sync', () => ({
+  subscribeChatSessions: vi.fn(() => vi.fn()),
+  saveChatSession: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  deleteChatSession: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  streamChefChat: vi.fn(),
+  callGenerateChatTitle: vi.fn().mockResolvedValue({ kind: 'ok', value: '' }),
+  isAuthTransitioning: vi.fn(() => false),
+}));
+
+import * as firebaseSync from '@salt/firebase-sync';
+import {
+  createChatSession,
+  persistSession,
+  removeSession,
+  sendMessage,
+} from '../src/lib/chatService.js';
+
+const fs = firebaseSync as Mocked<typeof firebaseSync>;
+
+const STORAGE_ERR: DomainError = { kind: 'StorageError', reason: 'unavailable' };
+const SYNC_ERR: DomainError = { kind: 'SyncError', reason: 'push-failed' };
+const NETWORK_ERR: DomainError = { kind: 'NetworkError', reason: 'offline' };
+const AUTH_ERR: DomainError = { kind: 'AuthError', reason: 'forbidden' };
+
+function makeSession(): ChatSessionDoc {
+  const ts = '2026-01-01T00:00:00.000Z';
+  return {
+    id: 'sess-1',
+    schemaVersion: 1,
+    ownerUid: 'u1',
+    recipeId: null,
+    title: 'New chat',
+    messages: [],
+    createdAt: ts,
+    updatedAt: ts,
+    expiresAt: ts,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  reportSpy.mockReset();
+  fs.saveChatSession.mockResolvedValue({ kind: 'ok', value: undefined });
+  fs.deleteChatSession.mockResolvedValue({ kind: 'ok', value: undefined });
+  fs.callGenerateChatTitle.mockResolvedValue({ kind: 'ok', value: '' });
+});
+
+describe('chatService — write/command failure reporting (Phase 2)', () => {
+  describe('createChatSession (saveChatSession adapter)', () => {
+    it('reports a StorageError save failure', async () => {
+      fs.saveChatSession.mockResolvedValueOnce({ kind: 'err', error: STORAGE_ERR });
+      await createChatSession('u1');
+      expect(reportSpy).toHaveBeenCalledWith(STORAGE_ERR, 'StorageError');
+    });
+
+    it('does NOT surface a NetworkError save failure (gate suppresses)', async () => {
+      fs.saveChatSession.mockResolvedValueOnce({ kind: 'err', error: NETWORK_ERR });
+      await createChatSession('u1');
+      expect(reportSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('persistSession (saveChatSession adapter)', () => {
+    it('reports a SyncError save failure', async () => {
+      fs.saveChatSession.mockResolvedValueOnce({ kind: 'err', error: SYNC_ERR });
+      await persistSession(makeSession());
+      expect(reportSpy).toHaveBeenCalledWith(SYNC_ERR, 'SyncError');
+    });
+  });
+
+  describe('removeSession (deleteChatSession adapter)', () => {
+    it('reports a StorageError delete failure', async () => {
+      fs.deleteChatSession.mockResolvedValueOnce({ kind: 'err', error: STORAGE_ERR });
+      await removeSession('sess-1');
+      expect(reportSpy).toHaveBeenCalledWith(STORAGE_ERR, 'StorageError');
+    });
+  });
+
+  describe('sendMessage (chefChat AI stream callable)', () => {
+    it('reports an AuthError stream failure (write-path AuthError IS reportable)', async () => {
+      fs.streamChefChat.mockResolvedValueOnce({ kind: 'err', error: AUTH_ERR });
+      await sendMessage(makeSession(), 'hi', () => {});
+      expect(reportSpy).toHaveBeenCalledWith(AUTH_ERR, 'AuthError');
+    });
+
+    it('does NOT surface a NetworkError stream failure (gate suppresses)', async () => {
+      fs.streamChefChat.mockResolvedValueOnce({ kind: 'err', error: NETWORK_ERR });
+      await sendMessage(makeSession(), 'hi', () => {});
+      expect(reportSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web-pwa/tests/errorReporting.test.ts
+++ b/apps/web-pwa/tests/errorReporting.test.ts
@@ -8,7 +8,12 @@ vi.mock('@salt/firebase-sync', () => ({
   isAuthTransitioning: () => isAuthTransitioning(),
 }));
 
-import { reportSubscriptionError } from '../src/lib/errorReporting.js';
+import {
+  reportSubscriptionError,
+  reportWriteError,
+  reportIfFailed,
+} from '../src/lib/errorReporting.js';
+import type { ReadResult } from '@salt/shared-types';
 
 describe('reportSubscriptionError (service-layer subscription onError gate)', () => {
   let report: ReturnType<typeof vi.fn>;
@@ -56,5 +61,93 @@ describe('reportSubscriptionError (service-layer subscription onError gate)', ()
     const err: DomainError = { kind: 'NetworkError', reason: 'offline' };
     reportSubscriptionError(errors, err, raw);
     expect(report).toHaveBeenCalledWith(raw, 'NetworkError');
+  });
+});
+
+// The category GATE ("report the unexpected, suppress the expected") lives inside
+// the real injected port's report() (isReportableCategory in @salt/observability,
+// tested there). At the helper level the port is a bare mock, so these tests
+// assert the helper FORWARDS every category to report() keyed by kind — the
+// suppression happens downstream. The write-path distinction this layer DOES own:
+// unlike reportSubscriptionError it never consults isAuthTransitioning(), so a
+// write that fails with AuthError is forwarded (it's a real authz failure the
+// user just triggered, not the listener teardown race).
+describe('reportWriteError (service-layer write/command failure forwarder)', () => {
+  let report: ReturnType<typeof vi.fn>;
+  let errors: ErrorReportingPort;
+
+  beforeEach(() => {
+    report = vi.fn();
+    errors = { report };
+    isAuthTransitioning.mockReturnValue(false);
+  });
+
+  it('forwards the RAW error keyed by the categorised kind', () => {
+    const raw = new Error('firestore write blew up');
+    const err: DomainError = { kind: 'StorageError', reason: 'unavailable' };
+    reportWriteError(errors, err, raw);
+    expect(report).toHaveBeenCalledWith(raw, 'StorageError');
+  });
+
+  it('falls back to the synthetic DomainError when no raw error is supplied', () => {
+    const err: DomainError = { kind: 'SyncError', reason: 'push-failed' };
+    reportWriteError(errors, err);
+    expect(report).toHaveBeenCalledWith(err, 'SyncError');
+  });
+
+  it('forwards write-path AuthError EVEN during an auth transition (no listener race here)', () => {
+    // This is the key divergence from reportSubscriptionError: write paths are
+    // caller-initiated, not in-flight listeners, so the teardown-race suppression
+    // does not apply — an AuthError write failure must reach the port.
+    isAuthTransitioning.mockReturnValue(true);
+    const raw = new Error('permission-denied');
+    const err: DomainError = { kind: 'AuthError', reason: 'forbidden' };
+    reportWriteError(errors, err, raw);
+    expect(report).toHaveBeenCalledWith(raw, 'AuthError');
+  });
+
+  it('forwards suppressed categories too (the port-side gate drops them, not the helper)', () => {
+    const err: DomainError = { kind: 'NetworkError', reason: 'offline' };
+    reportWriteError(errors, err);
+    expect(report).toHaveBeenCalledWith(err, 'NetworkError');
+  });
+});
+
+describe('reportIfFailed (ergonomic err-branch wrapper)', () => {
+  let report: ReturnType<typeof vi.fn>;
+  let errors: ErrorReportingPort;
+
+  beforeEach(() => {
+    report = vi.fn();
+    errors = { report };
+    isAuthTransitioning.mockReturnValue(false);
+  });
+
+  it('no-ops on a success result and returns it unchanged', () => {
+    const ok: ReadResult<number, DomainError> = { kind: 'ok', value: 42 };
+    const returned = reportIfFailed(errors, ok);
+    expect(report).not.toHaveBeenCalled();
+    expect(returned).toBe(ok);
+  });
+
+  it('reports on a failure result and returns it unchanged', () => {
+    const err: ReadResult<number, DomainError> = {
+      kind: 'err',
+      error: { kind: 'StorageError', reason: 'quota-exceeded' },
+    };
+    const returned = reportIfFailed(errors, err);
+    expect(report).toHaveBeenCalledWith(err.error, 'StorageError');
+    expect(returned).toBe(err);
+  });
+
+  it('forwards the raw error when supplied, still returning the result unchanged', () => {
+    const raw = new Error('boom');
+    const err: ReadResult<number, DomainError> = {
+      kind: 'err',
+      error: { kind: 'SyncError', reason: 'pull-failed' },
+    };
+    const returned = reportIfFailed(errors, err, raw);
+    expect(report).toHaveBeenCalledWith(raw, 'SyncError');
+    expect(returned).toBe(err);
   });
 });

--- a/apps/web-pwa/tests/errorReporting.test.ts
+++ b/apps/web-pwa/tests/errorReporting.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ErrorReportingPort } from '@salt/domain';
+import type { DomainError } from '@salt/shared-types';
+
+// Drive the auth-transition flag the service onError sites consult.
+const isAuthTransitioning = vi.fn(() => false);
+vi.mock('@salt/firebase-sync', () => ({
+  isAuthTransitioning: () => isAuthTransitioning(),
+}));
+
+import { reportSubscriptionError } from '../src/lib/errorReporting.js';
+
+describe('reportSubscriptionError (service-layer subscription onError gate)', () => {
+  let report: ReturnType<typeof vi.fn>;
+  let errors: ErrorReportingPort;
+
+  beforeEach(() => {
+    report = vi.fn();
+    errors = { report };
+    isAuthTransitioning.mockReturnValue(false);
+  });
+
+  it('forwards the RAW error (real stack), keyed by the categorised kind', () => {
+    const raw = new Error('firestore blew up');
+    const err: DomainError = { kind: 'StorageError', reason: 'unavailable' };
+    reportSubscriptionError(errors, err, raw);
+    expect(report).toHaveBeenCalledWith(raw, 'StorageError');
+  });
+
+  it('falls back to the synthetic DomainError when no raw error is supplied', () => {
+    const err: DomainError = { kind: 'StorageError', reason: 'corruption' };
+    reportSubscriptionError(errors, err);
+    expect(report).toHaveBeenCalledWith(err, 'StorageError');
+  });
+
+  it('suppresses AuthError while an auth transition is in flight (teardown race)', () => {
+    isAuthTransitioning.mockReturnValue(true);
+    const err: DomainError = { kind: 'AuthError', reason: 'forbidden' };
+    reportSubscriptionError(errors, err, new Error('permission-denied'));
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  it('reports a genuine AuthError when no transition is in flight (rules misconfig)', () => {
+    isAuthTransitioning.mockReturnValue(false);
+    const raw = new Error('permission-denied');
+    const err: DomainError = { kind: 'AuthError', reason: 'forbidden' };
+    reportSubscriptionError(errors, err, raw);
+    expect(report).toHaveBeenCalledWith(raw, 'AuthError');
+  });
+
+  it('forwards non-Auth categories straight through even during a transition', () => {
+    // The flag only ever gates AuthError; the report()-side category gate decides
+    // the rest (a NetworkError still gets forwarded and is dropped there).
+    isAuthTransitioning.mockReturnValue(true);
+    const raw = new Error('offline');
+    const err: DomainError = { kind: 'NetworkError', reason: 'offline' };
+    reportSubscriptionError(errors, err, raw);
+    expect(report).toHaveBeenCalledWith(raw, 'NetworkError');
+  });
+});

--- a/apps/web-pwa/tests/recipeService.addToList.test.ts
+++ b/apps/web-pwa/tests/recipeService.addToList.test.ts
@@ -9,6 +9,7 @@ vi.mock('@salt/firebase-sync', () => ({
   callParseRecipeIngredients: vi.fn(),
   callCanonicaliseRecipeIngredients: vi.fn(),
   saveShoppingListItem: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  isAuthTransitioning: vi.fn(() => false),
 }));
 
 vi.mock('@salt/observability', () => ({

--- a/apps/web-pwa/tests/recipeService.canonicalise.test.ts
+++ b/apps/web-pwa/tests/recipeService.canonicalise.test.ts
@@ -8,6 +8,7 @@ vi.mock('@salt/firebase-sync', () => ({
   deleteRecipe: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
   callParseRecipeIngredients: vi.fn(),
   callCanonicaliseRecipeIngredients: vi.fn(),
+  isAuthTransitioning: vi.fn(() => false),
 }));
 
 vi.mock('@salt/observability', () => ({

--- a/apps/web-pwa/tests/recipeService.errorReporting.test.ts
+++ b/apps/web-pwa/tests/recipeService.errorReporting.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, vi, type Mocked } from 'vitest';
+import type { DomainError } from '@salt/shared-types';
+import type { Recipe, Ingredient, IngredientGroup } from '@salt/domain';
+
+// Stable, gated report() spy — delegates to the REAL category gate so suppressed
+// write failures genuinely no-op (see canonService.errorReporting.test.ts).
+const { reportSpy } = vi.hoisted(() => ({ reportSpy: vi.fn() }));
+
+vi.mock('@salt/observability', async () => {
+  const actual = await vi.importActual<typeof import('@salt/observability')>('@salt/observability');
+  return {
+    isReportableCategory: actual.isReportableCategory,
+    createObservabilityErrorReportingAdapter: vi.fn(() => ({
+      report: (error: unknown, category: DomainError['kind']) => {
+        if (!actual.isReportableCategory(category)) return;
+        reportSpy(error, category);
+      },
+    })),
+  };
+});
+
+vi.mock('@salt/firebase-sync', () => ({
+  subscribeRecipes: vi.fn(() => vi.fn()),
+  saveRecipe: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  deleteRecipe: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  callParseRecipeIngredients: vi.fn(),
+  callCanonicaliseRecipeIngredients: vi.fn(),
+  callExtractRecipeFromUrl: vi.fn(),
+  saveShoppingListItem: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  isAuthTransitioning: vi.fn(() => false),
+}));
+
+const { mockGetCanonItemsSnapshot } = vi.hoisted(() => ({
+  mockGetCanonItemsSnapshot: vi.fn(() => [] as import('@salt/domain').CanonItem[]),
+}));
+vi.mock('../src/lib/canonService.js', () => ({
+  getCanonItemsSnapshot: mockGetCanonItemsSnapshot,
+}));
+
+import * as firebaseSync from '@salt/firebase-sync';
+import {
+  persistRecipe,
+  removeRecipe,
+  matchIngredient,
+  canonicaliseIngredients,
+  commitRecipeAddPlan,
+  type RecipeAddRow,
+} from '../src/lib/recipeService.js';
+
+const fs = firebaseSync as Mocked<typeof firebaseSync>;
+
+const STORAGE_ERR: DomainError = { kind: 'StorageError', reason: 'unavailable' };
+const SYNC_ERR: DomainError = { kind: 'SyncError', reason: 'push-failed' };
+const NETWORK_ERR: DomainError = { kind: 'NetworkError', reason: 'offline' };
+const CONFLICT_ERR: DomainError = { kind: 'ConflictError' };
+
+function makeRecipe(groups: IngredientGroup[] = []): Recipe {
+  return {
+    id: 'recipe-1',
+    schemaVersion: 1,
+    title: 'Test',
+    description: null,
+    ingredients: groups,
+    steps: [],
+    metadata: {
+      servings: null,
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      totalTimeMinutes: null,
+      tags: [],
+    },
+    source: null,
+    notes: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makeIngredient(id: string): Ingredient {
+  return {
+    id,
+    rawText: '2 eggs',
+    parsed: null,
+    canonId: null,
+    matchState: 'pending',
+    isOptional: false,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  reportSpy.mockReset();
+  fs.saveRecipe.mockResolvedValue({ kind: 'ok', value: undefined });
+  fs.deleteRecipe.mockResolvedValue({ kind: 'ok', value: undefined });
+  fs.saveShoppingListItem.mockResolvedValue({ kind: 'ok', value: undefined });
+  mockGetCanonItemsSnapshot.mockReturnValue([]);
+});
+
+describe('recipeService — write/command failure reporting (Phase 2)', () => {
+  describe('persistRecipe', () => {
+    it('reports a StorageError save failure', async () => {
+      fs.saveRecipe.mockResolvedValueOnce({ kind: 'err', error: STORAGE_ERR });
+      await persistRecipe(makeRecipe());
+      expect(reportSpy).toHaveBeenCalledWith(STORAGE_ERR, 'StorageError');
+    });
+
+    it('does NOT surface a ConflictError save failure (gate suppresses)', async () => {
+      fs.saveRecipe.mockResolvedValueOnce({ kind: 'err', error: CONFLICT_ERR });
+      await persistRecipe(makeRecipe());
+      expect(reportSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeRecipe', () => {
+    it('reports a SyncError delete failure', async () => {
+      fs.deleteRecipe.mockResolvedValueOnce({ kind: 'err', error: SYNC_ERR });
+      await removeRecipe('recipe-1');
+      expect(reportSpy).toHaveBeenCalledWith(SYNC_ERR, 'SyncError');
+    });
+  });
+
+  describe('matchIngredient (parse + canonicalise AI callables)', () => {
+    it('reports a StorageError parse failure', async () => {
+      fs.callParseRecipeIngredients.mockResolvedValueOnce({ kind: 'err', error: STORAGE_ERR });
+      await matchIngredient(makeIngredient('a'));
+      expect(reportSpy).toHaveBeenCalledWith(STORAGE_ERR, 'StorageError');
+    });
+
+    it('does NOT surface a NetworkError parse failure (gate suppresses)', async () => {
+      fs.callParseRecipeIngredients.mockResolvedValueOnce({ kind: 'err', error: NETWORK_ERR });
+      await matchIngredient(makeIngredient('a'));
+      expect(reportSpy).not.toHaveBeenCalled();
+    });
+
+    it('reports a StorageError canonicalise failure after a successful parse', async () => {
+      fs.callParseRecipeIngredients.mockResolvedValueOnce({
+        kind: 'ok',
+        value: [
+          {
+            heading: null,
+            items: [
+              { ...makeIngredient('a'), parsed: { item: 'egg', quantity: null, unit: null } },
+            ],
+          } as unknown as IngredientGroup,
+        ],
+      });
+      fs.callCanonicaliseRecipeIngredients.mockResolvedValueOnce({
+        kind: 'err',
+        error: STORAGE_ERR,
+      });
+      await matchIngredient(makeIngredient('a'));
+      expect(reportSpy).toHaveBeenCalledWith(STORAGE_ERR, 'StorageError');
+    });
+  });
+
+  describe('canonicaliseIngredients (batch AI callable)', () => {
+    it('reports a StorageError batch failure', async () => {
+      const recipe = makeRecipe([
+        {
+          heading: null,
+          items: [{ ...makeIngredient('a'), parsed: { item: 'egg', quantity: null, unit: null } }],
+        } as unknown as IngredientGroup,
+      ]);
+      fs.callCanonicaliseRecipeIngredients.mockResolvedValueOnce({
+        kind: 'err',
+        error: STORAGE_ERR,
+      });
+      await canonicaliseIngredients(recipe);
+      expect(reportSpy).toHaveBeenCalledWith(STORAGE_ERR, 'StorageError');
+    });
+  });
+
+  describe('commitRecipeAddPlan (shopping-list item writes)', () => {
+    const row: RecipeAddRow = {
+      ingredientId: 'a',
+      rawText: '2 eggs',
+      name: 'eggs',
+      fromCanon: false,
+      isOptional: false,
+      canonId: null,
+      matched: false,
+      add: true,
+      check: false,
+    };
+
+    it('reports the first StorageError item-write failure', async () => {
+      fs.saveShoppingListItem.mockResolvedValueOnce({ kind: 'err', error: STORAGE_ERR });
+      await commitRecipeAddPlan(makeRecipe(), 'list-1', 1, [row]);
+      expect(reportSpy).toHaveBeenCalledWith(STORAGE_ERR, 'StorageError');
+    });
+
+    it('does NOT report when all item writes succeed', async () => {
+      fs.saveShoppingListItem.mockResolvedValue({ kind: 'ok', value: undefined });
+      await commitRecipeAddPlan(makeRecipe(), 'list-1', 1, [row]);
+      expect(reportSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web-pwa/tests/recipeService.matchIngredient.test.ts
+++ b/apps/web-pwa/tests/recipeService.matchIngredient.test.ts
@@ -9,6 +9,7 @@ vi.mock('@salt/firebase-sync', () => ({
   callParseRecipeIngredients: vi.fn(),
   callCanonicaliseRecipeIngredients: vi.fn(),
   saveShoppingListItem: vi.fn(),
+  isAuthTransitioning: vi.fn(() => false),
 }));
 
 vi.mock('@salt/observability', () => ({

--- a/apps/web-pwa/tests/shoppingListService.errorReporting.test.ts
+++ b/apps/web-pwa/tests/shoppingListService.errorReporting.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi, type Mocked } from 'vitest';
+import type { DomainError } from '@salt/shared-types';
+
+// Stable, gated report() spy — delegates to the REAL category gate so suppressed
+// write failures genuinely no-op (see canonService.errorReporting.test.ts).
+const { reportSpy } = vi.hoisted(() => ({ reportSpy: vi.fn() }));
+
+vi.mock('@salt/observability', async () => {
+  const actual = await vi.importActual<typeof import('@salt/observability')>('@salt/observability');
+  return {
+    isReportableCategory: actual.isReportableCategory,
+    createObservabilityErrorReportingAdapter: vi.fn(() => ({
+      report: (error: unknown, category: DomainError['kind']) => {
+        if (!actual.isReportableCategory(category)) return;
+        reportSpy(error, category);
+      },
+    })),
+  };
+});
+
+vi.mock('@salt/firebase-sync', () => ({
+  subscribeShoppingLists: vi.fn(),
+  createShoppingList: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  renameShoppingList: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  deleteShoppingList: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  subscribeShoppingListItems: vi.fn(),
+  saveShoppingListItem: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  deleteShoppingListItem: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  deleteShoppingListItems: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  moveShoppingListItems: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  subscribeShoppingListsConfig: vi.fn(),
+  saveShoppingListsConfig: vi.fn().mockResolvedValue({ kind: 'ok', value: undefined }),
+  subscribeMembers: vi.fn(),
+  upsertMember: vi.fn(),
+  deleteMember: vi.fn(),
+  isAuthTransitioning: vi.fn(() => false),
+}));
+
+vi.mock('../src/lib/auth.svelte.js', () => ({
+  auth: { user: null as { uid: string; email: string | null } | null },
+}));
+
+import * as firebaseSync from '@salt/firebase-sync';
+import { auth } from '../src/lib/auth.svelte.js';
+import { __resetMembersServiceForTest } from '../src/lib/membersService.js';
+import {
+  addList,
+  addItemToList,
+  removeItems,
+  __resetShoppingListServiceForTest,
+} from '../src/lib/shoppingListService.svelte.js';
+
+const fs = firebaseSync as Mocked<typeof firebaseSync>;
+
+const STORAGE_ERR: DomainError = { kind: 'StorageError', reason: 'unavailable' };
+const SYNC_ERR: DomainError = { kind: 'SyncError', reason: 'push-failed' };
+const NETWORK_ERR: DomainError = { kind: 'NetworkError', reason: 'offline' };
+const VALIDATION_ERR: DomainError = { kind: 'ValidationError', code: 0 as never };
+
+beforeEach(() => {
+  __resetShoppingListServiceForTest();
+  __resetMembersServiceForTest();
+  vi.clearAllMocks();
+  reportSpy.mockReset();
+  fs.createShoppingList.mockResolvedValue({ kind: 'ok', value: undefined });
+  fs.saveShoppingListItem.mockResolvedValue({ kind: 'ok', value: undefined });
+  fs.deleteShoppingListItems.mockResolvedValue({ kind: 'ok', value: undefined });
+  fs.saveShoppingListsConfig.mockResolvedValue({ kind: 'ok', value: undefined });
+  auth.user = null;
+});
+
+describe('shoppingListService — write failure reporting (Phase 2)', () => {
+  describe('addList (createShoppingList adapter)', () => {
+    it('reports a StorageError create failure', async () => {
+      fs.createShoppingList.mockResolvedValueOnce({ kind: 'err', error: STORAGE_ERR });
+      await addList('Groceries');
+      expect(reportSpy).toHaveBeenCalledWith(STORAGE_ERR, 'StorageError');
+    });
+
+    it('does NOT surface a NetworkError create failure (gate suppresses)', async () => {
+      fs.createShoppingList.mockResolvedValueOnce({ kind: 'err', error: NETWORK_ERR });
+      await addList('Groceries');
+      expect(reportSpy).not.toHaveBeenCalled();
+    });
+
+    it('does NOT report on success', async () => {
+      await addList('Groceries');
+      expect(reportSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('addItemToList (saveShoppingListItem adapter)', () => {
+    it('reports a SyncError item-write failure', async () => {
+      fs.saveShoppingListItem.mockResolvedValueOnce({ kind: 'err', error: SYNC_ERR });
+      await addItemToList('list-1', 'milk');
+      expect(reportSpy).toHaveBeenCalledWith(SYNC_ERR, 'SyncError');
+    });
+  });
+
+  describe('removeItems (deleteShoppingListItems adapter)', () => {
+    it('reports a StorageError delete failure', async () => {
+      fs.deleteShoppingListItems.mockResolvedValueOnce({ kind: 'err', error: STORAGE_ERR });
+      await removeItems('list-1', ['i1', 'i2']);
+      expect(reportSpy).toHaveBeenCalledWith(STORAGE_ERR, 'StorageError');
+    });
+
+    it('does NOT surface a ValidationError delete failure (gate suppresses)', async () => {
+      fs.deleteShoppingListItems.mockResolvedValueOnce({ kind: 'err', error: VALIDATION_ERR });
+      await removeItems('list-1', ['i1']);
+      expect(reportSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web-pwa/tests/shoppingListService.manualSource.test.ts
+++ b/apps/web-pwa/tests/shoppingListService.manualSource.test.ts
@@ -18,6 +18,7 @@ vi.mock('@salt/firebase-sync', () => ({
   subscribeMembers: vi.fn(),
   upsertMember: vi.fn(),
   deleteMember: vi.fn(),
+  isAuthTransitioning: vi.fn(() => false),
 }));
 
 vi.mock('@salt/observability', () => ({

--- a/docs/error-reporting-calibration.md
+++ b/docs/error-reporting-calibration.md
@@ -45,6 +45,24 @@ Coverage is uniform across all failure boundaries — write/command failures,
 realtime `onError` callbacks, and server CF — gated by category, not by which
 call site happens to expose an `onError`.
 
+## Uncaught errors — separate, automatic path
+
+The category gate above governs **caught** errors only. **Uncaught** errors
+(unhandled exceptions and promise rejections) are captured automatically by
+PostHog's exception autocapture and appear as Error Tracking issues independently
+of `ErrorReportingPort`. This is controlled by the PostHog **project-level**
+autocapture setting — the browser SDK init (`init.ts`) does not set
+`capture_exceptions`, so no code change gates, forces, or duplicates it.
+
+Two consequences for the before/after read:
+
+- Caught errors are caught, so they never reach autocapture — nothing this
+  feature explicitly reports is double-counted.
+- The "should be ABSENT" list applies to the **explicit caught path**. A failure
+  in an otherwise-suppressed category (e.g. a `NetworkError`) that escapes
+  **uncaught** can still surface via autocapture. That is acceptable: an uncaught
+  error is genuinely unexpected regardless of the category it would have mapped to.
+
 ## Known, intentional asymmetries (NOT bugs)
 
 1. **Server reports carry no `error.category` property.** The client adapter

--- a/docs/error-reporting-calibration.md
+++ b/docs/error-reporting-calibration.md
@@ -1,0 +1,75 @@
+# Caught-error reporting — calibration note
+
+This is the operator/reviewer checklist for the category-gated caught-error
+reporting feature. The policy itself lives in
+[docs/salt-architecture.md §7.6](salt-architecture.md) ("report the unexpected,
+suppress the expected"); the gate is the single shared predicate
+`isReportableCategory` in
+`packages/adapters/observability/src/shared/reportableCategory.ts`, used verbatim
+by both the browser default subpath and the `/server` subpath. This note records
+how to confirm the rollout in PostHog and the known, intentional asymmetries so
+they are not mistaken for bugs.
+
+## Before/after check in PostHog Error Tracking
+
+Compare the Error Tracking issue list across the deploy boundary.
+
+**Should now be ABSENT (previously noisy — these are expected operational
+states, suppressed by category):**
+
+- `NetworkError` / offline — reads and writes degrade gracefully via Firestore
+  `persistentLocalCache`; an offline state is not a fault.
+- `ValidationError` — invalid user input, not a system failure.
+- `NotFound`.
+- `ConflictError` — resolved by the LWW policy in `packages/domain`.
+- The sign-out / token-refresh `permission-denied` race, where in-flight
+  realtime listeners receive `permission-denied` as auth tears down. `AuthError`
+  is reportable BY CATEGORY, but this specific teardown race is suppressed
+  separately via the auth-transition flag in `@salt/firebase-sync` that catch /
+  `onError` call sites consult before reporting. A genuine rules-misconfig
+  `permission-denied` (no transition in flight) still reports.
+
+**Should now be PRESENT, with real stacks (previously invisible — a handled
+failure never throws, so nothing automatic surfaced it):**
+
+- Browser write / command failures in reportable categories — `StorageError`
+  (corruption, quota exceeded, storage unavailable) and `SyncError` (a write the
+  user attempted that failed unexpectedly), captured with `error.category`.
+- All server-side Cloud Function / callable / AI-Genkit-flow failures —
+  unhandled CF exceptions and AI flow failures (timeouts, model errors).
+  Uncategorised server exceptions report by default (`undefined → report`).
+  These appear under the synthetic server person **`salt-cloud-functions`**
+  (the fixed `SERVER_DISTINCT_ID`), not a real user.
+
+Coverage is uniform across all failure boundaries — write/command failures,
+realtime `onError` callbacks, and server CF — gated by category, not by which
+call site happens to expose an `onError`.
+
+## Known, intentional asymmetries (NOT bugs)
+
+1. **Server reports carry no `error.category` property.** The client adapter
+   attaches `{ 'error.category': <kind> }`; the server adapter calls
+   `captureServerException(err)` → `captureException(err, SERVER_DISTINCT_ID)`
+   with the distinctId only and no properties bag — even when a category is
+   known. This is a deliberate scope decision for this feature (adding it would
+   be a behaviour change); attaching the category server-side is a possible
+   future enhancement, intentionally NOT done here. The report/suppress
+   *decision* is identical on both sides — only the attached metadata differs.
+
+2. **Some AI-flow failures do not surface as server reports.** Certain
+   embed / arbitrate / parse flow failures are reached via adapters that
+   downgrade them to a SUPPRESSED `NetworkError` Result. Because the gate keys on
+   category, that downgrade means the failure is not re-reported as a server
+   exception — this is intentional, to avoid double / over-reporting the same
+   underlying condition through two paths.
+
+## No raw user content in payloads
+
+The error's own message and stack are KEPT — they are the signal. The invariant
+is narrower: no SEPARATE free-form context / properties bag carrying user input
+(canon match text, recipe ingredient strings, …) is attached to a reported
+event. This is enforced by the scrubbing tests in
+`packages/adapters/observability/tests/payloadScrubbing.test.ts` (client:
+captured properties are exactly `['error.category']`; server: only the
+distinctId string, no properties bag), and the client/server parity is locked by
+`packages/adapters/observability/tests/reportabilityParity.test.ts`.

--- a/docs/salt-architecture.md
+++ b/docs/salt-architecture.md
@@ -245,9 +245,32 @@ No Firebase error codes may cross the boundary.
 
 ### 7.6 Logging and Error Reporting
 
-- Adapters may log internal errors for diagnostics via the `ErrorReportingPort`.
-- All error reporting is mediated through `ErrorReportingPort`.
-- **Cloud Functions** log via `firebase-functions/logger` with structured JSON shaped to match the `DomainError` taxonomy (`{ scope, docId, errorCategory }`).
+All error reporting is mediated through `ErrorReportingPort` — adapters never touch a telemetry SDK directly. Reporting is best-effort and must never throw across the boundary (§7.5, Rule 10): a dropped report is always preferable to a thrown error in a caller's hot path.
+
+**Principle: report the unexpected, suppress the expected.** The reason to report a *caught* error is that the friendly-handling path would otherwise hide it — a handled failure never throws, so nothing automatic will surface it. Reporting exists to make those invisible failures visible; it is **not** a mirror of every `Failure`. The decision to report is gated on the **`DomainError` category** (§7.2), not on which call site happens to have a `catch` or an `onError` callback.
+
+**Report** to the error-tracking backend (PostHog) via `ErrorReportingPort`:
+
+- `StorageError` — corruption, quota exceeded, storage unavailable.
+- `SyncError` — a write the user attempted that failed unexpectedly.
+- `AuthError` — **except** the sign-out / token-refresh race, where in-flight realtime listeners receive `permission-denied` as auth tears down. That specific case is a known false positive and is suppressed.
+- Any error that maps to **no** known operational category (unknown / unexpected). These are the highest-signal reports.
+- **Server-side:** unhandled Cloud Function exceptions and AI/Genkit flow failures (timeouts, model errors).
+
+**Do not report** (handle with a friendly message only — these are expected operational states, not faults):
+
+- `NetworkError` / offline — expected by design; reads and writes degrade gracefully via `persistentLocalCache`.
+- The sign-out / token-refresh `AuthError` race described above.
+- `ValidationError` — invalid user input, not a system failure.
+- `NotFound` and `ConflictError` — expected; `ConflictError` is resolved by the LWW policy in `packages/domain`.
+
+**Coverage.** Apply the policy uniformly across *all* failure boundaries — command/write failures that return `Failure<DomainError>`, realtime read/stream `onError` callbacks, and server-side Cloud Functions — gated by category. Do not report at only the subset of sites that happen to expose an `onError` callback.
+
+**Reported context.** Data is family-shared (no per-user PII by design), but raw user input (e.g. canon match text) must be scrubbed from reported error context. Report the error's type/message/stack and the `DomainError` category; do not attach free-form user content.
+
+**Cloud Functions** continue to log via `firebase-functions/logger` with structured JSON shaped to match the `DomainError` taxonomy (`{ scope, docId, errorCategory }`). Server-side PostHog error reporting is **additive** to this logging, not a replacement.
+
+**Enforcement.** Unlike the import-graph rules (§11), this policy is a runtime-categorization convention — it is enforced by code review, the category-gating helper at the `ErrorReportingPort` boundary, and unit tests, not by `eslint-plugin-boundaries`.
 
 ---
 

--- a/docs/salt-architecture.md
+++ b/docs/salt-architecture.md
@@ -249,6 +249,8 @@ All error reporting is mediated through `ErrorReportingPort` — adapters never 
 
 **Principle: report the unexpected, suppress the expected.** The reason to report a *caught* error is that the friendly-handling path would otherwise hide it — a handled failure never throws, so nothing automatic will surface it. Reporting exists to make those invisible failures visible; it is **not** a mirror of every `Failure`. The decision to report is gated on the **`DomainError` category** (§7.2), not on which call site happens to have a `catch` or an `onError` callback.
 
+**Caught vs uncaught.** This gated port governs *caught* errors only. *Uncaught* errors — unhandled exceptions and promise rejections — are surfaced automatically by PostHog's exception autocapture as Error Tracking issues, independently of `ErrorReportingPort`. This is controlled by the PostHog **project-level** autocapture setting; the browser SDK init (`init.ts`) deliberately does not set `capture_exceptions`, so it neither forces nor blocks it. An uncaught error is unexpected by definition, so it is intentionally **not** subject to the category gate — there is nothing to suppress. Because caught errors are, by definition, caught, they never reach autocapture, so the two paths never double-report.
+
 **Report** to the error-tracking backend (PostHog) via `ErrorReportingPort`:
 
 - `StorageError` — corruption, quota exceeded, storage unavailable.

--- a/docs/salt-architecture.md
+++ b/docs/salt-architecture.md
@@ -272,6 +272,8 @@ All error reporting is mediated through `ErrorReportingPort` — adapters never 
 
 **Enforcement.** Unlike the import-graph rules (§11), this policy is a runtime-categorization convention — it is enforced by code review, the category-gating helper at the `ErrorReportingPort` boundary, and unit tests, not by `eslint-plugin-boundaries`.
 
+**Calibration.** For the post-rollout PostHog Error Tracking before/after check, the synthetic server person, and the known intentional client/server asymmetries, see [docs/error-reporting-calibration.md](error-reporting-calibration.md).
+
 ---
 
 ## 8. Cloud Functions requirements

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - salt-vscode  (2026-06-27)
 
 ## Corpus Check
-- 826 files · ~293,151 words
+- 829 files · ~294,862 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3884 nodes · 7649 edges · 322 communities (271 shown, 51 thin omitted)
+- 3894 nodes · 7674 edges · 318 communities (271 shown, 47 thin omitted)
 - Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 121 edges (avg confidence: 0.81)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `511937f7`
+- Built from commit: `192fd590`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -227,7 +227,6 @@
 - [[_COMMUNITY_pnpm Workspace Config|pnpm Workspace Config]]
 - [[_COMMUNITY_Tokens|Tokens]]
 - [[_COMMUNITY_Tokens|Tokens]]
-- [[_COMMUNITY_Community 265|Community 265]]
 - [[_COMMUNITY_Community 266|Community 266]]
 - [[_COMMUNITY_Community 267|Community 267]]
 - [[_COMMUNITY_Community 268|Community 268]]
@@ -248,7 +247,6 @@
 - [[_COMMUNITY_Community 283|Community 283]]
 - [[_COMMUNITY_Community 284|Community 284]]
 - [[_COMMUNITY_Community 285|Community 285]]
-- [[_COMMUNITY_Community 286|Community 286]]
 - [[_COMMUNITY_Community 287|Community 287]]
 - [[_COMMUNITY_Community 288|Community 288]]
 - [[_COMMUNITY_Community 289|Community 289]]
@@ -260,7 +258,6 @@
 - [[_COMMUNITY_Community 295|Community 295]]
 - [[_COMMUNITY_Community 296|Community 296]]
 - [[_COMMUNITY_Community 297|Community 297]]
-- [[_COMMUNITY_Community 298|Community 298]]
 - [[_COMMUNITY_Community 299|Community 299]]
 - [[_COMMUNITY_Community 300|Community 300]]
 - [[_COMMUNITY_Community 301|Community 301]]
@@ -277,7 +274,6 @@
 - [[_COMMUNITY_Community 315|Community 315]]
 - [[_COMMUNITY_Community 316|Community 316]]
 - [[_COMMUNITY_Community 322|Community 322]]
-- [[_COMMUNITY_Community 323|Community 323]]
 - [[_COMMUNITY_Community 324|Community 324]]
 - [[_COMMUNITY_Community 325|Community 325]]
 - [[_COMMUNITY_Community 326|Community 326]]
@@ -286,7 +282,7 @@
 - [[_COMMUNITY_Community 330|Community 330]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `DomainError` - 99 edges
+1. `DomainError` - 100 edges
 2. `../../lib/canonService.js` - 82 edges
 3. `../../lib/shoppingListService.svelte.js` - 81 edges
 4. `ReadResult` - 78 edges
@@ -320,27 +316,27 @@
 - **Canon Matching Entry Points & Shared Core** — matching_pipeline_fast_path, matching_pipeline_match_or_create_canon_callable, matching_pipeline_on_shopping_list_item_write, matching_pipeline_canonicalise_recipe_ingredients, matching_pipeline_match_or_create_batch [EXTRACTED 1.00]
 - **Issue-Driven Agentic Workflow Commands** — commands_spec_feature_spec, commands_defect_defect_spec, commands_refactor_spec_refactor_spec, commands_run_run_issue [INFERRED 0.85]
 
-## Communities (322 total, 51 thin omitted)
+## Communities (318 total, 47 thin omitted)
 
 ### Community 0 - "Meal Planner & Attendees"
-Cohesion: 0.05
-Nodes (96): addAttendee(), DayContainer, removeAttendee(), setAttendeeHomeTime(), setAttendeeNote(), setDayChefs(), setDayGuests(), setDayNote() (+88 more)
+Cohesion: 0.12
+Nodes (31): addAttendee(), ../../lib/mealPlanService.js, addDays(), addTemplateAttendee(), addWeekAttendee(), _anchorDate, _config, currentWeekObject() (+23 more)
 
 ### Community 1 - "Aisles & Canon Stores"
 Cohesion: 0.11
-Nodes (31): fakeStore(), AddAccessoryInput, AddEquipmentInput, AddItemInput, AddRuleInput, EditRuleInput, MoveItemsResult, RemoveAccessoryInput (+23 more)
+Nodes (25): DayContainer, removeAttendee(), setAttendeeHomeTime(), setAttendeeNote(), setDayChefs(), setDayGuests(), setDayNote(), withDay() (+17 more)
 
 ### Community 2 - "Firebase-Sync Shopping Config"
 Cohesion: 0.14
-Nodes (23): ../../lib/aisleService.js, addAisle(), addAislesBulk(), deleteAisles(), idGen, mergeAisles(), renameAisle(), reorderAisles() (+15 more)
+Nodes (24): ../../lib/aisleService.js, addAisle(), addAislesBulk(), deleteAisles(), idGen, mergeAisles(), renameAisle(), reorderAisles() (+16 more)
 
 ### Community 3 - "Canon Approval UI"
-Cohesion: 0.08
-Nodes (34): base, approveCanonItem(), renameCanonItem(), setCanonItemAisle(), setCanonItemShoppingBehavior(), setCanonItemThreshold(), setCanonItemSynonyms(), setCanonItemThumbnail() (+26 more)
+Cohesion: 0.09
+Nodes (32): base, approveCanonItem(), renameCanonItem(), ../../lib/canonService.js, addCanonItem(), approveCanonItemWithOverrides(), commitCanonItemUpdate(), deleteCanonItem() (+24 more)
 
 ### Community 4 - "Shopping List Commands"
-Cohesion: 0.06
-Nodes (42): CheckItemInput, ConfirmItemNeededInput, createList(), CreateListInput, DeleteItemInput, deleteList(), DeleteListInput, EditItemAmountUnitInput (+34 more)
+Cohesion: 0.05
+Nodes (48): AddItemInput, CheckItemInput, ConfirmItemNeededInput, CreateListInput, DeleteItemInput, DeleteListInput, EditItemAmountUnitInput, EditItemNotesInput (+40 more)
 
 ### Community 5 - "Headless UI Primitives"
 Cohesion: 0.06
@@ -351,36 +347,36 @@ Cohesion: 0.10
 Nodes (30): createViaCombobox(), PASTE_TEXT, STUB_PARSE, AutoFixtures, E2E_RAW_DIR, test, gotoAndSignIn(), seedMemberAllowlist() (+22 more)
 
 ### Community 7 - "Firestore Stores & Classify"
-Cohesion: 0.11
-Nodes (18): eSim, eX, eY, applyClassification(), arbitrationFailureReasoning(), ArbitrationNew, ArbOutcome, Classification (+10 more)
+Cohesion: 0.06
+Nodes (40): eSim, eX, eY, MatchLogBuilder, CreateAisleInput, CreateAislesBulkInput, DeleteAislesInput, MatchOrCreatePorts (+32 more)
 
 ### Community 8 - "Shopping List UI"
-Cohesion: 0.09
-Nodes (52): addItem(), checkItem(), clearCheckedItems(), confirmItemNeeded(), deleteItem(), editItemAmountUnit(), editItemNotes(), editItemRawText() (+44 more)
+Cohesion: 0.07
+Nodes (55): addItem(), checkItem(), clearCheckedItems(), confirmItemNeeded(), createList(), deleteItem(), deleteList(), editItemAmountUnit() (+47 more)
 
 ### Community 9 - "Equipment & Rules"
-Cohesion: 0.08
-Nodes (50): addAccessory(), addEquipment(), addRule(), editRule(), removeAccessory(), removeEquipment(), removeRule(), renameEquipment() (+42 more)
+Cohesion: 0.07
+Nodes (57): addAccessory(), AddAccessoryInput, addEquipment(), AddEquipmentInput, addRule(), AddRuleInput, editRule(), EditRuleInput (+49 more)
 
 ### Community 10 - "Members Management"
-Cohesion: 0.06
-Nodes (41): createMember(), CreateMemberInput, normaliseMemberEmail(), updateMember(), UpdateMemberPatch, Member, auth, ../../lib/membersService.js (+33 more)
+Cohesion: 0.07
+Nodes (33): auth, ../../lib/membersService.js, createMemberEntry(), CreateMemberEntryInput, deleteMemberEntry(), findMemberByEmail(), getMembersSnapshot(), initMembersSync() (+25 more)
 
 ### Community 11 - "Canon Matching Core"
-Cohesion: 0.13
-Nodes (11): items, ApproveCanonItemOverrides, CreateCanonItemInput, ArbitrationExtras, CanonItem, MatchCandidate, MatchStage, synonymMatch() (+3 more)
+Cohesion: 0.06
+Nodes (22): catalog, AISLES, local, remote, items, ApproveCanonItemOverrides, CreateCanonItemInput, ArbitrationExtras (+14 more)
 
 ### Community 12 - "web-pwa Dependencies"
 Cohesion: 0.04
 Nodes (45): dependencies, @lucide/svelte, @salt/domain, @salt/firebase-sync, @salt/observability, @salt/shared-types, @salt/ui-components, svelte (+37 more)
 
 ### Community 13 - "UI-Components Package"
-Cohesion: 0.04
-Nodes (41): svelte-exmarkdown/gfm, dependencies, bits-ui, class-variance-authority, clsx, @floating-ui/dom, @lucide/svelte, svelte (+33 more)
+Cohesion: 0.05
+Nodes (40): dependencies, bits-ui, class-variance-authority, clsx, @floating-ui/dom, @lucide/svelte, svelte, svelte-dnd-action (+32 more)
 
 ### Community 14 - "Combobox Primitive"
-Cohesion: 0.08
-Nodes (38): CanonIconProps, ../../src/primitives/Combobox/Combobox.svelte, ctx, filterValue, initialItem, inputId, inputValue, listboxId (+30 more)
+Cohesion: 0.07
+Nodes (30): ../../src/primitives/Combobox/Combobox.svelte, ctx, filterValue, initialItem, inputId, inputValue, listboxId, ../../src/primitives/Combobox/ComboboxContent.svelte (+22 more)
 
 ### Community 15 - "Domain Zod Schemas"
 Cohesion: 0.09
@@ -391,8 +387,8 @@ Cohesion: 0.05
 Nodes (37): COLOR_MAP, CONTROLS_CHECKBOX_MAP, CONTROLS_SWITCH_MAP, cssVars, design, DESIGN_MD_PATH, designCheckbox, designColors (+29 more)
 
 ### Community 17 - "Canon Fast-Path Parity"
-Cohesion: 0.11
-Nodes (19): aisleStore, failingArbitration, failingEmbedding, ids, makeStore(), runCfPath(), runFastPath(), catalog (+11 more)
+Cohesion: 0.08
+Nodes (30): aisleStore, failingArbitration, failingEmbedding, ids, makeStore(), runCfPath(), runFastPath(), appendCanonSynonym() (+22 more)
 
 ### Community 18 - "Select Primitive"
 Cohesion: 0.09
@@ -403,44 +399,44 @@ Cohesion: 0.09
 Nodes (11): cp, DEFAULT_LABELS, FALLBACK_META, getTaskLabel(), metaFor(), net, NUKE_PORTS, SERVICE_META (+3 more)
 
 ### Community 20 - "Admin Routes"
-Cohesion: 0.17
-Nodes (10): ../../lib/auth.svelte.js, AuthStore, clearPendingEmail(), devSignIn(), formatError(), readPendingEmail(), writePendingEmail(), authProvider (+2 more)
+Cohesion: 0.18
+Nodes (10): ../../lib/auth.svelte.js, AuthStore, clearPendingEmail(), devSignIn(), formatError(), readPendingEmail(), writePendingEmail(), $lib/observability (+2 more)
 
 ### Community 21 - "Combobox & ListPage Types"
-Cohesion: 0.50
-Nodes (3): ../../primitives/EmptyState/EmptyState.svelte, EmptyStateProps, ./EmptyState.types
+Cohesion: 0.12
+Nodes (25): CanonIconProps, ComboboxContentProps, ComboboxCreateProps, ComboboxEmptyProps, ComboboxFieldProps, ComboboxGroupProps, ComboboxInputProps, ComboboxItem (+17 more)
 
 ### Community 22 - "Task Pilot Manifest"
 Cohesion: 0.06
 Nodes (35): categories, properties, title, contributes, commands, configuration, menus, views (+27 more)
 
 ### Community 23 - "Dialog & Popover Primitives"
-Cohesion: 0.10
-Nodes (14): DialogContentProps, DialogPartProps, DialogProps, state, TooltipContentProps, TooltipPartProps, TooltipProps, TooltipProviderProps (+6 more)
+Cohesion: 0.11
+Nodes (12): comboboxContentVariants, comboboxCreateVariants, comboboxInputVariants, comboboxItemVariants, comboboxTriggerVariants, DialogContentProps, DialogPartProps, DialogProps (+4 more)
 
 ### Community 24 - "Recipe Service"
-Cohesion: 0.09
-Nodes (25): ../../lib/recipeService.js, applySnapshot(), buildRecipeAddPlan(), canonicaliseIngredients(), getErrorReporter(), getRecipesSnapshot(), importRecipeFromUrl(), initRecipeSync() (+17 more)
+Cohesion: 0.08
+Nodes (20): ../../lib/recipeService.js, buildRecipeAddPlan(), getRecipesSnapshot(), importRecipeFromUrl(), isLoadingRecipes, _itemIds, latestLocalEdit, parseIngredients() (+12 more)
 
 ### Community 25 - "Observability (PostHog)"
-Cohesion: 0.11
-Nodes (30): getSessionURL(), identifyAnonymous(), identifyUser(), isSessionActive(), _phKey, startSession(), stopSession(), tagSession() (+22 more)
+Cohesion: 0.14
+Nodes (25): getSessionURL(), identifyAnonymous(), identifyUser(), isSessionActive(), _phKey, startSession(), stopSession(), tagSession() (+17 more)
 
 ### Community 26 - "Selectable List & Checkbox"
-Cohesion: 0.13
-Nodes (13): ../../primitives/Checkbox/Checkbox.svelte, EditableRowProps, createListSelection(), CreateListSelectionOptions, ListSelection, ./RowSelectCheckbox.svelte, SelectableListItem, SelectableListProps (+5 more)
+Cohesion: 0.11
+Nodes (16): ../../primitives/Checkbox/Checkbox.svelte, CheckboxProps, CheckedState, CheckboxRootVariants, EditableRowProps, createListSelection(), CreateListSelectionOptions, ListSelection (+8 more)
 
 ### Community 27 - "Layout Primitives"
-Cohesion: 0.06
-Nodes (23): CheckboxProps, CheckedState, CheckboxRootVariants, comboboxContentVariants, comboboxCreateVariants, comboboxInputVariants, comboboxItemVariants, comboboxTriggerVariants (+15 more)
+Cohesion: 0.08
+Nodes (14): DividerProps, GridProps, GridVariants, InlineProps, InlineVariants, StackProps, StackVariants, ./Divider.types (+6 more)
 
 ### Community 28 - "AI Flows & Telemetry"
 Cohesion: 0.17
-Nodes (15): readUsage(), tracedGenerate(), assembleDraft(), OutputSchema, canonicaliseRecipeIngredientsFlow, ItemResultSchema, OutputSchema, assembleDraft() (+7 more)
+Nodes (11): assembleDraft(), authorRecipeFlow, OutputSchema, canonicaliseRecipeIngredientsFlow, assembleDraft(), buildHtmlPrompt(), extractRecipeFromUrlFlow, OutputSchema (+3 more)
 
 ### Community 29 - "AI Timeout Guard"
-Cohesion: 0.17
-Nodes (15): embedTextFlow, generateCanonIconFlow, removeFlatBackground(), RemoveFlatBackgroundOptions, sampleBackgroundColour(), reportServerError(), buildIconDownloadUrl(), geminiApiKey (+7 more)
+Cohesion: 0.15
+Nodes (17): embedTextFlow, generateCanonIconFlow, removeFlatBackground(), RemoveFlatBackgroundOptions, sampleBackgroundColour(), reporter, reportFlowError(), reportServerError() (+9 more)
 
 ### Community 30 - "cloud-functions Dependencies"
 Cohesion: 0.07
@@ -451,23 +447,23 @@ Cohesion: 0.17
 Nodes (22): assertUrlAllowed(), fetchOnce(), guardedLookup(), SingleFetch, SsrfFetchError, SsrfFetchErrorReason, SsrfFetchResult, ssrfGuardedFetch() (+14 more)
 
 ### Community 32 - "Match Logging"
-Cohesion: 0.22
-Nodes (6): MatchLogBuilder, ArbitrationLog, CandidateLog, FinalDecision, StageLog, StageSkipReason
+Cohesion: 0.23
+Nodes (17): emptyDay(), emptyWeek(), instantiateWeek(), Attendee, Day, MealPlanConfig, MealPlanTemplate, MealPlanWeek (+9 more)
 
 ### Community 33 - "List Page Routes"
-Cohesion: 0.07
-Nodes (21): allVisibleIds, handleBulkApprove(), handleBulkRegenerateIcon(), selectedApprovalIds, selection, topApprovalItems, allIds, selection (+13 more)
+Cohesion: 0.06
+Nodes (18): allVisibleIds, handleBulkApprove(), handleBulkRegenerateIcon(), selectedApprovalIds, selection, topApprovalItems, allIds, selection (+10 more)
 
 ### Community 34 - "Cloud Function Callables"
 Cohesion: 0.07
-Nodes (31): beforeMemberCreated, posthogApiKey, regenerateCanonIcon, authorRecipeFlow, extractRecipeFromUrlFlow, UrlImportError, generateChatTitleFlow, identifyEquipmentFlow (+23 more)
+Nodes (25): beforeMemberCreated, posthogApiKey, regenerateCanonIcon, chefChatFlow, generateChatTitleFlow, identifyEquipmentFlow, populateEquipmentEntryFlow, registerGenkitDevTracing() (+17 more)
 
 ### Community 35 - "Slider"
 Cohesion: 0.14
 Nodes (18): ../../src/primitives/Slider/Slider.svelte, activeThumbIdx, sliderState, SliderProps, SliderRangeProps, SliderThumbProps, SliderTrackProps, SliderRootVariants (+10 more)
 
 ### Community 36 - "Entities"
-Cohesion: 0.19
+Cohesion: 0.21
 Nodes (16): clearIngredientMatch(), Ingredient, IngredientGroup, MatchState, ParsedIngredient, MixedQuantity, Quantity, RangeQuantity (+8 more)
 
 ### Community 37 - "Lib"
@@ -475,8 +471,8 @@ Cohesion: 0.14
 Nodes (23): ../../lib/aiModelCatalogService.js, applyCatalog(), _byRole, catalogByRole, emptyByRole(), ensureCatalog(), _fetchedAt, hasCatalog (+15 more)
 
 ### Community 38 - "Sheet"
-Cohesion: 0.10
-Nodes (19): ./ListPage.context.js, LIST_PAGE_CONTEXT, ListPageContext, BulkAction, BulkActionIcon, ListPageProps, ../../primitives/Sheet/Sheet.svelte, SheetContentProps (+11 more)
+Cohesion: 0.13
+Nodes (13): ../../primitives/Sheet/Sheet.svelte, SheetContentProps, SheetPartProps, SheetProps, SheetSide, SheetContentVariants, ../../primitives/Sheet/SheetContent.svelte, ../../primitives/Sheet/SheetHeader.svelte (+5 more)
 
 ### Community 39 - "Button"
 Cohesion: 0.11
@@ -487,52 +483,52 @@ Cohesion: 0.22
 Nodes (8): CardContentProps, CardDescriptionProps, CardFooterProps, CardHeaderProps, CardPartProps, CardProps, CardTitleProps, ./Card.types
 
 ### Community 41 - "Toast"
-Cohesion: 0.15
-Nodes (18): ../../src/primitives/Toast/Toast.svelte, ToastActionProps, ToastPartProps, ToastProps, ToastProviderProps, ToastViewportProps, ToastVariants, ../../src/primitives/Toast/ToastAction.svelte (+10 more)
+Cohesion: 0.17
+Nodes (16): ../../src/primitives/Toast/Toast.svelte, ToastActionProps, ToastPartProps, ToastProps, ToastProviderProps, ToastViewportProps, ToastVariants, ../../src/primitives/Toast/ToastAction.svelte (+8 more)
 
 ### Community 42 - "Lib"
 Cohesion: 0.14
-Nodes (23): ../../lib/chatService.js, applySnapshot(), createChatSession(), getChatSessionsSnapshot(), getErrorReporter(), initChatSync(), isLoadingSessions, latestLocalEdit (+15 more)
+Nodes (26): ../../lib/chatService.js, createChatSession(), getErrorReporter(), initChatSync(), isLoadingSessions, latestLocalEdit, newSession(), now() (+18 more)
 
 ### Community 43 - "Recipes"
 Cohesion: 0.08
 Nodes (19): activeSession, addToListOpen, amendBusy, canonalising, current, deleteBusy, deleteOpen, existingTags (+11 more)
 
 ### Community 44 - "Sidenav"
-Cohesion: 0.13
-Nodes (9): AppShellProps, BottomNavProps, NavItem, SideNavProps, TopBarProps, ./AppShell.types, ./BottomNav.types, ./SideNav.types (+1 more)
+Cohesion: 0.11
+Nodes (11): AppShellProps, BottomNavProps, NavItem, adminNavItem, navItems, SideNavProps, TopBarProps, ./AppShell.types (+3 more)
 
 ### Community 45 - "Radiogroup"
 Cohesion: 0.13
 Nodes (16): ../../src/primitives/RadioGroup/RadioGroup.svelte, descId, describedBy, errorId, generatedName, labelId, rgState, RadioGroupItemProps (+8 more)
 
 ### Community 46 - "Server"
-Cohesion: 0.18
-Nodes (20): ensureObservabilityInitialised(), AiGenerationEvent, AiGenerationUsage, captureAiGeneration(), captureServerEvent(), captureServerException(), flushServerObservability(), initServerObservability() (+12 more)
+Cohesion: 0.17
+Nodes (21): AiGenerationEvent, AiGenerationUsage, captureAiGeneration(), captureServerEvent(), captureServerException(), flushServerObservability(), ObservabilitySpan, OTEL_SPAN (+13 more)
 
 ### Community 47 - "Lib"
-Cohesion: 0.21
-Nodes (16): ../../lib/appSettingsService.js, buildNext(), buildNextFlow(), currentDoc(), effectiveFlowModels, effectiveModels, initAppSettingsSync(), _isCorrupt (+8 more)
+Cohesion: 0.15
+Nodes (21): ../../lib/appSettingsService.js, buildNext(), buildNextFlow(), currentDoc(), effectiveFlowModels, effectiveModels, initAppSettingsSync(), _isCorrupt (+13 more)
 
 ### Community 48 - "Design"
 Cohesion: 0.11
 Nodes (19): Adapter Sibling Non-Import Rule, AI / Genkit conventions, Data model conventions, Enforcement, Family-Shared Data Model (no user scoping), AI Access via Genkit Callables, graphify, Hard rules (+11 more)
 
 ### Community 49 - "Ai"
-Cohesion: 0.27
-Nodes (5): formatArbitration(), formatStage(), MatchLogSummary, nearMissCount(), summarizeMatchLog()
+Cohesion: 0.18
+Nodes (13): ensureObservabilityInitialised(), initServerObservability(), isServerObservabilityInitialised(), createPosthogServerErrorReportingAdapter(), isReportableCategory(), SUPPRESSED_CATEGORIES, initObservability(), createPosthogErrorReportingAdapter() (+5 more)
 
 ### Community 50 - "Lib"
-Cohesion: 0.11
-Nodes (12): ../admin/AdminGuard.svelte, isAdmin, settled, tools, @salt/domain, @salt/firebase-sync, ../../lib/titleCase.js, ./MealDayEditor.svelte (+4 more)
+Cohesion: 0.12
+Nodes (16): ../admin/AdminGuard.svelte, isAdmin, settled, tools, @salt/domain, ../../lib/titleCase.js, ../../lib/toastStore.js, AddToastOptions (+8 more)
 
 ### Community 51 - "Canon"
 Cohesion: 0.25
-Nodes (5): adminNavItem, navItems, $lib/observability, decoratedNavItems, needsApprovalCount
+Nodes (9): createMember(), CreateMemberInput, normaliseMemberEmail(), updateMember(), UpdateMemberPatch, Member, memberFirstName(), memberInitials() (+1 more)
 
 ### Community 52 - "Tests"
-Cohesion: 0.18
-Nodes (13): emptyIngredientGroup(), emptyRecipe(), newIngredient(), newStep(), flattenIngredients(), messyRecipe(), makeMatchedIngredient(), makeRecipe() (+5 more)
+Cohesion: 0.17
+Nodes (13): emptyIngredientGroup(), emptyRecipe(), newIngredient(), newStep(), matchedIngredient(), messyRecipe(), makeMatchedIngredient(), makeRecipe() (+5 more)
 
 ### Community 53 - "Docs"
 Cohesion: 0.09
@@ -567,8 +563,8 @@ Cohesion: 0.11
 Nodes (17): dependencies, @salt/ui-components, svelte, devDependencies, autoprefixer, postcss, @sveltejs/vite-plugin-svelte, tailwindcss (+9 more)
 
 ### Community 61 - "Ai"
-Cohesion: 0.11
-Nodes (26): AiCatalogModel, bareId(), CacheEntry, CatalogModelSchema, CatalogResponseSchema, fetchCatalog(), handleListAiModels(), ListAiModelsInputSchema (+18 more)
+Cohesion: 0.20
+Nodes (15): CatalogModelLike, hasMethod(), isEmbeddingModel(), isImageModel(), isTextModel(), metaHaystack(), methods(), probeMethodFor() (+7 more)
 
 ### Community 62 - "devDependencies"
 Cohesion: 0.12
@@ -579,16 +575,16 @@ Cohesion: 0.23
 Nodes (13): coerceDurationMinutes(), coerceServings(), coerceTags(), coerceText(), coerceTextList(), collectRecipeNodes(), extractJsonLdBlocks(), extractRecipeJsonLd() (+5 more)
 
 ### Community 64 - "Canon"
-Cohesion: 0.06
-Nodes (31): AISLES, BASE, BASE, createAisle(), CreateAisleInput, createAislesBulk(), CreateAislesBulkInput, deleteAisles() (+23 more)
+Cohesion: 0.08
+Nodes (24): fakeStore(), BASE, BASE, createAisle(), createAislesBulk(), deleteAisles(), renameAisle(), reorderAisles() (+16 more)
 
 ### Community 65 - "Canon Matching"
 Cohesion: 0.23
 Nodes (12): canon.match PostHog Event, Fire-and-Forget Logging, MatchLogBuilder, MatchLogEntry Schema, MatchLoggingPort Contract, createPosthogMatchLoggingAdapter (browser), createPosthogServerMatchLoggingAdapter (CF), createServerMatchLoggingAdapter (firebase-functions/logger) (+4 more)
 
 ### Community 66 - "Canon"
-Cohesion: 0.50
-Nodes (3): E2EBridge, SeedCanonItemInput, Window
+Cohesion: 0.18
+Nodes (14): authProvider, connectAuthEmulatorOnce(), createFirebaseAuth(), setAiStub(), callIdentifyEquipment(), callPopulateEquipmentEntry(), IdentifyEquipmentCandidate, IdentifyEquipmentResult (+6 more)
 
 ### Community 67 - "E2E"
 Cohesion: 0.21
@@ -604,7 +600,7 @@ Nodes (12): MealPlanConfigDoc, MealPlanConfigSchema, AttendeeDoc, AttendeeSchema
 
 ### Community 70 - "Tests"
 Cohesion: 0.12
-Nodes (4): SyncContextManager, TEST_KEY, TestPropagator, ThrowingPropagator
+Nodes (5): runWithExtractedTraceContext(), SyncContextManager, TEST_KEY, TestPropagator, ThrowingPropagator
 
 ### Community 71 - "Tooltip"
 Cohesion: 0.08
@@ -623,16 +619,16 @@ Cohesion: 0.13
 Nodes (14): dependencies, firebase, @salt/domain, @salt/shared-types, devDependencies, @firebase/rules-unit-testing, exports, name (+6 more)
 
 ### Community 75 - "Flows"
-Cohesion: 0.16
-Nodes (14): createFirestoreAisleStore(), createFirestoreCanonStore(), createServerArbitrationAdapter(), createServerEmbeddingAdapter(), createServerEntryParseAdapter(), createServerMatchLoggingAdapter(), buildMatchOrCreatePorts(), composeMatchLogging() (+6 more)
+Cohesion: 0.15
+Nodes (15): createFirestoreAisleStore(), createFirestoreCanonStore(), createServerArbitrationAdapter(), createServerEmbeddingAdapter(), createServerEntryParseAdapter(), createServerMatchLoggingAdapter(), ItemResultSchema, OutputSchema (+7 more)
 
 ### Community 76 - "Docs"
 Cohesion: 0.12
 Nodes (17): authorRecipe librarian flow (Flash, structured), Access & admin, Architecture placement, Canon interaction — batch CF, one read per recipe, Cross-module seams (already shipped, awaiting this module), Deferred: the AI-generation epic (own issue + design session), Document, Recipe module (+9 more)
 
 ### Community 77 - "Triggers"
-Cohesion: 0.22
-Nodes (5): EMULATOR_HOST, mockEmbed, mockGenerateIcon, mockRemoveBg, mockSave
+Cohesion: 0.14
+Nodes (7): mockGet, @salt/domain/schemas, EMULATOR_HOST, mockEmbed, mockGenerateIcon, mockRemoveBg, mockSave
 
 ### Community 78 - "Docs"
 Cohesion: 0.19
@@ -655,8 +651,8 @@ Cohesion: 0.33
 Nodes (6): 4.2 Focus Ring, 4.3 Disabled + Loading, 4.5 Dark Mode, 4. Styling System, Disabled (terminal state — no interaction), Loading (transient state — disables interaction without terminal semantics)
 
 ### Community 83 - "Queries"
-Cohesion: 0.20
-Nodes (10): collapse(), extractLeadingQuantity(), extractTrailingQuantity(), parseShoppingListEntry(), QuantityResult, stripLeadingOf(), TrailingQuantityResult, UNIT_WORDS (+2 more)
+Cohesion: 0.23
+Nodes (10): collapse(), extractLeadingQuantity(), extractTrailingQuantity(), ParsedEntry, parseShoppingListEntry(), QuantityResult, stripLeadingOf(), TrailingQuantityResult (+2 more)
 
 ### Community 84 - "Schemas"
 Cohesion: 0.14
@@ -675,7 +671,7 @@ Cohesion: 0.31
 Nodes (11): assertPortsFree(), findHubPid(), getOccupiedPorts(), hubIsRunning(), killPids(), listeningPids(), main(), PORTS (+3 more)
 
 ### Community 88 - "Sections"
-Cohesion: 0.17
+Cohesion: 0.10
 Nodes (10): [], allNotesSelected, formBody, formPublished, formTitle, isSubmitting, listSelectedCount, selectableSelectionMode (+2 more)
 
 ### Community 89 - "Canon"
@@ -683,8 +679,8 @@ Cohesion: 0.40
 Nodes (5): 1. Client config — build-time, committed, **not secret**, 2. Cloud Functions runtime secrets — Secret Manager, per project, **never committed**, 3. CI / GitHub Environments, Config & secrets — what lives where, WIF identifiers (provisioned — Phase 2)
 
 ### Community 90 - "Chat"
-Cohesion: 0.17
-Nodes (9): existingTags, inputText, isApplying, isSavingRecipe, isSending, now, stamped, streamingText (+1 more)
+Cohesion: 0.15
+Nodes (10): existingTags, inputText, isApplying, isSavingRecipe, isSending, now, stamped, streamingText (+2 more)
 
 ### Community 91 - "Domain"
 Cohesion: 0.17
@@ -695,20 +691,20 @@ Cohesion: 0.21
 Nodes (7): collections, getCollection(), mockArbitrate, mockEmbed, readCanonStorage(), seedAisles(), seedCanonItem()
 
 ### Community 93 - "Shared"
-Cohesion: 0.35
-Nodes (8): MatchLogEntry, createPosthogServerMatchLoggingAdapter(), CANON_MATCH_EVENT, CanonMatchEventProps, CanonMatchPath, scaleScore(), toCanonMatchEvent(), fixture
+Cohesion: 0.14
+Nodes (14): moveItems(), moveSelectedItems(), setActiveListId(), loadChatSession(), classifyFirestoreError(), firestoreCode(), listShoppingListItems(), moveShoppingListItems() (+6 more)
 
 ### Community 94 - "Text"
 Cohesion: 0.21
 Nodes (5): _bad, TextProps, TextVariants, ./Text.types, ./Text.variants
 
 ### Community 95 - "Ai"
-Cohesion: 0.20
-Nodes (14): seed, eX, failEmbedding(), makeAisleStore(), makeIds(), makePorts(), makeStore(), noMatchArbitration() (+6 more)
+Cohesion: 0.15
+Nodes (17): seed, eX, failEmbedding(), makeAisleStore(), makeIds(), makePorts(), makeStore(), noMatchArbitration() (+9 more)
 
 ### Community 96 - "Triggers"
-Cohesion: 0.15
-Nodes (9): AiTimeoutError, raceWithTimeout(), withAiTimeout(), WithAiTimeoutOptions, requireAdmin(), handleTestModel(), TestModelInputSchema, TestModelResult (+1 more)
+Cohesion: 0.11
+Nodes (20): AiTimeoutError, raceWithTimeout(), withAiTimeout(), WithAiTimeoutOptions, AiCatalogModel, bareId(), CacheEntry, CatalogModelSchema (+12 more)
 
 ### Community 97 - "Docs"
 Cohesion: 0.11
@@ -751,12 +747,12 @@ Cohesion: 0.24
 Nodes (4): HeadingProps, HeadingVariants, ./Heading.types, ./Heading.variants
 
 ### Community 107 - "Lib"
-Cohesion: 0.40
-Nodes (4): MatchOrCreateInput, MatchOrCreateResult, WireBatchResult, WireResult
+Cohesion: 0.20
+Nodes (8): state, TooltipContentProps, TooltipPartProps, TooltipProps, TooltipProviderProps, ../../headless/Tooltip.headless.svelte, ./Tooltip.types, ./Tooltip.variants
 
 ### Community 108 - "Tests"
-Cohesion: 0.20
-Nodes (4): countIngredient, fs, gramIngredient, { mockGetCanonItemsSnapshot }
+Cohesion: 0.15
+Nodes (11): emptyTemplate(), saveFirstDayOfWeek(), saveMealPlanConfig(), ADMIN, { mockMembers, mockIsLoadingMembers, mockTemplate, mockFirstDay, mockAuth }, CONFIG, ErrorCallback, { mockUnsubscribe, mockOnSnapshot, mockSetDoc, mockDoc, mockGetFirestore } (+3 more)
 
 ### Community 109 - "Docs"
 Cohesion: 0.40
@@ -787,12 +783,12 @@ Cohesion: 0.22
 Nodes (8): compilerOptions, composite, lib, outDir, rootDir, extends, include, references
 
 ### Community 116 - "Src"
-Cohesion: 0.21
-Nodes (6): local, remote, mergeCanonItems(), unionSynonyms(), ConflictStrategy, resolveCanonConflict()
+Cohesion: 0.14
+Nodes (12): currentWeek, firstDayOfWeek, mealPlanTemplate, seedMealPlanConfig(), seedMealPlanTemplate(), seedMealPlanWeek(), selectedStartDate, CONFIG (+4 more)
 
 ### Community 117 - "Src"
-Cohesion: 0.11
-Nodes (17): User, AuthProvider, authEmulatorConnected, connectAuthEmulatorOnce(), reportAuthFailure(), isAuthTransitioning(), setAuthTransitioning(), ErrorReportingPort (+9 more)
+Cohesion: 0.14
+Nodes (12): User, reportSubscriptionError(), AuthProvider, authEmulatorConnected, reportAuthFailure(), isAuthTransitioning(), setAuthTransitioning(), ErrorReportingPort (+4 more)
 
 ### Community 118 - "Domain"
 Cohesion: 0.25
@@ -883,8 +879,8 @@ Cohesion: 0.33
 Nodes (3): FakeHttpsError, handler, { mockGet, mockDoc, mockCollection }
 
 ### Community 141 - "Combobox"
-Cohesion: 0.05
-Nodes (61): mockGet, ../../lib/devSettingsService.js, canonIconGenerationEnabled, DEFAULTS, initDevSettingsSync(), _isLoading, setCanonIconGenerationEnabled(), _settings (+53 more)
+Cohesion: 0.09
+Nodes (20): initShoppingListSync(), deleteCanonItem(), loadShoppingListsConfig(), subscribeShoppingListsConfig(), listShoppingLists(), subscribeShoppingLists(), clearFirestoreEmulator(), initFirebaseEmulator() (+12 more)
 
 ### Community 142 - "Design"
 Cohesion: 0.14
@@ -935,8 +931,8 @@ Cohesion: 0.67
 Nodes (3): globalTeardown(), killE2eServer(), REPO_ROOT
 
 ### Community 157 - "Community 157"
-Cohesion: 0.18
-Nodes (8): RecipeAddRow, CONFLICT_ERR, fs, { mockGetCanonItemsSnapshot }, NETWORK_ERR, { reportSpy }, STORAGE_ERR, SYNC_ERR
+Cohesion: 0.15
+Nodes (17): reportIfFailed(), canonicaliseIngredients(), commitRecipeAddPlan(), getErrorReporter(), initRecipeSync(), matchIngredient(), persistRecipe(), RecipeAddRow (+9 more)
 
 ### Community 158 - "Scripts"
 Cohesion: 0.50
@@ -947,8 +943,12 @@ Cohesion: 0.83
 Nodes (3): functions_triggers_registered(), reachable(), healthcheck.sh script
 
 ### Community 161 - "Community 161"
-Cohesion: 0.16
-Nodes (12): aiFakeEnabled(), aiModelLabel(), fakeModels, flowModel(), CacheEntry, DEFAULT_SETTINGS, loadSettings(), resolveModel() (+4 more)
+Cohesion: 0.12
+Nodes (20): readUsage(), tracedGenerate(), aiFakeEnabled(), aiModelLabel(), fakeModels, flowModel(), CacheEntry, DEFAULT_SETTINGS (+12 more)
+
+### Community 162 - "Community 162"
+Cohesion: 0.24
+Nodes (9): ../../lib/devSettingsService.js, canonIconGenerationEnabled, DEFAULTS, initDevSettingsSync(), _isLoading, setCanonIconGenerationEnabled(), _settings, saveDevSettings() (+1 more)
 
 ### Community 164 - "Community 164"
 Cohesion: 0.33
@@ -1019,8 +1019,8 @@ Cohesion: 0.14
 Nodes (14): 0. v0.3 Scope, 1.1 Headless + Styled, 1.2 APG Compliance, 1. Shared v0.3 Rules, 5.1 Purpose, 5.2 Parts, 5.3 Root Props, 5.4 Events (+6 more)
 
 ### Community 275 - "Community 275"
-Cohesion: 0.16
-Nodes (9): eX, eY, failEmbedding(), makeAisleStore(), makeIds(), makePipeline(), makeStore(), noMatchArbitration() (+1 more)
+Cohesion: 0.17
+Nodes (8): eX, eY, failEmbedding(), makeAisleStore(), makeIds(), makePipeline(), makeStore(), noMatchArbitration()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.17
@@ -1035,8 +1035,8 @@ Cohesion: 0.11
 Nodes (18): Create the working branch (once, before phase 1), Per-Phase Handoff Contract, Orchestrator/Subagent Pattern, Pause conditions (stop and wait for user), Run Issue, Setup (once), Architecture Notes, Definition of Done (+10 more)
 
 ### Community 279 - "Community 279"
-Cohesion: 0.33
-Nodes (5): CollectionCallback, ErrorCallback, {
+Cohesion: 0.25
+Nodes (9): deleteRecipe(), loadRecipe(), saveRecipe(), subscribeRecipes(), CollectionCallback, ErrorCallback, {
   mockUnsubscribe,
   mockOnSnapshot,
   mockSetDoc,
@@ -1045,7 +1045,7 @@ Nodes (5): CollectionCallback, ErrorCallback, {
   mockDoc,
   mockCollection,
   mockGetFirestore,
-}, RECIPE, SnapDoc
+}, RECIPE (+1 more)
 
 ### Community 280 - "Community 280"
 Cohesion: 0.18
@@ -1060,20 +1060,16 @@ Cohesion: 0.40
 Nodes (5): 8.5 Switch, Accessibility, Events, Props, Styling
 
 ### Community 283 - "Community 283"
-Cohesion: 0.20
-Nodes (10): 8.10 Heading, 8.11 Text, 8.3 Textarea, 8. Primitive Definitions (v0.2 Core), Autoresize, Props, Props, Size styling (+2 more)
+Cohesion: 0.14
+Nodes (14): 8.10 Heading, 8.11 Text, 8.14 Spinner, 8.3 Textarea, 8. Primitive Definitions (v0.2 Core), Accessibility, Autoresize, Props (+6 more)
 
 ### Community 284 - "Community 284"
-Cohesion: 0.20
+Cohesion: 0.17
 Nodes (10): Authoring conventions, CI, E2E & emulator integration tests, Lifecycle, reuse & teardown, Port sets, Running locally, Spotting & clearing a poisoned environment, The containerized test emulator stacks (+2 more)
 
 ### Community 285 - "Community 285"
 Cohesion: 0.40
 Nodes (4): INPUT, mockFlush, mockGenerate, mockReport
-
-### Community 286 - "Community 286"
-Cohesion: 0.60
-Nodes (3): getInput(), openCombobox(), setup()
 
 ### Community 287 - "Community 287"
 Cohesion: 0.22
@@ -1090,6 +1086,10 @@ Nodes (9): 8.2 TextField, Accessibility, Error-message rendering, Events, Forbid
 ### Community 290 - "Community 290"
 Cohesion: 0.25
 Nodes (7): Adapter behaviour, Builder, Canon Matching — Logging & Observability, How to inspect logs manually, Port contract, Purpose, Schema
+
+### Community 291 - "Community 291"
+Cohesion: 0.20
+Nodes (6): Before/after check in PostHog Error Tracking, Caught-error reporting — calibration note, Known, intentional asymmetries (NOT bugs), No raw user content in payloads, Getting started, Salt 2.0
 
 ### Community 292 - "Community 292"
 Cohesion: 0.25
@@ -1179,10 +1179,6 @@ Nodes (6): 12. Testing strategy, Cloud Functions, Domain, firebase-sync, observa
 Cohesion: 0.50
 Nodes (4): 8.12 Icon, Accessibility, Props, Styling
 
-### Community 323 - "Community 323"
-Cohesion: 0.50
-Nodes (4): 8.14 Spinner, Accessibility, Props, Styling
-
 ### Community 324 - "Community 324"
 Cohesion: 0.50
 Nodes (4): 8.9 Card, Parts, Props (all parts), Styling
@@ -1204,24 +1200,24 @@ Cohesion: 0.50
 Nodes (4): 6.1 firebase-sync adapter, 6.2 observability adapter, 6.3 Common rules, 6. Adapter requirements
 
 ## Knowledge Gaps
-- **1365 isolated node(s):** `husky.sh script`, `name`, `version`, `private`, `type` (+1360 more)
+- **1371 isolated node(s):** `husky.sh script`, `name`, `version`, `private`, `type` (+1366 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **51 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **47 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `NavItem` connect `Sidenav` to `Canon`, `Combobox Primitive`?**
-  _High betweenness centrality (0.148) - this node is a cross-community bridge._
-- **Why does `../../lib/recipeService.js` connect `Recipe Service` to `Aisles & Canon Stores`, `Firebase-Sync Shopping Config`, `Canon Approval UI`, `Entities`, `Recipes`, `List Page Routes`, `Shopping List UI`, `Tests`, `Canon Matching Core`, `Recipes`, `Combobox`, `Tests`, `Tests`, `Lib`, `Canon`, `Tests`, `Chat`, `Community 157`?**
-  _High betweenness centrality (0.060) - this node is a cross-community bridge._
-- **Why does `CanonItem` connect `Canon Matching Core` to `Aisles & Canon Stores`, `Firebase-Sync Shopping Config`, `Canon Approval UI`, `E2E Test Suite`, `Firestore Stores & Classify`, `Community 265`, `Tests`, `Combobox`, `Canon Fast-Path Parity`, `Triggers`, `Community 275`, `Recipe Service`, `List Page Routes`, `Community 162`, `Canon`, `Canon`, `Flows`, `Ai`, `Triggers`, `Tests`, `Src`?**
-  _High betweenness centrality (0.056) - this node is a cross-community bridge._
+- **Why does `NavItem` connect `Sidenav` to `Combobox & ListPage Types`?**
+  _High betweenness centrality (0.152) - this node is a cross-community bridge._
+- **Why does `CanonItem` connect `Canon Matching Core` to `Canon`, `List Page Routes`, `Firebase-Sync Shopping Config`, `Canon Approval UI`, `Shopping List Commands`, `E2E Test Suite`, `Firestore Stores & Classify`, `Triggers`, `Tests`, `Combobox`, `Canon Fast-Path Parity`, `Triggers`, `Community 275`, `Recipe Service`, `Flows`, `Ai`?**
+  _High betweenness centrality (0.061) - this node is a cross-community bridge._
+- **Why does `../../lib/recipeService.js` connect `Recipe Service` to `Firebase-Sync Shopping Config`, `Canon Approval UI`, `Shopping List Commands`, `Shopping List UI`, `Tests`, `Canon Matching Core`, `Tests`, `Admin Routes`, `Community 279`, `Community 157`, `Entities`, `Recipes`, `Lib`, `Tests`, `Canon`, `Triggers`, `Chat`, `Recipes`, `Src`?**
+  _High betweenness centrality (0.061) - this node is a cross-community bridge._
 - **What connects `husky.sh script`, `name`, `version` to the rest of the system?**
-  _1385 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1391 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Meal Planner & Attendees` be split into smaller, more focused modules?**
-  _Cohesion score 0.05028011204481793 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.12258064516129032 - nodes in this community are weakly interconnected._
 - **Should `Aisles & Canon Stores` be split into smaller, more focused modules?**
-  _Cohesion score 0.10721153846153846 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.11264367816091954 - nodes in this community are weakly interconnected._
 - **Should `Firebase-Sync Shopping Config` be split into smaller, more focused modules?**
-  _Cohesion score 0.14408602150537633 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.13709677419354838 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - salt-vscode  (2026-06-27)
 
 ## Corpus Check
-- 818 files · ~286,952 words
+- 822 files · ~289,858 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3823 nodes · 7458 edges · 316 communities (268 shown, 48 thin omitted)
+- 3858 nodes · 7596 edges · 319 communities (267 shown, 52 thin omitted)
 - Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 120 edges (avg confidence: 0.81)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `fd895d59`
+- Built from commit: `77a9c480`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -132,6 +132,7 @@
 - [[_COMMUNITY_Scripts|Scripts]]
 - [[_COMMUNITY_Web Pwa|Web Pwa]]
 - [[_COMMUNITY_Src|Src]]
+- [[_COMMUNITY_Src|Src]]
 - [[_COMMUNITY_Domain|Domain]]
 - [[_COMMUNITY_Shared Types|Shared Types]]
 - [[_COMMUNITY_Testing Utils|Testing Utils]]
@@ -164,16 +165,21 @@
 - [[_COMMUNITY_Schemas|Schemas]]
 - [[_COMMUNITY_Schemas|Schemas]]
 - [[_COMMUNITY_Schemas|Schemas]]
+- [[_COMMUNITY_Community 150|Community 150]]
 - [[_COMMUNITY_Scripts|Scripts]]
 - [[_COMMUNITY_.Boundary Tests|.Boundary Tests]]
 - [[_COMMUNITY_Branding|Branding]]
 - [[_COMMUNITY_E2E|E2E]]
 - [[_COMMUNITY_Flows|Flows]]
 - [[_COMMUNITY_Src|Src]]
+- [[_COMMUNITY_Community 157|Community 157]]
 - [[_COMMUNITY_Scripts|Scripts]]
 - [[_COMMUNITY_Scripts|Scripts]]
 - [[_COMMUNITY_Test Emulators|Test Emulators]]
+- [[_COMMUNITY_Community 161|Community 161]]
+- [[_COMMUNITY_Community 162|Community 162]]
 - [[_COMMUNITY_Tests|Tests]]
+- [[_COMMUNITY_Community 164|Community 164]]
 - [[_COMMUNITY_Web Pwa|Web Pwa]]
 - [[_COMMUNITY_Src|Src]]
 - [[_COMMUNITY_Assets|Assets]]
@@ -221,6 +227,8 @@
 - [[_COMMUNITY_pnpm Workspace Config|pnpm Workspace Config]]
 - [[_COMMUNITY_Tokens|Tokens]]
 - [[_COMMUNITY_Tokens|Tokens]]
+- [[_COMMUNITY_Community 265|Community 265]]
+- [[_COMMUNITY_Community 266|Community 266]]
 - [[_COMMUNITY_Community 267|Community 267]]
 - [[_COMMUNITY_Community 268|Community 268]]
 - [[_COMMUNITY_Community 269|Community 269]]
@@ -233,7 +241,9 @@
 - [[_COMMUNITY_Community 276|Community 276]]
 - [[_COMMUNITY_Community 277|Community 277]]
 - [[_COMMUNITY_Community 278|Community 278]]
+- [[_COMMUNITY_Community 279|Community 279]]
 - [[_COMMUNITY_Community 280|Community 280]]
+- [[_COMMUNITY_Community 281|Community 281]]
 - [[_COMMUNITY_Community 283|Community 283]]
 - [[_COMMUNITY_Community 284|Community 284]]
 - [[_COMMUNITY_Community 287|Community 287]]
@@ -258,16 +268,10 @@
 - [[_COMMUNITY_Community 307|Community 307]]
 - [[_COMMUNITY_Community 308|Community 308]]
 - [[_COMMUNITY_Community 309|Community 309]]
-- [[_COMMUNITY_Community 310|Community 310]]
 - [[_COMMUNITY_Community 311|Community 311]]
-- [[_COMMUNITY_Community 312|Community 312]]
-- [[_COMMUNITY_Community 313|Community 313]]
 - [[_COMMUNITY_Community 314|Community 314]]
 - [[_COMMUNITY_Community 315|Community 315]]
 - [[_COMMUNITY_Community 316|Community 316]]
-- [[_COMMUNITY_Community 318|Community 318]]
-- [[_COMMUNITY_Community 319|Community 319]]
-- [[_COMMUNITY_Community 320|Community 320]]
 - [[_COMMUNITY_Community 322|Community 322]]
 - [[_COMMUNITY_Community 323|Community 323]]
 - [[_COMMUNITY_Community 324|Community 324]]
@@ -279,15 +283,15 @@
 - [[_COMMUNITY_Community 330|Community 330]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `DomainError` - 92 edges
-2. `../../lib/canonService.js` - 79 edges
-3. `../../lib/shoppingListService.svelte.js` - 77 edges
-4. `ReadResult` - 76 edges
+1. `DomainError` - 96 edges
+2. `../../lib/canonService.js` - 82 edges
+3. `../../lib/shoppingListService.svelte.js` - 81 edges
+4. `ReadResult` - 78 edges
 5. `../../lib/mealPlanService.js` - 75 edges
 6. `success` - 69 edges
 7. `CanonItem` - 63 edges
-8. `failure` - 62 edges
-9. `../../lib/recipeService.js` - 60 edges
+8. `../../lib/recipeService.js` - 62 edges
+9. `failure` - 62 edges
 10. `get()` - 54 edges
 
 ## Surprising Connections (you probably didn't know these)
@@ -313,27 +317,27 @@
 - **Canon Matching Entry Points & Shared Core** — matching_pipeline_fast_path, matching_pipeline_match_or_create_canon_callable, matching_pipeline_on_shopping_list_item_write, matching_pipeline_canonicalise_recipe_ingredients, matching_pipeline_match_or_create_batch [EXTRACTED 1.00]
 - **Issue-Driven Agentic Workflow Commands** — commands_spec_feature_spec, commands_defect_defect_spec, commands_refactor_spec_refactor_spec, commands_run_run_issue [INFERRED 0.85]
 
-## Communities (316 total, 48 thin omitted)
+## Communities (319 total, 52 thin omitted)
 
 ### Community 0 - "Meal Planner & Attendees"
 Cohesion: 0.05
-Nodes (96): addAttendee(), DayContainer, removeAttendee(), setAttendeeHomeTime(), setAttendeeNote(), setDayChefs(), setDayGuests(), setDayNote() (+88 more)
+Nodes (93): addAttendee(), DayContainer, removeAttendee(), setAttendeeHomeTime(), setAttendeeNote(), setDayChefs(), setDayGuests(), setDayNote() (+85 more)
 
 ### Community 1 - "Aisles & Canon Stores"
-Cohesion: 0.07
-Nodes (26): fakeStore(), AISLES, BASE, BASE, deleteAisles(), mergeAisles(), renameAisle(), reorderAisles() (+18 more)
+Cohesion: 0.08
+Nodes (34): fakeStore(), BASE, BASE, AddAccessoryInput, AddEquipmentInput, AddRuleInput, EditRuleInput, RemoveAccessoryInput (+26 more)
 
 ### Community 2 - "Firebase-Sync Shopping Config"
-Cohesion: 0.20
-Nodes (8): state, TooltipContentProps, TooltipPartProps, TooltipProps, TooltipProviderProps, ../../headless/Tooltip.headless.svelte, ./Tooltip.types, ./Tooltip.variants
+Cohesion: 0.15
+Nodes (25): createAisle(), createAislesBulk(), renameAisle(), reorderAisles(), ../../lib/aisleService.js, addAisle(), addAislesBulk(), deleteAisles() (+17 more)
 
 ### Community 3 - "Canon Approval UI"
-Cohesion: 0.05
-Nodes (60): base, approveCanonItem(), createAisle(), createAislesBulk(), MergeAislesInput, renameCanonItem(), setCanonItemAisle(), setCanonItemShoppingBehavior() (+52 more)
+Cohesion: 0.09
+Nodes (31): base, approveCanonItem(), MatchOrCreateResult, setCanonItemThumbnail(), ../../lib/canonService.js, addCanonItem(), approveCanonItemWithOverrides(), commitCanonItemUpdate() (+23 more)
 
 ### Community 4 - "Shopping List Commands"
-Cohesion: 0.07
-Nodes (38): AddItemInput, CheckItemInput, clearCheckedItems(), confirmItemNeeded(), ConfirmItemNeededInput, CreateListInput, DeleteItemInput, EditItemAmountUnitInput (+30 more)
+Cohesion: 0.06
+Nodes (42): AddItemInput, CheckItemInput, clearCheckedItems(), confirmItemNeeded(), ConfirmItemNeededInput, deleteItem(), DeleteItemInput, EditItemAmountUnitInput (+34 more)
 
 ### Community 5 - "Headless UI Primitives"
 Cohesion: 0.06
@@ -348,20 +352,20 @@ Cohesion: 0.22
 Nodes (6): allVisibleIds, handleBulkApprove(), selectedApprovalIds, selection, topApprovalItems, approveCanonItems()
 
 ### Community 8 - "Shopping List UI"
-Cohesion: 0.06
-Nodes (48): addItem(), checkItem(), createList(), deleteItem(), deleteList(), editItemAmountUnit(), editItemNotes(), editItemRawText() (+40 more)
+Cohesion: 0.08
+Nodes (58): addItem(), checkItem(), createList(), deleteList(), editItemAmountUnit(), renameList(), setDefaultList(), uncheckItem() (+50 more)
 
 ### Community 9 - "Equipment & Rules"
-Cohesion: 0.07
-Nodes (57): addAccessory(), AddAccessoryInput, addEquipment(), AddEquipmentInput, addRule(), AddRuleInput, editRule(), EditRuleInput (+49 more)
+Cohesion: 0.10
+Nodes (43): addAccessory(), addEquipment(), addRule(), editRule(), removeAccessory(), removeEquipment(), removeRule(), renameEquipment() (+35 more)
 
 ### Community 10 - "Members Management"
-Cohesion: 0.07
-Nodes (36): createMember(), CreateMemberInput, normaliseMemberEmail(), updateMember(), UpdateMemberPatch, Member, auth, ../../lib/membersService.js (+28 more)
+Cohesion: 0.05
+Nodes (49): createMember(), CreateMemberInput, normaliseMemberEmail(), updateMember(), UpdateMemberPatch, Member, ../../lib/auth.svelte.js, auth (+41 more)
 
 ### Community 11 - "Canon Matching Core"
-Cohesion: 0.08
-Nodes (28): local, remote, ApproveCanonItemOverrides, CreateAisleInput, CreateAislesBulkInput, CreateCanonItemInput, DeleteAislesInput, ArbitrationExtras (+20 more)
+Cohesion: 0.09
+Nodes (16): catalog, items, ApproveCanonItemOverrides, CreateCanonItemInput, ArbitrationExtras, renameCanonItem(), setCanonItemAisle(), setCanonItemShoppingBehavior() (+8 more)
 
 ### Community 12 - "web-pwa Dependencies"
 Cohesion: 0.04
@@ -373,7 +377,7 @@ Nodes (40): dependencies, bits-ui, class-variance-authority, clsx, @floating-ui/
 
 ### Community 14 - "Combobox Primitive"
 Cohesion: 0.07
-Nodes (27): ../../src/primitives/Combobox/Combobox.svelte, ctx, filterValue, initialItem, inputId, inputValue, listboxId, ../../src/primitives/Combobox/ComboboxContent.svelte (+19 more)
+Nodes (28): ../../src/primitives/Combobox/Combobox.svelte, ctx, filterValue, initialItem, inputId, inputValue, listboxId, ../../src/primitives/Combobox/ComboboxContent.svelte (+20 more)
 
 ### Community 15 - "Domain Zod Schemas"
 Cohesion: 0.09
@@ -384,20 +388,20 @@ Cohesion: 0.05
 Nodes (37): COLOR_MAP, CONTROLS_CHECKBOX_MAP, CONTROLS_SWITCH_MAP, cssVars, design, DESIGN_MD_PATH, designCheckbox, designColors (+29 more)
 
 ### Community 17 - "Canon Fast-Path Parity"
-Cohesion: 0.07
-Nodes (37): aisleStore, failingArbitration, failingEmbedding, ids, makeStore(), runCfPath(), runFastPath(), catalog (+29 more)
+Cohesion: 0.10
+Nodes (31): aisleStore, failingArbitration, failingEmbedding, ids, makeStore(), runCfPath(), runFastPath(), appendCanonSynonym() (+23 more)
 
 ### Community 18 - "Select Primitive"
 Cohesion: 0.09
-Nodes (29): @floating-ui/dom, ../../src/primitives/Select/Select.svelte, ctx, listboxId, triggerId, typeaheadBuffer, SelectContentProps, SelectGroupProps (+21 more)
+Nodes (28): ../../src/primitives/Select/Select.svelte, ctx, listboxId, triggerId, typeaheadBuffer, SelectContentProps, SelectGroupProps, SelectItemProps (+20 more)
 
 ### Community 19 - "Task Pilot Extension"
 Cohesion: 0.09
 Nodes (11): cp, DEFAULT_LABELS, FALLBACK_META, getTaskLabel(), metaFor(), net, NUKE_PORTS, SERVICE_META (+3 more)
 
 ### Community 20 - "Admin Routes"
-Cohesion: 0.13
-Nodes (12): ../admin/AdminGuard.svelte, isAdmin, settled, tools, @salt/domain, @salt/firebase-sync, ../../lib/titleCase.js, ./MealDayEditor.svelte (+4 more)
+Cohesion: 0.18
+Nodes (6): ../admin/AdminGuard.svelte, isAdmin, settled, tools, @salt/firebase-sync, routes
 
 ### Community 21 - "Combobox & ListPage Types"
 Cohesion: 0.12
@@ -409,31 +413,31 @@ Nodes (35): categories, properties, title, contributes, commands, configuration,
 
 ### Community 23 - "Dialog & Popover Primitives"
 Cohesion: 0.10
-Nodes (13): DialogContentProps, DialogPartProps, DialogProps, DialogContentVariants, PopoverContentProps, PopoverPartProps, PopoverProps, ../../headless/Dialog.headless.svelte (+5 more)
+Nodes (14): DialogContentProps, DialogPartProps, DialogProps, state, TooltipContentProps, TooltipPartProps, TooltipProps, TooltipProviderProps (+6 more)
 
 ### Community 24 - "Recipe Service"
-Cohesion: 0.10
-Nodes (24): ../../lib/recipeService.js, applySnapshot(), buildRecipeAddPlan(), canonicaliseIngredients(), getErrorReporter(), importRecipeFromUrl(), initRecipeSync(), isLoadingRecipes (+16 more)
+Cohesion: 0.09
+Nodes (25): ../../lib/recipeService.js, applySnapshot(), buildRecipeAddPlan(), canonicaliseIngredients(), getErrorReporter(), getRecipesSnapshot(), importRecipeFromUrl(), initRecipeSync() (+17 more)
 
 ### Community 25 - "Observability (PostHog)"
-Cohesion: 0.23
-Nodes (17): extractTraceHeaders(), identifyObservabilityAnonymous(), identifyObservabilityUser(), initObservability(), isObservabilityReady(), NOOP_SPAN, ObservabilityOptions, ObservabilitySpan (+9 more)
+Cohesion: 0.22
+Nodes (18): tagSession(), extractTraceHeaders(), identifyObservabilityAnonymous(), identifyObservabilityUser(), initObservability(), isObservabilityReady(), NOOP_SPAN, ObservabilityOptions (+10 more)
 
 ### Community 26 - "Selectable List & Checkbox"
-Cohesion: 0.11
-Nodes (16): ../../primitives/Checkbox/Checkbox.svelte, CheckboxProps, CheckedState, CheckboxRootVariants, EditableRowProps, createListSelection(), CreateListSelectionOptions, ListSelection (+8 more)
+Cohesion: 0.13
+Nodes (13): ../../primitives/Checkbox/Checkbox.svelte, EditableRowProps, createListSelection(), CreateListSelectionOptions, ListSelection, ./RowSelectCheckbox.svelte, SelectableListItem, SelectableListProps (+5 more)
 
 ### Community 27 - "Layout Primitives"
-Cohesion: 0.08
-Nodes (14): DividerProps, GridProps, GridVariants, InlineProps, InlineVariants, StackProps, StackVariants, ./Divider.types (+6 more)
+Cohesion: 0.06
+Nodes (23): CheckboxProps, CheckedState, CheckboxRootVariants, comboboxContentVariants, comboboxCreateVariants, comboboxInputVariants, comboboxItemVariants, comboboxTriggerVariants (+15 more)
 
 ### Community 28 - "AI Flows & Telemetry"
-Cohesion: 0.12
-Nodes (20): readUsage(), tracedGenerate(), aiFakeEnabled(), aiModelLabel(), fakeModels, flowModel(), CacheEntry, DEFAULT_SETTINGS (+12 more)
+Cohesion: 0.18
+Nodes (13): readUsage(), tracedGenerate(), aiModelLabel(), fakeModels, flowModel(), resolveModel(), OutputSchema, InputSchema (+5 more)
 
 ### Community 29 - "AI Timeout Guard"
-Cohesion: 0.11
-Nodes (19): AiTimeoutError, raceWithTimeout(), withAiTimeout(), WithAiTimeoutOptions, loadCanonIconSeed(), generateCanonIconFlow, GenerateCanonIconInputSchema, GenerateCanonIconOutputSchema (+11 more)
+Cohesion: 0.15
+Nodes (15): aiFakeEnabled(), embedTextFlow, FAKE_EMBEDDING, generateCanonIconFlow, removeFlatBackground(), RemoveFlatBackgroundOptions, sampleBackgroundColour(), buildIconDownloadUrl() (+7 more)
 
 ### Community 30 - "cloud-functions Dependencies"
 Cohesion: 0.07
@@ -444,8 +448,8 @@ Cohesion: 0.17
 Nodes (22): assertUrlAllowed(), fetchOnce(), guardedLookup(), SingleFetch, SsrfFetchError, SsrfFetchErrorReason, SsrfFetchResult, ssrfGuardedFetch() (+14 more)
 
 ### Community 32 - "Match Logging"
-Cohesion: 0.17
-Nodes (10): MatchLogBuilder, ArbitrationLog, FinalDecision, StageLog, StageSkipReason, formatArbitration(), formatStage(), MatchLogSummary (+2 more)
+Cohesion: 0.13
+Nodes (11): MatchLogBuilder, ArbitrationLog, CandidateLog, FinalDecision, StageLog, StageSkipReason, formatArbitration(), formatStage() (+3 more)
 
 ### Community 33 - "List Page Routes"
 Cohesion: 0.08
@@ -453,14 +457,14 @@ Nodes (16): handleBulkRegenerateIcon(), allIds, selection, visibleItems, ../../l
 
 ### Community 34 - "Cloud Function Callables"
 Cohesion: 0.08
-Nodes (22): beforeMemberCreated, regenerateCanonIcon, generateChatTitleFlow, identifyEquipmentFlow, populateEquipmentEntryFlow, registerGenkitDevTracing(), APP_CHECK_ENFORCEMENT, arbitrateCanon (+14 more)
+Nodes (24): beforeMemberCreated, regenerateCanonIcon, authorRecipeFlow, chefChatFlow, generateChatTitleFlow, identifyEquipmentFlow, populateEquipmentEntryFlow, registerGenkitDevTracing() (+16 more)
 
 ### Community 35 - "Slider"
 Cohesion: 0.14
 Nodes (18): ../../src/primitives/Slider/Slider.svelte, activeThumbIdx, sliderState, SliderProps, SliderRangeProps, SliderThumbProps, SliderTrackProps, SliderRootVariants (+10 more)
 
 ### Community 36 - "Entities"
-Cohesion: 0.21
+Cohesion: 0.19
 Nodes (16): clearIngredientMatch(), Ingredient, IngredientGroup, MatchState, ParsedIngredient, MixedQuantity, Quantity, RangeQuantity (+8 more)
 
 ### Community 37 - "Lib"
@@ -484,8 +488,8 @@ Cohesion: 0.17
 Nodes (16): ../../src/primitives/Toast/Toast.svelte, ToastActionProps, ToastPartProps, ToastProps, ToastProviderProps, ToastViewportProps, ToastVariants, ../../src/primitives/Toast/ToastAction.svelte (+8 more)
 
 ### Community 42 - "Lib"
-Cohesion: 0.18
-Nodes (20): ../../lib/chatService.js, applySnapshot(), createChatSession(), getErrorReporter(), initChatSync(), isLoadingSessions, latestLocalEdit, newSession() (+12 more)
+Cohesion: 0.14
+Nodes (22): ../../lib/chatService.js, applySnapshot(), createChatSession(), getChatSessionsSnapshot(), getErrorReporter(), initChatSync(), isLoadingSessions, latestLocalEdit (+14 more)
 
 ### Community 43 - "Recipes"
 Cohesion: 0.08
@@ -505,27 +509,27 @@ Nodes (19): ensureObservabilityInitialised(), AiGenerationEvent, AiGenerationUsa
 
 ### Community 47 - "Lib"
 Cohesion: 0.15
-Nodes (21): ../../lib/appSettingsService.js, buildNext(), buildNextFlow(), currentDoc(), effectiveFlowModels, effectiveModels, initAppSettingsSync(), _isCorrupt (+13 more)
+Nodes (20): ../../lib/appSettingsService.js, buildNext(), buildNextFlow(), currentDoc(), effectiveFlowModels, effectiveModels, initAppSettingsSync(), _isCorrupt (+12 more)
 
 ### Community 48 - "Design"
 Cohesion: 0.10
 Nodes (21): Adapter Sibling Non-Import Rule, AI / Genkit conventions, Data model conventions, Enforcement, Family-Shared Data Model (no user scoping), AI Access via Genkit Callables, graphify, Hard rules (+13 more)
 
 ### Community 49 - "Ai"
-Cohesion: 0.22
-Nodes (8): getSessionURL(), identifyAnonymous(), identifyUser(), isSessionActive(), _phKey, startSession(), stopSession(), tagSession()
+Cohesion: 0.17
+Nodes (9): installE2EHooks(), getSessionURL(), identifyAnonymous(), identifyUser(), isSessionActive(), _phKey, startSession(), stopSession() (+1 more)
 
 ### Community 50 - "Lib"
-Cohesion: 0.20
-Nodes (10): ../../lib/auth.svelte.js, AuthStore, clearPendingEmail(), devSignIn(), formatError(), readPendingEmail(), writePendingEmail(), authProvider (+2 more)
+Cohesion: 0.14
+Nodes (6): @salt/domain, ../../lib/titleCase.js, ./MealDayEditor.svelte, ./RecipeAddToListSheet.svelte, @salt/shared-types, @salt/ui-components
 
 ### Community 51 - "Canon"
 Cohesion: 0.25
 Nodes (5): adminNavItem, navItems, $lib/observability, decoratedNavItems, needsApprovalCount
 
 ### Community 52 - "Tests"
-Cohesion: 0.17
-Nodes (13): emptyIngredientGroup(), emptyRecipe(), newIngredient(), newStep(), matchedIngredient(), messyRecipe(), makeMatchedIngredient(), makeRecipe() (+5 more)
+Cohesion: 0.18
+Nodes (13): emptyIngredientGroup(), emptyRecipe(), newIngredient(), newStep(), flattenIngredients(), messyRecipe(), makeMatchedIngredient(), makeRecipe() (+5 more)
 
 ### Community 53 - "Docs"
 Cohesion: 0.18
@@ -560,8 +564,8 @@ Cohesion: 0.11
 Nodes (17): dependencies, @salt/ui-components, svelte, devDependencies, autoprefixer, postcss, @sveltejs/vite-plugin-svelte, tailwindcss (+9 more)
 
 ### Community 61 - "Ai"
-Cohesion: 0.11
-Nodes (26): AiCatalogModel, bareId(), CacheEntry, CatalogModelSchema, CatalogResponseSchema, fetchCatalog(), handleListAiModels(), ListAiModelsInputSchema (+18 more)
+Cohesion: 0.20
+Nodes (15): CatalogModelLike, hasMethod(), isEmbeddingModel(), isImageModel(), isTextModel(), metaHaystack(), methods(), probeMethodFor() (+7 more)
 
 ### Community 62 - "devDependencies"
 Cohesion: 0.12
@@ -572,24 +576,24 @@ Cohesion: 0.23
 Nodes (13): coerceDurationMinutes(), coerceServings(), coerceTags(), coerceText(), coerceTextList(), collectRecipeNodes(), extractJsonLdBlocks(), extractRecipeJsonLd() (+5 more)
 
 ### Community 64 - "Canon"
-Cohesion: 0.08
-Nodes (22): seed, eSim, eX, eY, eX, failEmbedding(), makeAisleStore(), makeIds() (+14 more)
+Cohesion: 0.09
+Nodes (26): eSim, eX, eY, CreateAisleInput, CreateAislesBulkInput, DeleteAislesInput, MatchOrCreatePorts, ItemMergeChoice (+18 more)
 
 ### Community 65 - "Canon Matching"
 Cohesion: 0.23
 Nodes (12): canon.match PostHog Event, Fire-and-Forget Logging, MatchLogBuilder, MatchLogEntry Schema, MatchLoggingPort Contract, createPosthogMatchLoggingAdapter (browser), createPosthogServerMatchLoggingAdapter (CF), createServerMatchLoggingAdapter (firebase-functions/logger) (+4 more)
 
 ### Community 66 - "Canon"
-Cohesion: 0.09
-Nodes (15): DeleteListInput, SetDefaultListInput, ShoppingList, ShoppingListsConfig, ShoppingListPort, ShoppingListsConfigPort, { mockCanonItems, mockAisles, mockLists, mockItems, mockDefaultListId, mockLoading }, { mockCanonItems, mockAisles, mockLists, mockItems, mockDefaultListId, mockLoading } (+7 more)
+Cohesion: 0.15
+Nodes (11): CreateListInput, DeleteListInput, RenameListInput, SetDefaultListInput, ShoppingList, ShoppingListsConfig, ShoppingListPort, ShoppingListsConfigPort (+3 more)
 
 ### Community 67 - "E2E"
 Cohesion: 0.21
 Nodes (15): APP_DIR, buildCloudFunctions(), dockerCompose(), dockerInspect(), e2eServerHealthy(), emulatorImageIsStale(), ensureE2eServer(), globalSetup() (+7 more)
 
 ### Community 68 - "Flows"
-Cohesion: 0.17
-Nodes (11): assembleDraft(), authorRecipeFlow, OutputSchema, canonicaliseRecipeIngredientsFlow, assembleDraft(), buildHtmlPrompt(), extractRecipeFromUrlFlow, OutputSchema (+3 more)
+Cohesion: 0.21
+Nodes (9): assembleDraft(), canonicaliseRecipeIngredientsFlow, assembleDraft(), buildHtmlPrompt(), extractRecipeFromUrlFlow, OutputSchema, stripHtmlNoise(), UrlImportError (+1 more)
 
 ### Community 69 - "Schemas"
 Cohesion: 0.16
@@ -616,16 +620,16 @@ Cohesion: 0.13
 Nodes (14): dependencies, firebase, @salt/domain, @salt/shared-types, devDependencies, @firebase/rules-unit-testing, exports, name (+6 more)
 
 ### Community 75 - "Flows"
-Cohesion: 0.23
-Nodes (11): createFirestoreAisleStore(), createFirestoreCanonStore(), createServerArbitrationAdapter(), createServerEmbeddingAdapter(), createServerMatchLoggingAdapter(), ItemResultSchema, OutputSchema, buildMatchOrCreatePorts() (+3 more)
+Cohesion: 0.16
+Nodes (14): createFirestoreAisleStore(), createFirestoreCanonStore(), createServerArbitrationAdapter(), createServerEmbeddingAdapter(), createServerMatchLoggingAdapter(), ItemResultSchema, OutputSchema, buildMatchOrCreatePorts() (+6 more)
 
 ### Community 76 - "Docs"
 Cohesion: 0.12
 Nodes (17): authorRecipe librarian flow (Flash, structured), Access & admin, Architecture placement, Canon interaction — batch CF, one read per recipe, Cross-module seams (already shipped, awaiting this module), Deferred: the AI-generation epic (own issue + design session), Document, Recipe module (+9 more)
 
 ### Community 77 - "Triggers"
-Cohesion: 0.11
-Nodes (11): requireAdmin(), mockGet, handleTestModel(), TestModelInputSchema, TestModelResult, @salt/domain/schemas, EMULATOR_HOST, mockEmbed (+3 more)
+Cohesion: 0.14
+Nodes (7): mockGet, @salt/domain/schemas, EMULATOR_HOST, mockEmbed, mockGenerateIcon, mockRemoveBg, mockSave
 
 ### Community 78 - "Docs"
 Cohesion: 0.19
@@ -648,8 +652,8 @@ Cohesion: 0.29
 Nodes (7): Stage 1 — Exact name match, Stage 2 — Token overlap, Stage 3 — Synonym exact match, Stage 4 — String similarity (Levenshtein), Stage 5 — Embedding cosine, Stage 6 — Merged shortlist + AI arbitration, Stage-by-stage narrative
 
 ### Community 83 - "Queries"
-Cohesion: 0.16
-Nodes (12): EntryParsePort, collapse(), extractLeadingQuantity(), extractTrailingQuantity(), ParsedEntry, parseShoppingListEntry(), QuantityResult, stripLeadingOf() (+4 more)
+Cohesion: 0.27
+Nodes (9): collapse(), extractLeadingQuantity(), extractTrailingQuantity(), parseShoppingListEntry(), QuantityResult, stripLeadingOf(), TrailingQuantityResult, UNIT_WORDS (+1 more)
 
 ### Community 84 - "Schemas"
 Cohesion: 0.14
@@ -668,7 +672,7 @@ Cohesion: 0.31
 Nodes (11): assertPortsFree(), findHubPid(), getOccupiedPorts(), hubIsRunning(), killPids(), listeningPids(), main(), PORTS (+3 more)
 
 ### Community 88 - "Sections"
-Cohesion: 0.10
+Cohesion: 0.17
 Nodes (10): [], allNotesSelected, formBody, formPublished, formTitle, isSubmitting, listSelectedCount, selectableSelectionMode (+2 more)
 
 ### Community 89 - "Canon"
@@ -696,12 +700,12 @@ Cohesion: 0.21
 Nodes (5): _bad, TextProps, TextVariants, ./Text.types, ./Text.variants
 
 ### Community 95 - "Ai"
-Cohesion: 0.33
-Nodes (5): comboboxContentVariants, comboboxCreateVariants, comboboxInputVariants, comboboxItemVariants, comboboxTriggerVariants
+Cohesion: 0.22
+Nodes (12): seed, eX, failEmbedding(), makeAisleStore(), makeIds(), makePorts(), makeStore(), noMatchArbitration() (+4 more)
 
 ### Community 96 - "Triggers"
-Cohesion: 0.22
-Nodes (6): createServerEntryParseAdapter(), parseEntryFlow, ParseEntryInputSchema, geminiApiKey, onShoppingListItemWrite, posthogApiKey
+Cohesion: 0.10
+Nodes (21): createServerEntryParseAdapter(), AiTimeoutError, raceWithTimeout(), withAiTimeout(), WithAiTimeoutOptions, AiCatalogModel, bareId(), CacheEntry (+13 more)
 
 ### Community 97 - "Docs"
 Cohesion: 0.12
@@ -744,12 +748,12 @@ Cohesion: 0.24
 Nodes (4): HeadingProps, HeadingVariants, ./Heading.types, ./Heading.variants
 
 ### Community 107 - "Lib"
-Cohesion: 0.24
-Nodes (9): ../../lib/devSettingsService.js, canonIconGenerationEnabled, DEFAULTS, initDevSettingsSync(), _isLoading, setCanonIconGenerationEnabled(), _settings, saveDevSettings() (+1 more)
+Cohesion: 0.25
+Nodes (8): ../../lib/devSettingsService.js, canonIconGenerationEnabled, DEFAULTS, initDevSettingsSync(), _isLoading, setCanonIconGenerationEnabled(), _settings, subscribeDevSettings()
 
 ### Community 108 - "Tests"
-Cohesion: 0.18
-Nodes (5): commitRecipeAddPlan(), countIngredient, fs, gramIngredient, { mockGetCanonItemsSnapshot }
+Cohesion: 0.20
+Nodes (4): countIngredient, fs, gramIngredient, { mockGetCanonItemsSnapshot }
 
 ### Community 109 - "Docs"
 Cohesion: 0.40
@@ -779,9 +783,13 @@ Nodes (4): initial, ports, stillBusy, survivors
 Cohesion: 0.22
 Nodes (8): compilerOptions, composite, lib, outDir, rootDir, extends, include, references
 
+### Community 116 - "Src"
+Cohesion: 0.21
+Nodes (6): local, remote, mergeCanonItems(), unionSynonyms(), ConflictStrategy, resolveCanonConflict()
+
 ### Community 117 - "Src"
-Cohesion: 0.10
-Nodes (19): User, reportSubscriptionError(), AuthProvider, authEmulatorConnected, connectAuthEmulatorOnce(), reportAuthFailure(), isAuthTransitioning(), setAuthTransitioning() (+11 more)
+Cohesion: 0.09
+Nodes (21): User, reportSubscriptionError(), AuthProvider, authEmulatorConnected, connectAuthEmulatorOnce(), createFirebaseAuth(), reportAuthFailure(), isAuthTransitioning() (+13 more)
 
 ### Community 118 - "Domain"
 Cohesion: 0.25
@@ -872,8 +880,8 @@ Cohesion: 0.33
 Nodes (3): FakeHttpsError, handler, { mockGet, mockDoc, mockCollection }
 
 ### Community 141 - "Combobox"
-Cohesion: 0.08
-Nodes (42): addList(), loadChatSession(), setAiStub(), callIdentifyEquipment(), callPopulateEquipmentEntry(), IdentifyEquipmentCandidate, IdentifyEquipmentResult, PopulateAccessory (+34 more)
+Cohesion: 0.07
+Nodes (48): subscribeAisles(), saveAppSettings(), deleteCanonItem(), subscribeCanonItems(), deleteChatSession(), expiresAt(), loadChatSession(), saveChatSession() (+40 more)
 
 ### Community 142 - "Design"
 Cohesion: 0.14
@@ -903,6 +911,10 @@ Nodes (4): ArbitrationRequestInput, ArbitrationRequestSchema, CanonArbitrationAI
 Cohesion: 0.40
 Nodes (4): CanonicaliseRecipeIngredientsInput, CanonicaliseRecipeIngredientsInputSchema, CanonicaliseRecipeIngredientsItem, CanonicaliseRecipeIngredientsItemSchema
 
+### Community 150 - "Community 150"
+Cohesion: 0.26
+Nodes (6): PopoverContentProps, PopoverPartProps, PopoverProps, ../../headless/Popover.headless.svelte, ./Popover.types, ./Popover.variants
+
 ### Community 151 - "Scripts"
 Cohesion: 0.40
 Nodes (3): deployPkg, pkgRoot, src
@@ -919,6 +931,10 @@ Nodes (4): Lucide Cooking Pot Glyph, Salt PWA Master Icon (Cooking Pot), PWA Mas
 Cohesion: 0.67
 Nodes (3): globalTeardown(), killE2eServer(), REPO_ROOT
 
+### Community 157 - "Community 157"
+Cohesion: 0.18
+Nodes (8): RecipeAddRow, CONFLICT_ERR, fs, { mockGetCanonItemsSnapshot }, NETWORK_ERR, { reportSpy }, STORAGE_ERR, SYNC_ERR
+
 ### Community 158 - "Scripts"
 Cohesion: 0.50
 Nodes (3): email, member, useEmulator
@@ -926,6 +942,14 @@ Nodes (3): email, member, useEmulator
 ### Community 160 - "Test Emulators"
 Cohesion: 0.83
 Nodes (3): functions_triggers_registered(), reachable(), healthcheck.sh script
+
+### Community 161 - "Community 161"
+Cohesion: 0.22
+Nodes (5): CacheEntry, DEFAULT_SETTINGS, loadSettings(), arbitrateCanonFlow, ArbitrationResultSchema
+
+### Community 164 - "Community 164"
+Cohesion: 0.33
+Nodes (3): loadCanonIconSeed(), GenerateCanonIconInputSchema, GenerateCanonIconOutputSchema
 
 ### Community 167 - "Assets"
 Cohesion: 1.00
@@ -980,16 +1004,16 @@ Cohesion: 0.18
 Nodes (12): 11.1 Overview, 11.2 Props, 11.3 Behaviour, 11.4 Testing requirements, 11. EditableRow (primitive), 13.1 `ToastViewport` — `pointer-events-none` container, 13.2 `BottomNav` — full-height tap targets (`items-stretch`), 13. Pinned interaction constraints (+4 more)
 
 ### Community 273 - "Community 273"
-Cohesion: 0.14
-Nodes (13): 0. Roadmap Split, 5.1 Universal Requirements, 5.2 Keyboard Map, 5.3 Focus Management, 5. Accessibility System, 6.1 Required Test Suites, 6.2 Test File Template, 6. Testing System (+5 more)
+Cohesion: 0.10
+Nodes (19): 0. Roadmap Split, 1.1 Technology Stack, 1.2 Boundaries, 1.3 Package Surface, 1.4 Event Naming Rule, 1.5 Spec Versioning & Amendment Rule, 1. Foundations, 5.1 Universal Requirements (+11 more)
 
 ### Community 274 - "Community 274"
 Cohesion: 0.14
 Nodes (14): 0. v0.3 Scope, 1.1 Headless + Styled, 1.2 APG Compliance, 1. Shared v0.3 Rules, 5.1 Purpose, 5.2 Parts, 5.3 Root Props, 5.4 Events (+6 more)
 
 ### Community 275 - "Community 275"
-Cohesion: 0.14
-Nodes (11): eX, eY, failEmbedding(), makeAisleStore(), makeIds(), makePipeline(), makeStore(), noMatchArbitration() (+3 more)
+Cohesion: 0.17
+Nodes (8): eX, eY, failEmbedding(), makeAisleStore(), makeIds(), makePipeline(), makeStore(), noMatchArbitration()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.17
@@ -1003,13 +1027,26 @@ Nodes (13): A. Async settling & determinism, Appendix — evaluation of the gene
 Cohesion: 0.17
 Nodes (11): Architecture Notes, Definition of Done, Feature Spec, Open Questions / Decisions, Phase 1: [Name], Phase 2: [Name], Phased GitHub Issue Structure, Phases (+3 more)
 
+### Community 279 - "Community 279"
+Cohesion: 0.33
+Nodes (5): CollectionCallback, ErrorCallback, {
+  mockUnsubscribe,
+  mockOnSnapshot,
+  mockSetDoc,
+  mockDeleteDoc,
+  mockGetDoc,
+  mockDoc,
+  mockCollection,
+  mockGetFirestore,
+}, RECIPE, SnapDoc
+
 ### Community 280 - "Community 280"
 Cohesion: 0.18
 Nodes (11): 10. Shared types requirements, 13. Deployment units, 14. Non-negotiables, 1.1 Schema evolution and production data, 1. Purpose, 2. Mono‑repo structure (logical modules), 4. Domain layer requirements, 5. Workspace and access model (+3 more)
 
 ### Community 283 - "Community 283"
-Cohesion: 0.20
-Nodes (10): 8.10 Heading, 8.11 Text, 8.3 Textarea, 8. Primitive Definitions (v0.2 Core), Autoresize, Props, Props, Size styling (+2 more)
+Cohesion: 0.10
+Nodes (20): 8.10 Heading, 8.11 Text, 8.13 Layout Primitives — Stack / Inline / Grid / Divider, 8.3 Textarea, 8.5 Switch, 8. Primitive Definitions (v0.2 Core), Accessibility, Autoresize (+12 more)
 
 ### Community 284 - "Community 284"
 Cohesion: 0.20
@@ -1056,8 +1093,8 @@ Cohesion: 0.25
 Nodes (8): 3.1 Purpose, 3.2 Parts, 3.3 Root Props, 3.4 SelectTrigger Props, 3.5 Events, 3.6 APG Requirements (Listbox), 3.7 Behavior, 3. Select
 
 ### Community 299 - "Community 299"
-Cohesion: 0.29
-Nodes (7): 3.1 Folder Structure, 3.2 Export Rules, 3.3 Tailwind + Token Ownership, 3.4 bits-ui / melt-ui Versions, 3.7 bits-ui Mapping Table, 3.8 Provenance Header Convention, 3. Component Architecture
+Cohesion: 0.17
+Nodes (12): 3.1 Folder Structure, 3.2 Export Rules, 3.3 Tailwind + Token Ownership, 3.4 bits-ui / melt-ui Versions, 3.5 Helpers, 3.7 bits-ui Mapping Table, 3.8 Provenance Header Convention, 3. Component Architecture (+4 more)
 
 ### Community 300 - "Community 300"
 Cohesion: 0.29
@@ -1099,21 +1136,9 @@ Nodes (7): 7.1 Error Shape, 7.2 DomainError Categories, 7.3 Loading States, 7.4 
 Cohesion: 0.29
 Nodes (6): Agentic search, Available MCP tools, Multi-Repo, Smart Features, vexp context tools <!-- vexp v2.0.23 -->, Workflow
 
-### Community 310 - "Community 310"
-Cohesion: 0.33
-Nodes (6): 1.1 Technology Stack, 1.2 Boundaries, 1.3 Package Surface, 1.4 Event Naming Rule, 1.5 Spec Versioning & Amendment Rule, 1. Foundations
-
 ### Community 311 - "Community 311"
-Cohesion: 0.33
-Nodes (6): 4.1 Tokens, Elevation, Motion, Radius, Semantic colors, Z-index
-
-### Community 312 - "Community 312"
-Cohesion: 0.33
-Nodes (6): 4.2 Focus Ring, 4.3 Disabled + Loading, 4.5 Dark Mode, 4. Styling System, Disabled (terminal state — no interaction), Loading (transient state — disables interaction without terminal semantics)
-
-### Community 313 - "Community 313"
-Cohesion: 0.33
-Nodes (6): 4.4 Shared Size Scale, Control Size Scale (Checkbox, Switch), Dialog Size Scale, Field Size Scale (TextField, Textarea frame, Button), Icon / Spinner sizes, Text Size Scale (Text primitive)
+Cohesion: 0.11
+Nodes (18): 4.1 Tokens, 4.2 Focus Ring, 4.3 Disabled + Loading, 4.4 Shared Size Scale, 4.5 Dark Mode, 4. Styling System, Control Size Scale (Checkbox, Switch), Dialog Size Scale (+10 more)
 
 ### Community 314 - "Community 314"
 Cohesion: 0.33
@@ -1126,18 +1151,6 @@ Nodes (6): 8.7 Popover, Events (Root), Parts, Props (Content), Props (Root), Sty
 ### Community 316 - "Community 316"
 Cohesion: 0.33
 Nodes (6): 12. Testing strategy, Cloud Functions, Domain, firebase-sync, observability, UI
-
-### Community 318 - "Community 318"
-Cohesion: 0.40
-Nodes (5): 3.5 Helpers, `src/lib/cn.ts`, `src/lib/context.ts`, `src/lib/useId.ts`, `src/lib/variants.ts`
-
-### Community 319 - "Community 319"
-Cohesion: 0.40
-Nodes (5): 8.13 Layout Primitives — Stack / Inline / Grid / Divider, Divider, Grid, Inline, Stack
-
-### Community 320 - "Community 320"
-Cohesion: 0.40
-Nodes (5): 8.5 Switch, Accessibility, Events, Props, Styling
 
 ### Community 322 - "Community 322"
 Cohesion: 0.50
@@ -1172,24 +1185,24 @@ Cohesion: 0.67
 Nodes (3): Phase 1: [Name], Phase 2: [Name], Phases
 
 ## Knowledge Gaps
-- **1327 isolated node(s):** `husky.sh script`, `name`, `version`, `private`, `type` (+1322 more)
+- **1351 isolated node(s):** `husky.sh script`, `name`, `version`, `private`, `type` (+1346 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **48 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **52 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
 - **Why does `NavItem` connect `Sidenav` to `Canon`, `Combobox & ListPage Types`?**
-  _High betweenness centrality (0.140) - this node is a cross-community bridge._
-- **Why does `../../lib/recipeService.js` connect `Recipe Service` to `Aisles & Canon Stores`, `Canon Approval UI`, `Entities`, `Shopping List Commands`, `Recipes`, `Shopping List UI`, `Tests`, `Canon Matching Core`, `Tests`, `Triggers`, `Combobox`, `Recipes`, `Tests`, `Canon`, `Admin Routes`, `Src`, `Tests`, `Chat`?**
-  _High betweenness centrality (0.048) - this node is a cross-community bridge._
-- **Why does `../../lib/canonService.js` connect `Canon Approval UI` to `Match Logging`, `Canon`, `Aisles & Canon Stores`, `List Page Routes`, `Recipes`, `Firestore Stores & Classify`, `Shopping List UI`, `Canon Matching Core`, `Recipes`, `Canon Fast-Path Parity`, `Canon`, `Admin Routes`, `Src`, `Recipe Service`?**
-  _High betweenness centrality (0.042) - this node is a cross-community bridge._
+  _High betweenness centrality (0.145) - this node is a cross-community bridge._
+- **Why does `../../lib/recipeService.js` connect `Recipe Service` to `Aisles & Canon Stores`, `Firebase-Sync Shopping Config`, `Canon Approval UI`, `Shopping List Commands`, `Shopping List UI`, `Tests`, `Canon Matching Core`, `Combobox`, `Tests`, `Admin Routes`, `Community 157`, `Entities`, `Recipes`, `Lib`, `Canon`, `Tests`, `Triggers`, `Chat`, `Recipes`, `Tests`, `Src`?**
+  _High betweenness centrality (0.046) - this node is a cross-community bridge._
+- **Why does `../../lib/canonService.js` connect `Canon Approval UI` to `Aisles & Canon Stores`, `Firebase-Sync Shopping Config`, `Firestore Stores & Classify`, `Shopping List UI`, `Community 265`, `Canon Matching Core`, `Combobox`, `Canon Fast-Path Parity`, `Admin Routes`, `Recipe Service`, `Match Logging`, `List Page Routes`, `Community 162`, `Recipes`, `Lib`, `Canon`, `Canon`, `Recipes`, `Src`?**
+  _High betweenness centrality (0.044) - this node is a cross-community bridge._
 - **What connects `husky.sh script`, `name`, `version` to the rest of the system?**
-  _1347 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1371 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Meal Planner & Attendees` be split into smaller, more focused modules?**
-  _Cohesion score 0.05028011204481793 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.050974512743628186 - nodes in this community are weakly interconnected._
 - **Should `Aisles & Canon Stores` be split into smaller, more focused modules?**
-  _Cohesion score 0.06758742286218043 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.07911392405063292 - nodes in this community are weakly interconnected._
 - **Should `Canon Approval UI` be split into smaller, more focused modules?**
-  _Cohesion score 0.054612054612054615 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.08902439024390243 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - salt-vscode  (2026-06-27)
 
 ## Corpus Check
-- 829 files · ~294,862 words
+- 829 files · ~295,146 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3894 nodes · 7674 edges · 318 communities (271 shown, 47 thin omitted)
+- 3895 nodes · 7675 edges · 326 communities (275 shown, 51 thin omitted)
 - Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 121 edges (avg confidence: 0.81)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `192fd590`
+- Built from commit: `585c82e8`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -227,6 +227,7 @@
 - [[_COMMUNITY_pnpm Workspace Config|pnpm Workspace Config]]
 - [[_COMMUNITY_Tokens|Tokens]]
 - [[_COMMUNITY_Tokens|Tokens]]
+- [[_COMMUNITY_Community 265|Community 265]]
 - [[_COMMUNITY_Community 266|Community 266]]
 - [[_COMMUNITY_Community 267|Community 267]]
 - [[_COMMUNITY_Community 268|Community 268]]
@@ -247,6 +248,7 @@
 - [[_COMMUNITY_Community 283|Community 283]]
 - [[_COMMUNITY_Community 284|Community 284]]
 - [[_COMMUNITY_Community 285|Community 285]]
+- [[_COMMUNITY_Community 286|Community 286]]
 - [[_COMMUNITY_Community 287|Community 287]]
 - [[_COMMUNITY_Community 288|Community 288]]
 - [[_COMMUNITY_Community 289|Community 289]]
@@ -258,6 +260,7 @@
 - [[_COMMUNITY_Community 295|Community 295]]
 - [[_COMMUNITY_Community 296|Community 296]]
 - [[_COMMUNITY_Community 297|Community 297]]
+- [[_COMMUNITY_Community 298|Community 298]]
 - [[_COMMUNITY_Community 299|Community 299]]
 - [[_COMMUNITY_Community 300|Community 300]]
 - [[_COMMUNITY_Community 301|Community 301]]
@@ -269,10 +272,15 @@
 - [[_COMMUNITY_Community 307|Community 307]]
 - [[_COMMUNITY_Community 308|Community 308]]
 - [[_COMMUNITY_Community 309|Community 309]]
+- [[_COMMUNITY_Community 310|Community 310]]
 - [[_COMMUNITY_Community 311|Community 311]]
+- [[_COMMUNITY_Community 312|Community 312]]
+- [[_COMMUNITY_Community 313|Community 313]]
 - [[_COMMUNITY_Community 314|Community 314]]
 - [[_COMMUNITY_Community 315|Community 315]]
 - [[_COMMUNITY_Community 316|Community 316]]
+- [[_COMMUNITY_Community 317|Community 317]]
+- [[_COMMUNITY_Community 318|Community 318]]
 - [[_COMMUNITY_Community 322|Community 322]]
 - [[_COMMUNITY_Community 324|Community 324]]
 - [[_COMMUNITY_Community 325|Community 325]]
@@ -316,27 +324,27 @@
 - **Canon Matching Entry Points & Shared Core** — matching_pipeline_fast_path, matching_pipeline_match_or_create_canon_callable, matching_pipeline_on_shopping_list_item_write, matching_pipeline_canonicalise_recipe_ingredients, matching_pipeline_match_or_create_batch [EXTRACTED 1.00]
 - **Issue-Driven Agentic Workflow Commands** — commands_spec_feature_spec, commands_defect_defect_spec, commands_refactor_spec_refactor_spec, commands_run_run_issue [INFERRED 0.85]
 
-## Communities (318 total, 47 thin omitted)
+## Communities (326 total, 51 thin omitted)
 
 ### Community 0 - "Meal Planner & Attendees"
-Cohesion: 0.12
-Nodes (31): addAttendee(), ../../lib/mealPlanService.js, addDays(), addTemplateAttendee(), addWeekAttendee(), _anchorDate, _config, currentWeekObject() (+23 more)
+Cohesion: 0.05
+Nodes (96): addAttendee(), DayContainer, removeAttendee(), setAttendeeHomeTime(), setAttendeeNote(), setDayChefs(), setDayGuests(), setDayNote() (+88 more)
 
 ### Community 1 - "Aisles & Canon Stores"
-Cohesion: 0.11
-Nodes (25): DayContainer, removeAttendee(), setAttendeeHomeTime(), setAttendeeNote(), setDayChefs(), setDayGuests(), setDayNote(), withDay() (+17 more)
+Cohesion: 0.13
+Nodes (18): AddAccessoryInput, AddEquipmentInput, addRule(), AddRuleInput, editRule(), EditRuleInput, RemoveAccessoryInput, RemoveEquipmentInput (+10 more)
 
 ### Community 2 - "Firebase-Sync Shopping Config"
-Cohesion: 0.14
-Nodes (24): ../../lib/aisleService.js, addAisle(), addAislesBulk(), deleteAisles(), idGen, mergeAisles(), renameAisle(), reorderAisles() (+16 more)
+Cohesion: 0.22
+Nodes (17): createAisle(), createAislesBulk(), deleteAisles(), ../../lib/aisleService.js, addAisle(), addAislesBulk(), deleteAisles(), idGen (+9 more)
 
 ### Community 3 - "Canon Approval UI"
-Cohesion: 0.09
-Nodes (32): base, approveCanonItem(), renameCanonItem(), ../../lib/canonService.js, addCanonItem(), approveCanonItemWithOverrides(), commitCanonItemUpdate(), deleteCanonItem() (+24 more)
+Cohesion: 0.07
+Nodes (37): base, handleBulkApprove(), approveCanonItem(), ../../lib/canonService.js, aisles, aisleUsage, approveCanonItems(), approveCanonItemWithOverrides() (+29 more)
 
 ### Community 4 - "Shopping List Commands"
-Cohesion: 0.05
-Nodes (48): AddItemInput, CheckItemInput, ConfirmItemNeededInput, CreateListInput, DeleteItemInput, DeleteListInput, EditItemAmountUnitInput, EditItemNotesInput (+40 more)
+Cohesion: 0.07
+Nodes (45): AddItemInput, CheckItemInput, clearCheckedItems(), confirmItemNeeded(), ConfirmItemNeededInput, CreateListInput, deleteItem(), DeleteItemInput (+37 more)
 
 ### Community 5 - "Headless UI Primitives"
 Cohesion: 0.06
@@ -347,24 +355,24 @@ Cohesion: 0.10
 Nodes (30): createViaCombobox(), PASTE_TEXT, STUB_PARSE, AutoFixtures, E2E_RAW_DIR, test, gotoAndSignIn(), seedMemberAllowlist() (+22 more)
 
 ### Community 7 - "Firestore Stores & Classify"
-Cohesion: 0.06
-Nodes (40): eSim, eX, eY, MatchLogBuilder, CreateAisleInput, CreateAislesBulkInput, DeleteAislesInput, MatchOrCreatePorts (+32 more)
+Cohesion: 0.08
+Nodes (26): eSim, eX, eY, CreateAisleInput, CreateAislesBulkInput, DeleteAislesInput, MatchOrCreatePorts, MatchOrCreateResult (+18 more)
 
 ### Community 8 - "Shopping List UI"
-Cohesion: 0.07
-Nodes (55): addItem(), checkItem(), clearCheckedItems(), confirmItemNeeded(), createList(), deleteItem(), deleteList(), editItemAmountUnit() (+47 more)
+Cohesion: 0.13
+Nodes (41): addItem(), checkItem(), uncheckItem(), get(), reportIfFailed(), findMemberByEmail(), commitRecipeAddPlan(), removeRecipe() (+33 more)
 
 ### Community 9 - "Equipment & Rules"
-Cohesion: 0.07
-Nodes (57): addAccessory(), AddAccessoryInput, addEquipment(), AddEquipmentInput, addRule(), AddRuleInput, editRule(), EditRuleInput (+49 more)
+Cohesion: 0.12
+Nodes (40): addAccessory(), addEquipment(), removeAccessory(), removeEquipment(), setAccessoryOwned(), ../../lib/equipmentService.js, addEquipmentAccessory(), addEquipmentItem() (+32 more)
 
 ### Community 10 - "Members Management"
 Cohesion: 0.07
-Nodes (33): auth, ../../lib/membersService.js, createMemberEntry(), CreateMemberEntryInput, deleteMemberEntry(), findMemberByEmail(), getMembersSnapshot(), initMembersSync() (+25 more)
+Nodes (33): createMember(), CreateMemberInput, normaliseMemberEmail(), updateMember(), UpdateMemberPatch, Member, auth, ../../lib/membersService.js (+25 more)
 
 ### Community 11 - "Canon Matching Core"
-Cohesion: 0.06
-Nodes (22): catalog, AISLES, local, remote, items, ApproveCanonItemOverrides, CreateCanonItemInput, ArbitrationExtras (+14 more)
+Cohesion: 0.12
+Nodes (14): catalog, ApproveCanonItemOverrides, CreateCanonItemInput, ArbitrationExtras, renameCanonItem(), setCanonItemAisle(), setCanonItemShoppingBehavior(), setCanonItemThreshold() (+6 more)
 
 ### Community 12 - "web-pwa Dependencies"
 Cohesion: 0.04
@@ -387,8 +395,8 @@ Cohesion: 0.05
 Nodes (37): COLOR_MAP, CONTROLS_CHECKBOX_MAP, CONTROLS_SWITCH_MAP, cssVars, design, DESIGN_MD_PATH, designCheckbox, designColors (+29 more)
 
 ### Community 17 - "Canon Fast-Path Parity"
-Cohesion: 0.08
-Nodes (30): aisleStore, failingArbitration, failingEmbedding, ids, makeStore(), runCfPath(), runFastPath(), appendCanonSynonym() (+22 more)
+Cohesion: 0.09
+Nodes (34): aisleStore, failingArbitration, failingEmbedding, ids, makeStore(), runCfPath(), runFastPath(), items (+26 more)
 
 ### Community 18 - "Select Primitive"
 Cohesion: 0.09
@@ -399,8 +407,8 @@ Cohesion: 0.09
 Nodes (11): cp, DEFAULT_LABELS, FALLBACK_META, getTaskLabel(), metaFor(), net, NUKE_PORTS, SERVICE_META (+3 more)
 
 ### Community 20 - "Admin Routes"
-Cohesion: 0.18
-Nodes (10): ../../lib/auth.svelte.js, AuthStore, clearPendingEmail(), devSignIn(), formatError(), readPendingEmail(), writePendingEmail(), $lib/observability (+2 more)
+Cohesion: 0.14
+Nodes (13): ../../lib/auth.svelte.js, AuthStore, clearPendingEmail(), devSignIn(), formatError(), readPendingEmail(), writePendingEmail(), authProvider (+5 more)
 
 ### Community 21 - "Combobox & ListPage Types"
 Cohesion: 0.12
@@ -415,8 +423,8 @@ Cohesion: 0.11
 Nodes (12): comboboxContentVariants, comboboxCreateVariants, comboboxInputVariants, comboboxItemVariants, comboboxTriggerVariants, DialogContentProps, DialogPartProps, DialogProps (+4 more)
 
 ### Community 24 - "Recipe Service"
-Cohesion: 0.08
-Nodes (20): ../../lib/recipeService.js, buildRecipeAddPlan(), getRecipesSnapshot(), importRecipeFromUrl(), isLoadingRecipes, _itemIds, latestLocalEdit, parseIngredients() (+12 more)
+Cohesion: 0.13
+Nodes (19): ../../lib/recipeService.js, applySnapshot(), buildRecipeAddPlan(), canonicaliseIngredients(), getErrorReporter(), initRecipeSync(), isLoadingRecipes, _itemIds (+11 more)
 
 ### Community 25 - "Observability (PostHog)"
 Cohesion: 0.14
@@ -435,8 +443,8 @@ Cohesion: 0.17
 Nodes (11): assembleDraft(), authorRecipeFlow, OutputSchema, canonicaliseRecipeIngredientsFlow, assembleDraft(), buildHtmlPrompt(), extractRecipeFromUrlFlow, OutputSchema (+3 more)
 
 ### Community 29 - "AI Timeout Guard"
-Cohesion: 0.15
-Nodes (17): embedTextFlow, generateCanonIconFlow, removeFlatBackground(), RemoveFlatBackgroundOptions, sampleBackgroundColour(), reporter, reportFlowError(), reportServerError() (+9 more)
+Cohesion: 0.18
+Nodes (14): generateCanonIconFlow, removeFlatBackground(), RemoveFlatBackgroundOptions, sampleBackgroundColour(), reportServerError(), buildIconDownloadUrl(), geminiApiKey, iconNeedsGeneration() (+6 more)
 
 ### Community 30 - "cloud-functions Dependencies"
 Cohesion: 0.07
@@ -447,16 +455,16 @@ Cohesion: 0.17
 Nodes (22): assertUrlAllowed(), fetchOnce(), guardedLookup(), SingleFetch, SsrfFetchError, SsrfFetchErrorReason, SsrfFetchResult, ssrfGuardedFetch() (+14 more)
 
 ### Community 32 - "Match Logging"
-Cohesion: 0.23
-Nodes (17): emptyDay(), emptyWeek(), instantiateWeek(), Attendee, Day, MealPlanConfig, MealPlanTemplate, MealPlanWeek (+9 more)
+Cohesion: 0.12
+Nodes (13): MatchLogBuilder, ArbitrationLog, CandidateLog, FinalDecision, MatchLogEntry, StageLog, StageSkipReason, MatchLoggingPort (+5 more)
 
 ### Community 33 - "List Page Routes"
-Cohesion: 0.06
-Nodes (18): allVisibleIds, handleBulkApprove(), handleBulkRegenerateIcon(), selectedApprovalIds, selection, topApprovalItems, allIds, selection (+10 more)
+Cohesion: 0.07
+Nodes (15): allVisibleIds, handleBulkRegenerateIcon(), selectedApprovalIds, selection, topApprovalItems, allIds, selection, visibleItems (+7 more)
 
 ### Community 34 - "Cloud Function Callables"
-Cohesion: 0.07
-Nodes (25): beforeMemberCreated, posthogApiKey, regenerateCanonIcon, chefChatFlow, generateChatTitleFlow, identifyEquipmentFlow, populateEquipmentEntryFlow, registerGenkitDevTracing() (+17 more)
+Cohesion: 0.08
+Nodes (24): beforeMemberCreated, posthogApiKey, regenerateCanonIcon, populateEquipmentEntryFlow, reporter, reportFlowError(), registerGenkitDevTracing(), APP_CHECK_ENFORCEMENT (+16 more)
 
 ### Community 35 - "Slider"
 Cohesion: 0.14
@@ -488,7 +496,7 @@ Nodes (16): ../../src/primitives/Toast/Toast.svelte, ToastActionProps, ToastPart
 
 ### Community 42 - "Lib"
 Cohesion: 0.14
-Nodes (26): ../../lib/chatService.js, createChatSession(), getErrorReporter(), initChatSync(), isLoadingSessions, latestLocalEdit, newSession(), now() (+18 more)
+Nodes (23): ../../lib/chatService.js, applySnapshot(), createChatSession(), getErrorReporter(), initChatSync(), isLoadingSessions, latestLocalEdit, newSession() (+15 more)
 
 ### Community 43 - "Recipes"
 Cohesion: 0.08
@@ -507,8 +515,8 @@ Cohesion: 0.17
 Nodes (21): AiGenerationEvent, AiGenerationUsage, captureAiGeneration(), captureServerEvent(), captureServerException(), flushServerObservability(), ObservabilitySpan, OTEL_SPAN (+13 more)
 
 ### Community 47 - "Lib"
-Cohesion: 0.15
-Nodes (21): ../../lib/appSettingsService.js, buildNext(), buildNextFlow(), currentDoc(), effectiveFlowModels, effectiveModels, initAppSettingsSync(), _isCorrupt (+13 more)
+Cohesion: 0.21
+Nodes (16): ../../lib/appSettingsService.js, buildNext(), buildNextFlow(), currentDoc(), effectiveFlowModels, effectiveModels, initAppSettingsSync(), _isCorrupt (+8 more)
 
 ### Community 48 - "Design"
 Cohesion: 0.11
@@ -519,12 +527,12 @@ Cohesion: 0.18
 Nodes (13): ensureObservabilityInitialised(), initServerObservability(), isServerObservabilityInitialised(), createPosthogServerErrorReportingAdapter(), isReportableCategory(), SUPPRESSED_CATEGORIES, initObservability(), createPosthogErrorReportingAdapter() (+5 more)
 
 ### Community 50 - "Lib"
-Cohesion: 0.12
+Cohesion: 0.13
 Nodes (16): ../admin/AdminGuard.svelte, isAdmin, settled, tools, @salt/domain, ../../lib/titleCase.js, ../../lib/toastStore.js, AddToastOptions (+8 more)
 
 ### Community 51 - "Canon"
-Cohesion: 0.25
-Nodes (9): createMember(), CreateMemberInput, normaliseMemberEmail(), updateMember(), UpdateMemberPatch, Member, memberFirstName(), memberInitials() (+1 more)
+Cohesion: 0.12
+Nodes (13): mockGet, importRecipeFromUrl(), @salt/domain/schemas, saveAppSettings(), subscribeAppSettings(), callExtractRecipeFromUrl(), classifyUrlImportError(), ErrorCallback (+5 more)
 
 ### Community 52 - "Tests"
 Cohesion: 0.17
@@ -575,16 +583,16 @@ Cohesion: 0.23
 Nodes (13): coerceDurationMinutes(), coerceServings(), coerceTags(), coerceText(), coerceTextList(), collectRecipeNodes(), extractJsonLdBlocks(), extractRecipeJsonLd() (+5 more)
 
 ### Community 64 - "Canon"
-Cohesion: 0.08
-Nodes (24): fakeStore(), BASE, BASE, createAisle(), createAislesBulk(), deleteAisles(), renameAisle(), reorderAisles() (+16 more)
+Cohesion: 0.10
+Nodes (15): fakeStore(), BASE, BASE, renameAisle(), reorderAisles(), Aisle, AislesDocument, ShoppingList (+7 more)
 
 ### Community 65 - "Canon Matching"
 Cohesion: 0.23
 Nodes (12): canon.match PostHog Event, Fire-and-Forget Logging, MatchLogBuilder, MatchLogEntry Schema, MatchLoggingPort Contract, createPosthogMatchLoggingAdapter (browser), createPosthogServerMatchLoggingAdapter (CF), createServerMatchLoggingAdapter (firebase-functions/logger) (+4 more)
 
 ### Community 66 - "Canon"
-Cohesion: 0.18
-Nodes (14): authProvider, connectAuthEmulatorOnce(), createFirebaseAuth(), setAiStub(), callIdentifyEquipment(), callPopulateEquipmentEntry(), IdentifyEquipmentCandidate, IdentifyEquipmentResult (+6 more)
+Cohesion: 0.17
+Nodes (6): createList(), deleteList(), editItemRawText(), EditItemRawTextInput, renameList(), setDefaultList()
 
 ### Community 67 - "E2E"
 Cohesion: 0.21
@@ -611,8 +619,8 @@ Cohesion: 0.33
 Nodes (6): 1.1 Technology Stack, 1.2 Boundaries, 1.3 Package Surface, 1.4 Event Naming Rule, 1.5 Spec Versioning & Amendment Rule, 1. Foundations
 
 ### Community 73 - "Docs"
-Cohesion: 0.29
-Nodes (7): 10.1 Overview, 10.2 `createListSelection(options)`, 10.3 Component props, 10.4 Behaviour, 10.5 Accessibility, 10.6 Testing requirements, 10. List selection (`createListSelection` + `SelectableList` / `SelectAllCheckbox` / `RowSelectCheckbox`)
+Cohesion: 0.22
+Nodes (6): createServerEntryParseAdapter(), parseEntryFlow, ParseEntryInputSchema, geminiApiKey, onShoppingListItemWrite, posthogApiKey
 
 ### Community 74 - "Firebase Sync"
 Cohesion: 0.13
@@ -620,15 +628,15 @@ Nodes (14): dependencies, firebase, @salt/domain, @salt/shared-types, devDepende
 
 ### Community 75 - "Flows"
 Cohesion: 0.15
-Nodes (15): createFirestoreAisleStore(), createFirestoreCanonStore(), createServerArbitrationAdapter(), createServerEmbeddingAdapter(), createServerEntryParseAdapter(), createServerMatchLoggingAdapter(), ItemResultSchema, OutputSchema (+7 more)
+Nodes (13): createFirestoreAisleStore(), createFirestoreCanonStore(), createServerArbitrationAdapter(), createServerEmbeddingAdapter(), createServerMatchLoggingAdapter(), arbitrateCanonFlow, ArbitrationResultSchema, ItemResultSchema (+5 more)
 
 ### Community 76 - "Docs"
 Cohesion: 0.12
 Nodes (17): authorRecipe librarian flow (Flash, structured), Access & admin, Architecture placement, Canon interaction — batch CF, one read per recipe, Cross-module seams (already shipped, awaiting this module), Deferred: the AI-generation epic (own issue + design session), Document, Recipe module (+9 more)
 
 ### Community 77 - "Triggers"
-Cohesion: 0.14
-Nodes (7): mockGet, @salt/domain/schemas, EMULATOR_HOST, mockEmbed, mockGenerateIcon, mockRemoveBg, mockSave
+Cohesion: 0.22
+Nodes (5): EMULATOR_HOST, mockEmbed, mockGenerateIcon, mockRemoveBg, mockSave
 
 ### Community 78 - "Docs"
 Cohesion: 0.19
@@ -651,8 +659,8 @@ Cohesion: 0.33
 Nodes (6): 4.2 Focus Ring, 4.3 Disabled + Loading, 4.5 Dark Mode, 4. Styling System, Disabled (terminal state — no interaction), Loading (transient state — disables interaction without terminal semantics)
 
 ### Community 83 - "Queries"
-Cohesion: 0.23
-Nodes (10): collapse(), extractLeadingQuantity(), extractTrailingQuantity(), ParsedEntry, parseShoppingListEntry(), QuantityResult, stripLeadingOf(), TrailingQuantityResult (+2 more)
+Cohesion: 0.16
+Nodes (12): EntryParsePort, collapse(), extractLeadingQuantity(), extractTrailingQuantity(), ParsedEntry, parseShoppingListEntry(), QuantityResult, stripLeadingOf() (+4 more)
 
 ### Community 84 - "Schemas"
 Cohesion: 0.14
@@ -679,7 +687,7 @@ Cohesion: 0.40
 Nodes (5): 1. Client config — build-time, committed, **not secret**, 2. Cloud Functions runtime secrets — Secret Manager, per project, **never committed**, 3. CI / GitHub Environments, Config & secrets — what lives where, WIF identifiers (provisioned — Phase 2)
 
 ### Community 90 - "Chat"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (10): existingTags, inputText, isApplying, isSavingRecipe, isSending, now, stamped, streamingText (+2 more)
 
 ### Community 91 - "Domain"
@@ -691,20 +699,20 @@ Cohesion: 0.21
 Nodes (7): collections, getCollection(), mockArbitrate, mockEmbed, readCanonStorage(), seedAisles(), seedCanonItem()
 
 ### Community 93 - "Shared"
-Cohesion: 0.14
-Nodes (14): moveItems(), moveSelectedItems(), setActiveListId(), loadChatSession(), classifyFirestoreError(), firestoreCode(), listShoppingListItems(), moveShoppingListItems() (+6 more)
+Cohesion: 0.06
+Nodes (50): callAuthorRecipe(), classifyError(), callMatchOrCreate(), WireBatchResult, WireResult, callGenerateChatTitle(), getErr(), streamChefChat() (+42 more)
 
 ### Community 94 - "Text"
 Cohesion: 0.21
 Nodes (5): _bad, TextProps, TextVariants, ./Text.types, ./Text.variants
 
 ### Community 95 - "Ai"
-Cohesion: 0.15
-Nodes (17): seed, eX, failEmbedding(), makeAisleStore(), makeIds(), makePorts(), makeStore(), noMatchArbitration() (+9 more)
+Cohesion: 0.22
+Nodes (12): seed, eX, failEmbedding(), makeAisleStore(), makeIds(), makePorts(), makeStore(), noMatchArbitration() (+4 more)
 
 ### Community 96 - "Triggers"
 Cohesion: 0.11
-Nodes (20): AiTimeoutError, raceWithTimeout(), withAiTimeout(), WithAiTimeoutOptions, AiCatalogModel, bareId(), CacheEntry, CatalogModelSchema (+12 more)
+Nodes (21): AiTimeoutError, raceWithTimeout(), withAiTimeout(), WithAiTimeoutOptions, AiCatalogModel, bareId(), CacheEntry, CatalogModelSchema (+13 more)
 
 ### Community 97 - "Docs"
 Cohesion: 0.11
@@ -751,8 +759,8 @@ Cohesion: 0.20
 Nodes (8): state, TooltipContentProps, TooltipPartProps, TooltipProps, TooltipProviderProps, ../../headless/Tooltip.headless.svelte, ./Tooltip.types, ./Tooltip.variants
 
 ### Community 108 - "Tests"
-Cohesion: 0.15
-Nodes (11): emptyTemplate(), saveFirstDayOfWeek(), saveMealPlanConfig(), ADMIN, { mockMembers, mockIsLoadingMembers, mockTemplate, mockFirstDay, mockAuth }, CONFIG, ErrorCallback, { mockUnsubscribe, mockOnSnapshot, mockSetDoc, mockDoc, mockGetFirestore } (+3 more)
+Cohesion: 0.20
+Nodes (4): countIngredient, fs, gramIngredient, { mockGetCanonItemsSnapshot }
 
 ### Community 109 - "Docs"
 Cohesion: 0.40
@@ -783,12 +791,12 @@ Cohesion: 0.22
 Nodes (8): compilerOptions, composite, lib, outDir, rootDir, extends, include, references
 
 ### Community 116 - "Src"
-Cohesion: 0.14
-Nodes (12): currentWeek, firstDayOfWeek, mealPlanTemplate, seedMealPlanConfig(), seedMealPlanTemplate(), seedMealPlanWeek(), selectedStartDate, CONFIG (+4 more)
+Cohesion: 0.28
+Nodes (5): getChatSessionsSnapshot(), installE2EHooks(), getEquipmentSnapshot(), registerServiceWorker(), getRecipesSnapshot()
 
 ### Community 117 - "Src"
-Cohesion: 0.14
-Nodes (12): User, reportSubscriptionError(), AuthProvider, authEmulatorConnected, reportAuthFailure(), isAuthTransitioning(), setAuthTransitioning(), ErrorReportingPort (+4 more)
+Cohesion: 0.11
+Nodes (17): User, AuthProvider, authEmulatorConnected, connectAuthEmulatorOnce(), reportAuthFailure(), isAuthTransitioning(), setAuthTransitioning(), ErrorReportingPort (+9 more)
 
 ### Community 118 - "Domain"
 Cohesion: 0.25
@@ -879,8 +887,8 @@ Cohesion: 0.33
 Nodes (3): FakeHttpsError, handler, { mockGet, mockDoc, mockCollection }
 
 ### Community 141 - "Combobox"
-Cohesion: 0.09
-Nodes (20): initShoppingListSync(), deleteCanonItem(), loadShoppingListsConfig(), subscribeShoppingListsConfig(), listShoppingLists(), subscribeShoppingLists(), clearFirestoreEmulator(), initFirebaseEmulator() (+12 more)
+Cohesion: 0.11
+Nodes (15): ShoppingListsConfig, subscribeAisles(), deleteCanonItem(), subscribeCanonItems(), loadShoppingListsConfig(), saveShoppingListsConfig(), subscribeShoppingListsConfig(), walkThroughCapture() (+7 more)
 
 ### Community 142 - "Design"
 Cohesion: 0.14
@@ -893,6 +901,10 @@ Nodes (3): AiIngredient, mockGenerate, mockUUID
 ### Community 144 - "Tests"
 Cohesion: 0.33
 Nodes (3): fs, parsedFlour, parseGroup
+
+### Community 145 - "Triggers"
+Cohesion: 0.12
+Nodes (8): local, remote, mergeCanonItems(), unionSynonyms(), ConflictStrategy, resolveCanonConflict(), EMULATOR_HOST, mockMatchOrCreate
 
 ### Community 146 - "Docs"
 Cohesion: 0.40
@@ -931,8 +943,8 @@ Cohesion: 0.67
 Nodes (3): globalTeardown(), killE2eServer(), REPO_ROOT
 
 ### Community 157 - "Community 157"
-Cohesion: 0.15
-Nodes (17): reportIfFailed(), canonicaliseIngredients(), commitRecipeAddPlan(), getErrorReporter(), initRecipeSync(), matchIngredient(), persistRecipe(), RecipeAddRow (+9 more)
+Cohesion: 0.18
+Nodes (8): RecipeAddRow, CONFLICT_ERR, fs, { mockGetCanonItemsSnapshot }, NETWORK_ERR, { reportSpy }, STORAGE_ERR, SYNC_ERR
 
 ### Community 158 - "Scripts"
 Cohesion: 0.50
@@ -943,8 +955,8 @@ Cohesion: 0.83
 Nodes (3): functions_triggers_registered(), reachable(), healthcheck.sh script
 
 ### Community 161 - "Community 161"
-Cohesion: 0.12
-Nodes (20): readUsage(), tracedGenerate(), aiFakeEnabled(), aiModelLabel(), fakeModels, flowModel(), CacheEntry, DEFAULT_SETTINGS (+12 more)
+Cohesion: 0.14
+Nodes (18): readUsage(), tracedGenerate(), aiFakeEnabled(), aiModelLabel(), fakeModels, flowModel(), CacheEntry, DEFAULT_SETTINGS (+10 more)
 
 ### Community 162 - "Community 162"
 Cohesion: 0.24
@@ -982,6 +994,10 @@ Nodes (3): Cooking Pot with Lid Glyph, Salt App Icon (512px) — Cooking Pot, Sa
 Cohesion: 1.00
 Nodes (3): Task Pilot Tasks Icon, Task List Visualization, Task Pilot VS Code Extension
 
+### Community 265 - "Community 265"
+Cohesion: 0.25
+Nodes (7): __resetShoppingListServiceForTest(), fs, NETWORK_ERR, { reportSpy }, STORAGE_ERR, SYNC_ERR, VALIDATION_ERR
+
 ### Community 266 - "Community 266"
 Cohesion: 0.40
 Nodes (5): 3.5 Helpers, `src/lib/cn.ts`, `src/lib/context.ts`, `src/lib/useId.ts`, `src/lib/variants.ts`
@@ -1007,8 +1023,8 @@ Cohesion: 0.13
 Nodes (14): Architecture Notes, Behavior Contract, Current State & Motivation, Definition of Done, Open Questions / Decisions, Phase 1: [Name], Phase 2: [Name], Phases (+6 more)
 
 ### Community 272 - "Community 272"
-Cohesion: 0.18
-Nodes (12): 11.1 Overview, 11.2 Props, 11.3 Behaviour, 11.4 Testing requirements, 11. EditableRow (primitive), 13.1 `ToastViewport` — `pointer-events-none` container, 13.2 `BottomNav` — full-height tap targets (`items-stretch`), 13. Pinned interaction constraints (+4 more)
+Cohesion: 0.15
+Nodes (14): 10.1 Overview, 10.2 `createListSelection(options)`, 10.3 Component props, 10.4 Behaviour, 10.5 Accessibility, 10.6 Testing requirements, 10. List selection (`createListSelection` + `SelectableList` / `SelectAllCheckbox` / `RowSelectCheckbox`), 13.1 `ToastViewport` — `pointer-events-none` container (+6 more)
 
 ### Community 273 - "Community 273"
 Cohesion: 0.14
@@ -1034,19 +1050,6 @@ Nodes (13): A. Async settling & determinism, Appendix — evaluation of the gene
 Cohesion: 0.11
 Nodes (18): Create the working branch (once, before phase 1), Per-Phase Handoff Contract, Orchestrator/Subagent Pattern, Pause conditions (stop and wait for user), Run Issue, Setup (once), Architecture Notes, Definition of Done (+10 more)
 
-### Community 279 - "Community 279"
-Cohesion: 0.25
-Nodes (9): deleteRecipe(), loadRecipe(), saveRecipe(), subscribeRecipes(), CollectionCallback, ErrorCallback, {
-  mockUnsubscribe,
-  mockOnSnapshot,
-  mockSetDoc,
-  mockDeleteDoc,
-  mockGetDoc,
-  mockDoc,
-  mockCollection,
-  mockGetFirestore,
-}, RECIPE (+1 more)
-
 ### Community 280 - "Community 280"
 Cohesion: 0.18
 Nodes (11): 10. Shared types requirements, 13. Deployment units, 14. Non-negotiables, 1.1 Schema evolution and production data, 1. Purpose, 2. Mono‑repo structure (logical modules), 4. Domain layer requirements, 5. Workspace and access model (+3 more)
@@ -1060,11 +1063,11 @@ Cohesion: 0.40
 Nodes (5): 8.5 Switch, Accessibility, Events, Props, Styling
 
 ### Community 283 - "Community 283"
-Cohesion: 0.14
-Nodes (14): 8.10 Heading, 8.11 Text, 8.14 Spinner, 8.3 Textarea, 8. Primitive Definitions (v0.2 Core), Accessibility, Autoresize, Props (+6 more)
+Cohesion: 0.20
+Nodes (10): 8.10 Heading, 8.11 Text, 8.3 Textarea, 8. Primitive Definitions (v0.2 Core), Autoresize, Props, Props, Size styling (+2 more)
 
 ### Community 284 - "Community 284"
-Cohesion: 0.17
+Cohesion: 0.20
 Nodes (10): Authoring conventions, CI, E2E & emulator integration tests, Lifecycle, reuse & teardown, Port sets, Running locally, Spotting & clearing a poisoned environment, The containerized test emulator stacks (+2 more)
 
 ### Community 285 - "Community 285"
@@ -1086,10 +1089,6 @@ Nodes (9): 8.2 TextField, Accessibility, Error-message rendering, Events, Forbid
 ### Community 290 - "Community 290"
 Cohesion: 0.25
 Nodes (7): Adapter behaviour, Builder, Canon Matching — Logging & Observability, How to inspect logs manually, Port contract, Purpose, Schema
-
-### Community 291 - "Community 291"
-Cohesion: 0.20
-Nodes (6): Before/after check in PostHog Error Tracking, Caught-error reporting — calibration note, Known, intentional asymmetries (NOT bugs), No raw user content in payloads, Getting started, Salt 2.0
 
 ### Community 292 - "Community 292"
 Cohesion: 0.25
@@ -1114,6 +1113,10 @@ Nodes (8): 2.1 Purpose, 2.2 Parts, 2.3 Root Props, 2.4 Item Props, 2.5 Events, 2
 ### Community 297 - "Community 297"
 Cohesion: 0.25
 Nodes (8): 3.1 Purpose, 3.2 Parts, 3.3 Root Props, 3.4 SelectTrigger Props, 3.5 Events, 3.6 APG Requirements (Listbox), 3.7 Behavior, 3. Select
+
+### Community 298 - "Community 298"
+Cohesion: 0.33
+Nodes (5): AisleDTO, AisleListDTO, CanonItemDTO, conflict, WriteResult
 
 ### Community 299 - "Community 299"
 Cohesion: 0.29
@@ -1159,9 +1162,21 @@ Nodes (7): 7.1 Error Shape, 7.2 DomainError Categories, 7.3 Loading States, 7.4 
 Cohesion: 0.29
 Nodes (6): Agentic search, Available MCP tools, Multi-Repo, Smart Features, vexp context tools <!-- vexp v2.0.23 -->, Workflow
 
+### Community 310 - "Community 310"
+Cohesion: 0.40
+Nodes (5): 11.1 Overview, 11.2 Props, 11.3 Behaviour, 11.4 Testing requirements, 11. EditableRow (primitive)
+
 ### Community 311 - "Community 311"
 Cohesion: 0.33
 Nodes (6): 4.1 Tokens, Elevation, Motion, Radius, Semantic colors, Z-index
+
+### Community 312 - "Community 312"
+Cohesion: 0.40
+Nodes (5): Before/after check in PostHog Error Tracking, Caught-error reporting — calibration note, Known, intentional asymmetries (NOT bugs), No raw user content in payloads, Uncaught errors — separate, automatic path
+
+### Community 313 - "Community 313"
+Cohesion: 0.50
+Nodes (4): 8.14 Spinner, Accessibility, Props, Styling
 
 ### Community 314 - "Community 314"
 Cohesion: 0.33
@@ -1200,24 +1215,24 @@ Cohesion: 0.50
 Nodes (4): 6.1 firebase-sync adapter, 6.2 observability adapter, 6.3 Common rules, 6. Adapter requirements
 
 ## Knowledge Gaps
-- **1371 isolated node(s):** `husky.sh script`, `name`, `version`, `private`, `type` (+1366 more)
+- **1372 isolated node(s):** `husky.sh script`, `name`, `version`, `private`, `type` (+1367 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **47 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **51 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
 - **Why does `NavItem` connect `Sidenav` to `Combobox & ListPage Types`?**
   _High betweenness centrality (0.152) - this node is a cross-community bridge._
-- **Why does `CanonItem` connect `Canon Matching Core` to `Canon`, `List Page Routes`, `Firebase-Sync Shopping Config`, `Canon Approval UI`, `Shopping List Commands`, `E2E Test Suite`, `Firestore Stores & Classify`, `Triggers`, `Tests`, `Combobox`, `Canon Fast-Path Parity`, `Triggers`, `Community 275`, `Recipe Service`, `Flows`, `Ai`?**
+- **Why does `CanonItem` connect `Canon Matching Core` to `Firebase-Sync Shopping Config`, `Canon Approval UI`, `E2E Test Suite`, `Firestore Stores & Classify`, `Tests`, `Combobox`, `Canon Fast-Path Parity`, `Triggers`, `Community 275`, `Community 279`, `Recipe Service`, `Community 286`, `List Page Routes`, `Canon`, `Community 317`, `Community 318`, `Canon`, `Flows`, `Ai`, `Triggers`, `Tests`, `Src`?**
   _High betweenness centrality (0.061) - this node is a cross-community bridge._
-- **Why does `../../lib/recipeService.js` connect `Recipe Service` to `Firebase-Sync Shopping Config`, `Canon Approval UI`, `Shopping List Commands`, `Shopping List UI`, `Tests`, `Canon Matching Core`, `Tests`, `Admin Routes`, `Community 279`, `Community 157`, `Entities`, `Recipes`, `Lib`, `Tests`, `Canon`, `Triggers`, `Chat`, `Recipes`, `Src`?**
+- **Why does `../../lib/recipeService.js` connect `Recipe Service` to `Firebase-Sync Shopping Config`, `Canon Approval UI`, `Shopping List Commands`, `Shopping List UI`, `Tests`, `Canon Matching Core`, `Tests`, `Admin Routes`, `Community 157`, `Entities`, `Lib`, `Recipes`, `Lib`, `Canon`, `Tests`, `Canon`, `Chat`, `Shared`, `Recipes`, `Tests`, `Src`?**
   _High betweenness centrality (0.061) - this node is a cross-community bridge._
 - **What connects `husky.sh script`, `name`, `version` to the rest of the system?**
-  _1391 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1392 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Meal Planner & Attendees` be split into smaller, more focused modules?**
-  _Cohesion score 0.12258064516129032 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.05028011204481793 - nodes in this community are weakly interconnected._
 - **Should `Aisles & Canon Stores` be split into smaller, more focused modules?**
-  _Cohesion score 0.11264367816091954 - nodes in this community are weakly interconnected._
-- **Should `Firebase-Sync Shopping Config` be split into smaller, more focused modules?**
-  _Cohesion score 0.13709677419354838 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.13213213213213212 - nodes in this community are weakly interconnected._
+- **Should `Canon Approval UI` be split into smaller, more focused modules?**
+  _Cohesion score 0.06980392156862746 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - salt-vscode  (2026-06-27)
 
 ## Corpus Check
-- 814 files · ~285,434 words
+- 818 files · ~286,952 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3820 nodes · 7416 edges · 331 communities (278 shown, 53 thin omitted)
+- 3823 nodes · 7458 edges · 316 communities (268 shown, 48 thin omitted)
 - Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 120 edges (avg confidence: 0.81)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `64a386d0`
+- Built from commit: `fd895d59`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -132,7 +132,6 @@
 - [[_COMMUNITY_Scripts|Scripts]]
 - [[_COMMUNITY_Web Pwa|Web Pwa]]
 - [[_COMMUNITY_Src|Src]]
-- [[_COMMUNITY_Src|Src]]
 - [[_COMMUNITY_Domain|Domain]]
 - [[_COMMUNITY_Shared Types|Shared Types]]
 - [[_COMMUNITY_Testing Utils|Testing Utils]]
@@ -166,7 +165,6 @@
 - [[_COMMUNITY_Schemas|Schemas]]
 - [[_COMMUNITY_Schemas|Schemas]]
 - [[_COMMUNITY_Scripts|Scripts]]
-- [[_COMMUNITY_Scripts|Scripts]]
 - [[_COMMUNITY_.Boundary Tests|.Boundary Tests]]
 - [[_COMMUNITY_Branding|Branding]]
 - [[_COMMUNITY_E2E|E2E]]
@@ -174,12 +172,8 @@
 - [[_COMMUNITY_Src|Src]]
 - [[_COMMUNITY_Scripts|Scripts]]
 - [[_COMMUNITY_Scripts|Scripts]]
-- [[_COMMUNITY_Scripts|Scripts]]
 - [[_COMMUNITY_Test Emulators|Test Emulators]]
 - [[_COMMUNITY_Tests|Tests]]
-- [[_COMMUNITY_Tests|Tests]]
-- [[_COMMUNITY_Tests|Tests]]
-- [[_COMMUNITY_Types|Types]]
 - [[_COMMUNITY_Web Pwa|Web Pwa]]
 - [[_COMMUNITY_Src|Src]]
 - [[_COMMUNITY_Assets|Assets]]
@@ -227,8 +221,6 @@
 - [[_COMMUNITY_pnpm Workspace Config|pnpm Workspace Config]]
 - [[_COMMUNITY_Tokens|Tokens]]
 - [[_COMMUNITY_Tokens|Tokens]]
-- [[_COMMUNITY_Community 265|Community 265]]
-- [[_COMMUNITY_Community 266|Community 266]]
 - [[_COMMUNITY_Community 267|Community 267]]
 - [[_COMMUNITY_Community 268|Community 268]]
 - [[_COMMUNITY_Community 269|Community 269]]
@@ -241,14 +233,9 @@
 - [[_COMMUNITY_Community 276|Community 276]]
 - [[_COMMUNITY_Community 277|Community 277]]
 - [[_COMMUNITY_Community 278|Community 278]]
-- [[_COMMUNITY_Community 279|Community 279]]
 - [[_COMMUNITY_Community 280|Community 280]]
-- [[_COMMUNITY_Community 281|Community 281]]
-- [[_COMMUNITY_Community 282|Community 282]]
 - [[_COMMUNITY_Community 283|Community 283]]
 - [[_COMMUNITY_Community 284|Community 284]]
-- [[_COMMUNITY_Community 285|Community 285]]
-- [[_COMMUNITY_Community 286|Community 286]]
 - [[_COMMUNITY_Community 287|Community 287]]
 - [[_COMMUNITY_Community 288|Community 288]]
 - [[_COMMUNITY_Community 289|Community 289]]
@@ -260,7 +247,6 @@
 - [[_COMMUNITY_Community 295|Community 295]]
 - [[_COMMUNITY_Community 296|Community 296]]
 - [[_COMMUNITY_Community 297|Community 297]]
-- [[_COMMUNITY_Community 298|Community 298]]
 - [[_COMMUNITY_Community 299|Community 299]]
 - [[_COMMUNITY_Community 300|Community 300]]
 - [[_COMMUNITY_Community 301|Community 301]]
@@ -279,11 +265,9 @@
 - [[_COMMUNITY_Community 314|Community 314]]
 - [[_COMMUNITY_Community 315|Community 315]]
 - [[_COMMUNITY_Community 316|Community 316]]
-- [[_COMMUNITY_Community 317|Community 317]]
 - [[_COMMUNITY_Community 318|Community 318]]
 - [[_COMMUNITY_Community 319|Community 319]]
 - [[_COMMUNITY_Community 320|Community 320]]
-- [[_COMMUNITY_Community 321|Community 321]]
 - [[_COMMUNITY_Community 322|Community 322]]
 - [[_COMMUNITY_Community 323|Community 323]]
 - [[_COMMUNITY_Community 324|Community 324]]
@@ -295,27 +279,27 @@
 - [[_COMMUNITY_Community 330|Community 330]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `DomainError` - 86 edges
-2. `../../lib/canonService.js` - 77 edges
-3. `ReadResult` - 76 edges
-4. `../../lib/shoppingListService.svelte.js` - 75 edges
+1. `DomainError` - 92 edges
+2. `../../lib/canonService.js` - 79 edges
+3. `../../lib/shoppingListService.svelte.js` - 77 edges
+4. `ReadResult` - 76 edges
 5. `../../lib/mealPlanService.js` - 75 edges
 6. `success` - 69 edges
 7. `CanonItem` - 63 edges
 8. `failure` - 62 edges
-9. `../../lib/recipeService.js` - 58 edges
+9. `../../lib/recipeService.js` - 60 edges
 10. `get()` - 54 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `Salt 2.0 Architecture Contract` --semantically_similar_to--> `Salt 2.0 Architecture Contract (prose)`  [INFERRED] [semantically similar]
-  CLAUDE.md → docs/salt-architecture.md
 - `Layer map` --semantically_similar_to--> `Allowed Import Dependency Graph`  [INFERRED] [semantically similar]
   CLAUDE.md → docs/salt-architecture.md
-- `No IndexedDB / Firestore persistentLocalCache Rule` --semantically_similar_to--> `Firestore persistentLocalCache Offline Layer`  [INFERRED] [semantically similar]
-  CLAUDE.md → docs/salt-architecture.md
-- `Observability Dual Subpath (browser vs server)` --semantically_similar_to--> `observability Adapter (dual subpath)`  [INFERRED] [semantically similar]
+- `Salt 2.0 Architecture Contract` --semantically_similar_to--> `Salt 2.0 Architecture Contract (prose)`  [INFERRED] [semantically similar]
   CLAUDE.md → docs/salt-architecture.md
 - `Boundary Enforcement (lint/typecheck/CI)` --semantically_similar_to--> `Enforcement Rules (ESLint/tsconfig/commit gateway)`  [INFERRED] [semantically similar]
+  CLAUDE.md → docs/salt-architecture.md
+- `isSessionActive()` --calls--> `isObservabilitySessionActive()`  [INFERRED]
+  apps/web-pwa/src/lib/observability.ts → packages/adapters/observability/src/sessionControl.ts
+- `No IndexedDB / Firestore persistentLocalCache Rule` --semantically_similar_to--> `Firestore persistentLocalCache Offline Layer`  [INFERRED] [semantically similar]
   CLAUDE.md → docs/salt-architecture.md
 
 ## Import Cycles
@@ -329,27 +313,27 @@
 - **Canon Matching Entry Points & Shared Core** — matching_pipeline_fast_path, matching_pipeline_match_or_create_canon_callable, matching_pipeline_on_shopping_list_item_write, matching_pipeline_canonicalise_recipe_ingredients, matching_pipeline_match_or_create_batch [EXTRACTED 1.00]
 - **Issue-Driven Agentic Workflow Commands** — commands_spec_feature_spec, commands_defect_defect_spec, commands_refactor_spec_refactor_spec, commands_run_run_issue [INFERRED 0.85]
 
-## Communities (331 total, 53 thin omitted)
+## Communities (316 total, 48 thin omitted)
 
 ### Community 0 - "Meal Planner & Attendees"
-Cohesion: 0.06
-Nodes (84): addAttendee(), DayContainer, removeAttendee(), setAttendeeHomeTime(), setAttendeeNote(), setDayChefs(), setDayGuests(), setDayNote() (+76 more)
+Cohesion: 0.05
+Nodes (96): addAttendee(), DayContainer, removeAttendee(), setAttendeeHomeTime(), setAttendeeNote(), setDayChefs(), setDayGuests(), setDayNote() (+88 more)
 
 ### Community 1 - "Aisles & Canon Stores"
 Cohesion: 0.07
-Nodes (26): AISLES, BASE, BASE, createAisle(), CreateAisleInput, createAislesBulk(), CreateAislesBulkInput, deleteAisles() (+18 more)
+Nodes (26): fakeStore(), AISLES, BASE, BASE, deleteAisles(), mergeAisles(), renameAisle(), reorderAisles() (+18 more)
 
 ### Community 2 - "Firebase-Sync Shopping Config"
-Cohesion: 0.13
-Nodes (20): addAisle(), addAislesBulk(), deleteAisles(), mergeAisles(), renameAisle(), reorderAisles(), getAislesSnapshot(), getErrorReporter() (+12 more)
+Cohesion: 0.20
+Nodes (8): state, TooltipContentProps, TooltipPartProps, TooltipProps, TooltipProviderProps, ../../headless/Tooltip.headless.svelte, ./Tooltip.types, ./Tooltip.variants
 
 ### Community 3 - "Canon Approval UI"
-Cohesion: 0.06
-Nodes (37): base, approveCanonItem(), createCanonItem(), MatchOrCreateInput, MatchOrCreateResult, renameCanonItem(), setCanonItemThumbnail(), ../../lib/aisleService.js (+29 more)
+Cohesion: 0.05
+Nodes (60): base, approveCanonItem(), createAisle(), createAislesBulk(), MergeAislesInput, renameCanonItem(), setCanonItemAisle(), setCanonItemShoppingBehavior() (+52 more)
 
 ### Community 4 - "Shopping List Commands"
-Cohesion: 0.11
-Nodes (18): AddItemInput, CheckItemInput, DeleteItemInput, EditItemAmountUnitInput, EditItemNotesInput, EditItemRawTextInput, MoveItemsInput, MoveItemsResult (+10 more)
+Cohesion: 0.07
+Nodes (38): AddItemInput, CheckItemInput, clearCheckedItems(), confirmItemNeeded(), ConfirmItemNeededInput, CreateListInput, DeleteItemInput, EditItemAmountUnitInput (+30 more)
 
 ### Community 5 - "Headless UI Primitives"
 Cohesion: 0.06
@@ -360,32 +344,32 @@ Cohesion: 0.10
 Nodes (30): createViaCombobox(), PASTE_TEXT, STUB_PARSE, AutoFixtures, E2E_RAW_DIR, test, gotoAndSignIn(), seedMemberAllowlist() (+22 more)
 
 ### Community 7 - "Firestore Stores & Classify"
-Cohesion: 0.13
-Nodes (26): fakeStore(), AddAccessoryInput, AddEquipmentInput, AddRuleInput, EditRuleInput, RemoveAccessoryInput, RemoveEquipmentInput, RemoveRuleInput (+18 more)
+Cohesion: 0.22
+Nodes (6): allVisibleIds, handleBulkApprove(), selectedApprovalIds, selection, topApprovalItems, approveCanonItems()
 
 ### Community 8 - "Shopping List UI"
-Cohesion: 0.08
-Nodes (45): addItem(), checkItem(), deleteItem(), editItemAmountUnit(), editItemNotes(), editItemRawText(), moveItems(), setDefaultList() (+37 more)
+Cohesion: 0.06
+Nodes (48): addItem(), checkItem(), createList(), deleteItem(), deleteList(), editItemAmountUnit(), editItemNotes(), editItemRawText() (+40 more)
 
 ### Community 9 - "Equipment & Rules"
-Cohesion: 0.10
-Nodes (43): addAccessory(), addEquipment(), addRule(), editRule(), removeAccessory(), removeEquipment(), removeRule(), renameEquipment() (+35 more)
+Cohesion: 0.07
+Nodes (57): addAccessory(), AddAccessoryInput, addEquipment(), AddEquipmentInput, addRule(), AddRuleInput, editRule(), EditRuleInput (+49 more)
 
 ### Community 10 - "Members Management"
-Cohesion: 0.12
-Nodes (19): auth, ../../lib/membersService.js, createMemberEntry(), CreateMemberEntryInput, deleteMemberEntry(), initMembersSync(), isEmailAdmin(), isLoadingMembers (+11 more)
+Cohesion: 0.07
+Nodes (36): createMember(), CreateMemberInput, normaliseMemberEmail(), updateMember(), UpdateMemberPatch, Member, auth, ../../lib/membersService.js (+28 more)
 
 ### Community 11 - "Canon Matching Core"
-Cohesion: 0.09
-Nodes (18): catalog, local, remote, ApproveCanonItemOverrides, CreateCanonItemInput, ArbitrationExtras, mergeCanonItems(), unionSynonyms() (+10 more)
+Cohesion: 0.08
+Nodes (28): local, remote, ApproveCanonItemOverrides, CreateAisleInput, CreateAislesBulkInput, CreateCanonItemInput, DeleteAislesInput, ArbitrationExtras (+20 more)
 
 ### Community 12 - "web-pwa Dependencies"
 Cohesion: 0.04
 Nodes (45): dependencies, @lucide/svelte, @salt/domain, @salt/firebase-sync, @salt/observability, @salt/shared-types, @salt/ui-components, svelte (+37 more)
 
 ### Community 13 - "UI-Components Package"
-Cohesion: 0.04
-Nodes (41): svelte-exmarkdown/gfm, dependencies, bits-ui, class-variance-authority, clsx, @floating-ui/dom, @lucide/svelte, svelte (+33 more)
+Cohesion: 0.05
+Nodes (40): dependencies, bits-ui, class-variance-authority, clsx, @floating-ui/dom, @lucide/svelte, svelte, svelte-dnd-action (+32 more)
 
 ### Community 14 - "Combobox Primitive"
 Cohesion: 0.07
@@ -400,8 +384,8 @@ Cohesion: 0.05
 Nodes (37): COLOR_MAP, CONTROLS_CHECKBOX_MAP, CONTROLS_SWITCH_MAP, cssVars, design, DESIGN_MD_PATH, designCheckbox, designColors (+29 more)
 
 ### Community 17 - "Canon Fast-Path Parity"
-Cohesion: 0.08
-Nodes (31): runFastPath(), items, appendCanonSynonym(), MatchLogBuilder, applyClassification(), arbitrationFailureReasoning(), ArbitrationNew, ArbOutcome (+23 more)
+Cohesion: 0.07
+Nodes (37): aisleStore, failingArbitration, failingEmbedding, ids, makeStore(), runCfPath(), runFastPath(), catalog (+29 more)
 
 ### Community 18 - "Select Primitive"
 Cohesion: 0.09
@@ -412,8 +396,8 @@ Cohesion: 0.09
 Nodes (11): cp, DEFAULT_LABELS, FALLBACK_META, getTaskLabel(), metaFor(), net, NUKE_PORTS, SERVICE_META (+3 more)
 
 ### Community 20 - "Admin Routes"
-Cohesion: 0.12
-Nodes (16): ../admin/AdminGuard.svelte, isAdmin, settled, tools, @salt/domain, ../../lib/titleCase.js, ../../lib/toastStore.js, AddToastOptions (+8 more)
+Cohesion: 0.13
+Nodes (12): ../admin/AdminGuard.svelte, isAdmin, settled, tools, @salt/domain, @salt/firebase-sync, ../../lib/titleCase.js, ./MealDayEditor.svelte (+4 more)
 
 ### Community 21 - "Combobox & ListPage Types"
 Cohesion: 0.12
@@ -425,31 +409,31 @@ Nodes (35): categories, properties, title, contributes, commands, configuration,
 
 ### Community 23 - "Dialog & Popover Primitives"
 Cohesion: 0.10
-Nodes (14): DialogContentProps, DialogPartProps, DialogProps, state, TooltipContentProps, TooltipPartProps, TooltipProps, TooltipProviderProps (+6 more)
+Nodes (13): DialogContentProps, DialogPartProps, DialogProps, DialogContentVariants, PopoverContentProps, PopoverPartProps, PopoverProps, ../../headless/Dialog.headless.svelte (+5 more)
 
 ### Community 24 - "Recipe Service"
 Cohesion: 0.10
-Nodes (25): getCanonItemsSnapshot(), ../../lib/recipeService.js, applySnapshot(), buildRecipeAddPlan(), canonicaliseIngredients(), getErrorReporter(), importRecipeFromUrl(), initRecipeSync() (+17 more)
+Nodes (24): ../../lib/recipeService.js, applySnapshot(), buildRecipeAddPlan(), canonicaliseIngredients(), getErrorReporter(), importRecipeFromUrl(), initRecipeSync(), isLoadingRecipes (+16 more)
 
 ### Community 25 - "Observability (PostHog)"
-Cohesion: 0.14
-Nodes (25): getSessionURL(), identifyAnonymous(), identifyUser(), isSessionActive(), _phKey, startSession(), stopSession(), tagSession() (+17 more)
+Cohesion: 0.23
+Nodes (17): extractTraceHeaders(), identifyObservabilityAnonymous(), identifyObservabilityUser(), initObservability(), isObservabilityReady(), NOOP_SPAN, ObservabilityOptions, ObservabilitySpan (+9 more)
 
 ### Community 26 - "Selectable List & Checkbox"
-Cohesion: 0.13
-Nodes (13): ../../primitives/Checkbox/Checkbox.svelte, EditableRowProps, createListSelection(), CreateListSelectionOptions, ListSelection, ./RowSelectCheckbox.svelte, SelectableListItem, SelectableListProps (+5 more)
+Cohesion: 0.11
+Nodes (16): ../../primitives/Checkbox/Checkbox.svelte, CheckboxProps, CheckedState, CheckboxRootVariants, EditableRowProps, createListSelection(), CreateListSelectionOptions, ListSelection (+8 more)
 
 ### Community 27 - "Layout Primitives"
-Cohesion: 0.06
-Nodes (23): CheckboxProps, CheckedState, CheckboxRootVariants, comboboxContentVariants, comboboxCreateVariants, comboboxInputVariants, comboboxItemVariants, comboboxTriggerVariants (+15 more)
+Cohesion: 0.08
+Nodes (14): DividerProps, GridProps, GridVariants, InlineProps, InlineVariants, StackProps, StackVariants, ./Divider.types (+6 more)
 
 ### Community 28 - "AI Flows & Telemetry"
-Cohesion: 0.16
-Nodes (12): readUsage(), tracedGenerate(), aiModelLabel(), fakeModels, flowModel(), chefChatFlow, generateChatTitleFlow, InputSchema (+4 more)
+Cohesion: 0.12
+Nodes (20): readUsage(), tracedGenerate(), aiFakeEnabled(), aiModelLabel(), fakeModels, flowModel(), CacheEntry, DEFAULT_SETTINGS (+12 more)
 
 ### Community 29 - "AI Timeout Guard"
-Cohesion: 0.19
-Nodes (12): aiFakeEnabled(), generateCanonIconFlow, removeFlatBackground(), RemoveFlatBackgroundOptions, sampleBackgroundColour(), buildIconDownloadUrl(), geminiApiKey, iconNeedsGeneration() (+4 more)
+Cohesion: 0.11
+Nodes (19): AiTimeoutError, raceWithTimeout(), withAiTimeout(), WithAiTimeoutOptions, loadCanonIconSeed(), generateCanonIconFlow, GenerateCanonIconInputSchema, GenerateCanonIconOutputSchema (+11 more)
 
 ### Community 30 - "cloud-functions Dependencies"
 Cohesion: 0.07
@@ -460,16 +444,16 @@ Cohesion: 0.17
 Nodes (22): assertUrlAllowed(), fetchOnce(), guardedLookup(), SingleFetch, SsrfFetchError, SsrfFetchErrorReason, SsrfFetchResult, ssrfGuardedFetch() (+14 more)
 
 ### Community 32 - "Match Logging"
-Cohesion: 0.53
-Nodes (5): formatArbitration(), formatStage(), MatchLogSummary, nearMissCount(), summarizeMatchLog()
+Cohesion: 0.17
+Nodes (10): MatchLogBuilder, ArbitrationLog, FinalDecision, StageLog, StageSkipReason, formatArbitration(), formatStage(), MatchLogSummary (+2 more)
 
 ### Community 33 - "List Page Routes"
-Cohesion: 0.07
-Nodes (16): allVisibleIds, handleBulkApprove(), handleBulkRegenerateIcon(), selectedApprovalIds, selection, topApprovalItems, allIds, selection (+8 more)
+Cohesion: 0.08
+Nodes (16): handleBulkRegenerateIcon(), allIds, selection, visibleItems, ../../lib/deferredDelete.svelte.js, DeferredDelete, ../../lib/toastStore.js, addToast() (+8 more)
 
 ### Community 34 - "Cloud Function Callables"
 Cohesion: 0.08
-Nodes (21): beforeMemberCreated, regenerateCanonIcon, authorRecipeFlow, UrlImportError, registerGenkitDevTracing(), APP_CHECK_ENFORCEMENT, arbitrateCanon, authorRecipe (+13 more)
+Nodes (22): beforeMemberCreated, regenerateCanonIcon, generateChatTitleFlow, identifyEquipmentFlow, populateEquipmentEntryFlow, registerGenkitDevTracing(), APP_CHECK_ENFORCEMENT, arbitrateCanon (+14 more)
 
 ### Community 35 - "Slider"
 Cohesion: 0.14
@@ -492,16 +476,16 @@ Cohesion: 0.11
 Nodes (10): ../../primitives/Button/Button.svelte, ButtonProps, ButtonVariants, FormPageProps, ../../primitives/Spinner/Spinner.svelte, SpinnerProps, ../../headless/Button.headless.svelte, ./Button.types (+2 more)
 
 ### Community 40 - "Card"
-Cohesion: 0.18
-Nodes (10): CardContentProps, CardDescriptionProps, CardFooterProps, CardHeaderProps, CardPartProps, CardProps, CardTitleProps, ../../lib/cn (+2 more)
+Cohesion: 0.16
+Nodes (11): CardContentProps, CardDescriptionProps, CardFooterProps, CardHeaderProps, CardPartProps, CardProps, CardTitleProps, svelte-exmarkdown/gfm (+3 more)
 
 ### Community 41 - "Toast"
 Cohesion: 0.17
 Nodes (16): ../../src/primitives/Toast/Toast.svelte, ToastActionProps, ToastPartProps, ToastProps, ToastProviderProps, ToastViewportProps, ToastVariants, ../../src/primitives/Toast/ToastAction.svelte (+8 more)
 
 ### Community 42 - "Lib"
-Cohesion: 0.17
-Nodes (21): ../../lib/chatService.js, applySnapshot(), createChatSession(), getErrorReporter(), initChatSync(), isLoadingSessions, latestLocalEdit, newSession() (+13 more)
+Cohesion: 0.18
+Nodes (20): ../../lib/chatService.js, applySnapshot(), createChatSession(), getErrorReporter(), initChatSync(), isLoadingSessions, latestLocalEdit, newSession() (+12 more)
 
 ### Community 43 - "Recipes"
 Cohesion: 0.08
@@ -520,32 +504,32 @@ Cohesion: 0.19
 Nodes (19): ensureObservabilityInitialised(), AiGenerationEvent, AiGenerationUsage, captureAiGeneration(), captureServerEvent(), captureServerException(), flushServerObservability(), initServerObservability() (+11 more)
 
 ### Community 47 - "Lib"
-Cohesion: 0.21
-Nodes (16): ../../lib/appSettingsService.js, buildNext(), buildNextFlow(), currentDoc(), effectiveFlowModels, effectiveModels, initAppSettingsSync(), _isCorrupt (+8 more)
+Cohesion: 0.15
+Nodes (21): ../../lib/appSettingsService.js, buildNext(), buildNextFlow(), currentDoc(), effectiveFlowModels, effectiveModels, initAppSettingsSync(), _isCorrupt (+13 more)
 
 ### Community 48 - "Design"
 Cohesion: 0.10
-Nodes (22): Adapter Sibling Non-Import Rule, AI / Genkit conventions, Boundary Enforcement (lint/typecheck/CI), Data model conventions, Enforcement, Family-Shared Data Model (no user scoping), AI Access via Genkit Callables, graphify (+14 more)
+Nodes (21): Adapter Sibling Non-Import Rule, AI / Genkit conventions, Data model conventions, Enforcement, Family-Shared Data Model (no user scoping), AI Access via Genkit Callables, graphify, Hard rules (+13 more)
 
 ### Community 49 - "Ai"
-Cohesion: 0.11
-Nodes (21): AiTimeoutError, raceWithTimeout(), withAiTimeout(), WithAiTimeoutOptions, AiCatalogModel, bareId(), CacheEntry, CatalogModelSchema (+13 more)
+Cohesion: 0.22
+Nodes (8): getSessionURL(), identifyAnonymous(), identifyUser(), isSessionActive(), _phKey, startSession(), stopSession(), tagSession()
 
 ### Community 50 - "Lib"
-Cohesion: 0.15
-Nodes (12): ../../lib/auth.svelte.js, AuthStore, clearPendingEmail(), devSignIn(), formatError(), readPendingEmail(), writePendingEmail(), adminNavItem (+4 more)
+Cohesion: 0.20
+Nodes (10): ../../lib/auth.svelte.js, AuthStore, clearPendingEmail(), devSignIn(), formatError(), readPendingEmail(), writePendingEmail(), authProvider (+2 more)
 
 ### Community 51 - "Canon"
-Cohesion: 0.21
-Nodes (13): seed, eX, failEmbedding(), makeAisleStore(), makeIds(), makePorts(), makeStore(), noMatchArbitration() (+5 more)
+Cohesion: 0.25
+Nodes (5): adminNavItem, navItems, $lib/observability, decoratedNavItems, needsApprovalCount
 
 ### Community 52 - "Tests"
 Cohesion: 0.17
 Nodes (13): emptyIngredientGroup(), emptyRecipe(), newIngredient(), newStep(), matchedIngredient(), messyRecipe(), makeMatchedIngredient(), makeRecipe() (+5 more)
 
 ### Community 53 - "Docs"
-Cohesion: 0.24
-Nodes (10): Managed Export/Import (no triggers), Batched Embedding Cache (no stage-5 fork), matchOrCreateBatch Three-Phase Orchestrator, matchOrCreateCanon CF Callable, onCanonItemWritten Trigger (icon/embedding), onShoppingListItemWrite Trigger, Client Config vs Runtime Secrets Split, Dev/Staging Share One Google AI Studio Project (+2 more)
+Cohesion: 0.18
+Nodes (13): Cross-Project Import IAM (objectViewer + legacyBucketReader), Managed Export/Import (no triggers), Prod -> Staging Firestore Refresh Flow, Staging-Only Hard Refuse Safety Guard, Task Pilot Sidebar Tasks, Batched Embedding Cache (no stage-5 fork), matchOrCreateBatch Three-Phase Orchestrator, matchOrCreateCanon CF Callable (+5 more)
 
 ### Community 54 - "Detailpage"
 Cohesion: 0.13
@@ -576,36 +560,36 @@ Cohesion: 0.11
 Nodes (17): dependencies, @salt/ui-components, svelte, devDependencies, autoprefixer, postcss, @sveltejs/vite-plugin-svelte, tailwindcss (+9 more)
 
 ### Community 61 - "Ai"
-Cohesion: 0.20
-Nodes (15): CatalogModelLike, hasMethod(), isEmbeddingModel(), isImageModel(), isTextModel(), metaHaystack(), methods(), probeMethodFor() (+7 more)
+Cohesion: 0.11
+Nodes (26): AiCatalogModel, bareId(), CacheEntry, CatalogModelSchema, CatalogResponseSchema, fetchCatalog(), handleListAiModels(), ListAiModelsInputSchema (+18 more)
 
 ### Community 62 - "devDependencies"
 Cohesion: 0.12
 Nodes (17): devDependencies, @commitlint/cli, @commitlint/config-conventional, dependency-cruiser, eslint, eslint-plugin-boundaries, eslint-plugin-playwright, firebase-tools (+9 more)
 
 ### Community 63 - "Adapters"
-Cohesion: 0.26
-Nodes (12): coerceDurationMinutes(), coerceServings(), coerceTags(), coerceText(), coerceTextList(), collectRecipeNodes(), extractJsonLdBlocks(), extractRecipeJsonLd() (+4 more)
+Cohesion: 0.23
+Nodes (13): coerceDurationMinutes(), coerceServings(), coerceTags(), coerceText(), coerceTextList(), collectRecipeNodes(), extractJsonLdBlocks(), extractRecipeJsonLd() (+5 more)
 
 ### Community 64 - "Canon"
-Cohesion: 0.07
-Nodes (21): aisleStore, failingArbitration, failingEmbedding, ids, makeStore(), runCfPath(), eSim, eX (+13 more)
+Cohesion: 0.08
+Nodes (22): seed, eSim, eX, eY, eX, failEmbedding(), makeAisleStore(), makeIds() (+14 more)
 
 ### Community 65 - "Canon Matching"
-Cohesion: 0.31
-Nodes (9): canon.match PostHog Event, Fire-and-Forget Logging, MatchLogBuilder, MatchLogEntry Schema, MatchLoggingPort Contract, createPosthogMatchLoggingAdapter (browser), createPosthogServerMatchLoggingAdapter (CF), createServerMatchLoggingAdapter (firebase-functions/logger) (+1 more)
+Cohesion: 0.23
+Nodes (12): canon.match PostHog Event, Fire-and-Forget Logging, MatchLogBuilder, MatchLogEntry Schema, MatchLoggingPort Contract, createPosthogMatchLoggingAdapter (browser), createPosthogServerMatchLoggingAdapter (CF), createServerMatchLoggingAdapter (firebase-functions/logger) (+4 more)
 
 ### Community 66 - "Canon"
-Cohesion: 0.13
-Nodes (15): clearCheckedItems(), confirmItemNeeded(), ConfirmItemNeededInput, createList(), CreateListInput, deleteList(), DeleteListInput, renameList() (+7 more)
+Cohesion: 0.09
+Nodes (15): DeleteListInput, SetDefaultListInput, ShoppingList, ShoppingListsConfig, ShoppingListPort, ShoppingListsConfigPort, { mockCanonItems, mockAisles, mockLists, mockItems, mockDefaultListId, mockLoading }, { mockCanonItems, mockAisles, mockLists, mockItems, mockDefaultListId, mockLoading } (+7 more)
 
 ### Community 67 - "E2E"
 Cohesion: 0.21
 Nodes (15): APP_DIR, buildCloudFunctions(), dockerCompose(), dockerInspect(), e2eServerHealthy(), emulatorImageIsStale(), ensureE2eServer(), globalSetup() (+7 more)
 
 ### Community 68 - "Flows"
-Cohesion: 0.18
-Nodes (14): JsonLdRecipe, assembleDraft(), OutputSchema, canonicaliseRecipeIngredientsFlow, ItemResultSchema, OutputSchema, assembleDraft(), buildHtmlPrompt() (+6 more)
+Cohesion: 0.17
+Nodes (11): assembleDraft(), authorRecipeFlow, OutputSchema, canonicaliseRecipeIngredientsFlow, assembleDraft(), buildHtmlPrompt(), extractRecipeFromUrlFlow, OutputSchema (+3 more)
 
 ### Community 69 - "Schemas"
 Cohesion: 0.16
@@ -616,32 +600,32 @@ Cohesion: 0.12
 Nodes (4): SyncContextManager, TEST_KEY, TestPropagator, ThrowingPropagator
 
 ### Community 71 - "Tooltip"
-Cohesion: 0.08
-Nodes (24): Authority and runtime, Batch entry point — recipe ingredient canonicalisation, Batched embedding without forking stage 5, Canon deletion is resolved at display time — never written back, Canon Item Matching Pipeline, Edits clear the match eagerly, Flow diagram, Growing snapshot (+16 more)
+Cohesion: 0.12
+Nodes (17): Authority and runtime, Batch entry point — recipe ingredient canonicalisation, Batched embedding without forking stage 5, Canon deletion is resolved at display time — never written back, Canon Item Matching Pipeline, Edits clear the match eagerly, Flow diagram, Growing snapshot (+9 more)
 
 ### Community 72 - "Sections"
-Cohesion: 0.16
-Nodes (17): setAiStub(), IdentifyEquipmentCandidate, IdentifyEquipmentResult, PopulateAccessory, PopulateEquipmentEntryResult, saveMealPlanConfig(), saveMealPlanTemplate(), saveMealPlanWeek() (+9 more)
+Cohesion: 0.36
+Nodes (4): isReportableCategory(), SUPPRESSED_CATEGORIES, createPosthogErrorReportingAdapter(), { captureException, init }
 
 ### Community 73 - "Docs"
-Cohesion: 0.19
-Nodes (13): Last-Write-Wins Per Document, No IndexedDB / Firestore persistentLocalCache Rule, Observability Dual Subpath (browser vs server), Realtime Cross-Tab Convergence (long-poll settle), PostHog Project Per Deploy Target, Adapter Error Contract (Success/Failure/Conflict), Salt 2.0 Architecture Contract (prose), chatSessions Owner-Scoped Exception (+5 more)
+Cohesion: 0.29
+Nodes (7): 10.1 Overview, 10.2 `createListSelection(options)`, 10.3 Component props, 10.4 Behaviour, 10.5 Accessibility, 10.6 Testing requirements, 10. List selection (`createListSelection` + `SelectableList` / `SelectAllCheckbox` / `RowSelectCheckbox`)
 
 ### Community 74 - "Firebase Sync"
 Cohesion: 0.13
 Nodes (14): dependencies, firebase, @salt/domain, @salt/shared-types, devDependencies, @firebase/rules-unit-testing, exports, name (+6 more)
 
 ### Community 75 - "Flows"
-Cohesion: 0.31
-Nodes (9): createFirestoreAisleStore(), createFirestoreCanonStore(), createServerArbitrationAdapter(), createServerEmbeddingAdapter(), createServerMatchLoggingAdapter(), buildMatchOrCreatePorts(), composeMatchLogging(), matchOrCreateCanonFlow (+1 more)
+Cohesion: 0.23
+Nodes (11): createFirestoreAisleStore(), createFirestoreCanonStore(), createServerArbitrationAdapter(), createServerEmbeddingAdapter(), createServerMatchLoggingAdapter(), ItemResultSchema, OutputSchema, buildMatchOrCreatePorts() (+3 more)
 
 ### Community 76 - "Docs"
 Cohesion: 0.12
 Nodes (17): authorRecipe librarian flow (Flash, structured), Access & admin, Architecture placement, Canon interaction — batch CF, one read per recipe, Cross-module seams (already shipped, awaiting this module), Deferred: the AI-generation epic (own issue + design session), Document, Recipe module (+9 more)
 
 ### Community 77 - "Triggers"
-Cohesion: 0.22
-Nodes (5): EMULATOR_HOST, mockEmbed, mockGenerateIcon, mockRemoveBg, mockSave
+Cohesion: 0.11
+Nodes (11): requireAdmin(), mockGet, handleTestModel(), TestModelInputSchema, TestModelResult, @salt/domain/schemas, EMULATOR_HOST, mockEmbed (+3 more)
 
 ### Community 78 - "Docs"
 Cohesion: 0.19
@@ -660,12 +644,12 @@ Cohesion: 0.14
 Nodes (14): esbuild, fast-xml-parser, firebase-admin>uuid, form-data@>=4.0.0 <4.0.6, hono, js-yaml@4, @opentelemetry/api, protobufjs (+6 more)
 
 ### Community 82 - "Src"
-Cohesion: 0.21
-Nodes (10): authProvider, connectAuthEmulatorOnce(), createFirebaseAuth(), AppCheckConfig, emulatorConnectedApps, initFirebase(), setFirestoreNetwork(), clearFirestoreEmulator() (+2 more)
+Cohesion: 0.29
+Nodes (7): Stage 1 — Exact name match, Stage 2 — Token overlap, Stage 3 — Synonym exact match, Stage 4 — String similarity (Levenshtein), Stage 5 — Embedding cosine, Stage 6 — Merged shortlist + AI arbitration, Stage-by-stage narrative
 
 ### Community 83 - "Queries"
-Cohesion: 0.20
-Nodes (10): collapse(), extractLeadingQuantity(), extractTrailingQuantity(), parseShoppingListEntry(), QuantityResult, stripLeadingOf(), TrailingQuantityResult, UNIT_WORDS (+2 more)
+Cohesion: 0.16
+Nodes (12): EntryParsePort, collapse(), extractLeadingQuantity(), extractTrailingQuantity(), ParsedEntry, parseShoppingListEntry(), QuantityResult, stripLeadingOf() (+4 more)
 
 ### Community 84 - "Schemas"
 Cohesion: 0.14
@@ -688,12 +672,12 @@ Cohesion: 0.10
 Nodes (10): [], allNotesSelected, formBody, formPublished, formTitle, isSubmitting, listSelectedCount, selectableSelectionMode (+2 more)
 
 ### Community 89 - "Canon"
-Cohesion: 0.10
-Nodes (20): Cross-Project Import IAM (objectViewer + legacyBucketReader), Prod -> Staging Firestore Refresh Flow, Staging-Only Hard Refuse Safety Guard, Task Pilot Sidebar Tasks, 1. Client config — build-time, committed, **not secret**, 2. Cloud Functions runtime secrets — Secret Manager, per project, **never committed**, 3. CI / GitHub Environments, Config & secrets — what lives where (+12 more)
+Cohesion: 0.12
+Nodes (17): 1. Client config — build-time, committed, **not secret**, 2. Cloud Functions runtime secrets — Secret Manager, per project, **never committed**, 3. CI / GitHub Environments, Config & secrets — what lives where, Cutting a release (promote staging → production), Deploying, Firebase projects (`.firebaserc` aliases), First deploy to a fresh project (one-time bootstrap) (+9 more)
 
 ### Community 90 - "Chat"
-Cohesion: 0.15
-Nodes (10): existingTags, inputText, isApplying, isSavingRecipe, isSending, now, stamped, streamingText (+2 more)
+Cohesion: 0.17
+Nodes (9): existingTags, inputText, isApplying, isSavingRecipe, isSending, now, stamped, streamingText (+1 more)
 
 ### Community 91 - "Domain"
 Cohesion: 0.17
@@ -704,24 +688,24 @@ Cohesion: 0.21
 Nodes (7): collections, getCollection(), mockArbitrate, mockEmbed, readCanonStorage(), seedAisles(), seedCanonItem()
 
 ### Community 93 - "Shared"
-Cohesion: 0.19
-Nodes (10): MatchLogEntry, createPosthogServerMatchLoggingAdapter(), CANON_MATCH_EVENT, CanonMatchEventProps, CanonMatchPath, scaleScore(), toCanonMatchEvent(), ObservabilitySpan (+2 more)
+Cohesion: 0.31
+Nodes (9): MatchLogEntry, createPosthogServerMatchLoggingAdapter(), CANON_MATCH_EVENT, CanonMatchEventProps, CanonMatchPath, scaleScore(), toCanonMatchEvent(), createPosthogMatchLoggingAdapter() (+1 more)
 
 ### Community 94 - "Text"
 Cohesion: 0.21
 Nodes (5): _bad, TextProps, TextVariants, ./Text.types, ./Text.variants
 
 ### Community 95 - "Ai"
-Cohesion: 0.13
-Nodes (10): CacheEntry, DEFAULT_SETTINGS, loadSettings(), resolveModel(), loadCanonIconSeed(), arbitrateCanonFlow, ArbitrationResultSchema, FAKE_EMBEDDING (+2 more)
+Cohesion: 0.33
+Nodes (5): comboboxContentVariants, comboboxCreateVariants, comboboxInputVariants, comboboxItemVariants, comboboxTriggerVariants
 
 ### Community 96 - "Triggers"
-Cohesion: 0.18
-Nodes (8): createServerEntryParseAdapter(), parseEntryFlow, ParseEntryInputSchema, EntryParsePort, ParsedEntry, geminiApiKey, onShoppingListItemWrite, posthogApiKey
+Cohesion: 0.22
+Nodes (6): createServerEntryParseAdapter(), parseEntryFlow, ParseEntryInputSchema, geminiApiKey, onShoppingListItemWrite, posthogApiKey
 
 ### Community 97 - "Docs"
-Cohesion: 0.20
-Nodes (11): Domain Purity Rule, CanonLookupPort, Canon Module (worked example), Coordinators (cross-module workflows), Cross-Cutting Ports (ErrorReporting, MatchLogging), Module Boundary Rule (index.ts only), Domain Module Pattern Guide, Domain Module Structure (entities/ports/commands/queries) (+3 more)
+Cohesion: 0.12
+Nodes (21): Domain Purity Rule, No IndexedDB / Firestore persistentLocalCache Rule, CanonLookupPort, Canon Module (worked example), Coordinators (cross-module workflows), Cross-Cutting Ports (ErrorReporting, MatchLogging), Module Boundary Rule (index.ts only), Domain Module Pattern Guide (+13 more)
 
 ### Community 98 - "Commands"
 Cohesion: 0.29
@@ -764,8 +748,8 @@ Cohesion: 0.24
 Nodes (9): ../../lib/devSettingsService.js, canonIconGenerationEnabled, DEFAULTS, initDevSettingsSync(), _isLoading, setCanonIconGenerationEnabled(), _settings, saveDevSettings() (+1 more)
 
 ### Community 108 - "Tests"
-Cohesion: 0.20
-Nodes (4): countIngredient, fs, gramIngredient, { mockGetCanonItemsSnapshot }
+Cohesion: 0.18
+Nodes (5): commitRecipeAddPlan(), countIngredient, fs, gramIngredient, { mockGetCanonItemsSnapshot }
 
 ### Community 109 - "Docs"
 Cohesion: 0.40
@@ -795,13 +779,9 @@ Nodes (4): initial, ports, stillBusy, survivors
 Cohesion: 0.22
 Nodes (8): compilerOptions, composite, lib, outDir, rootDir, extends, include, references
 
-### Community 116 - "Src"
-Cohesion: 0.23
-Nodes (10): createMember(), CreateMemberInput, normaliseMemberEmail(), updateMember(), UpdateMemberPatch, Member, getMembersSnapshot(), memberFirstName() (+2 more)
-
 ### Community 117 - "Src"
-Cohesion: 0.27
-Nodes (4): User, AuthProvider, authEmulatorConnected, ErrorReportingPort
+Cohesion: 0.10
+Nodes (19): User, reportSubscriptionError(), AuthProvider, authEmulatorConnected, connectAuthEmulatorOnce(), reportAuthFailure(), isAuthTransitioning(), setAuthTransitioning() (+11 more)
 
 ### Community 118 - "Domain"
 Cohesion: 0.25
@@ -892,8 +872,8 @@ Cohesion: 0.33
 Nodes (3): FakeHttpsError, handler, { mockGet, mockDoc, mockCollection }
 
 ### Community 141 - "Combobox"
-Cohesion: 0.17
-Nodes (13): removeItems(), classifyFirestoreError(), firestoreCode(), deleteShoppingListItem(), deleteShoppingListItems(), listShoppingListItems(), moveShoppingListItems(), subscribeShoppingListItems() (+5 more)
+Cohesion: 0.08
+Nodes (42): addList(), loadChatSession(), setAiStub(), callIdentifyEquipment(), callPopulateEquipmentEntry(), IdentifyEquipmentCandidate, IdentifyEquipmentResult, PopulateAccessory (+34 more)
 
 ### Community 142 - "Design"
 Cohesion: 0.14
@@ -947,10 +927,6 @@ Nodes (3): email, member, useEmulator
 Cohesion: 0.83
 Nodes (3): functions_triggers_registered(), reachable(), healthcheck.sh script
 
-### Community 164 - "Types"
-Cohesion: 0.50
-Nodes (3): E2EBridge, SeedCanonItemInput, Window
-
 ### Community 167 - "Assets"
 Cohesion: 1.00
 Nodes (3): Hand-drawn Red Apple Icon, Canon Icon Seed: Red Apple, Canon Food Icon Seed Reference
@@ -979,14 +955,6 @@ Nodes (3): Cooking Pot with Lid Glyph, Salt App Icon (512px) — Cooking Pot, Sa
 Cohesion: 1.00
 Nodes (3): Task Pilot Tasks Icon, Task List Visualization, Task Pilot VS Code Extension
 
-### Community 265 - "Community 265"
-Cohesion: 0.14
-Nodes (14): AisleGroup, AisleInfo, AisleRow, AmountSubtotal, buildSubtotals(), CanonInfo, GroupedShoppingList, groupItemsByAisle() (+6 more)
-
-### Community 266 - "Community 266"
-Cohesion: 0.14
-Nodes (11): mockGet, @salt/domain/schemas, saveAppSettings(), subscribeAppSettings(), subscribeEquipmentManifest(), ErrorCallback, { mockUnsubscribe, mockOnSnapshot, mockSetDoc, mockDoc, mockGetFirestore }, SnapCallback (+3 more)
-
 ### Community 267 - "Community 267"
 Cohesion: 0.12
 Nodes (16): CanonIcon component, CanonItem.thumbnail (tri-state), Two-tier image system (pictogram + hero), Architecture contract notes, Canon item icons (Tier-1 pictograms), `CanonIcon` props, Data model, Generation pipeline (+8 more)
@@ -1008,8 +976,8 @@ Cohesion: 0.13
 Nodes (14): Architecture Notes, Behavior Contract, Current State & Motivation, Definition of Done, Open Questions / Decisions, Phase 1: [Name], Phase 2: [Name], Phases (+6 more)
 
 ### Community 272 - "Community 272"
-Cohesion: 0.15
-Nodes (14): 10.1 Overview, 10.2 `createListSelection(options)`, 10.3 Component props, 10.4 Behaviour, 10.5 Accessibility, 10.6 Testing requirements, 10. List selection (`createListSelection` + `SelectableList` / `SelectAllCheckbox` / `RowSelectCheckbox`), 13.1 `ToastViewport` — `pointer-events-none` container (+6 more)
+Cohesion: 0.18
+Nodes (12): 11.1 Overview, 11.2 Props, 11.3 Behaviour, 11.4 Testing requirements, 11. EditableRow (primitive), 13.1 `ToastViewport` — `pointer-events-none` container, 13.2 `BottomNav` — full-height tap targets (`items-stretch`), 13. Pinned interaction constraints (+4 more)
 
 ### Community 273 - "Community 273"
 Cohesion: 0.14
@@ -1020,8 +988,8 @@ Cohesion: 0.14
 Nodes (14): 0. v0.3 Scope, 1.1 Headless + Styled, 1.2 APG Compliance, 1. Shared v0.3 Rules, 5.1 Purpose, 5.2 Parts, 5.3 Root Props, 5.4 Events (+6 more)
 
 ### Community 275 - "Community 275"
-Cohesion: 0.23
-Nodes (8): MatchCandidate, MatchStage, ArbitrationRequest, ArbitrationResult, CanonArbitrationPort, CanonLookupPort, createCanonLookup(), FindClosestMatchResult
+Cohesion: 0.14
+Nodes (11): eX, eY, failEmbedding(), makeAisleStore(), makeIds(), makePipeline(), makeStore(), noMatchArbitration() (+3 more)
 
 ### Community 276 - "Community 276"
 Cohesion: 0.17
@@ -1035,40 +1003,9 @@ Nodes (13): A. Async settling & determinism, Appendix — evaluation of the gene
 Cohesion: 0.17
 Nodes (11): Architecture Notes, Definition of Done, Feature Spec, Open Questions / Decisions, Phase 1: [Name], Phase 2: [Name], Phased GitHub Issue Structure, Phases (+3 more)
 
-### Community 279 - "Community 279"
-Cohesion: 0.26
-Nodes (6): PopoverContentProps, PopoverPartProps, PopoverProps, ../../headless/Popover.headless.svelte, ./Popover.types, ./Popover.variants
-
 ### Community 280 - "Community 280"
 Cohesion: 0.18
 Nodes (11): 10. Shared types requirements, 13. Deployment units, 14. Non-negotiables, 1.1 Schema evolution and production data, 1. Purpose, 2. Mono‑repo structure (logical modules), 4. Domain layer requirements, 5. Workspace and access model (+3 more)
-
-### Community 281 - "Community 281"
-Cohesion: 0.25
-Nodes (9): deleteRecipe(), loadRecipe(), saveRecipe(), subscribeRecipes(), CollectionCallback, ErrorCallback, {
-  mockUnsubscribe,
-  mockOnSnapshot,
-  mockSetDoc,
-  mockDeleteDoc,
-  mockGetDoc,
-  mockDoc,
-  mockCollection,
-  mockGetFirestore,
-}, RECIPE (+1 more)
-
-### Community 282 - "Community 282"
-Cohesion: 0.27
-Nodes (9): createShoppingList(), deleteShoppingList(), listShoppingLists(), renameShoppingList(), subscribeShoppingLists(), ErrorCallback, LIST_1, {
-  mockUnsubscribe,
-  mockOnSnapshot,
-  mockSetDoc,
-  mockDeleteDoc,
-  mockGetDocs,
-  mockUpdateDoc,
-  mockDoc,
-  mockCollection,
-  mockGetFirestore,
-} (+1 more)
 
 ### Community 283 - "Community 283"
 Cohesion: 0.20
@@ -1077,22 +1014,6 @@ Nodes (10): 8.10 Heading, 8.11 Text, 8.3 Textarea, 8. Primitive Definitions (v0.
 ### Community 284 - "Community 284"
 Cohesion: 0.20
 Nodes (10): Authoring conventions, CI, E2E & emulator integration tests, Lifecycle, reuse & teardown, Port sets, Running locally, Spotting & clearing a poisoned environment, The containerized test emulator stacks (+2 more)
-
-### Community 285 - "Community 285"
-Cohesion: 0.27
-Nodes (8): initShoppingListSync(), loadShoppingListsConfig(), saveShoppingListsConfig(), subscribeShoppingListsConfig(), CONFIG, ErrorCallback, { mockUnsubscribe, mockOnSnapshot, mockSetDoc, mockGetDoc, mockDoc, mockGetFirestore }, SnapCallback
-
-### Community 286 - "Community 286"
-Cohesion: 0.27
-Nodes (6): deleteMember(), subscribeMembers(), upsertMember(), ErrorCallback, {
-  mockUnsubscribe,
-  mockOnSnapshot,
-  mockSetDoc,
-  mockDeleteDoc,
-  mockDoc,
-  mockCollection,
-  mockGetFirestore,
-}, SnapCallback
 
 ### Community 287 - "Community 287"
 Cohesion: 0.22
@@ -1123,8 +1044,8 @@ Cohesion: 0.25
 Nodes (8): 8.6 Dialog, Accessibility, Content Props, Events (Root), Forbidden, Parts, Root Props, Styling
 
 ### Community 295 - "Community 295"
-Cohesion: 0.32
-Nodes (8): WAI-ARIA Accessibility Requirements, bits-ui Primitive Mapping, Button Canonical Primitive, Controlled/Uncontrolled Bindable Pattern, Headless + Styled Two-Layer Architecture, Tailwind Preset Token Source of Truth, Required Test Suite Template, Salt UI Primitives Specification v0.2
+Cohesion: 0.24
+Nodes (10): Boundary Enforcement (lint/typecheck/CI), WAI-ARIA Accessibility Requirements, bits-ui Primitive Mapping, Button Canonical Primitive, Controlled/Uncontrolled Bindable Pattern, Headless + Styled Two-Layer Architecture, Provenance Header Convention, Tailwind Preset Token Source of Truth (+2 more)
 
 ### Community 296 - "Community 296"
 Cohesion: 0.25
@@ -1133,10 +1054,6 @@ Nodes (8): 2.1 Purpose, 2.2 Parts, 2.3 Root Props, 2.4 Item Props, 2.5 Events, 2
 ### Community 297 - "Community 297"
 Cohesion: 0.25
 Nodes (8): 3.1 Purpose, 3.2 Parts, 3.3 Root Props, 3.4 SelectTrigger Props, 3.5 Events, 3.6 APG Requirements (Listbox), 3.7 Behavior, 3. Select
-
-### Community 298 - "Community 298"
-Cohesion: 0.25
-Nodes (7): After a restore — re-apply staging-only config, One-time setup, Refreshing staging with prod data, Safety, Scope, Usage, Why managed export/import (and not a copy script)
 
 ### Community 299 - "Community 299"
 Cohesion: 0.29
@@ -1222,10 +1139,6 @@ Nodes (5): 8.13 Layout Primitives — Stack / Inline / Grid / Divider, Divider, 
 Cohesion: 0.40
 Nodes (5): 8.5 Switch, Accessibility, Events, Props, Styling
 
-### Community 321 - "Community 321"
-Cohesion: 0.40
-Nodes (5): 11.1 Overview, 11.2 Props, 11.3 Behaviour, 11.4 Testing requirements, 11. EditableRow (primitive)
-
 ### Community 322 - "Community 322"
 Cohesion: 0.50
 Nodes (4): 8.12 Icon, Accessibility, Props, Styling
@@ -1259,24 +1172,24 @@ Cohesion: 0.67
 Nodes (3): Phase 1: [Name], Phase 2: [Name], Phases
 
 ## Knowledge Gaps
-- **1328 isolated node(s):** `husky.sh script`, `name`, `version`, `private`, `type` (+1323 more)
+- **1327 isolated node(s):** `husky.sh script`, `name`, `version`, `private`, `type` (+1322 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **53 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **48 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `NavItem` connect `Sidenav` to `Lib`, `Combobox & ListPage Types`?**
-  _High betweenness centrality (0.139) - this node is a cross-community bridge._
-- **Why does `../../lib/canonService.js` connect `Canon Approval UI` to `List Page Routes`, `Aisles & Canon Stores`, `Firebase-Sync Shopping Config`, `Recipes`, `Firestore Stores & Classify`, `Shopping List UI`, `Canon Matching Core`, `Recipes`, `Canon Fast-Path Parity`, `Lib`, `Admin Routes`, `Recipe Service`?**
-  _High betweenness centrality (0.046) - this node is a cross-community bridge._
-- **Why does `../../lib/recipeService.js` connect `Recipe Service` to `Canon`, `Canon Approval UI`, `Entities`, `Shopping List Commands`, `Recipes`, `Firestore Stores & Classify`, `Shopping List UI`, `Tests`, `Community 266`, `Canon Matching Core`, `Recipes`, `Tests`, `Tests`, `Lib`, `Admin Routes`, `Tests`, `Community 281`, `Chat`?**
-  _High betweenness centrality (0.043) - this node is a cross-community bridge._
+- **Why does `NavItem` connect `Sidenav` to `Canon`, `Combobox & ListPage Types`?**
+  _High betweenness centrality (0.140) - this node is a cross-community bridge._
+- **Why does `../../lib/recipeService.js` connect `Recipe Service` to `Aisles & Canon Stores`, `Canon Approval UI`, `Entities`, `Shopping List Commands`, `Recipes`, `Shopping List UI`, `Tests`, `Canon Matching Core`, `Tests`, `Triggers`, `Combobox`, `Recipes`, `Tests`, `Canon`, `Admin Routes`, `Src`, `Tests`, `Chat`?**
+  _High betweenness centrality (0.048) - this node is a cross-community bridge._
+- **Why does `../../lib/canonService.js` connect `Canon Approval UI` to `Match Logging`, `Canon`, `Aisles & Canon Stores`, `List Page Routes`, `Recipes`, `Firestore Stores & Classify`, `Shopping List UI`, `Canon Matching Core`, `Recipes`, `Canon Fast-Path Parity`, `Canon`, `Admin Routes`, `Src`, `Recipe Service`?**
+  _High betweenness centrality (0.042) - this node is a cross-community bridge._
 - **What connects `husky.sh script`, `name`, `version` to the rest of the system?**
-  _1348 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1347 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Meal Planner & Attendees` be split into smaller, more focused modules?**
-  _Cohesion score 0.0573225516621743 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.05028011204481793 - nodes in this community are weakly interconnected._
 - **Should `Aisles & Canon Stores` be split into smaller, more focused modules?**
-  _Cohesion score 0.07023705004389816 - nodes in this community are weakly interconnected._
-- **Should `Firebase-Sync Shopping Config` be split into smaller, more focused modules?**
-  _Cohesion score 0.13230769230769232 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.06758742286218043 - nodes in this community are weakly interconnected._
+- **Should `Canon Approval UI` be split into smaller, more focused modules?**
+  _Cohesion score 0.054612054612054615 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - salt-vscode  (2026-06-27)
 
 ## Corpus Check
-- 822 files · ~289,858 words
+- 826 files · ~293,151 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3858 nodes · 7596 edges · 319 communities (267 shown, 52 thin omitted)
-- Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 120 edges (avg confidence: 0.81)
+- 3884 nodes · 7649 edges · 322 communities (271 shown, 51 thin omitted)
+- Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 121 edges (avg confidence: 0.81)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `77a9c480`
+- Built from commit: `511937f7`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -244,8 +244,11 @@
 - [[_COMMUNITY_Community 279|Community 279]]
 - [[_COMMUNITY_Community 280|Community 280]]
 - [[_COMMUNITY_Community 281|Community 281]]
+- [[_COMMUNITY_Community 282|Community 282]]
 - [[_COMMUNITY_Community 283|Community 283]]
 - [[_COMMUNITY_Community 284|Community 284]]
+- [[_COMMUNITY_Community 285|Community 285]]
+- [[_COMMUNITY_Community 286|Community 286]]
 - [[_COMMUNITY_Community 287|Community 287]]
 - [[_COMMUNITY_Community 288|Community 288]]
 - [[_COMMUNITY_Community 289|Community 289]]
@@ -257,6 +260,7 @@
 - [[_COMMUNITY_Community 295|Community 295]]
 - [[_COMMUNITY_Community 296|Community 296]]
 - [[_COMMUNITY_Community 297|Community 297]]
+- [[_COMMUNITY_Community 298|Community 298]]
 - [[_COMMUNITY_Community 299|Community 299]]
 - [[_COMMUNITY_Community 300|Community 300]]
 - [[_COMMUNITY_Community 301|Community 301]]
@@ -279,11 +283,10 @@
 - [[_COMMUNITY_Community 326|Community 326]]
 - [[_COMMUNITY_Community 327|Community 327]]
 - [[_COMMUNITY_Community 328|Community 328]]
-- [[_COMMUNITY_Community 329|Community 329]]
 - [[_COMMUNITY_Community 330|Community 330]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `DomainError` - 96 edges
+1. `DomainError` - 99 edges
 2. `../../lib/canonService.js` - 82 edges
 3. `../../lib/shoppingListService.svelte.js` - 81 edges
 4. `ReadResult` - 78 edges
@@ -301,9 +304,9 @@
   CLAUDE.md → docs/salt-architecture.md
 - `Boundary Enforcement (lint/typecheck/CI)` --semantically_similar_to--> `Enforcement Rules (ESLint/tsconfig/commit gateway)`  [INFERRED] [semantically similar]
   CLAUDE.md → docs/salt-architecture.md
-- `isSessionActive()` --calls--> `isObservabilitySessionActive()`  [INFERRED]
-  apps/web-pwa/src/lib/observability.ts → packages/adapters/observability/src/sessionControl.ts
 - `No IndexedDB / Firestore persistentLocalCache Rule` --semantically_similar_to--> `Firestore persistentLocalCache Offline Layer`  [INFERRED] [semantically similar]
+  CLAUDE.md → docs/salt-architecture.md
+- `Observability Dual Subpath (browser vs server)` --semantically_similar_to--> `observability Adapter (dual subpath)`  [INFERRED] [semantically similar]
   CLAUDE.md → docs/salt-architecture.md
 
 ## Import Cycles
@@ -317,27 +320,27 @@
 - **Canon Matching Entry Points & Shared Core** — matching_pipeline_fast_path, matching_pipeline_match_or_create_canon_callable, matching_pipeline_on_shopping_list_item_write, matching_pipeline_canonicalise_recipe_ingredients, matching_pipeline_match_or_create_batch [EXTRACTED 1.00]
 - **Issue-Driven Agentic Workflow Commands** — commands_spec_feature_spec, commands_defect_defect_spec, commands_refactor_spec_refactor_spec, commands_run_run_issue [INFERRED 0.85]
 
-## Communities (319 total, 52 thin omitted)
+## Communities (322 total, 51 thin omitted)
 
 ### Community 0 - "Meal Planner & Attendees"
 Cohesion: 0.05
-Nodes (93): addAttendee(), DayContainer, removeAttendee(), setAttendeeHomeTime(), setAttendeeNote(), setDayChefs(), setDayGuests(), setDayNote() (+85 more)
+Nodes (96): addAttendee(), DayContainer, removeAttendee(), setAttendeeHomeTime(), setAttendeeNote(), setDayChefs(), setDayGuests(), setDayNote() (+88 more)
 
 ### Community 1 - "Aisles & Canon Stores"
-Cohesion: 0.08
-Nodes (34): fakeStore(), BASE, BASE, AddAccessoryInput, AddEquipmentInput, AddRuleInput, EditRuleInput, RemoveAccessoryInput (+26 more)
+Cohesion: 0.11
+Nodes (31): fakeStore(), AddAccessoryInput, AddEquipmentInput, AddItemInput, AddRuleInput, EditRuleInput, MoveItemsResult, RemoveAccessoryInput (+23 more)
 
 ### Community 2 - "Firebase-Sync Shopping Config"
-Cohesion: 0.15
-Nodes (25): createAisle(), createAislesBulk(), renameAisle(), reorderAisles(), ../../lib/aisleService.js, addAisle(), addAislesBulk(), deleteAisles() (+17 more)
+Cohesion: 0.14
+Nodes (23): ../../lib/aisleService.js, addAisle(), addAislesBulk(), deleteAisles(), idGen, mergeAisles(), renameAisle(), reorderAisles() (+15 more)
 
 ### Community 3 - "Canon Approval UI"
-Cohesion: 0.09
-Nodes (31): base, approveCanonItem(), MatchOrCreateResult, setCanonItemThumbnail(), ../../lib/canonService.js, addCanonItem(), approveCanonItemWithOverrides(), commitCanonItemUpdate() (+23 more)
+Cohesion: 0.08
+Nodes (34): base, approveCanonItem(), renameCanonItem(), setCanonItemAisle(), setCanonItemShoppingBehavior(), setCanonItemThreshold(), setCanonItemSynonyms(), setCanonItemThumbnail() (+26 more)
 
 ### Community 4 - "Shopping List Commands"
 Cohesion: 0.06
-Nodes (42): AddItemInput, CheckItemInput, clearCheckedItems(), confirmItemNeeded(), ConfirmItemNeededInput, deleteItem(), DeleteItemInput, EditItemAmountUnitInput (+34 more)
+Nodes (42): CheckItemInput, ConfirmItemNeededInput, createList(), CreateListInput, DeleteItemInput, deleteList(), DeleteListInput, EditItemAmountUnitInput (+34 more)
 
 ### Community 5 - "Headless UI Primitives"
 Cohesion: 0.06
@@ -348,36 +351,36 @@ Cohesion: 0.10
 Nodes (30): createViaCombobox(), PASTE_TEXT, STUB_PARSE, AutoFixtures, E2E_RAW_DIR, test, gotoAndSignIn(), seedMemberAllowlist() (+22 more)
 
 ### Community 7 - "Firestore Stores & Classify"
-Cohesion: 0.22
-Nodes (6): allVisibleIds, handleBulkApprove(), selectedApprovalIds, selection, topApprovalItems, approveCanonItems()
+Cohesion: 0.11
+Nodes (18): eSim, eX, eY, applyClassification(), arbitrationFailureReasoning(), ArbitrationNew, ArbOutcome, Classification (+10 more)
 
 ### Community 8 - "Shopping List UI"
-Cohesion: 0.08
-Nodes (58): addItem(), checkItem(), createList(), deleteList(), editItemAmountUnit(), renameList(), setDefaultList(), uncheckItem() (+50 more)
+Cohesion: 0.09
+Nodes (52): addItem(), checkItem(), clearCheckedItems(), confirmItemNeeded(), deleteItem(), editItemAmountUnit(), editItemNotes(), editItemRawText() (+44 more)
 
 ### Community 9 - "Equipment & Rules"
-Cohesion: 0.10
-Nodes (43): addAccessory(), addEquipment(), addRule(), editRule(), removeAccessory(), removeEquipment(), removeRule(), renameEquipment() (+35 more)
+Cohesion: 0.08
+Nodes (50): addAccessory(), addEquipment(), addRule(), editRule(), removeAccessory(), removeEquipment(), removeRule(), renameEquipment() (+42 more)
 
 ### Community 10 - "Members Management"
-Cohesion: 0.05
-Nodes (49): createMember(), CreateMemberInput, normaliseMemberEmail(), updateMember(), UpdateMemberPatch, Member, ../../lib/auth.svelte.js, auth (+41 more)
+Cohesion: 0.06
+Nodes (41): createMember(), CreateMemberInput, normaliseMemberEmail(), updateMember(), UpdateMemberPatch, Member, auth, ../../lib/membersService.js (+33 more)
 
 ### Community 11 - "Canon Matching Core"
-Cohesion: 0.09
-Nodes (16): catalog, items, ApproveCanonItemOverrides, CreateCanonItemInput, ArbitrationExtras, renameCanonItem(), setCanonItemAisle(), setCanonItemShoppingBehavior() (+8 more)
+Cohesion: 0.13
+Nodes (11): items, ApproveCanonItemOverrides, CreateCanonItemInput, ArbitrationExtras, CanonItem, MatchCandidate, MatchStage, synonymMatch() (+3 more)
 
 ### Community 12 - "web-pwa Dependencies"
 Cohesion: 0.04
 Nodes (45): dependencies, @lucide/svelte, @salt/domain, @salt/firebase-sync, @salt/observability, @salt/shared-types, @salt/ui-components, svelte (+37 more)
 
 ### Community 13 - "UI-Components Package"
-Cohesion: 0.05
-Nodes (40): dependencies, bits-ui, class-variance-authority, clsx, @floating-ui/dom, @lucide/svelte, svelte, svelte-dnd-action (+32 more)
+Cohesion: 0.04
+Nodes (41): svelte-exmarkdown/gfm, dependencies, bits-ui, class-variance-authority, clsx, @floating-ui/dom, @lucide/svelte, svelte (+33 more)
 
 ### Community 14 - "Combobox Primitive"
-Cohesion: 0.07
-Nodes (28): ../../src/primitives/Combobox/Combobox.svelte, ctx, filterValue, initialItem, inputId, inputValue, listboxId, ../../src/primitives/Combobox/ComboboxContent.svelte (+20 more)
+Cohesion: 0.08
+Nodes (38): CanonIconProps, ../../src/primitives/Combobox/Combobox.svelte, ctx, filterValue, initialItem, inputId, inputValue, listboxId (+30 more)
 
 ### Community 15 - "Domain Zod Schemas"
 Cohesion: 0.09
@@ -388,24 +391,24 @@ Cohesion: 0.05
 Nodes (37): COLOR_MAP, CONTROLS_CHECKBOX_MAP, CONTROLS_SWITCH_MAP, cssVars, design, DESIGN_MD_PATH, designCheckbox, designColors (+29 more)
 
 ### Community 17 - "Canon Fast-Path Parity"
-Cohesion: 0.10
-Nodes (31): aisleStore, failingArbitration, failingEmbedding, ids, makeStore(), runCfPath(), runFastPath(), appendCanonSynonym() (+23 more)
+Cohesion: 0.11
+Nodes (19): aisleStore, failingArbitration, failingEmbedding, ids, makeStore(), runCfPath(), runFastPath(), catalog (+11 more)
 
 ### Community 18 - "Select Primitive"
 Cohesion: 0.09
-Nodes (28): ../../src/primitives/Select/Select.svelte, ctx, listboxId, triggerId, typeaheadBuffer, SelectContentProps, SelectGroupProps, SelectItemProps (+20 more)
+Nodes (29): @floating-ui/dom, ../../src/primitives/Select/Select.svelte, ctx, listboxId, triggerId, typeaheadBuffer, SelectContentProps, SelectGroupProps (+21 more)
 
 ### Community 19 - "Task Pilot Extension"
 Cohesion: 0.09
 Nodes (11): cp, DEFAULT_LABELS, FALLBACK_META, getTaskLabel(), metaFor(), net, NUKE_PORTS, SERVICE_META (+3 more)
 
 ### Community 20 - "Admin Routes"
-Cohesion: 0.18
-Nodes (6): ../admin/AdminGuard.svelte, isAdmin, settled, tools, @salt/firebase-sync, routes
+Cohesion: 0.17
+Nodes (10): ../../lib/auth.svelte.js, AuthStore, clearPendingEmail(), devSignIn(), formatError(), readPendingEmail(), writePendingEmail(), authProvider (+2 more)
 
 ### Community 21 - "Combobox & ListPage Types"
-Cohesion: 0.12
-Nodes (25): CanonIconProps, ComboboxContentProps, ComboboxCreateProps, ComboboxEmptyProps, ComboboxFieldProps, ComboboxGroupProps, ComboboxInputProps, ComboboxItem (+17 more)
+Cohesion: 0.50
+Nodes (3): ../../primitives/EmptyState/EmptyState.svelte, EmptyStateProps, ./EmptyState.types
 
 ### Community 22 - "Task Pilot Manifest"
 Cohesion: 0.06
@@ -420,8 +423,8 @@ Cohesion: 0.09
 Nodes (25): ../../lib/recipeService.js, applySnapshot(), buildRecipeAddPlan(), canonicaliseIngredients(), getErrorReporter(), getRecipesSnapshot(), importRecipeFromUrl(), initRecipeSync() (+17 more)
 
 ### Community 25 - "Observability (PostHog)"
-Cohesion: 0.22
-Nodes (18): tagSession(), extractTraceHeaders(), identifyObservabilityAnonymous(), identifyObservabilityUser(), initObservability(), isObservabilityReady(), NOOP_SPAN, ObservabilityOptions (+10 more)
+Cohesion: 0.11
+Nodes (30): getSessionURL(), identifyAnonymous(), identifyUser(), isSessionActive(), _phKey, startSession(), stopSession(), tagSession() (+22 more)
 
 ### Community 26 - "Selectable List & Checkbox"
 Cohesion: 0.13
@@ -432,12 +435,12 @@ Cohesion: 0.06
 Nodes (23): CheckboxProps, CheckedState, CheckboxRootVariants, comboboxContentVariants, comboboxCreateVariants, comboboxInputVariants, comboboxItemVariants, comboboxTriggerVariants (+15 more)
 
 ### Community 28 - "AI Flows & Telemetry"
-Cohesion: 0.18
-Nodes (13): readUsage(), tracedGenerate(), aiModelLabel(), fakeModels, flowModel(), resolveModel(), OutputSchema, InputSchema (+5 more)
+Cohesion: 0.17
+Nodes (15): readUsage(), tracedGenerate(), assembleDraft(), OutputSchema, canonicaliseRecipeIngredientsFlow, ItemResultSchema, OutputSchema, assembleDraft() (+7 more)
 
 ### Community 29 - "AI Timeout Guard"
-Cohesion: 0.15
-Nodes (15): aiFakeEnabled(), embedTextFlow, FAKE_EMBEDDING, generateCanonIconFlow, removeFlatBackground(), RemoveFlatBackgroundOptions, sampleBackgroundColour(), buildIconDownloadUrl() (+7 more)
+Cohesion: 0.17
+Nodes (15): embedTextFlow, generateCanonIconFlow, removeFlatBackground(), RemoveFlatBackgroundOptions, sampleBackgroundColour(), reportServerError(), buildIconDownloadUrl(), geminiApiKey (+7 more)
 
 ### Community 30 - "cloud-functions Dependencies"
 Cohesion: 0.07
@@ -448,16 +451,16 @@ Cohesion: 0.17
 Nodes (22): assertUrlAllowed(), fetchOnce(), guardedLookup(), SingleFetch, SsrfFetchError, SsrfFetchErrorReason, SsrfFetchResult, ssrfGuardedFetch() (+14 more)
 
 ### Community 32 - "Match Logging"
-Cohesion: 0.13
-Nodes (11): MatchLogBuilder, ArbitrationLog, CandidateLog, FinalDecision, StageLog, StageSkipReason, formatArbitration(), formatStage() (+3 more)
+Cohesion: 0.22
+Nodes (6): MatchLogBuilder, ArbitrationLog, CandidateLog, FinalDecision, StageLog, StageSkipReason
 
 ### Community 33 - "List Page Routes"
-Cohesion: 0.08
-Nodes (16): handleBulkRegenerateIcon(), allIds, selection, visibleItems, ../../lib/deferredDelete.svelte.js, DeferredDelete, ../../lib/toastStore.js, addToast() (+8 more)
+Cohesion: 0.07
+Nodes (21): allVisibleIds, handleBulkApprove(), handleBulkRegenerateIcon(), selectedApprovalIds, selection, topApprovalItems, allIds, selection (+13 more)
 
 ### Community 34 - "Cloud Function Callables"
-Cohesion: 0.08
-Nodes (24): beforeMemberCreated, regenerateCanonIcon, authorRecipeFlow, chefChatFlow, generateChatTitleFlow, identifyEquipmentFlow, populateEquipmentEntryFlow, registerGenkitDevTracing() (+16 more)
+Cohesion: 0.07
+Nodes (31): beforeMemberCreated, posthogApiKey, regenerateCanonIcon, authorRecipeFlow, extractRecipeFromUrlFlow, UrlImportError, generateChatTitleFlow, identifyEquipmentFlow (+23 more)
 
 ### Community 35 - "Slider"
 Cohesion: 0.14
@@ -472,24 +475,24 @@ Cohesion: 0.14
 Nodes (23): ../../lib/aiModelCatalogService.js, applyCatalog(), _byRole, catalogByRole, emptyByRole(), ensureCatalog(), _fetchedAt, hasCatalog (+15 more)
 
 ### Community 38 - "Sheet"
-Cohesion: 0.13
-Nodes (13): ../../primitives/Sheet/Sheet.svelte, SheetContentProps, SheetPartProps, SheetProps, SheetSide, SheetContentVariants, ../../primitives/Sheet/SheetContent.svelte, ../../primitives/Sheet/SheetHeader.svelte (+5 more)
+Cohesion: 0.10
+Nodes (19): ./ListPage.context.js, LIST_PAGE_CONTEXT, ListPageContext, BulkAction, BulkActionIcon, ListPageProps, ../../primitives/Sheet/Sheet.svelte, SheetContentProps (+11 more)
 
 ### Community 39 - "Button"
 Cohesion: 0.11
 Nodes (10): ../../primitives/Button/Button.svelte, ButtonProps, ButtonVariants, FormPageProps, ../../primitives/Spinner/Spinner.svelte, SpinnerProps, ../../headless/Button.headless.svelte, ./Button.types (+2 more)
 
 ### Community 40 - "Card"
-Cohesion: 0.16
-Nodes (11): CardContentProps, CardDescriptionProps, CardFooterProps, CardHeaderProps, CardPartProps, CardProps, CardTitleProps, svelte-exmarkdown/gfm (+3 more)
+Cohesion: 0.22
+Nodes (8): CardContentProps, CardDescriptionProps, CardFooterProps, CardHeaderProps, CardPartProps, CardProps, CardTitleProps, ./Card.types
 
 ### Community 41 - "Toast"
-Cohesion: 0.17
-Nodes (16): ../../src/primitives/Toast/Toast.svelte, ToastActionProps, ToastPartProps, ToastProps, ToastProviderProps, ToastViewportProps, ToastVariants, ../../src/primitives/Toast/ToastAction.svelte (+8 more)
+Cohesion: 0.15
+Nodes (18): ../../src/primitives/Toast/Toast.svelte, ToastActionProps, ToastPartProps, ToastProps, ToastProviderProps, ToastViewportProps, ToastVariants, ../../src/primitives/Toast/ToastAction.svelte (+10 more)
 
 ### Community 42 - "Lib"
 Cohesion: 0.14
-Nodes (22): ../../lib/chatService.js, applySnapshot(), createChatSession(), getChatSessionsSnapshot(), getErrorReporter(), initChatSync(), isLoadingSessions, latestLocalEdit (+14 more)
+Nodes (23): ../../lib/chatService.js, applySnapshot(), createChatSession(), getChatSessionsSnapshot(), getErrorReporter(), initChatSync(), isLoadingSessions, latestLocalEdit (+15 more)
 
 ### Community 43 - "Recipes"
 Cohesion: 0.08
@@ -504,24 +507,24 @@ Cohesion: 0.13
 Nodes (16): ../../src/primitives/RadioGroup/RadioGroup.svelte, descId, describedBy, errorId, generatedName, labelId, rgState, RadioGroupItemProps (+8 more)
 
 ### Community 46 - "Server"
-Cohesion: 0.19
-Nodes (19): ensureObservabilityInitialised(), AiGenerationEvent, AiGenerationUsage, captureAiGeneration(), captureServerEvent(), captureServerException(), flushServerObservability(), initServerObservability() (+11 more)
+Cohesion: 0.18
+Nodes (20): ensureObservabilityInitialised(), AiGenerationEvent, AiGenerationUsage, captureAiGeneration(), captureServerEvent(), captureServerException(), flushServerObservability(), initServerObservability() (+12 more)
 
 ### Community 47 - "Lib"
-Cohesion: 0.15
-Nodes (20): ../../lib/appSettingsService.js, buildNext(), buildNextFlow(), currentDoc(), effectiveFlowModels, effectiveModels, initAppSettingsSync(), _isCorrupt (+12 more)
+Cohesion: 0.21
+Nodes (16): ../../lib/appSettingsService.js, buildNext(), buildNextFlow(), currentDoc(), effectiveFlowModels, effectiveModels, initAppSettingsSync(), _isCorrupt (+8 more)
 
 ### Community 48 - "Design"
-Cohesion: 0.10
-Nodes (21): Adapter Sibling Non-Import Rule, AI / Genkit conventions, Data model conventions, Enforcement, Family-Shared Data Model (no user scoping), AI Access via Genkit Callables, graphify, Hard rules (+13 more)
+Cohesion: 0.11
+Nodes (19): Adapter Sibling Non-Import Rule, AI / Genkit conventions, Data model conventions, Enforcement, Family-Shared Data Model (no user scoping), AI Access via Genkit Callables, graphify, Hard rules (+11 more)
 
 ### Community 49 - "Ai"
-Cohesion: 0.17
-Nodes (9): installE2EHooks(), getSessionURL(), identifyAnonymous(), identifyUser(), isSessionActive(), _phKey, startSession(), stopSession() (+1 more)
+Cohesion: 0.27
+Nodes (5): formatArbitration(), formatStage(), MatchLogSummary, nearMissCount(), summarizeMatchLog()
 
 ### Community 50 - "Lib"
-Cohesion: 0.14
-Nodes (6): @salt/domain, ../../lib/titleCase.js, ./MealDayEditor.svelte, ./RecipeAddToListSheet.svelte, @salt/shared-types, @salt/ui-components
+Cohesion: 0.11
+Nodes (12): ../admin/AdminGuard.svelte, isAdmin, settled, tools, @salt/domain, @salt/firebase-sync, ../../lib/titleCase.js, ./MealDayEditor.svelte (+4 more)
 
 ### Community 51 - "Canon"
 Cohesion: 0.25
@@ -532,8 +535,8 @@ Cohesion: 0.18
 Nodes (13): emptyIngredientGroup(), emptyRecipe(), newIngredient(), newStep(), flattenIngredients(), messyRecipe(), makeMatchedIngredient(), makeRecipe() (+5 more)
 
 ### Community 53 - "Docs"
-Cohesion: 0.18
-Nodes (13): Cross-Project Import IAM (objectViewer + legacyBucketReader), Managed Export/Import (no triggers), Prod -> Staging Firestore Refresh Flow, Staging-Only Hard Refuse Safety Guard, Task Pilot Sidebar Tasks, Batched Embedding Cache (no stage-5 fork), matchOrCreateBatch Three-Phase Orchestrator, matchOrCreateCanon CF Callable (+5 more)
+Cohesion: 0.09
+Nodes (25): Cross-Project Import IAM (objectViewer + legacyBucketReader), Managed Export/Import (no triggers), Prod -> Staging Firestore Refresh Flow, Staging-Only Hard Refuse Safety Guard, Task Pilot Sidebar Tasks, Cutting a release (promote staging → production), Deploying, Firebase projects (`.firebaserc` aliases) (+17 more)
 
 ### Community 54 - "Detailpage"
 Cohesion: 0.13
@@ -564,8 +567,8 @@ Cohesion: 0.11
 Nodes (17): dependencies, @salt/ui-components, svelte, devDependencies, autoprefixer, postcss, @sveltejs/vite-plugin-svelte, tailwindcss (+9 more)
 
 ### Community 61 - "Ai"
-Cohesion: 0.20
-Nodes (15): CatalogModelLike, hasMethod(), isEmbeddingModel(), isImageModel(), isTextModel(), metaHaystack(), methods(), probeMethodFor() (+7 more)
+Cohesion: 0.11
+Nodes (26): AiCatalogModel, bareId(), CacheEntry, CatalogModelSchema, CatalogResponseSchema, fetchCatalog(), handleListAiModels(), ListAiModelsInputSchema (+18 more)
 
 ### Community 62 - "devDependencies"
 Cohesion: 0.12
@@ -576,24 +579,24 @@ Cohesion: 0.23
 Nodes (13): coerceDurationMinutes(), coerceServings(), coerceTags(), coerceText(), coerceTextList(), collectRecipeNodes(), extractJsonLdBlocks(), extractRecipeJsonLd() (+5 more)
 
 ### Community 64 - "Canon"
-Cohesion: 0.09
-Nodes (26): eSim, eX, eY, CreateAisleInput, CreateAislesBulkInput, DeleteAislesInput, MatchOrCreatePorts, ItemMergeChoice (+18 more)
+Cohesion: 0.06
+Nodes (31): AISLES, BASE, BASE, createAisle(), CreateAisleInput, createAislesBulk(), CreateAislesBulkInput, deleteAisles() (+23 more)
 
 ### Community 65 - "Canon Matching"
 Cohesion: 0.23
 Nodes (12): canon.match PostHog Event, Fire-and-Forget Logging, MatchLogBuilder, MatchLogEntry Schema, MatchLoggingPort Contract, createPosthogMatchLoggingAdapter (browser), createPosthogServerMatchLoggingAdapter (CF), createServerMatchLoggingAdapter (firebase-functions/logger) (+4 more)
 
 ### Community 66 - "Canon"
-Cohesion: 0.15
-Nodes (11): CreateListInput, DeleteListInput, RenameListInput, SetDefaultListInput, ShoppingList, ShoppingListsConfig, ShoppingListPort, ShoppingListsConfigPort (+3 more)
+Cohesion: 0.50
+Nodes (3): E2EBridge, SeedCanonItemInput, Window
 
 ### Community 67 - "E2E"
 Cohesion: 0.21
 Nodes (15): APP_DIR, buildCloudFunctions(), dockerCompose(), dockerInspect(), e2eServerHealthy(), emulatorImageIsStale(), ensureE2eServer(), globalSetup() (+7 more)
 
 ### Community 68 - "Flows"
-Cohesion: 0.21
-Nodes (9): assembleDraft(), canonicaliseRecipeIngredientsFlow, assembleDraft(), buildHtmlPrompt(), extractRecipeFromUrlFlow, OutputSchema, stripHtmlNoise(), UrlImportError (+1 more)
+Cohesion: 0.20
+Nodes (6): extractRecipeFromUrlFlow, FakeHttpsError, mockFlush, mockReport, UrlImportError, VALID
 
 ### Community 69 - "Schemas"
 Cohesion: 0.16
@@ -604,12 +607,12 @@ Cohesion: 0.12
 Nodes (4): SyncContextManager, TEST_KEY, TestPropagator, ThrowingPropagator
 
 ### Community 71 - "Tooltip"
-Cohesion: 0.12
-Nodes (17): Authority and runtime, Batch entry point — recipe ingredient canonicalisation, Batched embedding without forking stage 5, Canon deletion is resolved at display time — never written back, Canon Item Matching Pipeline, Edits clear the match eagerly, Flow diagram, Growing snapshot (+9 more)
+Cohesion: 0.08
+Nodes (24): Authority and runtime, Batch entry point — recipe ingredient canonicalisation, Batched embedding without forking stage 5, Canon deletion is resolved at display time — never written back, Canon Item Matching Pipeline, Edits clear the match eagerly, Flow diagram, Growing snapshot (+16 more)
 
 ### Community 72 - "Sections"
-Cohesion: 0.36
-Nodes (4): isReportableCategory(), SUPPRESSED_CATEGORIES, createPosthogErrorReportingAdapter(), { captureException, init }
+Cohesion: 0.33
+Nodes (6): 1.1 Technology Stack, 1.2 Boundaries, 1.3 Package Surface, 1.4 Event Naming Rule, 1.5 Spec Versioning & Amendment Rule, 1. Foundations
 
 ### Community 73 - "Docs"
 Cohesion: 0.29
@@ -621,15 +624,15 @@ Nodes (14): dependencies, firebase, @salt/domain, @salt/shared-types, devDepende
 
 ### Community 75 - "Flows"
 Cohesion: 0.16
-Nodes (14): createFirestoreAisleStore(), createFirestoreCanonStore(), createServerArbitrationAdapter(), createServerEmbeddingAdapter(), createServerMatchLoggingAdapter(), ItemResultSchema, OutputSchema, buildMatchOrCreatePorts() (+6 more)
+Nodes (14): createFirestoreAisleStore(), createFirestoreCanonStore(), createServerArbitrationAdapter(), createServerEmbeddingAdapter(), createServerEntryParseAdapter(), createServerMatchLoggingAdapter(), buildMatchOrCreatePorts(), composeMatchLogging() (+6 more)
 
 ### Community 76 - "Docs"
 Cohesion: 0.12
 Nodes (17): authorRecipe librarian flow (Flash, structured), Access & admin, Architecture placement, Canon interaction — batch CF, one read per recipe, Cross-module seams (already shipped, awaiting this module), Deferred: the AI-generation epic (own issue + design session), Document, Recipe module (+9 more)
 
 ### Community 77 - "Triggers"
-Cohesion: 0.14
-Nodes (7): mockGet, @salt/domain/schemas, EMULATOR_HOST, mockEmbed, mockGenerateIcon, mockRemoveBg, mockSave
+Cohesion: 0.22
+Nodes (5): EMULATOR_HOST, mockEmbed, mockGenerateIcon, mockRemoveBg, mockSave
 
 ### Community 78 - "Docs"
 Cohesion: 0.19
@@ -648,12 +651,12 @@ Cohesion: 0.14
 Nodes (14): esbuild, fast-xml-parser, firebase-admin>uuid, form-data@>=4.0.0 <4.0.6, hono, js-yaml@4, @opentelemetry/api, protobufjs (+6 more)
 
 ### Community 82 - "Src"
-Cohesion: 0.29
-Nodes (7): Stage 1 — Exact name match, Stage 2 — Token overlap, Stage 3 — Synonym exact match, Stage 4 — String similarity (Levenshtein), Stage 5 — Embedding cosine, Stage 6 — Merged shortlist + AI arbitration, Stage-by-stage narrative
+Cohesion: 0.33
+Nodes (6): 4.2 Focus Ring, 4.3 Disabled + Loading, 4.5 Dark Mode, 4. Styling System, Disabled (terminal state — no interaction), Loading (transient state — disables interaction without terminal semantics)
 
 ### Community 83 - "Queries"
-Cohesion: 0.27
-Nodes (9): collapse(), extractLeadingQuantity(), extractTrailingQuantity(), parseShoppingListEntry(), QuantityResult, stripLeadingOf(), TrailingQuantityResult, UNIT_WORDS (+1 more)
+Cohesion: 0.20
+Nodes (10): collapse(), extractLeadingQuantity(), extractTrailingQuantity(), parseShoppingListEntry(), QuantityResult, stripLeadingOf(), TrailingQuantityResult, UNIT_WORDS (+2 more)
 
 ### Community 84 - "Schemas"
 Cohesion: 0.14
@@ -676,8 +679,8 @@ Cohesion: 0.17
 Nodes (10): [], allNotesSelected, formBody, formPublished, formTitle, isSubmitting, listSelectedCount, selectableSelectionMode (+2 more)
 
 ### Community 89 - "Canon"
-Cohesion: 0.12
-Nodes (17): 1. Client config — build-time, committed, **not secret**, 2. Cloud Functions runtime secrets — Secret Manager, per project, **never committed**, 3. CI / GitHub Environments, Config & secrets — what lives where, Cutting a release (promote staging → production), Deploying, Firebase projects (`.firebaserc` aliases), First deploy to a fresh project (one-time bootstrap) (+9 more)
+Cohesion: 0.40
+Nodes (5): 1. Client config — build-time, committed, **not secret**, 2. Cloud Functions runtime secrets — Secret Manager, per project, **never committed**, 3. CI / GitHub Environments, Config & secrets — what lives where, WIF identifiers (provisioned — Phase 2)
 
 ### Community 90 - "Chat"
 Cohesion: 0.17
@@ -692,28 +695,28 @@ Cohesion: 0.21
 Nodes (7): collections, getCollection(), mockArbitrate, mockEmbed, readCanonStorage(), seedAisles(), seedCanonItem()
 
 ### Community 93 - "Shared"
-Cohesion: 0.31
-Nodes (9): MatchLogEntry, createPosthogServerMatchLoggingAdapter(), CANON_MATCH_EVENT, CanonMatchEventProps, CanonMatchPath, scaleScore(), toCanonMatchEvent(), createPosthogMatchLoggingAdapter() (+1 more)
+Cohesion: 0.35
+Nodes (8): MatchLogEntry, createPosthogServerMatchLoggingAdapter(), CANON_MATCH_EVENT, CanonMatchEventProps, CanonMatchPath, scaleScore(), toCanonMatchEvent(), fixture
 
 ### Community 94 - "Text"
 Cohesion: 0.21
 Nodes (5): _bad, TextProps, TextVariants, ./Text.types, ./Text.variants
 
 ### Community 95 - "Ai"
-Cohesion: 0.22
-Nodes (12): seed, eX, failEmbedding(), makeAisleStore(), makeIds(), makePorts(), makeStore(), noMatchArbitration() (+4 more)
+Cohesion: 0.20
+Nodes (14): seed, eX, failEmbedding(), makeAisleStore(), makeIds(), makePorts(), makeStore(), noMatchArbitration() (+6 more)
 
 ### Community 96 - "Triggers"
-Cohesion: 0.10
-Nodes (21): createServerEntryParseAdapter(), AiTimeoutError, raceWithTimeout(), withAiTimeout(), WithAiTimeoutOptions, AiCatalogModel, bareId(), CacheEntry (+13 more)
+Cohesion: 0.15
+Nodes (9): AiTimeoutError, raceWithTimeout(), withAiTimeout(), WithAiTimeoutOptions, requireAdmin(), handleTestModel(), TestModelInputSchema, TestModelResult (+1 more)
 
 ### Community 97 - "Docs"
-Cohesion: 0.12
-Nodes (21): Domain Purity Rule, No IndexedDB / Firestore persistentLocalCache Rule, CanonLookupPort, Canon Module (worked example), Coordinators (cross-module workflows), Cross-Cutting Ports (ErrorReporting, MatchLogging), Module Boundary Rule (index.ts only), Domain Module Pattern Guide (+13 more)
+Cohesion: 0.11
+Nodes (23): Domain Purity Rule, Last-Write-Wins Per Document, No IndexedDB / Firestore persistentLocalCache Rule, CanonLookupPort, Canon Module (worked example), Coordinators (cross-module workflows), Cross-Cutting Ports (ErrorReporting, MatchLogging), Module Boundary Rule (index.ts only) (+15 more)
 
 ### Community 98 - "Commands"
-Cohesion: 0.29
-Nodes (7): Create the working branch (once, before phase 1), Per-Phase Handoff Contract, Orchestrator/Subagent Pattern, Pause conditions (stop and wait for user), Run Issue, Setup (once), Intended Experience
+Cohesion: 0.33
+Nodes (6): 4.4 Shared Size Scale, Control Size Scale (Checkbox, Switch), Dialog Size Scale, Field Size Scale (TextField, Textarea frame, Button), Icon / Spinner sizes, Text Size Scale (Text primitive)
 
 ### Community 99 - "Progress"
 Cohesion: 0.24
@@ -736,8 +739,8 @@ Cohesion: 0.18
 Nodes (10): dependencies, @salt/domain, @salt/shared-types, exports, name, private, scripts, test (+2 more)
 
 ### Community 104 - "Triggers"
-Cohesion: 0.18
-Nodes (8): ItemData, mockEntryParseAdapterParse, mockLoggerInfo, mockLoggerWarn, mockMatchOrCreate, mockSpan, mockUpdate, PENDING_ITEM
+Cohesion: 0.15
+Nodes (10): ItemData, mockEntryParseAdapterParse, mockFlush, mockLoggerInfo, mockLoggerWarn, mockMatchOrCreate, mockReport, mockSpan (+2 more)
 
 ### Community 105 - "Cloud Functions"
 Cohesion: 0.20
@@ -748,8 +751,8 @@ Cohesion: 0.24
 Nodes (4): HeadingProps, HeadingVariants, ./Heading.types, ./Heading.variants
 
 ### Community 107 - "Lib"
-Cohesion: 0.25
-Nodes (8): ../../lib/devSettingsService.js, canonIconGenerationEnabled, DEFAULTS, initDevSettingsSync(), _isLoading, setCanonIconGenerationEnabled(), _settings, subscribeDevSettings()
+Cohesion: 0.40
+Nodes (4): MatchOrCreateInput, MatchOrCreateResult, WireBatchResult, WireResult
 
 ### Community 108 - "Tests"
 Cohesion: 0.20
@@ -788,8 +791,8 @@ Cohesion: 0.21
 Nodes (6): local, remote, mergeCanonItems(), unionSynonyms(), ConflictStrategy, resolveCanonConflict()
 
 ### Community 117 - "Src"
-Cohesion: 0.09
-Nodes (21): User, reportSubscriptionError(), AuthProvider, authEmulatorConnected, connectAuthEmulatorOnce(), createFirebaseAuth(), reportAuthFailure(), isAuthTransitioning() (+13 more)
+Cohesion: 0.11
+Nodes (17): User, AuthProvider, authEmulatorConnected, connectAuthEmulatorOnce(), reportAuthFailure(), isAuthTransitioning(), setAuthTransitioning(), ErrorReportingPort (+9 more)
 
 ### Community 118 - "Domain"
 Cohesion: 0.25
@@ -880,8 +883,8 @@ Cohesion: 0.33
 Nodes (3): FakeHttpsError, handler, { mockGet, mockDoc, mockCollection }
 
 ### Community 141 - "Combobox"
-Cohesion: 0.07
-Nodes (48): subscribeAisles(), saveAppSettings(), deleteCanonItem(), subscribeCanonItems(), deleteChatSession(), expiresAt(), loadChatSession(), saveChatSession() (+40 more)
+Cohesion: 0.05
+Nodes (61): mockGet, ../../lib/devSettingsService.js, canonIconGenerationEnabled, DEFAULTS, initDevSettingsSync(), _isLoading, setCanonIconGenerationEnabled(), _settings (+53 more)
 
 ### Community 142 - "Design"
 Cohesion: 0.14
@@ -944,8 +947,8 @@ Cohesion: 0.83
 Nodes (3): functions_triggers_registered(), reachable(), healthcheck.sh script
 
 ### Community 161 - "Community 161"
-Cohesion: 0.22
-Nodes (5): CacheEntry, DEFAULT_SETTINGS, loadSettings(), arbitrateCanonFlow, ArbitrationResultSchema
+Cohesion: 0.16
+Nodes (12): aiFakeEnabled(), aiModelLabel(), fakeModels, flowModel(), CacheEntry, DEFAULT_SETTINGS, loadSettings(), resolveModel() (+4 more)
 
 ### Community 164 - "Community 164"
 Cohesion: 0.33
@@ -979,6 +982,10 @@ Nodes (3): Cooking Pot with Lid Glyph, Salt App Icon (512px) — Cooking Pot, Sa
 Cohesion: 1.00
 Nodes (3): Task Pilot Tasks Icon, Task List Visualization, Task Pilot VS Code Extension
 
+### Community 266 - "Community 266"
+Cohesion: 0.40
+Nodes (5): 3.5 Helpers, `src/lib/cn.ts`, `src/lib/context.ts`, `src/lib/useId.ts`, `src/lib/variants.ts`
+
 ### Community 267 - "Community 267"
 Cohesion: 0.12
 Nodes (16): CanonIcon component, CanonItem.thumbnail (tri-state), Two-tier image system (pictogram + hero), Architecture contract notes, Canon item icons (Tier-1 pictograms), `CanonIcon` props, Data model, Generation pipeline (+8 more)
@@ -992,8 +999,8 @@ Cohesion: 0.12
 Nodes (16): 9.1 Overview, 9.2 Behaviour, 9.3.1 `BulkAction` — declarative contextual bar, 9.3.2 Move / target picker, 9.3.3 Deferred bulk delete + Undo snackbar, 9.3 `ListPage` props changes, 9.4 Consuming-page contract (bindable prop), 9.5 Clearing selection on exit (+8 more)
 
 ### Community 270 - "Community 270"
-Cohesion: 0.13
-Nodes (14): Architecture Notes & Constraints, Blast Radius, Defect Spec, Definition of Done, Observed vs Expected, Open Questions / Decisions, Reproduction, Root Cause (+6 more)
+Cohesion: 0.11
+Nodes (17): Architecture Notes & Constraints, Blast Radius, Defect Spec, Definition of Done, Observed vs Expected, Open Questions / Decisions, Phase 1: [Name], Phase 2: [Name] (+9 more)
 
 ### Community 271 - "Community 271"
 Cohesion: 0.13
@@ -1004,16 +1011,16 @@ Cohesion: 0.18
 Nodes (12): 11.1 Overview, 11.2 Props, 11.3 Behaviour, 11.4 Testing requirements, 11. EditableRow (primitive), 13.1 `ToastViewport` — `pointer-events-none` container, 13.2 `BottomNav` — full-height tap targets (`items-stretch`), 13. Pinned interaction constraints (+4 more)
 
 ### Community 273 - "Community 273"
-Cohesion: 0.10
-Nodes (19): 0. Roadmap Split, 1.1 Technology Stack, 1.2 Boundaries, 1.3 Package Surface, 1.4 Event Naming Rule, 1.5 Spec Versioning & Amendment Rule, 1. Foundations, 5.1 Universal Requirements (+11 more)
+Cohesion: 0.14
+Nodes (13): 0. Roadmap Split, 5.1 Universal Requirements, 5.2 Keyboard Map, 5.3 Focus Management, 5. Accessibility System, 6.1 Required Test Suites, 6.2 Test File Template, 6. Testing System (+5 more)
 
 ### Community 274 - "Community 274"
 Cohesion: 0.14
 Nodes (14): 0. v0.3 Scope, 1.1 Headless + Styled, 1.2 APG Compliance, 1. Shared v0.3 Rules, 5.1 Purpose, 5.2 Parts, 5.3 Root Props, 5.4 Events (+6 more)
 
 ### Community 275 - "Community 275"
-Cohesion: 0.17
-Nodes (8): eX, eY, failEmbedding(), makeAisleStore(), makeIds(), makePipeline(), makeStore(), noMatchArbitration()
+Cohesion: 0.16
+Nodes (9): eX, eY, failEmbedding(), makeAisleStore(), makeIds(), makePipeline(), makeStore(), noMatchArbitration() (+1 more)
 
 ### Community 276 - "Community 276"
 Cohesion: 0.17
@@ -1024,8 +1031,8 @@ Cohesion: 0.15
 Nodes (13): A. Async settling & determinism, Appendix — evaluation of the generic best-practice list against Salt, B. Locators, C. Isolation & state, D. Realtime & cross-tab convergence  _(Salt-specific)_, E. AI & Cloud-Function trigger determinism  _(Salt-specific)_, F. Timeouts, G. Config & harness invariants (+5 more)
 
 ### Community 278 - "Community 278"
-Cohesion: 0.17
-Nodes (11): Architecture Notes, Definition of Done, Feature Spec, Open Questions / Decisions, Phase 1: [Name], Phase 2: [Name], Phased GitHub Issue Structure, Phases (+3 more)
+Cohesion: 0.11
+Nodes (18): Create the working branch (once, before phase 1), Per-Phase Handoff Contract, Orchestrator/Subagent Pattern, Pause conditions (stop and wait for user), Run Issue, Setup (once), Architecture Notes, Definition of Done (+10 more)
 
 ### Community 279 - "Community 279"
 Cohesion: 0.33
@@ -1044,13 +1051,29 @@ Nodes (5): CollectionCallback, ErrorCallback, {
 Cohesion: 0.18
 Nodes (11): 10. Shared types requirements, 13. Deployment units, 14. Non-negotiables, 1.1 Schema evolution and production data, 1. Purpose, 2. Mono‑repo structure (logical modules), 4. Domain layer requirements, 5. Workspace and access model (+3 more)
 
+### Community 281 - "Community 281"
+Cohesion: 0.40
+Nodes (5): 8.13 Layout Primitives — Stack / Inline / Grid / Divider, Divider, Grid, Inline, Stack
+
+### Community 282 - "Community 282"
+Cohesion: 0.40
+Nodes (5): 8.5 Switch, Accessibility, Events, Props, Styling
+
 ### Community 283 - "Community 283"
-Cohesion: 0.10
-Nodes (20): 8.10 Heading, 8.11 Text, 8.13 Layout Primitives — Stack / Inline / Grid / Divider, 8.3 Textarea, 8.5 Switch, 8. Primitive Definitions (v0.2 Core), Accessibility, Autoresize (+12 more)
+Cohesion: 0.20
+Nodes (10): 8.10 Heading, 8.11 Text, 8.3 Textarea, 8. Primitive Definitions (v0.2 Core), Autoresize, Props, Props, Size styling (+2 more)
 
 ### Community 284 - "Community 284"
 Cohesion: 0.20
 Nodes (10): Authoring conventions, CI, E2E & emulator integration tests, Lifecycle, reuse & teardown, Port sets, Running locally, Spotting & clearing a poisoned environment, The containerized test emulator stacks (+2 more)
+
+### Community 285 - "Community 285"
+Cohesion: 0.40
+Nodes (4): INPUT, mockFlush, mockGenerate, mockReport
+
+### Community 286 - "Community 286"
+Cohesion: 0.60
+Nodes (3): getInput(), openCombobox(), setup()
 
 ### Community 287 - "Community 287"
 Cohesion: 0.22
@@ -1093,8 +1116,8 @@ Cohesion: 0.25
 Nodes (8): 3.1 Purpose, 3.2 Parts, 3.3 Root Props, 3.4 SelectTrigger Props, 3.5 Events, 3.6 APG Requirements (Listbox), 3.7 Behavior, 3. Select
 
 ### Community 299 - "Community 299"
-Cohesion: 0.17
-Nodes (12): 3.1 Folder Structure, 3.2 Export Rules, 3.3 Tailwind + Token Ownership, 3.4 bits-ui / melt-ui Versions, 3.5 Helpers, 3.7 bits-ui Mapping Table, 3.8 Provenance Header Convention, 3. Component Architecture (+4 more)
+Cohesion: 0.29
+Nodes (7): 3.1 Folder Structure, 3.2 Export Rules, 3.3 Tailwind + Token Ownership, 3.4 bits-ui / melt-ui Versions, 3.7 bits-ui Mapping Table, 3.8 Provenance Header Convention, 3. Component Architecture
 
 ### Community 300 - "Community 300"
 Cohesion: 0.29
@@ -1137,8 +1160,8 @@ Cohesion: 0.29
 Nodes (6): Agentic search, Available MCP tools, Multi-Repo, Smart Features, vexp context tools <!-- vexp v2.0.23 -->, Workflow
 
 ### Community 311 - "Community 311"
-Cohesion: 0.11
-Nodes (18): 4.1 Tokens, 4.2 Focus Ring, 4.3 Disabled + Loading, 4.4 Shared Size Scale, 4.5 Dark Mode, 4. Styling System, Control Size Scale (Checkbox, Switch), Dialog Size Scale (+10 more)
+Cohesion: 0.33
+Nodes (6): 4.1 Tokens, Elevation, Motion, Radius, Semantic colors, Z-index
 
 ### Community 314 - "Community 314"
 Cohesion: 0.33
@@ -1180,29 +1203,25 @@ Nodes (4): 3. Dependency graph (allowed imports), Allowed, Forbidden, Narrow exc
 Cohesion: 0.50
 Nodes (4): 6.1 firebase-sync adapter, 6.2 observability adapter, 6.3 Common rules, 6. Adapter requirements
 
-### Community 329 - "Community 329"
-Cohesion: 0.67
-Nodes (3): Phase 1: [Name], Phase 2: [Name], Phases
-
 ## Knowledge Gaps
-- **1351 isolated node(s):** `husky.sh script`, `name`, `version`, `private`, `type` (+1346 more)
+- **1365 isolated node(s):** `husky.sh script`, `name`, `version`, `private`, `type` (+1360 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **52 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **51 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `NavItem` connect `Sidenav` to `Canon`, `Combobox & ListPage Types`?**
-  _High betweenness centrality (0.145) - this node is a cross-community bridge._
-- **Why does `../../lib/recipeService.js` connect `Recipe Service` to `Aisles & Canon Stores`, `Firebase-Sync Shopping Config`, `Canon Approval UI`, `Shopping List Commands`, `Shopping List UI`, `Tests`, `Canon Matching Core`, `Combobox`, `Tests`, `Admin Routes`, `Community 157`, `Entities`, `Recipes`, `Lib`, `Canon`, `Tests`, `Triggers`, `Chat`, `Recipes`, `Tests`, `Src`?**
-  _High betweenness centrality (0.046) - this node is a cross-community bridge._
-- **Why does `../../lib/canonService.js` connect `Canon Approval UI` to `Aisles & Canon Stores`, `Firebase-Sync Shopping Config`, `Firestore Stores & Classify`, `Shopping List UI`, `Community 265`, `Canon Matching Core`, `Combobox`, `Canon Fast-Path Parity`, `Admin Routes`, `Recipe Service`, `Match Logging`, `List Page Routes`, `Community 162`, `Recipes`, `Lib`, `Canon`, `Canon`, `Recipes`, `Src`?**
-  _High betweenness centrality (0.044) - this node is a cross-community bridge._
+- **Why does `NavItem` connect `Sidenav` to `Canon`, `Combobox Primitive`?**
+  _High betweenness centrality (0.148) - this node is a cross-community bridge._
+- **Why does `../../lib/recipeService.js` connect `Recipe Service` to `Aisles & Canon Stores`, `Firebase-Sync Shopping Config`, `Canon Approval UI`, `Entities`, `Recipes`, `List Page Routes`, `Shopping List UI`, `Tests`, `Canon Matching Core`, `Recipes`, `Combobox`, `Tests`, `Tests`, `Lib`, `Canon`, `Tests`, `Chat`, `Community 157`?**
+  _High betweenness centrality (0.060) - this node is a cross-community bridge._
+- **Why does `CanonItem` connect `Canon Matching Core` to `Aisles & Canon Stores`, `Firebase-Sync Shopping Config`, `Canon Approval UI`, `E2E Test Suite`, `Firestore Stores & Classify`, `Community 265`, `Tests`, `Combobox`, `Canon Fast-Path Parity`, `Triggers`, `Community 275`, `Recipe Service`, `List Page Routes`, `Community 162`, `Canon`, `Canon`, `Flows`, `Ai`, `Triggers`, `Tests`, `Src`?**
+  _High betweenness centrality (0.056) - this node is a cross-community bridge._
 - **What connects `husky.sh script`, `name`, `version` to the rest of the system?**
-  _1371 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1385 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Meal Planner & Attendees` be split into smaller, more focused modules?**
-  _Cohesion score 0.050974512743628186 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.05028011204481793 - nodes in this community are weakly interconnected._
 - **Should `Aisles & Canon Stores` be split into smaller, more focused modules?**
-  _Cohesion score 0.07911392405063292 - nodes in this community are weakly interconnected._
-- **Should `Canon Approval UI` be split into smaller, more focused modules?**
-  _Cohesion score 0.08902439024390243 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.10721153846153846 - nodes in this community are weakly interconnected._
+- **Should `Firebase-Sync Shopping Config` be split into smaller, more focused modules?**
+  _Cohesion score 0.14408602150537633 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -661,7 +661,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_firestoreaislestore",
-      "community": 1,
+      "community": 64,
       "norm_label": "firestoreaislestore.ts"
     },
     {
@@ -671,7 +671,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "adapters_firestoreaislestore_classify",
-      "community": 1,
+      "community": 64,
       "norm_label": "classify()"
     },
     {
@@ -691,7 +691,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_firestorecanonstore",
-      "community": 1,
+      "community": 64,
       "norm_label": "firestorecanonstore.ts"
     },
     {
@@ -701,7 +701,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "adapters_firestorecanonstore_classify",
-      "community": 1,
+      "community": 64,
       "norm_label": "classify()"
     },
     {
@@ -851,7 +851,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_serverarbitration",
-      "community": 64,
+      "community": 7,
       "norm_label": "serverarbitration.ts"
     },
     {
@@ -871,7 +871,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_serverembedding",
-      "community": 96,
+      "community": 161,
       "norm_label": "serverembedding.ts"
     },
     {
@@ -891,7 +891,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_serverentryparse",
-      "community": 75,
+      "community": 96,
       "norm_label": "serverentryparse.ts"
     },
     {
@@ -1101,7 +1101,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_aigenerationtelemetry",
-      "community": 28,
+      "community": 161,
       "norm_label": "aigenerationtelemetry.ts"
     },
     {
@@ -1111,7 +1111,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "ai_aigenerationtelemetry_readusage",
-      "community": 28,
+      "community": 161,
       "norm_label": "readusage()"
     },
     {
@@ -1121,7 +1121,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "ai_aigenerationtelemetry_tracedgenerate",
-      "community": 28,
+      "community": 161,
       "norm_label": "tracedgenerate()"
     },
     {
@@ -1191,7 +1191,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_listaimodels",
-      "community": 61,
+      "community": 96,
       "norm_label": "listaimodels.ts"
     },
     {
@@ -1201,7 +1201,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "ai_listaimodels_catalogmodelschema",
-      "community": 61,
+      "community": 96,
       "norm_label": "catalogmodelschema"
     },
     {
@@ -1211,7 +1211,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "ai_listaimodels_catalogresponseschema",
-      "community": 61,
+      "community": 96,
       "norm_label": "catalogresponseschema"
     },
     {
@@ -1221,7 +1221,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "ai_listaimodels_listaimodelsinputschema",
-      "community": 61,
+      "community": 96,
       "norm_label": "listaimodelsinputschema"
     },
     {
@@ -1231,7 +1231,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "ai_listaimodels_aicatalogmodel",
-      "community": 61,
+      "community": 96,
       "norm_label": "aicatalogmodel"
     },
     {
@@ -1241,7 +1241,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "ai_listaimodels_listaimodelsresult",
-      "community": 61,
+      "community": 96,
       "norm_label": "listaimodelsresult"
     },
     {
@@ -1251,7 +1251,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "ai_listaimodels_cacheentry",
-      "community": 61,
+      "community": 96,
       "norm_label": "cacheentry"
     },
     {
@@ -1261,7 +1261,7 @@
       "source_location": "L59",
       "_origin": "ast",
       "id": "ai_listaimodels_bareid",
-      "community": 61,
+      "community": 96,
       "norm_label": "bareid()"
     },
     {
@@ -1271,7 +1271,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "ai_listaimodels_fetchcatalog",
-      "community": 61,
+      "community": 96,
       "norm_label": "fetchcatalog()"
     },
     {
@@ -1281,7 +1281,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "ai_listaimodels_loadcatalog",
-      "community": 61,
+      "community": 96,
       "norm_label": "loadcatalog()"
     },
     {
@@ -1291,7 +1291,7 @@
       "source_location": "L114",
       "_origin": "ast",
       "id": "ai_listaimodels_handlelistaimodels",
-      "community": 61,
+      "community": 96,
       "norm_label": "handlelistaimodels()"
     },
     {
@@ -1301,7 +1301,7 @@
       "source_location": "L124",
       "_origin": "ast",
       "id": "ai_listaimodels_resetlistaimodelscachefortest",
-      "community": 61,
+      "community": 96,
       "norm_label": "__resetlistaimodelscachefortest()"
     },
     {
@@ -1401,7 +1401,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "ai_modelcapabilities_modelsupportsrole",
-      "community": 61,
+      "community": 96,
       "norm_label": "modelsupportsrole()"
     },
     {
@@ -1691,7 +1691,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "flows_authorrecipe_authorrecipeflow",
-      "community": 34,
+      "community": 28,
       "norm_label": "authorrecipeflow"
     },
     {
@@ -1711,7 +1711,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_canonicaliserecipeingredients",
-      "community": 28,
+      "community": 75,
       "norm_label": "canonicaliserecipeingredients.ts"
     },
     {
@@ -1721,7 +1721,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "flows_canonicaliserecipeingredients_itemresultschema",
-      "community": 28,
+      "community": 75,
       "norm_label": "itemresultschema"
     },
     {
@@ -1731,7 +1731,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "flows_canonicaliserecipeingredients_outputschema",
-      "community": 28,
+      "community": 75,
       "norm_label": "outputschema"
     },
     {
@@ -1751,7 +1751,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_chefchat",
-      "community": 96,
+      "community": 161,
       "norm_label": "chefchat.ts"
     },
     {
@@ -1761,7 +1761,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "flows_chefchat_readequipmentcontext",
-      "community": 96,
+      "community": 161,
       "norm_label": "readequipmentcontext()"
     },
     {
@@ -1771,7 +1771,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "flows_chefchat_readrecipecontext",
-      "community": 96,
+      "community": 161,
       "norm_label": "readrecipecontext()"
     },
     {
@@ -1781,7 +1781,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "flows_chefchat_buildsystemprompt",
-      "community": 96,
+      "community": 161,
       "norm_label": "buildsystemprompt()"
     },
     {
@@ -1791,7 +1791,7 @@
       "source_location": "L99",
       "_origin": "ast",
       "id": "flows_chefchat_chefchatflow",
-      "community": 96,
+      "community": 34,
       "norm_label": "chefchatflow"
     },
     {
@@ -1841,7 +1841,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_urlimporterror",
-      "community": 34,
+      "community": 28,
       "norm_label": "urlimporterror"
     },
     {
@@ -1851,7 +1851,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_urlimporterror_constructor",
-      "community": 34,
+      "community": 28,
       "norm_label": ".constructor()"
     },
     {
@@ -1871,7 +1871,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_extractrecipefromurlflow",
-      "community": 34,
+      "community": 28,
       "norm_label": "extractrecipefromurlflow"
     },
     {
@@ -2021,7 +2021,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_identifyequipment",
-      "community": 34,
+      "community": 161,
       "norm_label": "identifyequipment.ts"
     },
     {
@@ -2041,7 +2041,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "flows_identifyequipment_system_instructions",
-      "community": 34,
+      "community": 161,
       "norm_label": "system_instructions"
     },
     {
@@ -2091,7 +2091,7 @@
       "source_location": "L68",
       "_origin": "ast",
       "id": "flows_matchorcreatecanon_ensureobservabilityinitialised",
-      "community": 46,
+      "community": 49,
       "norm_label": "ensureobservabilityinitialised()"
     },
     {
@@ -2111,7 +2111,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_parseentry",
-      "community": 28,
+      "community": 161,
       "norm_label": "parseentry.ts"
     },
     {
@@ -2121,7 +2121,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "flows_parseentry_parseentryinputschema",
-      "community": 28,
+      "community": 161,
       "norm_label": "parseentryinputschema"
     },
     {
@@ -2131,7 +2131,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "flows_parseentry_parseentryflow",
-      "community": 75,
+      "community": 161,
       "norm_label": "parseentryflow"
     },
     {
@@ -2141,7 +2141,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "flows_parseentry_buildprompt",
-      "community": 28,
+      "community": 161,
       "norm_label": "buildprompt()"
     },
     {
@@ -2151,7 +2151,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_parserecipeingredients",
-      "community": 28,
+      "community": 161,
       "norm_label": "parserecipeingredients.ts"
     },
     {
@@ -2171,7 +2171,7 @@
       "source_location": "L71",
       "_origin": "ast",
       "id": "flows_parserecipeingredients_system_instructions",
-      "community": 28,
+      "community": 161,
       "norm_label": "system_instructions"
     },
     {
@@ -2181,7 +2181,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_populateequipmententry",
-      "community": 34,
+      "community": 161,
       "norm_label": "populateequipmententry.ts"
     },
     {
@@ -2201,7 +2201,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "flows_populateequipmententry_system_instructions",
-      "community": 34,
+      "community": 161,
       "norm_label": "system_instructions"
     },
     {
@@ -2211,7 +2211,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_genkit",
-      "community": 28,
+      "community": 161,
       "norm_label": "genkit.ts"
     },
     {
@@ -2221,7 +2221,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "src_genkit_ai",
-      "community": 28,
+      "community": 161,
       "norm_label": "ai"
     },
     {
@@ -2451,7 +2451,7 @@
       "source_location": "L345",
       "_origin": "ast",
       "id": "src_index_reportunexpected",
-      "community": 34,
+      "community": 29,
       "norm_label": "reportunexpected()"
     },
     {
@@ -2481,7 +2481,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "observability_reportservererror",
-      "community": 34,
+      "community": 29,
       "norm_label": "reportservererror.ts"
     },
     {
@@ -2491,7 +2491,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "observability_reportservererror_reporter",
-      "community": 34,
+      "community": 29,
       "norm_label": "reporter"
     },
     {
@@ -2511,7 +2511,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "observability_reportservererror_reportflowerror",
-      "community": 34,
+      "community": 29,
       "norm_label": "reportflowerror()"
     },
     {
@@ -2611,7 +2611,7 @@
       "source_location": "L205",
       "_origin": "ast",
       "id": "triggers_oncanonitemwritten_oncanonitemwritten",
-      "community": 29,
+      "community": 34,
       "norm_label": "oncanonitemwritten"
     },
     {
@@ -2831,7 +2831,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_resolvemodel_test",
-      "community": 141,
+      "community": 77,
       "norm_label": "resolvemodel.test.ts"
     },
     {
@@ -2841,7 +2841,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "ai_resolvemodel_test_mockget",
-      "community": 141,
+      "community": 77,
       "norm_label": "mockget"
     },
     {
@@ -3258,7 +3258,7 @@
       "label": "invoke()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
-      "source_location": "L83",
+      "source_location": "L89",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_reporting_test_invoke",
       "community": 68,
@@ -3268,7 +3268,7 @@
       "label": "VALID",
       "file_type": "code",
       "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
-      "source_location": "L86",
+      "source_location": "L92",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_reporting_test_valid",
       "community": 68,
@@ -4321,7 +4321,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "apps_kitchen_sink_src_app_svelte_src_app",
-      "community": 50,
+      "community": 88,
       "norm_label": "app.svelte"
     },
     {
@@ -4332,7 +4332,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_colorssection",
-      "community": 50,
+      "community": 88,
       "norm_label": "colorssection.svelte"
     },
     {
@@ -4343,7 +4343,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_typographysection",
-      "community": 50,
+      "community": 88,
       "norm_label": "typographysection.svelte"
     },
     {
@@ -4354,7 +4354,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_layoutsection",
-      "community": 50,
+      "community": 88,
       "norm_label": "layoutsection.svelte"
     },
     {
@@ -4365,7 +4365,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_buttonsection",
-      "community": 50,
+      "community": 88,
       "norm_label": "buttonsection.svelte"
     },
     {
@@ -4376,7 +4376,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_formsection",
-      "community": 50,
+      "community": 88,
       "norm_label": "formsection.svelte"
     },
     {
@@ -4387,7 +4387,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_comboboxsection",
-      "community": 50,
+      "community": 88,
       "norm_label": "comboboxsection.svelte"
     },
     {
@@ -4398,7 +4398,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_overlaysection",
-      "community": 50,
+      "community": 88,
       "norm_label": "overlaysection.svelte"
     },
     {
@@ -4409,7 +4409,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_feedbacksection",
-      "community": 50,
+      "community": 88,
       "norm_label": "feedbacksection.svelte"
     },
     {
@@ -6210,7 +6210,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "apps_web_pwa_src_app_svelte_src_app",
-      "community": 51,
+      "community": 20,
       "norm_label": "app.svelte"
     },
     {
@@ -6220,7 +6220,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "src_app_needsapprovalcount",
-      "community": 51,
+      "community": 20,
       "norm_label": "needsapprovalcount"
     },
     {
@@ -6230,7 +6230,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "src_app_decoratednavitems",
-      "community": 51,
+      "community": 20,
       "norm_label": "decoratednavitems"
     },
     {
@@ -6273,7 +6273,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_nav",
-      "community": 51,
+      "community": 44,
       "norm_label": "nav.ts"
     },
     {
@@ -6295,7 +6295,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_toaststore",
-      "community": 33,
+      "community": 50,
       "norm_label": "../../lib/toaststore.js"
     },
     {
@@ -6383,7 +6383,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_devsettingsservice",
-      "community": 141,
+      "community": 162,
       "norm_label": "../../lib/devsettingsservice.js"
     },
     {
@@ -6415,7 +6415,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "dev_sessionoverlay",
-      "community": 51,
+      "community": 20,
       "norm_label": "sessionoverlay.svelte"
     },
     {
@@ -6425,7 +6425,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "boundary_tests_no_firebase_sync_internal",
-      "community": 141,
+      "community": 64,
       "norm_label": "no-firebase-sync-internal.ts"
     },
     {
@@ -6477,7 +6477,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_firebase",
-      "community": 20,
+      "community": 66,
       "norm_label": "firebase.ts"
     },
     {
@@ -7089,7 +7089,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "lib_canonservice_recomputeaisleusage",
-      "community": 3,
+      "community": 8,
       "norm_label": "recomputeaisleusage()"
     },
     {
@@ -7149,7 +7149,7 @@
       "source_location": "L179",
       "_origin": "ast",
       "id": "lib_canonservice_addcanonitem",
-      "community": 17,
+      "community": 3,
       "norm_label": "addcanonitem()"
     },
     {
@@ -7239,7 +7239,7 @@
       "source_location": "L306",
       "_origin": "ast",
       "id": "lib_canonservice_splitmostrecentsynonym",
-      "community": 265,
+      "community": 2,
       "norm_label": "splitmostrecentsynonym()"
     },
     {
@@ -7309,7 +7309,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "lib_chatservice_getchatsessionssnapshot",
-      "community": 42,
+      "community": 8,
       "norm_label": "getchatsessionssnapshot()"
     },
     {
@@ -7349,7 +7349,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "lib_chatservice_applysnapshot",
-      "community": 42,
+      "community": 8,
       "norm_label": "applysnapshot()"
     },
     {
@@ -7409,7 +7409,7 @@
       "source_location": "L126",
       "_origin": "ast",
       "id": "lib_chatservice_removesession",
-      "community": 8,
+      "community": 42,
       "norm_label": "removesession()"
     },
     {
@@ -7460,7 +7460,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "observability",
-      "community": 51,
+      "community": 20,
       "norm_label": "$lib/observability"
     },
     {
@@ -7470,7 +7470,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "lib_devsettingsservice_defaults",
-      "community": 141,
+      "community": 162,
       "norm_label": "defaults"
     },
     {
@@ -7480,7 +7480,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "lib_devsettingsservice_settings",
-      "community": 141,
+      "community": 162,
       "norm_label": "_settings"
     },
     {
@@ -7490,7 +7490,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "lib_devsettingsservice_isloading",
-      "community": 141,
+      "community": 162,
       "norm_label": "_isloading"
     },
     {
@@ -7500,7 +7500,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "lib_devsettingsservice_canonicongenerationenabled",
-      "community": 141,
+      "community": 162,
       "norm_label": "canonicongenerationenabled"
     },
     {
@@ -7510,7 +7510,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "lib_devsettingsservice_initdevsettingssync",
-      "community": 141,
+      "community": 162,
       "norm_label": "initdevsettingssync()"
     },
     {
@@ -7520,7 +7520,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "lib_devsettingsservice_setcanonicongenerationenabled",
-      "community": 141,
+      "community": 162,
       "norm_label": "setcanonicongenerationenabled()"
     },
     {
@@ -7530,7 +7530,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "lib_devsettingsservice_resetdevsettingsservicefortest",
-      "community": 141,
+      "community": 162,
       "norm_label": "__resetdevsettingsservicefortest()"
     },
     {
@@ -7790,7 +7790,7 @@
       "source_location": "L304",
       "_origin": "ast",
       "id": "lib_equipmentservice_getequipmentsnapshot",
-      "community": 9,
+      "community": 8,
       "norm_label": "getequipmentsnapshot()"
     },
     {
@@ -7810,7 +7810,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_errorreporting",
-      "community": 8,
+      "community": 117,
       "norm_label": "errorreporting.ts"
     },
     {
@@ -7820,7 +7820,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "lib_errorreporting_reportsubscriptionerror",
-      "community": 8,
+      "community": 117,
       "norm_label": "reportsubscriptionerror()"
     },
     {
@@ -7830,7 +7830,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "lib_errorreporting_reportwriteerror",
-      "community": 8,
+      "community": 42,
       "norm_label": "reportwriteerror()"
     },
     {
@@ -7840,7 +7840,7 @@
       "source_location": "L56",
       "_origin": "ast",
       "id": "lib_errorreporting_reportiffailed",
-      "community": 8,
+      "community": 157,
       "norm_label": "reportiffailed()"
     },
     {
@@ -7850,7 +7850,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_firebase_authprovider",
-      "community": 20,
+      "community": 66,
       "norm_label": "authprovider"
     },
     {
@@ -7960,7 +7960,7 @@
       "source_location": "L76",
       "_origin": "ast",
       "id": "lib_mealplanservice_firstdayofweek",
-      "community": 0,
+      "community": 116,
       "norm_label": "firstdayofweek"
     },
     {
@@ -7970,7 +7970,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "lib_mealplanservice_currentweek",
-      "community": 0,
+      "community": 116,
       "norm_label": "currentweek"
     },
     {
@@ -8060,7 +8060,7 @@
       "source_location": "L179",
       "_origin": "ast",
       "id": "lib_mealplanservice_currenttemplateobject",
-      "community": 0,
+      "community": 1,
       "norm_label": "currenttemplateobject()"
     },
     {
@@ -8080,7 +8080,7 @@
       "source_location": "L191",
       "_origin": "ast",
       "id": "lib_mealplanservice_persisttemplate",
-      "community": 0,
+      "community": 1,
       "norm_label": "persisttemplate()"
     },
     {
@@ -8100,7 +8100,7 @@
       "source_location": "L209",
       "_origin": "ast",
       "id": "lib_mealplanservice_setweekdaynote",
-      "community": 0,
+      "community": 1,
       "norm_label": "setweekdaynote()"
     },
     {
@@ -8110,7 +8110,7 @@
       "source_location": "L212",
       "_origin": "ast",
       "id": "lib_mealplanservice_setweekdaychefs",
-      "community": 0,
+      "community": 1,
       "norm_label": "setweekdaychefs()"
     },
     {
@@ -8120,7 +8120,7 @@
       "source_location": "L215",
       "_origin": "ast",
       "id": "lib_mealplanservice_setweekdayguests",
-      "community": 0,
+      "community": 1,
       "norm_label": "setweekdayguests()"
     },
     {
@@ -8150,7 +8150,7 @@
       "source_location": "L224",
       "_origin": "ast",
       "id": "lib_mealplanservice_setweekattendeehometime",
-      "community": 0,
+      "community": 1,
       "norm_label": "setweekattendeehometime()"
     },
     {
@@ -8160,7 +8160,7 @@
       "source_location": "L231",
       "_origin": "ast",
       "id": "lib_mealplanservice_setweekattendeenote",
-      "community": 0,
+      "community": 1,
       "norm_label": "setweekattendeenote()"
     },
     {
@@ -8170,7 +8170,7 @@
       "source_location": "L236",
       "_origin": "ast",
       "id": "lib_mealplanservice_savefirstdayofweek",
-      "community": 0,
+      "community": 108,
       "norm_label": "savefirstdayofweek()"
     },
     {
@@ -8180,7 +8180,7 @@
       "source_location": "L241",
       "_origin": "ast",
       "id": "lib_mealplanservice_settemplatedaynote",
-      "community": 0,
+      "community": 1,
       "norm_label": "settemplatedaynote()"
     },
     {
@@ -8190,7 +8190,7 @@
       "source_location": "L244",
       "_origin": "ast",
       "id": "lib_mealplanservice_settemplatedaychefs",
-      "community": 0,
+      "community": 1,
       "norm_label": "settemplatedaychefs()"
     },
     {
@@ -8200,7 +8200,7 @@
       "source_location": "L247",
       "_origin": "ast",
       "id": "lib_mealplanservice_settemplatedayguests",
-      "community": 0,
+      "community": 1,
       "norm_label": "settemplatedayguests()"
     },
     {
@@ -8220,7 +8220,7 @@
       "source_location": "L253",
       "_origin": "ast",
       "id": "lib_mealplanservice_removetemplateattendee",
-      "community": 0,
+      "community": 1,
       "norm_label": "removetemplateattendee()"
     },
     {
@@ -8230,7 +8230,7 @@
       "source_location": "L256",
       "_origin": "ast",
       "id": "lib_mealplanservice_settemplateattendeehometime",
-      "community": 0,
+      "community": 1,
       "norm_label": "settemplateattendeehometime()"
     },
     {
@@ -8240,7 +8240,7 @@
       "source_location": "L263",
       "_origin": "ast",
       "id": "lib_mealplanservice_settemplateattendeenote",
-      "community": 0,
+      "community": 1,
       "norm_label": "settemplateattendeenote()"
     },
     {
@@ -8260,7 +8260,7 @@
       "source_location": "L285",
       "_origin": "ast",
       "id": "lib_mealplanservice_seedmealplanconfig",
-      "community": 0,
+      "community": 116,
       "norm_label": "seedmealplanconfig()"
     },
     {
@@ -8270,7 +8270,7 @@
       "source_location": "L290",
       "_origin": "ast",
       "id": "lib_mealplanservice_seedmealplantemplate",
-      "community": 0,
+      "community": 116,
       "norm_label": "seedmealplantemplate()"
     },
     {
@@ -8280,7 +8280,7 @@
       "source_location": "L296",
       "_origin": "ast",
       "id": "lib_mealplanservice_seedmealplanweek",
-      "community": 0,
+      "community": 116,
       "norm_label": "seedmealplanweek()"
     },
     {
@@ -8400,7 +8400,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "lib_membersservice_reordermembers",
-      "community": 10,
+      "community": 8,
       "norm_label": "reordermembers()"
     },
     {
@@ -8440,7 +8440,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "lib_nav_navitems",
-      "community": 51,
+      "community": 44,
       "norm_label": "navitems"
     },
     {
@@ -8450,7 +8450,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "lib_nav_adminnavitem",
-      "community": 51,
+      "community": 44,
       "norm_label": "adminnavitem"
     },
     {
@@ -8610,7 +8610,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "lib_recipeservice_geterrorreporter",
-      "community": 24,
+      "community": 157,
       "norm_label": "geterrorreporter()"
     },
     {
@@ -8630,7 +8630,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "lib_recipeservice_applysnapshot",
-      "community": 24,
+      "community": 8,
       "norm_label": "applysnapshot()"
     },
     {
@@ -8640,7 +8640,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "lib_recipeservice_initrecipesync",
-      "community": 24,
+      "community": 157,
       "norm_label": "initrecipesync()"
     },
     {
@@ -8650,7 +8650,7 @@
       "source_location": "L109",
       "_origin": "ast",
       "id": "lib_recipeservice_persistrecipe",
-      "community": 24,
+      "community": 157,
       "norm_label": "persistrecipe()"
     },
     {
@@ -8720,7 +8720,7 @@
       "source_location": "L177",
       "_origin": "ast",
       "id": "lib_recipeservice_canonicaliseingredients",
-      "community": 24,
+      "community": 157,
       "norm_label": "canonicaliseingredients()"
     },
     {
@@ -8730,7 +8730,7 @@
       "source_location": "L234",
       "_origin": "ast",
       "id": "lib_recipeservice_matchingredient",
-      "community": 24,
+      "community": 157,
       "norm_label": "matchingredient()"
     },
     {
@@ -8740,7 +8740,7 @@
       "source_location": "L263",
       "_origin": "ast",
       "id": "lib_recipeservice_removerecipe",
-      "community": 8,
+      "community": 157,
       "norm_label": "removerecipe()"
     },
     {
@@ -8800,7 +8800,7 @@
       "source_location": "L354",
       "_origin": "ast",
       "id": "lib_recipeservice_commitrecipeaddplan",
-      "community": 8,
+      "community": 157,
       "norm_label": "commitrecipeaddplan()"
     },
     {
@@ -8900,7 +8900,7 @@
       "source_location": "L101",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_setactivelistid",
-      "community": 8,
+      "community": 93,
       "norm_label": "setactivelistid()"
     },
     {
@@ -8910,7 +8910,7 @@
       "source_location": "L118",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_initshoppinglistsync",
-      "community": 8,
+      "community": 141,
       "norm_label": "initshoppinglistsync()"
     },
     {
@@ -9080,7 +9080,7 @@
       "source_location": "L358",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_moveselecteditems",
-      "community": 8,
+      "community": 93,
       "norm_label": "moveselecteditems()"
     },
     {
@@ -9151,7 +9151,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "lib_toaststore_toastactionconfig",
-      "community": 33,
+      "community": 50,
       "norm_label": "toastactionconfig"
     },
     {
@@ -9161,7 +9161,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "lib_toaststore_toastitem",
-      "community": 33,
+      "community": 50,
       "norm_label": "toastitem"
     },
     {
@@ -9171,7 +9171,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "lib_toaststore_addtoastoptions",
-      "community": 33,
+      "community": 50,
       "norm_label": "addtoastoptions"
     },
     {
@@ -9181,7 +9181,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "lib_toaststore_toasts",
-      "community": 33,
+      "community": 50,
       "norm_label": "toasts"
     },
     {
@@ -9201,7 +9201,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "lib_toaststore_dismisstoast",
-      "community": 33,
+      "community": 50,
       "norm_label": "dismisstoast()"
     },
     {
@@ -9211,7 +9211,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "types_e2e_d",
-      "community": 66,
+      "community": 4,
       "norm_label": "e2e.d.ts"
     },
     {
@@ -9221,7 +9221,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "types_e2e_d_seedcanoniteminput",
-      "community": 66,
+      "community": 4,
       "norm_label": "seedcanoniteminput"
     },
     {
@@ -9231,7 +9231,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "types_e2e_d_e2ebridge",
-      "community": 66,
+      "community": 4,
       "norm_label": "e2ebridge"
     },
     {
@@ -9241,7 +9241,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "types_e2e_d_window",
-      "community": 66,
+      "community": 4,
       "norm_label": "window"
     },
     {
@@ -9373,7 +9373,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "schemas",
-      "community": 141,
+      "community": 77,
       "norm_label": "@salt/domain/schemas"
     },
     {
@@ -9404,7 +9404,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "firebase_sync",
-      "community": 50,
+      "community": 90,
       "norm_label": "@salt/firebase-sync"
     },
     {
@@ -9424,7 +9424,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canoncreatepage",
-      "community": 33,
+      "community": 50,
       "norm_label": "canoncreatepage.svelte"
     },
     {
@@ -9555,7 +9555,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "chat_chatlistpage",
-      "community": 20,
+      "community": 50,
       "norm_label": "chatlistpage.svelte"
     },
     {
@@ -10056,7 +10056,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "recipes_recipelistpage",
-      "community": 33,
+      "community": 50,
       "norm_label": "recipelistpage.svelte"
     },
     {
@@ -10316,7 +10316,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "settings_settingspage",
-      "community": 20,
+      "community": 50,
       "norm_label": "settingspage.svelte"
     },
     {
@@ -10336,7 +10336,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shopping_shoppinglistpage",
-      "community": 162,
+      "community": 50,
       "norm_label": "shoppinglistpage.svelte"
     },
     {
@@ -10346,7 +10346,7 @@
       "source_location": "L885",
       "_origin": "ast",
       "id": "shopping_shoppinglistpage_each",
-      "community": 162,
+      "community": 50,
       "norm_label": "#each()"
     },
     {
@@ -10396,7 +10396,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_adminmealplanpage_test",
-      "community": 0,
+      "community": 108,
       "norm_label": "adminmealplanpage.test.ts"
     },
     {
@@ -10406,7 +10406,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "tests_adminmealplanpage_test_mockmembers_mockisloadingmembers_mocktemplate_mockfirstday_mockauth",
-      "community": 0,
+      "community": 108,
       "norm_label": "{ mockmembers, mockisloadingmembers, mocktemplate, mockfirstday, mockauth }"
     },
     {
@@ -10416,7 +10416,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "tests_adminmealplanpage_test_member",
-      "community": 0,
+      "community": 108,
       "norm_label": "member()"
     },
     {
@@ -10426,7 +10426,7 @@
       "source_location": "L71",
       "_origin": "ast",
       "id": "tests_adminmealplanpage_test_admin",
-      "community": 0,
+      "community": 108,
       "norm_label": "admin"
     },
     {
@@ -10596,7 +10596,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test",
-      "community": 9,
+      "community": 33,
       "norm_label": "equipmentcapturepage.test.ts"
     },
     {
@@ -10606,7 +10606,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_mockisloadingequipment",
-      "community": 9,
+      "community": 33,
       "norm_label": "{ mockisloadingequipment }"
     },
     {
@@ -10616,7 +10616,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_makemanifest",
-      "community": 9,
+      "community": 33,
       "norm_label": "makemanifest()"
     },
     {
@@ -10626,7 +10626,7 @@
       "source_location": "L60",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_walkthroughcapture",
-      "community": 9,
+      "community": 33,
       "norm_label": "walkthroughcapture()"
     },
     {
@@ -10676,7 +10676,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_mealplanweekpage_test",
-      "community": 0,
+      "community": 1,
       "norm_label": "mealplanweekpage.test.ts"
     },
     {
@@ -10686,7 +10686,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_mealplanweekpage_test_mockmembers_mockweek_mockstart_mockloading",
-      "community": 0,
+      "community": 1,
       "norm_label": "{ mockmembers, mockweek, mockstart, mockloading }"
     },
     {
@@ -10696,7 +10696,7 @@
       "source_location": "L70",
       "_origin": "ast",
       "id": "tests_mealplanweekpage_test_expandday",
-      "community": 0,
+      "community": 1,
       "norm_label": "expandday()"
     },
     {
@@ -10706,7 +10706,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "tests_mealplanweekpage_test_member",
-      "community": 0,
+      "community": 1,
       "norm_label": "member()"
     },
     {
@@ -10716,7 +10716,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "tests_mealplanweekpage_test_alice",
-      "community": 0,
+      "community": 1,
       "norm_label": "alice"
     },
     {
@@ -10726,7 +10726,7 @@
       "source_location": "L88",
       "_origin": "ast",
       "id": "tests_mealplanweekpage_test_bob",
-      "community": 0,
+      "community": 1,
       "norm_label": "bob"
     },
     {
@@ -10846,7 +10846,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test",
-      "community": 162,
+      "community": 4,
       "norm_label": "shoppinglistpage.danglingcanon.test.ts"
     },
     {
@@ -10856,7 +10856,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_mockcanonitems_mockaisles_mocklists_mockitems_mockdefaultlistid_mockloading",
-      "community": 162,
+      "community": 4,
       "norm_label": "{ mockcanonitems, mockaisles, mocklists, mockitems, mockdefaultlistid, mockloading }"
     },
     {
@@ -10866,7 +10866,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_canonitem",
-      "community": 162,
+      "community": 4,
       "norm_label": "canonitem()"
     },
     {
@@ -10876,7 +10876,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_item",
-      "community": 162,
+      "community": 4,
       "norm_label": "item()"
     },
     {
@@ -10886,7 +10886,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test",
-      "community": 162,
+      "community": 4,
       "norm_label": "shoppinglistpage.icon.test.ts"
     },
     {
@@ -10896,7 +10896,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_mockcanonitems_mockaisles_mocklists_mockitems_mockdefaultlistid_mockloading",
-      "community": 162,
+      "community": 4,
       "norm_label": "{ mockcanonitems, mockaisles, mocklists, mockitems, mockdefaultlistid, mockloading }"
     },
     {
@@ -10906,7 +10906,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_canonitem",
-      "community": 162,
+      "community": 4,
       "norm_label": "canonitem()"
     },
     {
@@ -10916,7 +10916,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_item",
-      "community": 162,
+      "community": 4,
       "norm_label": "item()"
     },
     {
@@ -11266,7 +11266,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_errorreporting_test",
-      "community": 8,
+      "community": 117,
       "norm_label": "errorreporting.test.ts"
     },
     {
@@ -11276,7 +11276,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "tests_errorreporting_test_isauthtransitioning",
-      "community": 8,
+      "community": 117,
       "norm_label": "isauthtransitioning"
     },
     {
@@ -11286,7 +11286,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test",
-      "community": 0,
+      "community": 116,
       "norm_label": "mealplanservice.sync.test.ts"
     },
     {
@@ -11296,7 +11296,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test_fs",
-      "community": 0,
+      "community": 116,
       "norm_label": "fs"
     },
     {
@@ -11306,7 +11306,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test_weekcb",
-      "community": 0,
+      "community": 116,
       "norm_label": "weekcb"
     },
     {
@@ -11316,7 +11316,7 @@
       "source_location": "L47",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test_configcb",
-      "community": 0,
+      "community": 116,
       "norm_label": "configcb"
     },
     {
@@ -11326,7 +11326,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test_templatecb",
-      "community": 0,
+      "community": 116,
       "norm_label": "templatecb"
     },
     {
@@ -11336,7 +11336,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test_config",
-      "community": 0,
+      "community": 116,
       "norm_label": "config"
     },
     {
@@ -11346,7 +11346,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test_wiresubscriptions",
-      "community": 0,
+      "community": 116,
       "norm_label": "wiresubscriptions()"
     },
     {
@@ -11406,7 +11406,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test",
-      "community": 108,
+      "community": 24,
       "norm_label": "recipeservice.addtolist.test.ts"
     },
     {
@@ -11416,7 +11416,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_mockgetcanonitemssnapshot",
-      "community": 108,
+      "community": 24,
       "norm_label": "{ mockgetcanonitemssnapshot }"
     },
     {
@@ -11426,7 +11426,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_fs",
-      "community": 108,
+      "community": 24,
       "norm_label": "fs"
     },
     {
@@ -11436,7 +11436,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_makecanonitem",
-      "community": 108,
+      "community": 24,
       "norm_label": "makecanonitem()"
     },
     {
@@ -11446,7 +11446,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_makegroup",
-      "community": 108,
+      "community": 24,
       "norm_label": "makegroup()"
     },
     {
@@ -11456,7 +11456,7 @@
       "source_location": "L59",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_makerecipe",
-      "community": 108,
+      "community": 24,
       "norm_label": "makerecipe()"
     },
     {
@@ -11466,7 +11466,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_gramingredient",
-      "community": 108,
+      "community": 24,
       "norm_label": "gramingredient"
     },
     {
@@ -11476,7 +11476,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_weightingredient",
-      "community": 108,
+      "community": 24,
       "norm_label": "weightingredient()"
     },
     {
@@ -11486,7 +11486,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_countingredient",
-      "community": 108,
+      "community": 24,
       "norm_label": "countingredient"
     },
     {
@@ -11496,7 +11496,7 @@
       "source_location": "L112",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_matchedingredient",
-      "community": 108,
+      "community": 24,
       "norm_label": "matchedingredient()"
     },
     {
@@ -13082,7 +13082,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_aislesubscription",
-      "community": 141,
+      "community": 64,
       "norm_label": "aislesubscription.ts"
     },
     {
@@ -13092,7 +13092,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_aislesubscription_subscribeaisles",
-      "community": 141,
+      "community": 3,
       "norm_label": "subscribeaisles()"
     },
     {
@@ -13112,7 +13112,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_appsettingssync",
-      "community": 141,
+      "community": 64,
       "norm_label": "appsettingssync.ts"
     },
     {
@@ -13122,7 +13122,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "src_appsettingssync_subscribeappsettings",
-      "community": 141,
+      "community": 47,
       "norm_label": "subscribeappsettings()"
     },
     {
@@ -13132,7 +13132,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_appsettingssync_saveappsettings",
-      "community": 141,
+      "community": 47,
       "norm_label": "saveappsettings()"
     },
     {
@@ -13162,7 +13162,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "src_auth_connectauthemulatoronce",
-      "community": 117,
+      "community": 66,
       "norm_label": "connectauthemulatoronce()"
     },
     {
@@ -13202,7 +13202,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "src_auth_createfirebaseauth",
-      "community": 20,
+      "community": 66,
       "norm_label": "createfirebaseauth()"
     },
     {
@@ -13242,7 +13242,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_authorrecipecallable",
-      "community": 1,
+      "community": 64,
       "norm_label": "authorrecipecallable.ts"
     },
     {
@@ -13252,7 +13252,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "src_authorrecipecallable_classifyerror",
-      "community": 1,
+      "community": 64,
       "norm_label": "classifyerror()"
     },
     {
@@ -13262,7 +13262,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "src_authorrecipecallable_callauthorrecipe",
-      "community": 1,
+      "community": 64,
       "norm_label": "callauthorrecipe()"
     },
     {
@@ -13272,7 +13272,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_canonmatching",
-      "community": 107,
+      "community": 95,
       "norm_label": "canonmatching.ts"
     },
     {
@@ -13282,7 +13282,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "src_canonmatching_wireresult",
-      "community": 107,
+      "community": 95,
       "norm_label": "wireresult"
     },
     {
@@ -13292,7 +13292,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "src_canonmatching_callmatchorcreate",
-      "community": 17,
+      "community": 3,
       "norm_label": "callmatchorcreate()"
     },
     {
@@ -13302,7 +13302,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_canonmatching_wirebatchresult",
-      "community": 107,
+      "community": 95,
       "norm_label": "wirebatchresult"
     },
     {
@@ -13312,7 +13312,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "src_canonmatching_callcanonicaliserecipeingredients",
-      "community": 24,
+      "community": 157,
       "norm_label": "callcanonicaliserecipeingredients()"
     },
     {
@@ -13332,7 +13332,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_canonsubscription",
-      "community": 141,
+      "community": 64,
       "norm_label": "canonsubscription.ts"
     },
     {
@@ -13342,7 +13342,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_canonsubscription_subscribecanonitems",
-      "community": 141,
+      "community": 3,
       "norm_label": "subscribecanonitems()"
     },
     {
@@ -13372,7 +13372,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_chatcallables",
-      "community": 42,
+      "community": 64,
       "norm_label": "chatcallables.ts"
     },
     {
@@ -13412,7 +13412,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_chatsessionsubscription",
-      "community": 141,
+      "community": 64,
       "norm_label": "chatsessionsubscription.ts"
     },
     {
@@ -13422,7 +13422,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_expiresat",
-      "community": 141,
+      "community": 42,
       "norm_label": "expiresat()"
     },
     {
@@ -13442,7 +13442,7 @@
       "source_location": "L59",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_loadchatsession",
-      "community": 141,
+      "community": 93,
       "norm_label": "loadchatsession()"
     },
     {
@@ -13452,7 +13452,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_savechatsession",
-      "community": 141,
+      "community": 42,
       "norm_label": "savechatsession()"
     },
     {
@@ -13462,7 +13462,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_deletechatsession",
-      "community": 141,
+      "community": 42,
       "norm_label": "deletechatsession()"
     },
     {
@@ -13472,7 +13472,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_devsettingssync",
-      "community": 141,
+      "community": 64,
       "norm_label": "devsettingssync.ts"
     },
     {
@@ -13482,7 +13482,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "src_devsettingssync_subscribedevsettings",
-      "community": 141,
+      "community": 162,
       "norm_label": "subscribedevsettings()"
     },
     {
@@ -13492,7 +13492,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_devsettingssync_savedevsettings",
-      "community": 141,
+      "community": 162,
       "norm_label": "savedevsettings()"
     },
     {
@@ -13502,7 +13502,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_e2eaistubsync",
-      "community": 141,
+      "community": 66,
       "norm_label": "e2eaistubsync.ts"
     },
     {
@@ -13512,7 +13512,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "src_e2eaistubsync_setaistub",
-      "community": 141,
+      "community": 66,
       "norm_label": "setaistub()"
     },
     {
@@ -13522,7 +13522,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_equipmentcallables",
-      "community": 141,
+      "community": 66,
       "norm_label": "equipmentcallables.ts"
     },
     {
@@ -13532,7 +13532,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "src_equipmentcallables_identifyequipmentcandidate",
-      "community": 141,
+      "community": 66,
       "norm_label": "identifyequipmentcandidate"
     },
     {
@@ -13542,7 +13542,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "src_equipmentcallables_identifyequipmentresult",
-      "community": 141,
+      "community": 66,
       "norm_label": "identifyequipmentresult"
     },
     {
@@ -13552,7 +13552,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "src_equipmentcallables_populateaccessory",
-      "community": 141,
+      "community": 66,
       "norm_label": "populateaccessory"
     },
     {
@@ -13562,7 +13562,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "src_equipmentcallables_populateequipmententryresult",
-      "community": 141,
+      "community": 66,
       "norm_label": "populateequipmententryresult"
     },
     {
@@ -13572,7 +13572,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "src_equipmentcallables_callidentifyequipment",
-      "community": 9,
+      "community": 66,
       "norm_label": "callidentifyequipment()"
     },
     {
@@ -13582,7 +13582,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "src_equipmentcallables_callpopulateequipmententry",
-      "community": 9,
+      "community": 66,
       "norm_label": "callpopulateequipmententry()"
     },
     {
@@ -13592,7 +13592,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_equipmentmanifestsubscription",
-      "community": 141,
+      "community": 9,
       "norm_label": "equipmentmanifestsubscription.ts"
     },
     {
@@ -13602,7 +13602,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_equipmentmanifestsubscription_subscribeequipmentmanifest",
-      "community": 141,
+      "community": 9,
       "norm_label": "subscribeequipmentmanifest()"
     },
     {
@@ -13622,7 +13622,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_firestoreerrors",
-      "community": 141,
+      "community": 64,
       "norm_label": "firestoreerrors.ts"
     },
     {
@@ -13632,7 +13632,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "src_firestoreerrors_firestorecode",
-      "community": 141,
+      "community": 93,
       "norm_label": "firestorecode()"
     },
     {
@@ -13642,7 +13642,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "src_firestoreerrors_classifyfirestoreerror",
-      "community": 141,
+      "community": 93,
       "norm_label": "classifyfirestoreerror()"
     },
     {
@@ -13652,7 +13652,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_adapters_firebase_sync_src_index_ts_src_index",
-      "community": 141,
+      "community": 66,
       "norm_label": "index.ts"
     },
     {
@@ -13662,7 +13662,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_adapters_firebase_sync_src_init_ts_src_init",
-      "community": 117,
+      "community": 66,
       "norm_label": "init.ts"
     },
     {
@@ -13672,7 +13672,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "src_init_emulatorconnectedapps",
-      "community": 117,
+      "community": 66,
       "norm_label": "emulatorconnectedapps"
     },
     {
@@ -13682,7 +13682,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "src_init_appcheckconfig",
-      "community": 20,
+      "community": 66,
       "norm_label": "appcheckconfig"
     },
     {
@@ -13692,7 +13692,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "src_init_initfirebase",
-      "community": 117,
+      "community": 66,
       "norm_label": "initfirebase()"
     },
     {
@@ -13702,7 +13702,7 @@
       "source_location": "L96",
       "_origin": "ast",
       "id": "src_init_setfirestorenetwork",
-      "community": 117,
+      "community": 66,
       "norm_label": "setfirestorenetwork()"
     },
     {
@@ -13712,7 +13712,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_mealplansync",
-      "community": 0,
+      "community": 64,
       "norm_label": "mealplansync.ts"
     },
     {
@@ -13752,7 +13752,7 @@
       "source_location": "L93",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplanconfig",
-      "community": 0,
+      "community": 108,
       "norm_label": "savemealplanconfig()"
     },
     {
@@ -13762,7 +13762,7 @@
       "source_location": "L105",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplantemplate",
-      "community": 0,
+      "community": 1,
       "norm_label": "savemealplantemplate()"
     },
     {
@@ -13782,7 +13782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_memberssubscription",
-      "community": 141,
+      "community": 64,
       "norm_label": "memberssubscription.ts"
     },
     {
@@ -13792,7 +13792,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "src_memberssubscription_subscribemembers",
-      "community": 141,
+      "community": 10,
       "norm_label": "subscribemembers()"
     },
     {
@@ -13812,7 +13812,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "src_memberssubscription_deletemember",
-      "community": 141,
+      "community": 10,
       "norm_label": "deletemember()"
     },
     {
@@ -13822,7 +13822,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_recipecallables",
-      "community": 1,
+      "community": 64,
       "norm_label": "recipecallables.ts"
     },
     {
@@ -13862,7 +13862,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_recipesubscription",
-      "community": 141,
+      "community": 279,
       "norm_label": "recipesubscription.ts"
     },
     {
@@ -13872,7 +13872,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "src_recipesubscription_subscriberecipes",
-      "community": 24,
+      "community": 279,
       "norm_label": "subscriberecipes()"
     },
     {
@@ -13882,7 +13882,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "src_recipesubscription_loadrecipe",
-      "community": 141,
+      "community": 279,
       "norm_label": "loadrecipe()"
     },
     {
@@ -13892,7 +13892,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "src_recipesubscription_saverecipe",
-      "community": 141,
+      "community": 279,
       "norm_label": "saverecipe()"
     },
     {
@@ -13902,7 +13902,7 @@
       "source_location": "L73",
       "_origin": "ast",
       "id": "src_recipesubscription_deleterecipe",
-      "community": 141,
+      "community": 279,
       "norm_label": "deleterecipe()"
     },
     {
@@ -13912,7 +13912,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription",
-      "community": 141,
+      "community": 93,
       "norm_label": "shoppinglistitemsubscription.ts"
     },
     {
@@ -13922,7 +13922,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_subscribeshoppinglistitems",
-      "community": 141,
+      "community": 93,
       "norm_label": "subscribeshoppinglistitems()"
     },
     {
@@ -13932,7 +13932,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_listshoppinglistitems",
-      "community": 141,
+      "community": 93,
       "norm_label": "listshoppinglistitems()"
     },
     {
@@ -13952,7 +13952,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_deleteshoppinglistitem",
-      "community": 141,
+      "community": 8,
       "norm_label": "deleteshoppinglistitem()"
     },
     {
@@ -13972,7 +13972,7 @@
       "source_location": "L114",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_moveshoppinglistitems",
-      "community": 141,
+      "community": 93,
       "norm_label": "moveshoppinglistitems()"
     },
     {
@@ -13982,7 +13982,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription",
-      "community": 141,
+      "community": 64,
       "norm_label": "shoppinglistsubscription.ts"
     },
     {
@@ -14012,7 +14012,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_createshoppinglist",
-      "community": 141,
+      "community": 8,
       "norm_label": "createshoppinglist()"
     },
     {
@@ -14022,7 +14022,7 @@
       "source_location": "L78",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_renameshoppinglist",
-      "community": 141,
+      "community": 8,
       "norm_label": "renameshoppinglist()"
     },
     {
@@ -14032,7 +14032,7 @@
       "source_location": "L92",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_deleteshoppinglist",
-      "community": 141,
+      "community": 8,
       "norm_label": "deleteshoppinglist()"
     },
     {
@@ -14042,7 +14042,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription",
-      "community": 141,
+      "community": 64,
       "norm_label": "shoppinglistsconfigsubscription.ts"
     },
     {
@@ -14082,7 +14082,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_appsettingssync_test",
-      "community": 141,
+      "community": 47,
       "norm_label": "appsettingssync.test.ts"
     },
     {
@@ -14092,7 +14092,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdoc_mockgetfirestore",
-      "community": 141,
+      "community": 47,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -14102,7 +14102,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_snapcallback",
-      "community": 141,
+      "community": 47,
       "norm_label": "snapcallback"
     },
     {
@@ -14112,7 +14112,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_errorcallback",
-      "community": 141,
+      "community": 47,
       "norm_label": "errorcallback"
     },
     {
@@ -14172,7 +14172,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_emulatorhelpers",
-      "community": 117,
+      "community": 141,
       "norm_label": "emulatorhelpers.ts"
     },
     {
@@ -14182,7 +14182,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "tests_emulatorhelpers_initfirebaseemulator",
-      "community": 117,
+      "community": 141,
       "norm_label": "initfirebaseemulator()"
     },
     {
@@ -14192,7 +14192,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "tests_emulatorhelpers_resetdefaultapp",
-      "community": 117,
+      "community": 141,
       "norm_label": "resetdefaultapp()"
     },
     {
@@ -14202,7 +14202,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "tests_emulatorhelpers_clearfirestoreemulator",
-      "community": 117,
+      "community": 141,
       "norm_label": "clearfirestoreemulator()"
     },
     {
@@ -14252,7 +14252,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_firestoreerrors_test",
-      "community": 141,
+      "community": 93,
       "norm_label": "firestoreerrors.test.ts"
     },
     {
@@ -14262,7 +14262,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "tests_firestoreerrors_test_fberror",
-      "community": 141,
+      "community": 93,
       "norm_label": "fberror()"
     },
     {
@@ -14352,7 +14352,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_mealplansync_test",
-      "community": 0,
+      "community": 108,
       "norm_label": "mealplansync.test.ts"
     },
     {
@@ -14362,7 +14362,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_mealplansync_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdoc_mockgetfirestore",
-      "community": 0,
+      "community": 108,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -14372,7 +14372,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "tests_mealplansync_test_snapcallback",
-      "community": 0,
+      "community": 108,
       "norm_label": "snapcallback"
     },
     {
@@ -14382,7 +14382,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "tests_mealplansync_test_errorcallback",
-      "community": 0,
+      "community": 108,
       "norm_label": "errorcallback"
     },
     {
@@ -14392,7 +14392,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "tests_mealplansync_test_config",
-      "community": 0,
+      "community": 108,
       "norm_label": "config"
     },
     {
@@ -14402,7 +14402,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "tests_mealplansync_test_template",
-      "community": 0,
+      "community": 108,
       "norm_label": "template"
     },
     {
@@ -14412,7 +14412,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "tests_mealplansync_test_week",
-      "community": 0,
+      "community": 108,
       "norm_label": "week"
     },
     {
@@ -14532,7 +14532,7 @@
       "source_location": "L490",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_delay",
-      "community": 9,
+      "community": 141,
       "norm_label": "delay()"
     },
     {
@@ -14542,7 +14542,7 @@
       "source_location": "L494",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_waitfor",
-      "community": 9,
+      "community": 141,
       "norm_label": "waitfor()"
     },
     {
@@ -14612,7 +14612,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test",
-      "community": 141,
+      "community": 93,
       "norm_label": "shoppinglistitemsubscription.test.ts"
     },
     {
@@ -14622,7 +14622,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdeletedoc_mockgetdocs_mockdoc_mockcollection_mockgetfirestore_mockwritebatch_mockbatchdelete_mockbatchset_mockbatchcommit",
-      "community": 141,
+      "community": 93,
       "norm_label": "{\n  mockunsubscribe,\n  mockonsnapshot,\n  mocksetdoc,\n  mockdeletedoc,\n  mockgetdocs,\n  mockdoc,\n  mockcollection,\n  mockgetfirestore,\n  mockwritebatch,\n  mockbatchdelete,\n  mockbatchset,\n  mockbatchcommit,\n}"
     },
     {
@@ -14632,7 +14632,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_snapcallback",
-      "community": 141,
+      "community": 93,
       "norm_label": "snapcallback"
     },
     {
@@ -14642,7 +14642,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_errorcallback",
-      "community": 141,
+      "community": 93,
       "norm_label": "errorcallback"
     },
     {
@@ -14652,7 +14652,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_item_1",
-      "community": 141,
+      "community": 93,
       "norm_label": "item_1"
     },
     {
@@ -14662,7 +14662,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_item_2",
-      "community": 141,
+      "community": 93,
       "norm_label": "item_2"
     },
     {
@@ -15202,7 +15202,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "src_init_initobservability",
-      "community": 25,
+      "community": 49,
       "norm_label": "initobservability()"
     },
     {
@@ -15282,7 +15282,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_posthogerrorreportingadapter",
-      "community": 25,
+      "community": 49,
       "norm_label": "posthogerrorreportingadapter.ts"
     },
     {
@@ -15292,7 +15292,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter",
-      "community": 25,
+      "community": 49,
       "norm_label": "createposthogerrorreportingadapter()"
     },
     {
@@ -15302,7 +15302,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_posthogmatchloggingadapter",
-      "community": 93,
+      "community": 25,
       "norm_label": "posthogmatchloggingadapter.ts"
     },
     {
@@ -15342,7 +15342,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "server_init_isserverobservabilityinitialised",
-      "community": 46,
+      "community": 49,
       "norm_label": "isserverobservabilityinitialised()"
     },
     {
@@ -15362,7 +15362,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "server_init_initserverobservability",
-      "community": 46,
+      "community": 49,
       "norm_label": "initserverobservability()"
     },
     {
@@ -15502,7 +15502,7 @@
       "source_location": "L245",
       "_origin": "ast",
       "id": "server_init_runwithextractedtracecontext",
-      "community": 46,
+      "community": 70,
       "norm_label": "runwithextractedtracecontext()"
     },
     {
@@ -15512,7 +15512,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "server_posthogservererrorreportingadapter",
-      "community": 46,
+      "community": 49,
       "norm_label": "posthogservererrorreportingadapter.ts"
     },
     {
@@ -15522,7 +15522,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "server_posthogservererrorreportingadapter_createposthogservererrorreportingadapter",
-      "community": 46,
+      "community": 49,
       "norm_label": "createposthogservererrorreportingadapter()"
     },
     {
@@ -15532,7 +15532,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "server_posthogservermatchloggingadapter",
-      "community": 93,
+      "community": 46,
       "norm_label": "posthogservermatchloggingadapter.ts"
     },
     {
@@ -15542,7 +15542,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "server_posthogservermatchloggingadapter_createposthogservermatchloggingadapter",
-      "community": 93,
+      "community": 46,
       "norm_label": "createposthogservermatchloggingadapter()"
     },
     {
@@ -15632,7 +15632,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shared_matchoutcomeevent",
-      "community": 93,
+      "community": 46,
       "norm_label": "matchoutcomeevent.ts"
     },
     {
@@ -15642,7 +15642,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "shared_matchoutcomeevent_canon_match_event",
-      "community": 93,
+      "community": 46,
       "norm_label": "canon_match_event"
     },
     {
@@ -15652,7 +15652,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "shared_matchoutcomeevent_canonmatchpath",
-      "community": 93,
+      "community": 46,
       "norm_label": "canonmatchpath"
     },
     {
@@ -15662,7 +15662,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "shared_matchoutcomeevent_canonmatcheventprops",
-      "community": 93,
+      "community": 46,
       "norm_label": "canonmatcheventprops"
     },
     {
@@ -15672,7 +15672,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "shared_matchoutcomeevent_scalescore",
-      "community": 93,
+      "community": 46,
       "norm_label": "scalescore()"
     },
     {
@@ -15682,7 +15682,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "shared_matchoutcomeevent_tocanonmatchevent",
-      "community": 93,
+      "community": 46,
       "norm_label": "tocanonmatchevent()"
     },
     {
@@ -15692,7 +15692,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shared_reportablecategory",
-      "community": 25,
+      "community": 49,
       "norm_label": "reportablecategory.ts"
     },
     {
@@ -15702,7 +15702,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "shared_reportablecategory_suppressed_categories",
-      "community": 25,
+      "community": 49,
       "norm_label": "suppressed_categories"
     },
     {
@@ -15712,7 +15712,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "shared_reportablecategory_isreportablecategory",
-      "community": 25,
+      "community": 49,
       "norm_label": "isreportablecategory()"
     },
     {
@@ -15722,7 +15722,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_matchlogparity_test",
-      "community": 93,
+      "community": 46,
       "norm_label": "matchlogparity.test.ts"
     },
     {
@@ -15732,8 +15732,28 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "tests_matchlogparity_test_fixture",
-      "community": 93,
+      "community": 46,
       "norm_label": "fixture"
+    },
+    {
+      "label": "payloadScrubbing.test.ts",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "tests_payloadscrubbing_test",
+      "community": 49,
+      "norm_label": "payloadscrubbing.test.ts"
+    },
+    {
+      "label": "{ clientCapture, clientInit, serverCapture, FakePostHog }",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
+      "source_location": "L19",
+      "_origin": "ast",
+      "id": "tests_payloadscrubbing_test_clientcapture_clientinit_servercapture_fakeposthog",
+      "community": 49,
+      "norm_label": "{ clientcapture, clientinit, servercapture, fakeposthog }"
     },
     {
       "label": "posthogErrorReportingAdapter.test.ts",
@@ -15742,7 +15762,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_posthogerrorreportingadapter_test",
-      "community": 25,
+      "community": 49,
       "norm_label": "posthogerrorreportingadapter.test.ts"
     },
     {
@@ -15752,7 +15772,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_posthogerrorreportingadapter_test_captureexception_init",
-      "community": 25,
+      "community": 49,
       "norm_label": "{ captureexception, init }"
     },
     {
@@ -15762,7 +15782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_posthogservererrorreportingadapter_test",
-      "community": 46,
+      "community": 49,
       "norm_label": "posthogservererrorreportingadapter.test.ts"
     },
     {
@@ -15772,8 +15792,38 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "tests_posthogservererrorreportingadapter_test_captureexception_fakeposthog",
-      "community": 46,
+      "community": 49,
       "norm_label": "{ captureexception, fakeposthog }"
+    },
+    {
+      "label": "reportabilityParity.test.ts",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "tests_reportabilityparity_test",
+      "community": 49,
+      "norm_label": "reportabilityparity.test.ts"
+    },
+    {
+      "label": "{ clientCapture, clientInit, serverCapture, FakePostHog }",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "tests_reportabilityparity_test_clientcapture_clientinit_servercapture_fakeposthog",
+      "community": 49,
+      "norm_label": "{ clientcapture, clientinit, servercapture, fakeposthog }"
+    },
+    {
+      "label": "EXPECTED_REPORT",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L71",
+      "_origin": "ast",
+      "id": "tests_reportabilityparity_test_expected_report",
+      "community": 49,
+      "norm_label": "expected_report"
     },
     {
       "label": "reportableCategory.test.ts",
@@ -15782,7 +15832,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_reportablecategory_test",
-      "community": 25,
+      "community": 49,
       "norm_label": "reportablecategory.test.ts"
     },
     {
@@ -16352,7 +16402,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_buildmatchlog",
-      "community": 32,
+      "community": 7,
       "norm_label": "buildmatchlog.ts"
     },
     {
@@ -16362,7 +16412,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder",
-      "community": 32,
+      "community": 7,
       "norm_label": "matchlogbuilder"
     },
     {
@@ -16372,7 +16422,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_start",
-      "community": 32,
+      "community": 7,
       "norm_label": ".start()"
     },
     {
@@ -16382,7 +16432,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_setinputitemcount",
-      "community": 32,
+      "community": 7,
       "norm_label": ".setinputitemcount()"
     },
     {
@@ -16392,7 +16442,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_addstage",
-      "community": 32,
+      "community": 7,
       "norm_label": ".addstage()"
     },
     {
@@ -16402,7 +16452,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_setarbitration",
-      "community": 32,
+      "community": 7,
       "norm_label": ".setarbitration()"
     },
     {
@@ -16412,7 +16462,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_complete",
-      "community": 32,
+      "community": 7,
       "norm_label": ".complete()"
     },
     {
@@ -16432,7 +16482,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "commands_createaisle_createaisleinput",
-      "community": 64,
+      "community": 7,
       "norm_label": "createaisleinput"
     },
     {
@@ -16462,7 +16512,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "commands_createaislesbulk_createaislesbulkinput",
-      "community": 64,
+      "community": 7,
       "norm_label": "createaislesbulkinput"
     },
     {
@@ -16502,7 +16552,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "commands_createcanonitem_createcanonitem",
-      "community": 265,
+      "community": 17,
       "norm_label": "createcanonitem()"
     },
     {
@@ -16522,7 +16572,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_deleteaisles_deleteaislesinput",
-      "community": 64,
+      "community": 7,
       "norm_label": "deleteaislesinput"
     },
     {
@@ -16542,7 +16592,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_matchorcreate",
-      "community": 7,
+      "community": 17,
       "norm_label": "matchorcreate.ts"
     },
     {
@@ -16552,7 +16602,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateinput",
-      "community": 107,
+      "community": 95,
       "norm_label": "matchorcreateinput"
     },
     {
@@ -16562,7 +16612,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateresult",
-      "community": 107,
+      "community": 95,
       "norm_label": "matchorcreateresult"
     },
     {
@@ -16572,7 +16622,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateports",
-      "community": 64,
+      "community": 7,
       "norm_label": "matchorcreateports"
     },
     {
@@ -16582,7 +16632,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreate",
-      "community": 275,
+      "community": 17,
       "norm_label": "matchorcreate()"
     },
     {
@@ -16602,7 +16652,7 @@
       "source_location": "L147",
       "_origin": "ast",
       "id": "commands_matchorcreate_buildembeddingcache",
-      "community": 95,
+      "community": 17,
       "norm_label": "buildembeddingcache()"
     },
     {
@@ -16612,7 +16662,7 @@
       "source_location": "L177",
       "_origin": "ast",
       "id": "commands_matchorcreate_commitlog",
-      "community": 7,
+      "community": 17,
       "norm_label": "commitlog"
     },
     {
@@ -16622,7 +16672,7 @@
       "source_location": "L183",
       "_origin": "ast",
       "id": "commands_matchorcreate_arboutcome",
-      "community": 7,
+      "community": 17,
       "norm_label": "arboutcome"
     },
     {
@@ -16632,7 +16682,7 @@
       "source_location": "L185",
       "_origin": "ast",
       "id": "commands_matchorcreate_classification",
-      "community": 7,
+      "community": 17,
       "norm_label": "classification"
     },
     {
@@ -16652,7 +16702,7 @@
       "source_location": "L361",
       "_origin": "ast",
       "id": "commands_matchorcreate_applyclassification",
-      "community": 7,
+      "community": 17,
       "norm_label": "applyclassification()"
     },
     {
@@ -16672,7 +16722,7 @@
       "source_location": "L478",
       "_origin": "ast",
       "id": "commands_matchorcreate_arbitrationnew",
-      "community": 7,
+      "community": 17,
       "norm_label": "arbitrationnew"
     },
     {
@@ -16682,7 +16732,7 @@
       "source_location": "L483",
       "_origin": "ast",
       "id": "commands_matchorcreate_extrasfromnew",
-      "community": 7,
+      "community": 17,
       "norm_label": "extrasfromnew()"
     },
     {
@@ -16692,7 +16742,7 @@
       "source_location": "L494",
       "_origin": "ast",
       "id": "commands_matchorcreate_arbitrationfailurereasoning",
-      "community": 7,
+      "community": 17,
       "norm_label": "arbitrationfailurereasoning()"
     },
     {
@@ -16712,7 +16762,7 @@
       "source_location": "L505",
       "_origin": "ast",
       "id": "commands_matchorcreate_logarbitration",
-      "community": 7,
+      "community": 17,
       "norm_label": "logarbitration()"
     },
     {
@@ -16722,7 +16772,7 @@
       "source_location": "L530",
       "_origin": "ast",
       "id": "commands_matchorcreate_findsnapshotmatch",
-      "community": 7,
+      "community": 17,
       "norm_label": "findsnapshotmatch()"
     },
     {
@@ -16742,7 +16792,7 @@
       "source_location": "L565",
       "_origin": "ast",
       "id": "commands_matchorcreate_resolvematch",
-      "community": 7,
+      "community": 17,
       "norm_label": "resolvematch()"
     },
     {
@@ -16752,7 +16802,7 @@
       "source_location": "L584",
       "_origin": "ast",
       "id": "commands_matchorcreate_persistnew",
-      "community": 7,
+      "community": 17,
       "norm_label": "persistnew()"
     },
     {
@@ -16762,7 +16812,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_mergeaisles",
-      "community": 64,
+      "community": 7,
       "norm_label": "mergeaisles.ts"
     },
     {
@@ -16772,7 +16822,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_mergeaisles_itemmergechoice",
-      "community": 64,
+      "community": 7,
       "norm_label": "itemmergechoice"
     },
     {
@@ -16782,7 +16832,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "commands_mergeaisles_peritemmergechoice",
-      "community": 64,
+      "community": 7,
       "norm_label": "peritemmergechoice"
     },
     {
@@ -16792,7 +16842,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "commands_mergeaisles_mergeaislesinput",
-      "community": 64,
+      "community": 7,
       "norm_label": "mergeaislesinput"
     },
     {
@@ -16802,7 +16852,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "commands_mergeaisles_mergeaisles",
-      "community": 64,
+      "community": 7,
       "norm_label": "mergeaisles()"
     },
     {
@@ -16812,7 +16862,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_mergecanonitems",
-      "community": 116,
+      "community": 11,
       "norm_label": "mergecanonitems.ts"
     },
     {
@@ -16822,7 +16872,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "commands_mergecanonitems_mergecanonitems",
-      "community": 116,
+      "community": 11,
       "norm_label": "mergecanonitems()"
     },
     {
@@ -16832,7 +16882,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "commands_mergecanonitems_unionsynonyms",
-      "community": 116,
+      "community": 11,
       "norm_label": "unionsynonyms()"
     },
     {
@@ -16852,7 +16902,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_renameaisle_renameaisleinput",
-      "community": 64,
+      "community": 7,
       "norm_label": "renameaisleinput"
     },
     {
@@ -16902,7 +16952,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_reorderaisles_reorderaislesinput",
-      "community": 64,
+      "community": 7,
       "norm_label": "reorderaislesinput"
     },
     {
@@ -16922,7 +16972,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_resolvecanonconflict",
-      "community": 116,
+      "community": 11,
       "norm_label": "resolvecanonconflict.ts"
     },
     {
@@ -16932,7 +16982,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "commands_resolvecanonconflict_conflictstrategy",
-      "community": 116,
+      "community": 11,
       "norm_label": "conflictstrategy"
     },
     {
@@ -16942,7 +16992,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_resolvecanonconflict_resolvecanonconflict",
-      "community": 116,
+      "community": 11,
       "norm_label": "resolvecanonconflict()"
     },
     {
@@ -16962,7 +17012,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setcanonitemaisle_setcanonitemaisle",
-      "community": 3,
+      "community": 11,
       "norm_label": "setcanonitemaisle()"
     },
     {
@@ -16982,7 +17032,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setcanonitemshoppingfields_setcanonitemshoppingbehavior",
-      "community": 3,
+      "community": 11,
       "norm_label": "setcanonitemshoppingbehavior()"
     },
     {
@@ -16992,7 +17042,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "commands_setcanonitemshoppingfields_setcanonitemthreshold",
-      "community": 3,
+      "community": 11,
       "norm_label": "setcanonitemthreshold()"
     },
     {
@@ -17012,7 +17062,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setcanonitemsynonyms_setcanonitemsynonyms",
-      "community": 3,
+      "community": 11,
       "norm_label": "setcanonitemsynonyms()"
     },
     {
@@ -17032,7 +17082,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "commands_setcanonitemthumbnail_setcanonitemthumbnail",
-      "community": 3,
+      "community": 11,
       "norm_label": "setcanonitemthumbnail()"
     },
     {
@@ -17102,7 +17152,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_matchcandidate",
-      "community": 11,
+      "community": 7,
       "norm_label": "matchcandidate.ts"
     },
     {
@@ -17112,7 +17162,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "entities_matchcandidate_matchstage",
-      "community": 11,
+      "community": 7,
       "norm_label": "matchstage"
     },
     {
@@ -17122,7 +17172,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_matchcandidate_matchcandidate",
-      "community": 11,
+      "community": 7,
       "norm_label": "matchcandidate"
     },
     {
@@ -17132,7 +17182,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_matchlogentry",
-      "community": 32,
+      "community": 7,
       "norm_label": "matchlogentry.ts"
     },
     {
@@ -17142,7 +17192,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_matchlogentry_candidatelog",
-      "community": 32,
+      "community": 7,
       "norm_label": "candidatelog"
     },
     {
@@ -17152,7 +17202,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "entities_matchlogentry_stageskipreason",
-      "community": 32,
+      "community": 7,
       "norm_label": "stageskipreason"
     },
     {
@@ -17162,7 +17212,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "entities_matchlogentry_stagelog",
-      "community": 32,
+      "community": 7,
       "norm_label": "stagelog"
     },
     {
@@ -17172,7 +17222,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "entities_matchlogentry_finaldecision",
-      "community": 32,
+      "community": 7,
       "norm_label": "finaldecision"
     },
     {
@@ -17182,7 +17232,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "entities_matchlogentry_arbitrationlog",
-      "community": 32,
+      "community": 7,
       "norm_label": "arbitrationlog"
     },
     {
@@ -17192,7 +17242,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "entities_matchlogentry_matchlogentry",
-      "community": 93,
+      "community": 7,
       "norm_label": "matchlogentry"
     },
     {
@@ -17202,7 +17252,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_index",
-      "community": 64,
+      "community": 7,
       "norm_label": "index.ts"
     },
     {
@@ -17232,7 +17282,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_canonarbitrationport",
-      "community": 64,
+      "community": 7,
       "norm_label": "canonarbitrationport.ts"
     },
     {
@@ -17242,7 +17292,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_canonarbitrationport_arbitrationresult",
-      "community": 64,
+      "community": 7,
       "norm_label": "arbitrationresult"
     },
     {
@@ -17252,7 +17302,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "ports_canonarbitrationport_arbitrationrequest",
-      "community": 64,
+      "community": 7,
       "norm_label": "arbitrationrequest"
     },
     {
@@ -17262,7 +17312,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "ports_canonarbitrationport_canonarbitrationport",
-      "community": 64,
+      "community": 7,
       "norm_label": "canonarbitrationport"
     },
     {
@@ -17272,7 +17322,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_canonlocalstoreport",
-      "community": 64,
+      "community": 7,
       "norm_label": "canonlocalstoreport.ts"
     },
     {
@@ -17282,7 +17332,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_canonlocalstoreport_canonlocalstoreport",
-      "community": 64,
+      "community": 7,
       "norm_label": "canonlocalstoreport"
     },
     {
@@ -17292,7 +17342,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_canonlookupport",
-      "community": 11,
+      "community": 7,
       "norm_label": "canonlookupport.ts"
     },
     {
@@ -17302,7 +17352,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "ports_canonlookupport_canonlookupport",
-      "community": 64,
+      "community": 7,
       "norm_label": "canonlookupport"
     },
     {
@@ -17372,7 +17422,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_canonicon",
-      "community": 64,
+      "community": 7,
       "norm_label": "canonicon.ts"
     },
     {
@@ -17382,7 +17432,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "queries_canonicon_iscanoniconrenderable",
-      "community": 64,
+      "community": 7,
       "norm_label": "iscanoniconrenderable()"
     },
     {
@@ -17392,7 +17442,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_createcanonlookup",
-      "community": 64,
+      "community": 7,
       "norm_label": "createcanonlookup.ts"
     },
     {
@@ -17402,7 +17452,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "queries_createcanonlookup_createcanonlookup",
-      "community": 64,
+      "community": 7,
       "norm_label": "createcanonlookup()"
     },
     {
@@ -17432,7 +17482,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_findclosestmatch",
-      "community": 17,
+      "community": 7,
       "norm_label": "findclosestmatch.ts"
     },
     {
@@ -17442,7 +17492,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "queries_findclosestmatch_findclosestmatchresult",
-      "community": 64,
+      "community": 7,
       "norm_label": "findclosestmatchresult"
     },
     {
@@ -17462,7 +17512,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_getaisleusage",
-      "community": 64,
+      "community": 7,
       "norm_label": "getaisleusage.ts"
     },
     {
@@ -17472,7 +17522,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "queries_getaisleusage_getaisleusage",
-      "community": 64,
+      "community": 7,
       "norm_label": "getaisleusage()"
     },
     {
@@ -17612,7 +17662,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_summarizematchlog",
-      "community": 49,
+      "community": 7,
       "norm_label": "summarizematchlog.ts"
     },
     {
@@ -17622,7 +17672,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "queries_summarizematchlog_matchlogsummary",
-      "community": 49,
+      "community": 7,
       "norm_label": "matchlogsummary"
     },
     {
@@ -17632,7 +17682,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "queries_summarizematchlog_nearmisscount",
-      "community": 49,
+      "community": 7,
       "norm_label": "nearmisscount()"
     },
     {
@@ -17642,7 +17692,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "queries_summarizematchlog_formatstage",
-      "community": 49,
+      "community": 7,
       "norm_label": "formatstage()"
     },
     {
@@ -17652,7 +17702,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "queries_summarizematchlog_formatarbitration",
-      "community": 49,
+      "community": 7,
       "norm_label": "formatarbitration()"
     },
     {
@@ -17662,7 +17712,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "queries_summarizematchlog_summarizematchlog",
-      "community": 49,
+      "community": 7,
       "norm_label": "summarizematchlog()"
     },
     {
@@ -17722,7 +17772,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addaccessory",
-      "community": 1,
+      "community": 9,
       "norm_label": "addaccessory.ts"
     },
     {
@@ -17732,7 +17782,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_addaccessory_addaccessoryinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "addaccessoryinput"
     },
     {
@@ -17752,7 +17802,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addequipment",
-      "community": 1,
+      "community": 9,
       "norm_label": "addequipment.ts"
     },
     {
@@ -17762,7 +17812,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_addequipment_addequipmentinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "addequipmentinput"
     },
     {
@@ -17782,7 +17832,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addrule",
-      "community": 1,
+      "community": 9,
       "norm_label": "addrule.ts"
     },
     {
@@ -17792,7 +17842,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_addrule_addruleinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "addruleinput"
     },
     {
@@ -17812,7 +17862,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_editrule",
-      "community": 1,
+      "community": 9,
       "norm_label": "editrule.ts"
     },
     {
@@ -17822,7 +17872,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_editrule_editruleinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "editruleinput"
     },
     {
@@ -17842,7 +17892,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removeaccessory",
-      "community": 1,
+      "community": 9,
       "norm_label": "removeaccessory.ts"
     },
     {
@@ -17852,7 +17902,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removeaccessory_removeaccessoryinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "removeaccessoryinput"
     },
     {
@@ -17872,7 +17922,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removeequipment",
-      "community": 1,
+      "community": 9,
       "norm_label": "removeequipment.ts"
     },
     {
@@ -17882,7 +17932,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removeequipment_removeequipmentinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "removeequipmentinput"
     },
     {
@@ -17902,7 +17952,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removerule",
-      "community": 1,
+      "community": 9,
       "norm_label": "removerule.ts"
     },
     {
@@ -17912,7 +17962,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removerule_removeruleinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "removeruleinput"
     },
     {
@@ -17932,7 +17982,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_renameequipment",
-      "community": 1,
+      "community": 9,
       "norm_label": "renameequipment.ts"
     },
     {
@@ -17942,7 +17992,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_renameequipment_renameequipmentinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "renameequipmentinput"
     },
     {
@@ -17962,7 +18012,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_setaccessoryowned",
-      "community": 1,
+      "community": 9,
       "norm_label": "setaccessoryowned.ts"
     },
     {
@@ -17972,7 +18022,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setaccessoryowned_setaccessoryownedinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "setaccessoryownedinput"
     },
     {
@@ -17992,7 +18042,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentitem",
-      "community": 1,
+      "community": 9,
       "norm_label": "equipmentitem.ts"
     },
     {
@@ -18002,7 +18052,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentitem_accessory",
-      "community": 1,
+      "community": 9,
       "norm_label": "accessory"
     },
     {
@@ -18012,7 +18062,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "entities_equipmentitem_equipmentitem",
-      "community": 1,
+      "community": 9,
       "norm_label": "equipmentitem"
     },
     {
@@ -18022,7 +18072,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentmanifest",
-      "community": 1,
+      "community": 9,
       "norm_label": "equipmentmanifest.ts"
     },
     {
@@ -18032,7 +18082,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_equipmentmanifest_equipmentmanifest",
-      "community": 1,
+      "community": 9,
       "norm_label": "equipmentmanifest"
     },
     {
@@ -18042,7 +18092,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "equipment_index",
-      "community": 1,
+      "community": 9,
       "norm_label": "index.ts"
     },
     {
@@ -18052,7 +18102,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_equipmentmanifestport",
-      "community": 1,
+      "community": 9,
       "norm_label": "equipmentmanifestport.ts"
     },
     {
@@ -18062,7 +18112,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_equipmentmanifestport_equipmentmanifestport",
-      "community": 1,
+      "community": 9,
       "norm_label": "equipmentmanifestport"
     },
     {
@@ -18102,7 +18152,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_daymutators",
-      "community": 0,
+      "community": 1,
       "norm_label": "daymutators.ts"
     },
     {
@@ -18112,7 +18162,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "commands_daymutators_daycontainer",
-      "community": 0,
+      "community": 1,
       "norm_label": "daycontainer"
     },
     {
@@ -18122,7 +18172,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_daymutators_withday",
-      "community": 0,
+      "community": 1,
       "norm_label": "withday()"
     },
     {
@@ -18132,7 +18182,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "commands_daymutators_withattendee",
-      "community": 0,
+      "community": 1,
       "norm_label": "withattendee()"
     },
     {
@@ -18142,7 +18192,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "commands_daymutators_setdaynote",
-      "community": 0,
+      "community": 1,
       "norm_label": "setdaynote()"
     },
     {
@@ -18152,7 +18202,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "commands_daymutators_setdaychefs",
-      "community": 0,
+      "community": 1,
       "norm_label": "setdaychefs()"
     },
     {
@@ -18162,7 +18212,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "commands_daymutators_setdayguests",
-      "community": 0,
+      "community": 1,
       "norm_label": "setdayguests()"
     },
     {
@@ -18182,7 +18232,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "commands_daymutators_removeattendee",
-      "community": 0,
+      "community": 1,
       "norm_label": "removeattendee()"
     },
     {
@@ -18192,7 +18242,7 @@
       "source_location": "L77",
       "_origin": "ast",
       "id": "commands_daymutators_setattendeehometime",
-      "community": 0,
+      "community": 1,
       "norm_label": "setattendeehometime()"
     },
     {
@@ -18202,7 +18252,7 @@
       "source_location": "L88",
       "_origin": "ast",
       "id": "commands_daymutators_setattendeenote",
-      "community": 0,
+      "community": 1,
       "norm_label": "setattendeenote()"
     },
     {
@@ -18212,7 +18262,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_emptyday",
-      "community": 0,
+      "community": 32,
       "norm_label": "emptyday.ts"
     },
     {
@@ -18222,7 +18272,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "commands_emptyday_emptyday",
-      "community": 0,
+      "community": 32,
       "norm_label": "emptyday()"
     },
     {
@@ -18232,7 +18282,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "commands_emptyday_emptytemplate",
-      "community": 0,
+      "community": 108,
       "norm_label": "emptytemplate()"
     },
     {
@@ -18242,7 +18292,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "commands_emptyday_emptyweek",
-      "community": 0,
+      "community": 32,
       "norm_label": "emptyweek()"
     },
     {
@@ -18252,7 +18302,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_instantiateweek",
-      "community": 0,
+      "community": 32,
       "norm_label": "instantiateweek.ts"
     },
     {
@@ -18262,7 +18312,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "commands_instantiateweek_cloneday",
-      "community": 0,
+      "community": 32,
       "norm_label": "cloneday()"
     },
     {
@@ -18272,7 +18322,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "commands_instantiateweek_instantiateweek",
-      "community": 0,
+      "community": 32,
       "norm_label": "instantiateweek()"
     },
     {
@@ -18282,7 +18332,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_day",
-      "community": 0,
+      "community": 32,
       "norm_label": "day.ts"
     },
     {
@@ -18292,7 +18342,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "entities_day_attendee",
-      "community": 0,
+      "community": 32,
       "norm_label": "attendee"
     },
     {
@@ -18302,7 +18352,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "entities_day_day",
-      "community": 0,
+      "community": 32,
       "norm_label": "day"
     },
     {
@@ -18312,7 +18362,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_mealplanconfig",
-      "community": 0,
+      "community": 32,
       "norm_label": "mealplanconfig.ts"
     },
     {
@@ -18322,7 +18372,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_mealplanconfig_mealplanconfig",
-      "community": 0,
+      "community": 32,
       "norm_label": "mealplanconfig"
     },
     {
@@ -18332,7 +18382,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_mealplantemplate",
-      "community": 0,
+      "community": 32,
       "norm_label": "mealplantemplate.ts"
     },
     {
@@ -18342,7 +18392,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "entities_mealplantemplate_mealplantemplate",
-      "community": 0,
+      "community": 32,
       "norm_label": "mealplantemplate"
     },
     {
@@ -18352,7 +18402,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_mealplanweek",
-      "community": 0,
+      "community": 32,
       "norm_label": "mealplanweek.ts"
     },
     {
@@ -18362,7 +18412,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "entities_mealplanweek_mealplanweek",
-      "community": 0,
+      "community": 32,
       "norm_label": "mealplanweek"
     },
     {
@@ -18372,7 +18422,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_weekday",
-      "community": 0,
+      "community": 32,
       "norm_label": "weekday.ts"
     },
     {
@@ -18382,7 +18432,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_weekday_weekday",
-      "community": 0,
+      "community": 32,
       "norm_label": "weekday"
     },
     {
@@ -18392,7 +18442,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "entities_weekday_weekdays",
-      "community": 0,
+      "community": 32,
       "norm_label": "weekdays"
     },
     {
@@ -18402,7 +18452,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "mealplan_index",
-      "community": 0,
+      "community": 32,
       "norm_label": "index.ts"
     },
     {
@@ -18412,7 +18462,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_weekdays",
-      "community": 0,
+      "community": 32,
       "norm_label": "weekdays.ts"
     },
     {
@@ -18422,7 +18472,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "queries_weekdays_weekday_index",
-      "community": 0,
+      "community": 32,
       "norm_label": "weekday_index"
     },
     {
@@ -18432,7 +18482,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "queries_weekdays_toutcdate",
-      "community": 0,
+      "community": 32,
       "norm_label": "toutcdate()"
     },
     {
@@ -18442,7 +18492,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "queries_weekdays_formatutc",
-      "community": 0,
+      "community": 32,
       "norm_label": "formatutc()"
     },
     {
@@ -18452,7 +18502,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "queries_weekdays_mondayfirstindex",
-      "community": 0,
+      "community": 32,
       "norm_label": "mondayfirstindex()"
     },
     {
@@ -18462,7 +18512,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "queries_weekdays_weekdayof",
-      "community": 0,
+      "community": 32,
       "norm_label": "weekdayof()"
     },
     {
@@ -18472,7 +18522,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "queries_weekdays_weekstartfor",
-      "community": 0,
+      "community": 32,
       "norm_label": "weekstartfor()"
     },
     {
@@ -18482,7 +18532,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "queries_weekdays_weekdates",
-      "community": 0,
+      "community": 32,
       "norm_label": "weekdates()"
     },
     {
@@ -18492,7 +18542,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_createmember",
-      "community": 10,
+      "community": 51,
       "norm_label": "createmember.ts"
     },
     {
@@ -18502,7 +18552,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "commands_createmember_creatememberinput",
-      "community": 10,
+      "community": 51,
       "norm_label": "creatememberinput"
     },
     {
@@ -18512,7 +18562,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "commands_createmember_createmember",
-      "community": 10,
+      "community": 51,
       "norm_label": "createmember()"
     },
     {
@@ -18522,7 +18572,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_normalisememberemail",
-      "community": 10,
+      "community": 51,
       "norm_label": "normalisememberemail.ts"
     },
     {
@@ -18532,7 +18582,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "commands_normalisememberemail_normalisememberemail",
-      "community": 10,
+      "community": 51,
       "norm_label": "normalisememberemail()"
     },
     {
@@ -18542,7 +18592,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_updatemember",
-      "community": 10,
+      "community": 51,
       "norm_label": "updatemember.ts"
     },
     {
@@ -18552,7 +18602,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_updatemember_updatememberpatch",
-      "community": 10,
+      "community": 51,
       "norm_label": "updatememberpatch"
     },
     {
@@ -18562,7 +18612,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "commands_updatemember_updatemember",
-      "community": 10,
+      "community": 51,
       "norm_label": "updatemember()"
     },
     {
@@ -18572,7 +18622,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_member",
-      "community": 10,
+      "community": 51,
       "norm_label": "member.ts"
     },
     {
@@ -18582,7 +18632,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "entities_member_member",
-      "community": 10,
+      "community": 51,
       "norm_label": "member"
     },
     {
@@ -18592,7 +18642,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "members_index",
-      "community": 10,
+      "community": 51,
       "norm_label": "index.ts"
     },
     {
@@ -18602,7 +18652,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_memberfirstname",
-      "community": 10,
+      "community": 51,
       "norm_label": "memberfirstname.ts"
     },
     {
@@ -18612,7 +18662,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "queries_memberfirstname_memberfirstname",
-      "community": 10,
+      "community": 51,
       "norm_label": "memberfirstname()"
     },
     {
@@ -18622,7 +18672,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_memberinitials",
-      "community": 10,
+      "community": 51,
       "norm_label": "memberinitials.ts"
     },
     {
@@ -18632,7 +18682,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "queries_memberinitials_memberinitials",
-      "community": 10,
+      "community": 51,
       "norm_label": "memberinitials()"
     },
     {
@@ -18642,7 +18692,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_sortmembers",
-      "community": 10,
+      "community": 51,
       "norm_label": "sortmembers.ts"
     },
     {
@@ -18652,7 +18702,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "queries_sortmembers_sortmembers",
-      "community": 10,
+      "community": 51,
       "norm_label": "sortmembers()"
     },
     {
@@ -18932,7 +18982,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "queries_ingredients_flatteningredients",
-      "community": 52,
+      "community": 36,
       "norm_label": "flatteningredients()"
     },
     {
@@ -20742,7 +20792,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_additem",
-      "community": 1,
+      "community": 4,
       "norm_label": "additem.ts"
     },
     {
@@ -20752,7 +20802,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "commands_additem_additeminput",
-      "community": 1,
+      "community": 4,
       "norm_label": "additeminput"
     },
     {
@@ -20772,7 +20822,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_checkitem",
-      "community": 1,
+      "community": 4,
       "norm_label": "checkitem.ts"
     },
     {
@@ -20802,7 +20852,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_clearcheckeditems",
-      "community": 1,
+      "community": 4,
       "norm_label": "clearcheckeditems.ts"
     },
     {
@@ -20822,7 +20872,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_confirmitemneeded",
-      "community": 1,
+      "community": 4,
       "norm_label": "confirmitemneeded.ts"
     },
     {
@@ -20852,7 +20902,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_createlist",
-      "community": 4,
+      "community": 64,
       "norm_label": "createlist.ts"
     },
     {
@@ -20872,7 +20922,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createlist_createlist",
-      "community": 4,
+      "community": 8,
       "norm_label": "createlist()"
     },
     {
@@ -20882,7 +20932,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_deleteitem",
-      "community": 1,
+      "community": 4,
       "norm_label": "deleteitem.ts"
     },
     {
@@ -20932,7 +20982,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_deletelist_deletelist",
-      "community": 4,
+      "community": 8,
       "norm_label": "deletelist()"
     },
     {
@@ -20942,7 +20992,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_edititemamountunit",
-      "community": 1,
+      "community": 4,
       "norm_label": "edititemamountunit.ts"
     },
     {
@@ -20972,7 +21022,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_edititemnotes",
-      "community": 1,
+      "community": 4,
       "norm_label": "edititemnotes.ts"
     },
     {
@@ -21002,7 +21052,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_edititemrawtext",
-      "community": 1,
+      "community": 64,
       "norm_label": "edititemrawtext.ts"
     },
     {
@@ -21032,7 +21082,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_moveitems",
-      "community": 1,
+      "community": 4,
       "norm_label": "moveitems.ts"
     },
     {
@@ -21052,7 +21102,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_moveitems_moveitemsresult",
-      "community": 1,
+      "community": 4,
       "norm_label": "moveitemsresult"
     },
     {
@@ -21062,7 +21112,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "commands_moveitems_moveitems",
-      "community": 8,
+      "community": 93,
       "norm_label": "moveitems()"
     },
     {
@@ -21072,7 +21122,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_renamelist",
-      "community": 4,
+      "community": 64,
       "norm_label": "renamelist.ts"
     },
     {
@@ -21092,7 +21142,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_renamelist_renamelist",
-      "community": 4,
+      "community": 8,
       "norm_label": "renamelist()"
     },
     {
@@ -21122,7 +21172,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_setdefaultlist_setdefaultlist",
-      "community": 4,
+      "community": 8,
       "norm_label": "setdefaultlist()"
     },
     {
@@ -21132,7 +21182,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_uncheckitem",
-      "community": 1,
+      "community": 4,
       "norm_label": "uncheckitem.ts"
     },
     {
@@ -21182,7 +21232,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglistitem",
-      "community": 1,
+      "community": 4,
       "norm_label": "shoppinglistitem.ts"
     },
     {
@@ -21192,7 +21242,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "entities_shoppinglistitem_matchstate",
-      "community": 1,
+      "community": 4,
       "norm_label": "matchstate"
     },
     {
@@ -21202,7 +21252,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_shoppinglistitem_shoppinglistitem",
-      "community": 1,
+      "community": 4,
       "norm_label": "shoppinglistitem"
     },
     {
@@ -21232,7 +21282,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_sourceref",
-      "community": 1,
+      "community": 4,
       "norm_label": "sourceref.ts"
     },
     {
@@ -21242,7 +21292,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_sourceref_sourceref",
-      "community": 1,
+      "community": 4,
       "norm_label": "sourceref"
     },
     {
@@ -21262,7 +21312,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_entryparseport",
-      "community": 4,
+      "community": 83,
       "norm_label": "entryparseport.ts"
     },
     {
@@ -21272,7 +21322,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "ports_entryparseport_entryparseport",
-      "community": 4,
+      "community": 96,
       "norm_label": "entryparseport"
     },
     {
@@ -21302,7 +21352,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_shoppinglistitemport",
-      "community": 1,
+      "community": 4,
       "norm_label": "shoppinglistitemport.ts"
     },
     {
@@ -21582,7 +21632,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "queries_parseentry_parsedentry",
-      "community": 4,
+      "community": 83,
       "norm_label": "parsedentry"
     },
     {
@@ -21682,7 +21732,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_recipeitemadddefault",
-      "community": 24,
+      "community": 4,
       "norm_label": "recipeitemadddefault.ts"
     },
     {
@@ -21692,7 +21742,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "queries_recipeitemadddefault_recipeitemadddefault",
-      "community": 24,
+      "community": 4,
       "norm_label": "recipeitemadddefault"
     },
     {
@@ -21702,7 +21752,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_resolveitemdisplayname",
-      "community": 83,
+      "community": 4,
       "norm_label": "resolveitemdisplayname.ts"
     },
     {
@@ -21712,7 +21762,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "queries_resolveitemdisplayname_resolveitemdisplayname",
-      "community": 83,
+      "community": 4,
       "norm_label": "resolveitemdisplayname()"
     },
     {
@@ -21722,7 +21772,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_appsettings_schema_test",
-      "community": 141,
+      "community": 77,
       "norm_label": "appsettings.schema.test.ts"
     },
     {
@@ -21732,7 +21782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_matchlogbuilder_test",
-      "community": 32,
+      "community": 7,
       "norm_label": "matchlogbuilder.test.ts"
     },
     {
@@ -21742,7 +21792,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_matchlogbuilder_test_makestage",
-      "community": 32,
+      "community": 7,
       "norm_label": "makestage()"
     },
     {
@@ -21782,7 +21832,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canonicon_test",
-      "community": 64,
+      "community": 7,
       "norm_label": "canonicon.test.ts"
     },
     {
@@ -21792,7 +21842,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canonitem_schema_test",
-      "community": 265,
+      "community": 17,
       "norm_label": "canonitem.schema.test.ts"
     },
     {
@@ -21802,7 +21852,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_canonitem_schema_test_counterids",
-      "community": 265,
+      "community": 17,
       "norm_label": "counterids()"
     },
     {
@@ -21962,7 +22012,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_createcanonitem_test",
-      "community": 265,
+      "community": 17,
       "norm_label": "createcanonitem.test.ts"
     },
     {
@@ -21972,7 +22022,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_createcanonitem_test_counterids",
-      "community": 265,
+      "community": 17,
       "norm_label": "counterids()"
     },
     {
@@ -21982,7 +22032,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_createcanonlookup_test",
-      "community": 1,
+      "community": 64,
       "norm_label": "createcanonlookup.test.ts"
     },
     {
@@ -22002,7 +22052,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "canon_createcanonlookup_test_fakestore",
-      "community": 1,
+      "community": 64,
       "norm_label": "fakestore()"
     },
     {
@@ -22132,7 +22182,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_findclosestmatch_test",
-      "community": 17,
+      "community": 11,
       "norm_label": "findclosestmatch.test.ts"
     },
     {
@@ -22142,7 +22192,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_findclosestmatch_test_item",
-      "community": 17,
+      "community": 11,
       "norm_label": "item()"
     },
     {
@@ -22152,7 +22202,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "canon_findclosestmatch_test_catalog",
-      "community": 17,
+      "community": 11,
       "norm_label": "catalog"
     },
     {
@@ -22162,7 +22212,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_getaisleusage_test",
-      "community": 64,
+      "community": 11,
       "norm_label": "getaisleusage.test.ts"
     },
     {
@@ -22172,7 +22222,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_getaisleusage_test_makeaislestore",
-      "community": 64,
+      "community": 11,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22182,7 +22232,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "canon_getaisleusage_test_makecanonstore",
-      "community": 64,
+      "community": 11,
       "norm_label": "makecanonstore()"
     },
     {
@@ -22192,7 +22242,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "canon_getaisleusage_test_canonitem",
-      "community": 64,
+      "community": 11,
       "norm_label": "canonitem()"
     },
     {
@@ -22532,7 +22582,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_mergeaisles_test",
-      "community": 64,
+      "community": 11,
       "norm_label": "mergeaisles.test.ts"
     },
     {
@@ -22542,7 +22592,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_makeaislestore",
-      "community": 64,
+      "community": 11,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22552,7 +22602,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_makecanonstore",
-      "community": 64,
+      "community": 11,
       "norm_label": "makecanonstore()"
     },
     {
@@ -22562,7 +22612,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_canonitem",
-      "community": 64,
+      "community": 11,
       "norm_label": "canonitem()"
     },
     {
@@ -22572,7 +22622,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_aisles",
-      "community": 64,
+      "community": 11,
       "norm_label": "aisles"
     },
     {
@@ -22582,7 +22632,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_mergecanonitems_test",
-      "community": 116,
+      "community": 11,
       "norm_label": "mergecanonitems.test.ts"
     },
     {
@@ -22592,7 +22642,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_mergecanonitems_test_item",
-      "community": 116,
+      "community": 11,
       "norm_label": "item()"
     },
     {
@@ -22702,7 +22752,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test",
-      "community": 116,
+      "community": 11,
       "norm_label": "resolvecanonconflict.test.ts"
     },
     {
@@ -22712,7 +22762,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test_item",
-      "community": 116,
+      "community": 11,
       "norm_label": "item()"
     },
     {
@@ -22722,7 +22772,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test_local",
-      "community": 116,
+      "community": 11,
       "norm_label": "local"
     },
     {
@@ -22732,7 +22782,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test_remote",
-      "community": 116,
+      "community": 11,
       "norm_label": "remote"
     },
     {
@@ -22832,7 +22882,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test",
-      "community": 49,
+      "community": 7,
       "norm_label": "summarizematchlog.test.ts"
     },
     {
@@ -22842,7 +22892,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makestage",
-      "community": 49,
+      "community": 7,
       "norm_label": "makestage()"
     },
     {
@@ -22852,7 +22902,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makeentry",
-      "community": 49,
+      "community": 7,
       "norm_label": "makeentry()"
     },
     {
@@ -22862,7 +22912,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makearbitration",
-      "community": 49,
+      "community": 7,
       "norm_label": "makearbitration()"
     },
     {
@@ -22902,7 +22952,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_devsettings_schema_test",
-      "community": 141,
+      "community": 77,
       "norm_label": "devsettings.schema.test.ts"
     },
     {
@@ -22972,7 +23022,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "mealplan_mealplan_test",
-      "community": 0,
+      "community": 32,
       "norm_label": "mealplan.test.ts"
     },
     {
@@ -22982,7 +23032,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "mealplan_mealplan_test_config",
-      "community": 0,
+      "community": 32,
       "norm_label": "config()"
     },
     {
@@ -22992,7 +23042,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "mealplan_mealplan_test_templatewithlabels",
-      "community": 0,
+      "community": 32,
       "norm_label": "templatewithlabels()"
     },
     {
@@ -23002,7 +23052,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "members_members_test",
-      "community": 10,
+      "community": 51,
       "norm_label": "members.test.ts"
     },
     {
@@ -23012,7 +23062,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "members_members_test_makemember",
-      "community": 10,
+      "community": 51,
       "norm_label": "makemember()"
     },
     {
@@ -23022,7 +23072,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "recipe_clearingredientmatch_test",
-      "community": 36,
+      "community": 52,
       "norm_label": "clearingredientmatch.test.ts"
     },
     {
@@ -23032,7 +23082,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "recipe_clearingredientmatch_test_matchedingredient",
-      "community": 36,
+      "community": 52,
       "norm_label": "matchedingredient()"
     },
     {
@@ -23202,7 +23252,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_recipeitemadddefault_test",
-      "community": 24,
+      "community": 4,
       "norm_label": "recipeitemadddefault.test.ts"
     },
     {
@@ -23212,7 +23262,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_resolveitemdisplayname_test",
-      "community": 83,
+      "community": 4,
       "norm_label": "resolveitemdisplayname.test.ts"
     },
     {
@@ -23222,7 +23272,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "shoppinglist_resolveitemdisplayname_test_makeitem",
-      "community": 83,
+      "community": 4,
       "norm_label": "makeitem()"
     },
     {
@@ -23422,7 +23472,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_types_src_index_ts_src_index",
-      "community": 1,
+      "community": 64,
       "norm_label": "index.ts"
     },
     {
@@ -23432,7 +23482,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "src_index_success",
-      "community": 1,
+      "community": 64,
       "norm_label": "success"
     },
     {
@@ -23442,7 +23492,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "src_index_failure",
-      "community": 1,
+      "community": 64,
       "norm_label": "failure"
     },
     {
@@ -23452,7 +23502,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "src_index_conflict",
-      "community": 1,
+      "community": 64,
       "norm_label": "conflict"
     },
     {
@@ -23462,7 +23512,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "src_index_readresult",
-      "community": 1,
+      "community": 64,
       "norm_label": "readresult"
     },
     {
@@ -23472,7 +23522,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "src_index_writeresult",
-      "community": 1,
+      "community": 64,
       "norm_label": "writeresult"
     },
     {
@@ -23492,7 +23542,7 @@
       "source_location": "L54",
       "_origin": "ast",
       "id": "src_index_domainerror",
-      "community": 1,
+      "community": 64,
       "norm_label": "domainerror"
     },
     {
@@ -23522,7 +23572,7 @@
       "source_location": "L92",
       "_origin": "ast",
       "id": "src_index_canonitemdto",
-      "community": 1,
+      "community": 64,
       "norm_label": "canonitemdto"
     },
     {
@@ -23532,7 +23582,7 @@
       "source_location": "L107",
       "_origin": "ast",
       "id": "src_index_aisledto",
-      "community": 1,
+      "community": 64,
       "norm_label": "aisledto"
     },
     {
@@ -23542,7 +23592,7 @@
       "source_location": "L113",
       "_origin": "ast",
       "id": "src_index_aislelistdto",
-      "community": 1,
+      "community": 64,
       "norm_label": "aislelistdto"
     },
     {
@@ -23552,7 +23602,7 @@
       "source_location": "L118",
       "_origin": "ast",
       "id": "src_index_errorcode",
-      "community": 1,
+      "community": 64,
       "norm_label": "errorcode"
     },
     {
@@ -25322,7 +25372,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_ui_components_src_index_ts_src_index",
-      "community": 14,
+      "community": 21,
       "norm_label": "index.ts"
     },
     {
@@ -25342,7 +25392,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_lib_cn",
-      "community": 41,
+      "community": 14,
       "norm_label": "../../lib/cn"
     },
     {
@@ -25575,7 +25625,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_cn",
-      "community": 298,
+      "community": 21,
       "norm_label": "cn.ts"
     },
     {
@@ -25585,7 +25635,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "lib_cn_twmerge",
-      "community": 298,
+      "community": 21,
       "norm_label": "twmerge"
     },
     {
@@ -25595,7 +25645,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "lib_cn_cn",
-      "community": 298,
+      "community": 21,
       "norm_label": "cn()"
     },
     {
@@ -25645,7 +25695,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_variants",
-      "community": 27,
+      "community": 23,
       "norm_label": "variants.ts"
     },
     {
@@ -25767,7 +25817,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canonicon_canonicon",
-      "community": 41,
+      "community": 14,
       "norm_label": "canonicon.svelte"
     },
     {
@@ -25777,7 +25827,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_canonicon_canonicon_types",
-      "community": 41,
+      "community": 14,
       "norm_label": "./canonicon.types"
     },
     {
@@ -25787,7 +25837,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canonicon_canonicon_types",
-      "community": 14,
+      "community": 21,
       "norm_label": "canonicon.types.ts"
     },
     {
@@ -25797,7 +25847,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "canonicon_canonicon_types_canoniconprops",
-      "community": 14,
+      "community": 21,
       "norm_label": "canoniconprops"
     },
     {
@@ -25988,7 +26038,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "bits_ui",
-      "community": 23,
+      "community": 38,
       "norm_label": "bits-ui"
     },
     {
@@ -26028,7 +26078,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "checkbox_checkbox_types",
-      "community": 27,
+      "community": 26,
       "norm_label": "checkbox.types.ts"
     },
     {
@@ -26038,7 +26088,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "checkbox_checkbox_types_checkedstate",
-      "community": 27,
+      "community": 26,
       "norm_label": "checkedstate"
     },
     {
@@ -26048,7 +26098,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "checkbox_checkbox_types_checkboxprops",
-      "community": 27,
+      "community": 26,
       "norm_label": "checkboxprops"
     },
     {
@@ -26058,7 +26108,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "checkbox_checkbox_variants",
-      "community": 27,
+      "community": 26,
       "norm_label": "checkbox.variants.ts"
     },
     {
@@ -26068,7 +26118,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "checkbox_checkbox_variants_checkboxrootvariants",
-      "community": 27,
+      "community": 26,
       "norm_label": "checkboxrootvariants"
     },
     {
@@ -26078,7 +26128,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "checkbox_index",
-      "community": 27,
+      "community": 26,
       "norm_label": "index.ts"
     },
     {
@@ -26189,7 +26239,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "combobox_combobox_types",
-      "community": 14,
+      "community": 21,
       "norm_label": "combobox.types.ts"
     },
     {
@@ -26199,7 +26249,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxitem",
-      "community": 14,
+      "community": 21,
       "norm_label": "comboboxitem"
     },
     {
@@ -26209,7 +26259,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxprops",
-      "community": 14,
+      "community": 21,
       "norm_label": "comboboxprops"
     },
     {
@@ -26219,7 +26269,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxinputprops",
-      "community": 14,
+      "community": 21,
       "norm_label": "comboboxinputprops"
     },
     {
@@ -26229,7 +26279,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxfieldprops",
-      "community": 14,
+      "community": 21,
       "norm_label": "comboboxfieldprops"
     },
     {
@@ -26239,7 +26289,7 @@
       "source_location": "L56",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxtriggerprops",
-      "community": 14,
+      "community": 21,
       "norm_label": "comboboxtriggerprops"
     },
     {
@@ -26249,7 +26299,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxcontentprops",
-      "community": 14,
+      "community": 21,
       "norm_label": "comboboxcontentprops"
     },
     {
@@ -26259,7 +26309,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxitemprops",
-      "community": 14,
+      "community": 21,
       "norm_label": "comboboxitemprops"
     },
     {
@@ -26269,7 +26319,7 @@
       "source_location": "L73",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxgroupprops",
-      "community": 14,
+      "community": 21,
       "norm_label": "comboboxgroupprops"
     },
     {
@@ -26279,7 +26329,7 @@
       "source_location": "L78",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxlabelprops",
-      "community": 14,
+      "community": 21,
       "norm_label": "comboboxlabelprops"
     },
     {
@@ -26289,7 +26339,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxseparatorprops",
-      "community": 14,
+      "community": 21,
       "norm_label": "comboboxseparatorprops"
     },
     {
@@ -26299,7 +26349,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxemptyprops",
-      "community": 14,
+      "community": 21,
       "norm_label": "comboboxemptyprops"
     },
     {
@@ -26309,7 +26359,7 @@
       "source_location": "L92",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxcreateprops",
-      "community": 14,
+      "community": 21,
       "norm_label": "comboboxcreateprops"
     },
     {
@@ -26319,7 +26369,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "combobox_combobox_variants",
-      "community": 27,
+      "community": 23,
       "norm_label": "combobox.variants.ts"
     },
     {
@@ -26329,7 +26379,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxinputvariants",
-      "community": 27,
+      "community": 23,
       "norm_label": "comboboxinputvariants"
     },
     {
@@ -26339,7 +26389,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxtriggervariants",
-      "community": 27,
+      "community": 23,
       "norm_label": "comboboxtriggervariants"
     },
     {
@@ -26349,7 +26399,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxcontentvariants",
-      "community": 27,
+      "community": 23,
       "norm_label": "comboboxcontentvariants"
     },
     {
@@ -26359,7 +26409,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxitemvariants",
-      "community": 27,
+      "community": 23,
       "norm_label": "comboboxitemvariants"
     },
     {
@@ -26369,7 +26419,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxcreatevariants",
-      "community": 27,
+      "community": 23,
       "norm_label": "comboboxcreatevariants"
     },
     {
@@ -26679,7 +26729,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "combobox_index",
-      "community": 14,
+      "community": 21,
       "norm_label": "index.ts"
     },
     {
@@ -26759,7 +26809,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_dialog_variants",
-      "community": 27,
+      "community": 23,
       "norm_label": "dialog.variants.ts"
     },
     {
@@ -26769,7 +26819,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "dialog_dialog_variants_dialogcontentvariants",
-      "community": 27,
+      "community": 23,
       "norm_label": "dialogcontentvariants"
     },
     {
@@ -27382,7 +27432,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "markdown_markdown",
-      "community": 13,
+      "community": 14,
       "norm_label": "markdown.svelte"
     },
     {
@@ -27402,7 +27452,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "gfm",
-      "community": 13,
+      "community": 14,
       "norm_label": "svelte-exmarkdown/gfm"
     },
     {
@@ -28599,7 +28649,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "sortablelist_sortablelist_types",
-      "community": 14,
+      "community": 21,
       "norm_label": "sortablelist.types.ts"
     },
     {
@@ -28609,7 +28659,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "sortablelist_sortablelist_types_sortablelistprops",
-      "community": 14,
+      "community": 21,
       "norm_label": "sortablelistprops"
     },
     {
@@ -29306,7 +29356,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltip",
-      "community": 23,
+      "community": 107,
       "norm_label": "tooltip.svelte"
     },
     {
@@ -29316,7 +29366,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "tooltip_tooltip_state",
-      "community": 23,
+      "community": 107,
       "norm_label": "state"
     },
     {
@@ -29326,7 +29376,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "tooltip_tooltip_handleopenchange",
-      "community": 23,
+      "community": 107,
       "norm_label": "handleopenchange()"
     },
     {
@@ -29336,7 +29386,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_headless_tooltip_headless_svelte",
-      "community": 23,
+      "community": 107,
       "norm_label": "../../headless/tooltip.headless.svelte"
     },
     {
@@ -29346,7 +29396,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_tooltip_tooltip_types",
-      "community": 23,
+      "community": 107,
       "norm_label": "./tooltip.types"
     },
     {
@@ -29356,7 +29406,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltip_types",
-      "community": 23,
+      "community": 107,
       "norm_label": "tooltip.types.ts"
     },
     {
@@ -29366,7 +29416,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "tooltip_tooltip_types_tooltipproviderprops",
-      "community": 23,
+      "community": 107,
       "norm_label": "tooltipproviderprops"
     },
     {
@@ -29376,7 +29426,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "tooltip_tooltip_types_tooltipprops",
-      "community": 23,
+      "community": 107,
       "norm_label": "tooltipprops"
     },
     {
@@ -29386,7 +29436,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "tooltip_tooltip_types_tooltipcontentprops",
-      "community": 23,
+      "community": 107,
       "norm_label": "tooltipcontentprops"
     },
     {
@@ -29396,7 +29446,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "tooltip_tooltip_types_tooltippartprops",
-      "community": 23,
+      "community": 107,
       "norm_label": "tooltippartprops"
     },
     {
@@ -29416,7 +29466,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltipcontent",
-      "community": 23,
+      "community": 107,
       "norm_label": "tooltipcontent.svelte"
     },
     {
@@ -29426,7 +29476,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_tooltip_tooltip_variants",
-      "community": 23,
+      "community": 107,
       "norm_label": "./tooltip.variants"
     },
     {
@@ -29436,7 +29486,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltipprovider",
-      "community": 23,
+      "community": 107,
       "norm_label": "tooltipprovider.svelte"
     },
     {
@@ -29446,7 +29496,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltiptrigger",
-      "community": 23,
+      "community": 107,
       "norm_label": "tooltiptrigger.svelte"
     },
     {
@@ -29456,7 +29506,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_index",
-      "community": 23,
+      "community": 107,
       "norm_label": "index.ts"
     },
     {
@@ -29667,7 +29717,7 @@
       "_origin": "ast",
       "confidence": "EXTRACTED",
       "id": "listpage_listpage_context",
-      "community": 38,
+      "community": 21,
       "norm_label": "./listpage.context.js"
     },
     {
@@ -29677,7 +29727,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "listpage_listpage_context_listpagecontext",
-      "community": 38,
+      "community": 21,
       "norm_label": "listpagecontext"
     },
     {
@@ -29687,7 +29737,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "listpage_listpage_context_list_page_context",
-      "community": 38,
+      "community": 21,
       "norm_label": "list_page_context"
     },
     {
@@ -29747,7 +29797,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "listpage_listpage_types",
-      "community": 38,
+      "community": 21,
       "norm_label": "listpage.types.ts"
     },
     {
@@ -29757,7 +29807,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "listpage_listpage_types_bulkactionicon",
-      "community": 38,
+      "community": 21,
       "norm_label": "bulkactionicon"
     },
     {
@@ -29767,7 +29817,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "listpage_listpage_types_bulkaction",
-      "community": 38,
+      "community": 21,
       "norm_label": "bulkaction"
     },
     {
@@ -29777,7 +29827,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "listpage_listpage_types_listpageprops",
-      "community": 38,
+      "community": 21,
       "norm_label": "listpageprops"
     },
     {
@@ -29787,7 +29837,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "listpage_index",
-      "community": 38,
+      "community": 21,
       "norm_label": "index.ts"
     },
     {
@@ -30029,7 +30079,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_canonicon_test",
-      "community": 41,
+      "community": 14,
       "norm_label": "canonicon.test.ts"
     },
     {
@@ -30069,7 +30119,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_combobox_test",
-      "community": 286,
+      "community": 14,
       "norm_label": "combobox.test.ts"
     },
     {
@@ -30079,7 +30129,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "tests_combobox_test_setup",
-      "community": 286,
+      "community": 14,
       "norm_label": "setup()"
     },
     {
@@ -30089,7 +30139,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "tests_combobox_test_getinput",
-      "community": 286,
+      "community": 14,
       "norm_label": "getinput()"
     },
     {
@@ -30099,7 +30149,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "tests_combobox_test_getlistbox",
-      "community": 286,
+      "community": 14,
       "norm_label": "getlistbox()"
     },
     {
@@ -30109,7 +30159,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "tests_combobox_test_opencombobox",
-      "community": 286,
+      "community": 14,
       "norm_label": "opencombobox()"
     },
     {
@@ -30429,7 +30479,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_tooltip_test",
-      "community": 23,
+      "community": 107,
       "norm_label": "tooltip.test.ts"
     },
     {
@@ -30489,7 +30539,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_lib_cn_test",
-      "community": 298,
+      "community": 21,
       "norm_label": "lib.cn.test.ts"
     },
     {
@@ -34645,7 +34695,7 @@
       "source_location": "L1505",
       "_origin": "ast",
       "id": "design_ui_spec_v02_8_14_spinner",
-      "community": 323,
+      "community": 283,
       "norm_label": "8.14 spinner"
     },
     {
@@ -34655,7 +34705,7 @@
       "source_location": "L1507",
       "_origin": "ast",
       "id": "design_ui_spec_v02_props_1507",
-      "community": 323,
+      "community": 283,
       "norm_label": "props"
     },
     {
@@ -34665,7 +34715,7 @@
       "source_location": "L1515",
       "_origin": "ast",
       "id": "design_ui_spec_v02_accessibility_1515",
-      "community": 323,
+      "community": 283,
       "norm_label": "accessibility"
     },
     {
@@ -34675,7 +34725,7 @@
       "source_location": "L1520",
       "_origin": "ast",
       "id": "design_ui_spec_v02_styling_1520",
-      "community": 323,
+      "community": 283,
       "norm_label": "styling"
     },
     {
@@ -35855,7 +35905,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_e2e_test_spec",
-      "community": 291,
+      "community": 284,
       "norm_label": "e2e-test-spec.md"
     },
     {
@@ -35995,7 +36045,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_e2e",
-      "community": 291,
+      "community": 284,
       "norm_label": "e2e.md"
     },
     {
@@ -36097,6 +36147,56 @@
       "id": "docs_e2e_authoring_conventions",
       "community": 284,
       "norm_label": "authoring conventions"
+    },
+    {
+      "label": "error-reporting-calibration.md",
+      "file_type": "document",
+      "source_file": "docs/error-reporting-calibration.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "docs_error_reporting_calibration",
+      "community": 291,
+      "norm_label": "error-reporting-calibration.md"
+    },
+    {
+      "label": "Caught-error reporting \u2014 calibration note",
+      "file_type": "document",
+      "source_file": "docs/error-reporting-calibration.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "docs_error_reporting_calibration_caught_error_reporting_calibration_note",
+      "community": 291,
+      "norm_label": "caught-error reporting \u2014 calibration note"
+    },
+    {
+      "label": "Before/after check in PostHog Error Tracking",
+      "file_type": "document",
+      "source_file": "docs/error-reporting-calibration.md",
+      "source_location": "L13",
+      "_origin": "ast",
+      "id": "docs_error_reporting_calibration_before_after_check_in_posthog_error_tracking",
+      "community": 291,
+      "norm_label": "before/after check in posthog error tracking"
+    },
+    {
+      "label": "Known, intentional asymmetries (NOT bugs)",
+      "file_type": "document",
+      "source_file": "docs/error-reporting-calibration.md",
+      "source_location": "L48",
+      "_origin": "ast",
+      "id": "docs_error_reporting_calibration_known_intentional_asymmetries_not_bugs",
+      "community": 291,
+      "norm_label": "known, intentional asymmetries (not bugs)"
+    },
+    {
+      "label": "No raw user content in payloads",
+      "file_type": "document",
+      "source_file": "docs/error-reporting-calibration.md",
+      "source_location": "L66",
+      "_origin": "ast",
+      "id": "docs_error_reporting_calibration_no_raw_user_content_in_payloads",
+      "community": 291,
+      "norm_label": "no raw user content in payloads"
     },
     {
       "label": "matching-pipeline.md",
@@ -37002,7 +37102,7 @@
       "label": "8. Cloud Functions requirements",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L277",
+      "source_location": "L279",
       "_origin": "ast",
       "id": "docs_salt_architecture_8_cloud_functions_requirements",
       "community": 280,
@@ -37012,7 +37112,7 @@
       "label": "9. PWA (UI) requirements",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L308",
+      "source_location": "L310",
       "_origin": "ast",
       "id": "docs_salt_architecture_9_pwa_ui_requirements",
       "community": 280,
@@ -37022,7 +37122,7 @@
       "label": "10. Shared types requirements",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L328",
+      "source_location": "L330",
       "_origin": "ast",
       "id": "docs_salt_architecture_10_shared_types_requirements",
       "community": 280,
@@ -37032,7 +37132,7 @@
       "label": "11. Enforcement rules",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L343",
+      "source_location": "L345",
       "_origin": "ast",
       "id": "docs_salt_architecture_11_enforcement_rules",
       "community": 326,
@@ -37042,7 +37142,7 @@
       "label": "ESLint",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L345",
+      "source_location": "L347",
       "_origin": "ast",
       "id": "docs_salt_architecture_eslint",
       "community": 326,
@@ -37052,7 +37152,7 @@
       "label": "tsconfig",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L358",
+      "source_location": "L360",
       "_origin": "ast",
       "id": "docs_salt_architecture_tsconfig",
       "community": 326,
@@ -37062,7 +37162,7 @@
       "label": "Commit gateway",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L364",
+      "source_location": "L366",
       "_origin": "ast",
       "id": "docs_salt_architecture_commit_gateway",
       "community": 326,
@@ -37072,7 +37172,7 @@
       "label": "12. Testing strategy",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L381",
+      "source_location": "L383",
       "_origin": "ast",
       "id": "docs_salt_architecture_12_testing_strategy",
       "community": 316,
@@ -37082,7 +37182,7 @@
       "label": "Domain",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L383",
+      "source_location": "L385",
       "_origin": "ast",
       "id": "docs_salt_architecture_domain",
       "community": 316,
@@ -37092,7 +37192,7 @@
       "label": "firebase-sync",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L388",
+      "source_location": "L390",
       "_origin": "ast",
       "id": "docs_salt_architecture_firebase_sync",
       "community": 316,
@@ -37102,7 +37202,7 @@
       "label": "observability",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L393",
+      "source_location": "L395",
       "_origin": "ast",
       "id": "docs_salt_architecture_observability",
       "community": 316,
@@ -37112,7 +37212,7 @@
       "label": "Cloud Functions",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L398",
+      "source_location": "L400",
       "_origin": "ast",
       "id": "docs_salt_architecture_cloud_functions",
       "community": 316,
@@ -37122,7 +37222,7 @@
       "label": "UI",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L403",
+      "source_location": "L405",
       "_origin": "ast",
       "id": "docs_salt_architecture_ui",
       "community": 316,
@@ -37132,7 +37232,7 @@
       "label": "13. Deployment units",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L411",
+      "source_location": "L413",
       "_origin": "ast",
       "id": "docs_salt_architecture_13_deployment_units",
       "community": 280,
@@ -37142,7 +37242,7 @@
       "label": "14. Non-negotiables",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L423",
+      "source_location": "L425",
       "_origin": "ast",
       "id": "docs_salt_architecture_14_non_negotiables",
       "community": 280,
@@ -37255,7 +37355,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "lib_mealplanservice_mealplantemplate",
-      "community": 0,
+      "community": 116,
       "norm_label": "mealplantemplate"
     },
     {
@@ -37265,7 +37365,7 @@
       "source_location": "L70",
       "_origin": "ast",
       "id": "lib_mealplanservice_selectedstartdate",
-      "community": 0,
+      "community": 116,
       "norm_label": "selectedstartdate"
     },
     {
@@ -43223,9 +43323,9 @@
       "source_file": "apps/cloud-functions/src/callables/regenerateCanonIcon.ts",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "callables_regeneratecanonicon",
-      "target": "callables_regeneratecanonicon_posthogapikey",
-      "confidence_score": 1.0
+      "target": "callables_regeneratecanonicon_posthogapikey"
     },
     {
       "relation": "contains",
@@ -43244,9 +43344,9 @@
       "source_file": "apps/cloud-functions/src/callables/regenerateCanonIcon.ts",
       "source_location": "L5",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "callables_regeneratecanonicon",
-      "target": "observability_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror"
     },
     {
       "relation": "imports",
@@ -43255,9 +43355,9 @@
       "source_file": "apps/cloud-functions/src/callables/regenerateCanonIcon.ts",
       "source_location": "L5",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "callables_regeneratecanonicon",
-      "target": "observability_reportservererror_reportflowerror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportflowerror"
     },
     {
       "relation": "imports_from",
@@ -43791,9 +43891,9 @@
       "source_file": "apps/cloud-functions/src/flows/chefChat.ts",
       "source_location": "L15",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_chefchat",
-      "target": "observability_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror"
     },
     {
       "relation": "imports",
@@ -43802,9 +43902,9 @@
       "source_file": "apps/cloud-functions/src/flows/chefChat.ts",
       "source_location": "L15",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_chefchat",
-      "target": "observability_reportservererror_reportflowerror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportflowerror"
     },
     {
       "relation": "imports_from",
@@ -44323,9 +44423,9 @@
       "source_file": "apps/cloud-functions/src/flows/generateChatTitle.ts",
       "source_location": "L6",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_generatechattitle",
-      "target": "observability_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror"
     },
     {
       "relation": "imports",
@@ -44334,9 +44434,9 @@
       "source_file": "apps/cloud-functions/src/flows/generateChatTitle.ts",
       "source_location": "L6",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_generatechattitle",
-      "target": "observability_reportservererror_reportflowerror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportflowerror"
     },
     {
       "relation": "imports_from",
@@ -44409,9 +44509,9 @@
       "source_file": "apps/cloud-functions/src/flows/identifyEquipment.ts",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_identifyequipment",
-      "target": "observability_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror"
     },
     {
       "relation": "imports",
@@ -44420,9 +44520,9 @@
       "source_file": "apps/cloud-functions/src/flows/identifyEquipment.ts",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_identifyequipment",
-      "target": "observability_reportservererror_reportflowerror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportflowerror"
     },
     {
       "relation": "imports_from",
@@ -44848,9 +44948,9 @@
       "source_file": "apps/cloud-functions/src/flows/populateEquipmentEntry.ts",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_populateequipmententry",
-      "target": "observability_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror"
     },
     {
       "relation": "imports",
@@ -44859,9 +44959,9 @@
       "source_file": "apps/cloud-functions/src/flows/populateEquipmentEntry.ts",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_populateequipmententry",
-      "target": "observability_reportservererror_reportflowerror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportflowerror"
     },
     {
       "relation": "imports_from",
@@ -45052,9 +45152,9 @@
       "source_file": "apps/cloud-functions/src/index.ts",
       "source_location": "L18",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "apps_cloud_functions_src_index_ts_src_index",
-      "target": "observability_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror"
     },
     {
       "relation": "imports",
@@ -45063,9 +45163,9 @@
       "source_file": "apps/cloud-functions/src/index.ts",
       "source_location": "L18",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "apps_cloud_functions_src_index_ts_src_index",
-      "target": "observability_reportservererror_reportflowerror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportflowerror"
     },
     {
       "relation": "imports_from",
@@ -45244,9 +45344,9 @@
       "source_file": "apps/cloud-functions/src/index.ts",
       "source_location": "L345",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "apps_cloud_functions_src_index_ts_src_index",
-      "target": "src_index_reportunexpected",
-      "confidence_score": 1.0
+      "target": "src_index_reportunexpected"
     },
     {
       "relation": "contains",
@@ -45309,9 +45409,9 @@
       "source_file": "apps/cloud-functions/src/index.ts",
       "source_location": "L349",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "src_index_reportunexpected",
-      "target": "observability_reportservererror_reportflowerror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportflowerror"
     },
     {
       "relation": "contains",
@@ -45319,9 +45419,9 @@
       "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
       "source_location": "L17",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "observability_reportservererror",
-      "target": "observability_reportservererror_reporter",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reporter"
     },
     {
       "relation": "contains",
@@ -45329,9 +45429,9 @@
       "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
       "source_location": "L40",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "observability_reportservererror",
-      "target": "observability_reportservererror_reportflowerror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportflowerror"
     },
     {
       "relation": "contains",
@@ -45339,9 +45439,9 @@
       "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
       "source_location": "L25",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "observability_reportservererror",
-      "target": "observability_reportservererror_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportservererror"
     },
     {
       "relation": "imports",
@@ -45350,9 +45450,9 @@
       "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "observability_reportservererror",
-      "target": "src_index_domainerror",
-      "confidence_score": 1.0
+      "target": "src_index_domainerror"
     },
     {
       "relation": "imports_from",
@@ -45361,9 +45461,9 @@
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "triggers_oncanonitemwritten",
-      "target": "observability_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror"
     },
     {
       "relation": "imports_from",
@@ -45372,9 +45472,9 @@
       "source_file": "apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts",
       "source_location": "L13",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "triggers_onshoppinglistitemwrite",
-      "target": "observability_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror"
     },
     {
       "relation": "calls",
@@ -45383,9 +45483,9 @@
       "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "observability_reportservererror_reportflowerror",
-      "target": "observability_reportservererror_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportservererror"
     },
     {
       "relation": "imports",
@@ -45394,9 +45494,9 @@
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "triggers_oncanonitemwritten",
-      "target": "observability_reportservererror_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportservererror"
     },
     {
       "relation": "calls",
@@ -45405,9 +45505,9 @@
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
       "source_location": "L166",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "triggers_oncanonitemwritten_iscanonicongenerationenabled",
-      "target": "observability_reportservererror_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportservererror"
     },
     {
       "relation": "calls",
@@ -45416,9 +45516,9 @@
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
       "source_location": "L47",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "triggers_oncanonitemwritten_maybegenerateembedding",
-      "target": "observability_reportservererror_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportservererror"
     },
     {
       "relation": "calls",
@@ -45427,9 +45527,9 @@
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
       "source_location": "L136",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "triggers_oncanonitemwritten_maybegenerateicon",
-      "target": "observability_reportservererror_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportservererror"
     },
     {
       "relation": "imports",
@@ -45438,9 +45538,9 @@
       "source_file": "apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts",
       "source_location": "L13",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "triggers_onshoppinglistitemwrite",
-      "target": "observability_reportservererror_reportservererror",
-      "confidence_score": 1.0
+      "target": "observability_reportservererror_reportservererror"
     },
     {
       "relation": "calls",
@@ -45551,9 +45651,9 @@
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
       "source_location": "L25",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "triggers_oncanonitemwritten",
-      "target": "triggers_oncanonitemwritten_posthogapikey",
-      "confidence_score": 1.0
+      "target": "triggers_oncanonitemwritten_posthogapikey"
     },
     {
       "relation": "contains",
@@ -46109,9 +46209,9 @@
       "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
       "source_location": "L45",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_extractrecipefromurl_reporting_test",
-      "target": "flows_extractrecipefromurl_reporting_test_extractrecipefromurlflow",
-      "confidence_score": 1.0
+      "target": "flows_extractrecipefromurl_reporting_test_extractrecipefromurlflow"
     },
     {
       "relation": "contains",
@@ -46119,9 +46219,9 @@
       "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
       "source_location": "L25",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_extractrecipefromurl_reporting_test",
-      "target": "flows_extractrecipefromurl_reporting_test_fakehttpserror",
-      "confidence_score": 1.0
+      "target": "flows_extractrecipefromurl_reporting_test_fakehttpserror"
     },
     {
       "relation": "contains",
@@ -46129,9 +46229,9 @@
       "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
       "source_location": "L83",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_extractrecipefromurl_reporting_test",
-      "target": "flows_extractrecipefromurl_reporting_test_invoke",
-      "confidence_score": 1.0
+      "target": "flows_extractrecipefromurl_reporting_test_invoke"
     },
     {
       "relation": "contains",
@@ -46139,9 +46239,9 @@
       "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_extractrecipefromurl_reporting_test",
-      "target": "flows_extractrecipefromurl_reporting_test_mockflush",
-      "confidence_score": 1.0
+      "target": "flows_extractrecipefromurl_reporting_test_mockflush"
     },
     {
       "relation": "contains",
@@ -46149,9 +46249,9 @@
       "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
       "source_location": "L13",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_extractrecipefromurl_reporting_test",
-      "target": "flows_extractrecipefromurl_reporting_test_mockreport",
-      "confidence_score": 1.0
+      "target": "flows_extractrecipefromurl_reporting_test_mockreport"
     },
     {
       "relation": "contains",
@@ -46159,9 +46259,9 @@
       "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
       "source_location": "L47",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_extractrecipefromurl_reporting_test",
-      "target": "flows_extractrecipefromurl_reporting_test_urlimporterror",
-      "confidence_score": 1.0
+      "target": "flows_extractrecipefromurl_reporting_test_urlimporterror"
     },
     {
       "relation": "contains",
@@ -46169,9 +46269,9 @@
       "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
       "source_location": "L86",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_extractrecipefromurl_reporting_test",
-      "target": "flows_extractrecipefromurl_reporting_test_valid",
-      "confidence_score": 1.0
+      "target": "flows_extractrecipefromurl_reporting_test_valid"
     },
     {
       "relation": "method",
@@ -46179,9 +46279,9 @@
       "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
       "source_location": "L27",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_extractrecipefromurl_reporting_test_fakehttpserror",
-      "target": "flows_extractrecipefromurl_reporting_test_fakehttpserror_constructor",
-      "confidence_score": 1.0
+      "target": "flows_extractrecipefromurl_reporting_test_fakehttpserror_constructor"
     },
     {
       "relation": "method",
@@ -46189,9 +46289,9 @@
       "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
       "source_location": "L48",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_extractrecipefromurl_reporting_test_urlimporterror",
-      "target": "flows_extractrecipefromurl_reporting_test_urlimporterror_constructor",
-      "confidence_score": 1.0
+      "target": "flows_extractrecipefromurl_reporting_test_urlimporterror_constructor"
     },
     {
       "relation": "contains",
@@ -46209,9 +46309,9 @@
       "source_file": "apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_generatechattitle_reporting_test",
-      "target": "flows_generatechattitle_reporting_test_input",
-      "confidence_score": 1.0
+      "target": "flows_generatechattitle_reporting_test_input"
     },
     {
       "relation": "contains",
@@ -46219,9 +46319,9 @@
       "source_file": "apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_generatechattitle_reporting_test",
-      "target": "flows_generatechattitle_reporting_test_mockflush",
-      "confidence_score": 1.0
+      "target": "flows_generatechattitle_reporting_test_mockflush"
     },
     {
       "relation": "contains",
@@ -46229,9 +46329,9 @@
       "source_file": "apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts",
       "source_location": "L20",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_generatechattitle_reporting_test",
-      "target": "flows_generatechattitle_reporting_test_mockgenerate",
-      "confidence_score": 1.0
+      "target": "flows_generatechattitle_reporting_test_mockgenerate"
     },
     {
       "relation": "contains",
@@ -46239,9 +46339,9 @@
       "source_file": "apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts",
       "source_location": "L11",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "flows_generatechattitle_reporting_test",
-      "target": "flows_generatechattitle_reporting_test_mockreport",
-      "confidence_score": 1.0
+      "target": "flows_generatechattitle_reporting_test_mockreport"
     },
     {
       "relation": "contains",
@@ -47379,9 +47479,9 @@
       "source_file": "apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts",
       "source_location": "L46",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "triggers_onshoppinglistitemwrite_test",
-      "target": "triggers_onshoppinglistitemwrite_test_mockflush",
-      "confidence_score": 1.0
+      "target": "triggers_onshoppinglistitemwrite_test_mockflush"
     },
     {
       "relation": "contains",
@@ -47419,9 +47519,9 @@
       "source_file": "apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts",
       "source_location": "L45",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "triggers_onshoppinglistitemwrite_test",
-      "target": "triggers_onshoppinglistitemwrite_test_mockreport",
-      "confidence_score": 1.0
+      "target": "triggers_onshoppinglistitemwrite_test_mockreport"
     },
     {
       "relation": "contains",
@@ -74374,12 +74474,34 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
+      "source_location": "L55",
+      "weight": 1.0,
+      "source": "tests_payloadscrubbing_test",
+      "target": "src_init_initobservability",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
       "source_location": "L21",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "tests_posthogerrorreportingadapter_test",
       "target": "src_init_initobservability"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L61",
+      "weight": 1.0,
+      "source": "tests_reportabilityparity_test",
+      "target": "src_init_initobservability",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports",
@@ -74461,12 +74583,45 @@
       "relation": "imports_from",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
+      "source_location": "L57",
+      "weight": 1.0,
+      "source": "tests_payloadscrubbing_test",
+      "target": "src_posthogerrorreportingadapter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
       "source_location": "L22",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "tests_posthogerrorreportingadapter_test",
       "target": "src_posthogerrorreportingadapter"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L63",
+      "weight": 1.0,
+      "source": "tests_reportabilityparity_test",
+      "target": "src_posthogerrorreportingadapter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
+      "source_location": "L57",
+      "weight": 1.0,
+      "source": "tests_payloadscrubbing_test",
+      "target": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports",
@@ -74478,6 +74633,17 @@
       "confidence_score": 1.0,
       "source": "tests_posthogerrorreportingadapter_test",
       "target": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L63",
+      "weight": 1.0,
+      "source": "tests_reportabilityparity_test",
+      "target": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports",
@@ -75037,10 +75203,32 @@
       "relation": "imports_from",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "tests_payloadscrubbing_test",
+      "target": "server_init",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
       "source_location": "L30",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_posthogservererrorreportingadapter_test",
+      "target": "server_init"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "tests_reportabilityparity_test",
       "target": "server_init",
       "confidence_score": 1.0
     },
@@ -75059,10 +75247,32 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "tests_payloadscrubbing_test",
+      "target": "server_init_initserverobservability",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
       "source_location": "L30",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_posthogservererrorreportingadapter_test",
+      "target": "server_init_initserverobservability"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "tests_reportabilityparity_test",
       "target": "server_init_initserverobservability",
       "confidence_score": 1.0
     },
@@ -75171,9 +75381,9 @@
       "source_file": "packages/adapters/observability/src/server/posthogServerErrorReportingAdapter.ts",
       "source_location": "L4",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "server_posthogservererrorreportingadapter",
-      "target": "shared_reportablecategory",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory"
     },
     {
       "relation": "imports",
@@ -75182,9 +75392,9 @@
       "source_file": "packages/adapters/observability/src/server/posthogServerErrorReportingAdapter.ts",
       "source_location": "L4",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "server_posthogservererrorreportingadapter",
-      "target": "shared_reportablecategory_isreportablecategory",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory_isreportablecategory"
     },
     {
       "relation": "imports",
@@ -75204,8 +75414,19 @@
       "source_file": "packages/adapters/observability/src/server/posthogServerErrorReportingAdapter.ts",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "server_posthogservererrorreportingadapter",
-      "target": "src_index_domainerror",
+      "target": "src_index_domainerror"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
+      "source_location": "L58",
+      "weight": 1.0,
+      "source": "tests_payloadscrubbing_test",
+      "target": "server_posthogservererrorreportingadapter",
       "confidence_score": 1.0
     },
     {
@@ -75215,8 +75436,30 @@
       "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
       "source_location": "L31",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_posthogservererrorreportingadapter_test",
+      "target": "server_posthogservererrorreportingadapter"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "tests_reportabilityparity_test",
       "target": "server_posthogservererrorreportingadapter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
+      "source_location": "L58",
+      "weight": 1.0,
+      "source": "tests_payloadscrubbing_test",
+      "target": "server_posthogservererrorreportingadapter_createposthogservererrorreportingadapter",
       "confidence_score": 1.0
     },
     {
@@ -75226,7 +75469,18 @@
       "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
       "source_location": "L31",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_posthogservererrorreportingadapter_test",
+      "target": "server_posthogservererrorreportingadapter_createposthogservererrorreportingadapter"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "tests_reportabilityparity_test",
       "target": "server_posthogservererrorreportingadapter_createposthogservererrorreportingadapter",
       "confidence_score": 1.0
     },
@@ -75517,12 +75771,34 @@
       "relation": "imports_from",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L65",
+      "weight": 1.0,
+      "source": "tests_reportabilityparity_test",
+      "target": "shared_reportablecategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "packages/adapters/observability/tests/reportableCategory.test.ts",
       "source_location": "L3",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "tests_reportablecategory_test",
       "target": "shared_reportablecategory"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L65",
+      "weight": 1.0,
+      "source": "tests_reportabilityparity_test",
+      "target": "shared_reportablecategory_isreportablecategory",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports",
@@ -75557,6 +75833,16 @@
       "target": "tests_matchlogparity_test_fixture"
     },
     {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
+      "source_location": "L19",
+      "weight": 1.0,
+      "source": "tests_payloadscrubbing_test",
+      "target": "tests_payloadscrubbing_test_clientcapture_clientinit_servercapture_fakeposthog",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -75584,9 +75870,9 @@
       "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_posthogservererrorreportingadapter_test",
-      "target": "src_index_domainerror",
-      "confidence_score": 1.0
+      "target": "src_index_domainerror"
     },
     {
       "relation": "contains",
@@ -75594,8 +75880,39 @@
       "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
       "source_location": "L8",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_posthogservererrorreportingadapter_test",
-      "target": "tests_posthogservererrorreportingadapter_test_captureexception_fakeposthog",
+      "target": "tests_posthogservererrorreportingadapter_test_captureexception_fakeposthog"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "tests_reportabilityparity_test",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "tests_reportabilityparity_test",
+      "target": "tests_reportabilityparity_test_clientcapture_clientinit_servercapture_fakeposthog",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
+      "source_location": "L71",
+      "weight": 1.0,
+      "source": "tests_reportabilityparity_test",
+      "target": "tests_reportabilityparity_test_expected_report",
       "confidence_score": 1.0
     },
     {
@@ -116160,6 +116477,56 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "docs/error-reporting-calibration.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "docs_error_reporting_calibration",
+      "target": "docs_error_reporting_calibration_caught_error_reporting_calibration_note",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/error-reporting-calibration.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "docs_error_reporting_calibration",
+      "target": "docs_salt_architecture",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/error-reporting-calibration.md",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "docs_error_reporting_calibration_caught_error_reporting_calibration_note",
+      "target": "docs_error_reporting_calibration_before_after_check_in_posthog_error_tracking",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/error-reporting-calibration.md",
+      "source_location": "L48",
+      "weight": 1.0,
+      "source": "docs_error_reporting_calibration_caught_error_reporting_calibration_note",
+      "target": "docs_error_reporting_calibration_known_intentional_asymmetries_not_bugs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/error-reporting-calibration.md",
+      "source_location": "L66",
+      "weight": 1.0,
+      "source": "docs_error_reporting_calibration_caught_error_reporting_calibration_note",
+      "target": "docs_error_reporting_calibration_no_raw_user_content_in_payloads",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L1",
       "weight": 1.0,
@@ -119244,5 +119611,5 @@
       "source_file": ".claude/commands/spec.md"
     }
   ],
-  "built_at_commit": "511937f721cf38cefe42910e25dd40dceaf193a7"
+  "built_at_commit": "192fd59019686b330ff04ccfaeee3769ed101388"
 }

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -851,7 +851,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_serverarbitration",
-      "community": 1,
+      "community": 161,
       "norm_label": "serverarbitration.ts"
     },
     {
@@ -871,7 +871,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_serverembedding",
-      "community": 28,
+      "community": 96,
       "norm_label": "serverembedding.ts"
     },
     {
@@ -1041,7 +1041,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_withaitimeout",
-      "community": 29,
+      "community": 96,
       "norm_label": "withaitimeout.ts"
     },
     {
@@ -1051,7 +1051,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "adapters_withaitimeout_aitimeouterror",
-      "community": 29,
+      "community": 96,
       "norm_label": "aitimeouterror"
     },
     {
@@ -1061,7 +1061,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "adapters_withaitimeout_aitimeouterror_constructor",
-      "community": 29,
+      "community": 96,
       "norm_label": ".constructor()"
     },
     {
@@ -1071,7 +1071,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "adapters_withaitimeout_withaitimeoutoptions",
-      "community": 29,
+      "community": 96,
       "norm_label": "withaitimeoutoptions"
     },
     {
@@ -1081,7 +1081,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "adapters_withaitimeout_racewithtimeout",
-      "community": 29,
+      "community": 96,
       "norm_label": "racewithtimeout()"
     },
     {
@@ -1091,7 +1091,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "adapters_withaitimeout_withaitimeout",
-      "community": 29,
+      "community": 96,
       "norm_label": "withaitimeout()"
     },
     {
@@ -1141,7 +1141,7 @@
       "source_location": "L72",
       "_origin": "ast",
       "id": "ai_fakemodel_aifakeenabled",
-      "community": 28,
+      "community": 29,
       "norm_label": "aifakeenabled()"
     },
     {
@@ -1191,7 +1191,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_listaimodels",
-      "community": 61,
+      "community": 96,
       "norm_label": "listaimodels.ts"
     },
     {
@@ -1201,7 +1201,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "ai_listaimodels_catalogmodelschema",
-      "community": 61,
+      "community": 96,
       "norm_label": "catalogmodelschema"
     },
     {
@@ -1211,7 +1211,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "ai_listaimodels_catalogresponseschema",
-      "community": 61,
+      "community": 96,
       "norm_label": "catalogresponseschema"
     },
     {
@@ -1221,7 +1221,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "ai_listaimodels_listaimodelsinputschema",
-      "community": 61,
+      "community": 96,
       "norm_label": "listaimodelsinputschema"
     },
     {
@@ -1231,7 +1231,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "ai_listaimodels_aicatalogmodel",
-      "community": 61,
+      "community": 96,
       "norm_label": "aicatalogmodel"
     },
     {
@@ -1241,7 +1241,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "ai_listaimodels_listaimodelsresult",
-      "community": 61,
+      "community": 96,
       "norm_label": "listaimodelsresult"
     },
     {
@@ -1251,7 +1251,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "ai_listaimodels_cacheentry",
-      "community": 61,
+      "community": 96,
       "norm_label": "cacheentry"
     },
     {
@@ -1261,7 +1261,7 @@
       "source_location": "L59",
       "_origin": "ast",
       "id": "ai_listaimodels_bareid",
-      "community": 61,
+      "community": 96,
       "norm_label": "bareid()"
     },
     {
@@ -1271,7 +1271,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "ai_listaimodels_fetchcatalog",
-      "community": 61,
+      "community": 96,
       "norm_label": "fetchcatalog()"
     },
     {
@@ -1281,7 +1281,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "ai_listaimodels_loadcatalog",
-      "community": 61,
+      "community": 96,
       "norm_label": "loadcatalog()"
     },
     {
@@ -1291,7 +1291,7 @@
       "source_location": "L114",
       "_origin": "ast",
       "id": "ai_listaimodels_handlelistaimodels",
-      "community": 61,
+      "community": 96,
       "norm_label": "handlelistaimodels()"
     },
     {
@@ -1301,7 +1301,7 @@
       "source_location": "L124",
       "_origin": "ast",
       "id": "ai_listaimodels_resetlistaimodelscachefortest",
-      "community": 61,
+      "community": 96,
       "norm_label": "__resetlistaimodelscachefortest()"
     },
     {
@@ -1401,7 +1401,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "ai_modelcapabilities_modelsupportsrole",
-      "community": 61,
+      "community": 96,
       "norm_label": "modelsupportsrole()"
     },
     {
@@ -1421,7 +1421,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_requireadmin",
-      "community": 77,
+      "community": 96,
       "norm_label": "requireadmin.ts"
     },
     {
@@ -1431,7 +1431,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "ai_requireadmin_requireadmin",
-      "community": 77,
+      "community": 96,
       "norm_label": "requireadmin()"
     },
     {
@@ -1441,7 +1441,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_resolvemodel",
-      "community": 28,
+      "community": 161,
       "norm_label": "resolvemodel.ts"
     },
     {
@@ -1451,7 +1451,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "ai_resolvemodel_cacheentry",
-      "community": 28,
+      "community": 161,
       "norm_label": "cacheentry"
     },
     {
@@ -1461,7 +1461,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "ai_resolvemodel_default_settings",
-      "community": 28,
+      "community": 161,
       "norm_label": "default_settings"
     },
     {
@@ -1471,7 +1471,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "ai_resolvemodel_loadsettings",
-      "community": 28,
+      "community": 161,
       "norm_label": "loadsettings()"
     },
     {
@@ -1491,7 +1491,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "ai_resolvemodel_resetresolvemodelcachefortest",
-      "community": 28,
+      "community": 161,
       "norm_label": "__resetresolvemodelcachefortest()"
     },
     {
@@ -1501,7 +1501,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_testmodel",
-      "community": 77,
+      "community": 96,
       "norm_label": "testmodel.ts"
     },
     {
@@ -1511,7 +1511,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "ai_testmodel_testmodelinputschema",
-      "community": 77,
+      "community": 96,
       "norm_label": "testmodelinputschema"
     },
     {
@@ -1521,7 +1521,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "ai_testmodel_testmodelresult",
-      "community": 77,
+      "community": 96,
       "norm_label": "testmodelresult"
     },
     {
@@ -1531,7 +1531,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "ai_testmodel_probe",
-      "community": 77,
+      "community": 96,
       "norm_label": "probe()"
     },
     {
@@ -1541,7 +1541,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "ai_testmodel_handletestmodel",
-      "community": 77,
+      "community": 96,
       "norm_label": "handletestmodel()"
     },
     {
@@ -1591,7 +1591,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_dev",
-      "community": 28,
+      "community": 29,
       "norm_label": "dev.ts"
     },
     {
@@ -1601,7 +1601,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_arbitratecanon",
-      "community": 28,
+      "community": 161,
       "norm_label": "arbitratecanon.ts"
     },
     {
@@ -1611,7 +1611,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "flows_arbitratecanon_arbitrationresultschema",
-      "community": 28,
+      "community": 161,
       "norm_label": "arbitrationresultschema"
     },
     {
@@ -1621,7 +1621,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "flows_arbitratecanon_arbitratecanonflow",
-      "community": 28,
+      "community": 161,
       "norm_label": "arbitratecanonflow"
     },
     {
@@ -1631,7 +1631,7 @@
       "source_location": "L101",
       "_origin": "ast",
       "id": "flows_arbitratecanon_buildprompt",
-      "community": 28,
+      "community": 161,
       "norm_label": "buildprompt()"
     },
     {
@@ -1641,7 +1641,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "assets_canoniconseed",
-      "community": 29,
+      "community": 164,
       "norm_label": "canoniconseed.ts"
     },
     {
@@ -1651,7 +1651,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "assets_canoniconseed_loadcanoniconseed",
-      "community": 29,
+      "community": 164,
       "norm_label": "loadcanoniconseed()"
     },
     {
@@ -1661,7 +1661,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_authorrecipe",
-      "community": 68,
+      "community": 28,
       "norm_label": "authorrecipe.ts"
     },
     {
@@ -1671,7 +1671,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "flows_authorrecipe_outputschema",
-      "community": 68,
+      "community": 28,
       "norm_label": "outputschema"
     },
     {
@@ -1681,7 +1681,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "flows_authorrecipe_authorrecipeflow",
-      "community": 68,
+      "community": 34,
       "norm_label": "authorrecipeflow"
     },
     {
@@ -1781,7 +1781,7 @@
       "source_location": "L98",
       "_origin": "ast",
       "id": "flows_chefchat_chefchatflow",
-      "community": 28,
+      "community": 34,
       "norm_label": "chefchatflow"
     },
     {
@@ -1791,7 +1791,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_embedtext",
-      "community": 28,
+      "community": 29,
       "norm_label": "embedtext.ts"
     },
     {
@@ -1801,7 +1801,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "flows_embedtext_fake_embedding",
-      "community": 28,
+      "community": 29,
       "norm_label": "fake_embedding"
     },
     {
@@ -1811,7 +1811,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "flows_embedtext_embedtextflow",
-      "community": 28,
+      "community": 29,
       "norm_label": "embedtextflow"
     },
     {
@@ -1921,7 +1921,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_generatecanonicon",
-      "community": 29,
+      "community": 164,
       "norm_label": "generatecanonicon.ts"
     },
     {
@@ -1931,7 +1931,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "flows_generatecanonicon_buildiconprompt",
-      "community": 29,
+      "community": 164,
       "norm_label": "buildiconprompt()"
     },
     {
@@ -1941,7 +1941,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "flows_generatecanonicon_parsedataurl",
-      "community": 29,
+      "community": 164,
       "norm_label": "parsedataurl()"
     },
     {
@@ -1951,7 +1951,7 @@
       "source_location": "L47",
       "_origin": "ast",
       "id": "flows_generatecanonicon_generatecanoniconinputschema",
-      "community": 29,
+      "community": 164,
       "norm_label": "generatecanoniconinputschema"
     },
     {
@@ -1961,7 +1961,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "flows_generatecanonicon_generatecanoniconoutputschema",
-      "community": 29,
+      "community": 164,
       "norm_label": "generatecanoniconoutputschema"
     },
     {
@@ -2101,7 +2101,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_parseentry",
-      "community": 96,
+      "community": 28,
       "norm_label": "parseentry.ts"
     },
     {
@@ -2111,7 +2111,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "flows_parseentry_parseentryinputschema",
-      "community": 96,
+      "community": 28,
       "norm_label": "parseentryinputschema"
     },
     {
@@ -2131,7 +2131,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "flows_parseentry_buildprompt",
-      "community": 96,
+      "community": 28,
       "norm_label": "buildprompt()"
     },
     {
@@ -2551,7 +2551,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite",
-      "community": 96,
+      "community": 75,
       "norm_label": "onshoppinglistitemwrite.ts"
     },
     {
@@ -2561,7 +2561,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_geminiapikey",
-      "community": 96,
+      "community": 75,
       "norm_label": "geminiapikey"
     },
     {
@@ -2571,7 +2571,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_posthogapikey",
-      "community": 96,
+      "community": 75,
       "norm_label": "posthogapikey"
     },
     {
@@ -2581,7 +2581,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_lookscompound",
-      "community": 96,
+      "community": 75,
       "norm_label": "lookscompound()"
     },
     {
@@ -2591,7 +2591,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_onshoppinglistitemwrite",
-      "community": 96,
+      "community": 75,
       "norm_label": "onshoppinglistitemwrite"
     },
     {
@@ -4081,7 +4081,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "apps_kitchen_sink_src_app_svelte_src_app",
-      "community": 88,
+      "community": 50,
       "norm_label": "app.svelte"
     },
     {
@@ -4092,7 +4092,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_colorssection",
-      "community": 88,
+      "community": 50,
       "norm_label": "colorssection.svelte"
     },
     {
@@ -4103,7 +4103,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_typographysection",
-      "community": 88,
+      "community": 50,
       "norm_label": "typographysection.svelte"
     },
     {
@@ -4114,7 +4114,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_layoutsection",
-      "community": 88,
+      "community": 50,
       "norm_label": "layoutsection.svelte"
     },
     {
@@ -4125,7 +4125,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_buttonsection",
-      "community": 88,
+      "community": 50,
       "norm_label": "buttonsection.svelte"
     },
     {
@@ -4136,7 +4136,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_formsection",
-      "community": 88,
+      "community": 50,
       "norm_label": "formsection.svelte"
     },
     {
@@ -4147,7 +4147,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_comboboxsection",
-      "community": 88,
+      "community": 50,
       "norm_label": "comboboxsection.svelte"
     },
     {
@@ -4158,7 +4158,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_overlaysection",
-      "community": 88,
+      "community": 50,
       "norm_label": "overlaysection.svelte"
     },
     {
@@ -4169,7 +4169,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "sections_feedbacksection",
-      "community": 88,
+      "community": 50,
       "norm_label": "feedbacksection.svelte"
     },
     {
@@ -4200,7 +4200,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "ui_components",
-      "community": 20,
+      "community": 50,
       "norm_label": "@salt/ui-components"
     },
     {
@@ -6011,7 +6011,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "components_authgate",
-      "community": 50,
+      "community": 10,
       "norm_label": "authgate.svelte"
     },
     {
@@ -6022,7 +6022,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_auth_svelte",
-      "community": 50,
+      "community": 10,
       "norm_label": "../../lib/auth.svelte.js"
     },
     {
@@ -6164,7 +6164,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "domain",
-      "community": 20,
+      "community": 50,
       "norm_label": "@salt/domain"
     },
     {
@@ -6185,7 +6185,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "boundary_tests_no_firebase_sync_internal",
-      "community": 1,
+      "community": 141,
       "norm_label": "no-firebase-sync-internal.ts"
     },
     {
@@ -6226,7 +6226,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "components_loginpage",
-      "community": 50,
+      "community": 10,
       "norm_label": "loginpage.svelte"
     },
     {
@@ -6237,7 +6237,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_firebase",
-      "community": 50,
+      "community": 10,
       "norm_label": "firebase.ts"
     },
     {
@@ -6419,7 +6419,7 @@
       "_origin": "ast",
       "confidence": "EXTRACTED",
       "id": "lib_aisleservice",
-      "community": 3,
+      "community": 2,
       "norm_label": "../../lib/aisleservice.js"
     },
     {
@@ -6429,7 +6429,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "lib_aisleservice_idgen",
-      "community": 3,
+      "community": 2,
       "norm_label": "idgen"
     },
     {
@@ -6439,7 +6439,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "lib_aisleservice_addaisle",
-      "community": 3,
+      "community": 2,
       "norm_label": "addaisle()"
     },
     {
@@ -6449,7 +6449,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "lib_aisleservice_addaislesbulk",
-      "community": 3,
+      "community": 2,
       "norm_label": "addaislesbulk()"
     },
     {
@@ -6459,7 +6459,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_aisleservice_renameaisle",
-      "community": 3,
+      "community": 2,
       "norm_label": "renameaisle()"
     },
     {
@@ -6469,7 +6469,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "lib_aisleservice_reorderaisles",
-      "community": 3,
+      "community": 2,
       "norm_label": "reorderaisles()"
     },
     {
@@ -6479,7 +6479,7 @@
       "source_location": "L68",
       "_origin": "ast",
       "id": "lib_aisleservice_deleteaisles",
-      "community": 3,
+      "community": 2,
       "norm_label": "deleteaisles()"
     },
     {
@@ -6489,7 +6489,7 @@
       "source_location": "L82",
       "_origin": "ast",
       "id": "lib_aisleservice_mergeaisles",
-      "community": 3,
+      "community": 2,
       "norm_label": "mergeaisles()"
     },
     {
@@ -6659,7 +6659,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "lib_auth_svelte_readpendingemail",
-      "community": 50,
+      "community": 10,
       "norm_label": "readpendingemail()"
     },
     {
@@ -6669,7 +6669,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "lib_auth_svelte_writependingemail",
-      "community": 50,
+      "community": 10,
       "norm_label": "writependingemail()"
     },
     {
@@ -6679,7 +6679,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "lib_auth_svelte_clearpendingemail",
-      "community": 50,
+      "community": 10,
       "norm_label": "clearpendingemail()"
     },
     {
@@ -6689,7 +6689,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore",
-      "community": 50,
+      "community": 10,
       "norm_label": "authstore"
     },
     {
@@ -6699,7 +6699,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore_constructor",
-      "community": 50,
+      "community": 10,
       "norm_label": ".constructor()"
     },
     {
@@ -6709,7 +6709,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore_maybecompletefromurl",
-      "community": 50,
+      "community": 10,
       "norm_label": ".maybecompletefromurl()"
     },
     {
@@ -6719,7 +6719,7 @@
       "source_location": "L88",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore_finishsignin",
-      "community": 50,
+      "community": 10,
       "norm_label": ".finishsignin()"
     },
     {
@@ -6729,7 +6729,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore_completewithemail",
-      "community": 50,
+      "community": 10,
       "norm_label": ".completewithemail()"
     },
     {
@@ -6739,7 +6739,7 @@
       "source_location": "L110",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore_sendlink",
-      "community": 50,
+      "community": 10,
       "norm_label": ".sendlink()"
     },
     {
@@ -6749,7 +6749,7 @@
       "source_location": "L126",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore_signout",
-      "community": 50,
+      "community": 10,
       "norm_label": ".signout()"
     },
     {
@@ -6759,7 +6759,7 @@
       "source_location": "L135",
       "_origin": "ast",
       "id": "lib_auth_svelte_formaterror",
-      "community": 50,
+      "community": 10,
       "norm_label": "formaterror()"
     },
     {
@@ -6779,7 +6779,7 @@
       "source_location": "L145",
       "_origin": "ast",
       "id": "lib_auth_svelte_devsignin",
-      "community": 50,
+      "community": 10,
       "norm_label": "devsignin()"
     },
     {
@@ -6789,7 +6789,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "lib_canonservice_canonitems",
-      "community": 3,
+      "community": 2,
       "norm_label": "canonitems"
     },
     {
@@ -6799,7 +6799,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "lib_canonservice_aisles",
-      "community": 3,
+      "community": 2,
       "norm_label": "aisles"
     },
     {
@@ -6809,7 +6809,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "lib_canonservice_aisleusage",
-      "community": 3,
+      "community": 2,
       "norm_label": "aisleusage"
     },
     {
@@ -6819,7 +6819,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "lib_canonservice_isloadingaisles",
-      "community": 3,
+      "community": 2,
       "norm_label": "isloadingaisles"
     },
     {
@@ -6859,7 +6859,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "lib_canonservice_memaislestore",
-      "community": 3,
+      "community": 2,
       "norm_label": "memaislestore()"
     },
     {
@@ -6869,7 +6869,7 @@
       "source_location": "L111",
       "_origin": "ast",
       "id": "lib_canonservice_memcanonstore",
-      "community": 3,
+      "community": 2,
       "norm_label": "memcanonstore()"
     },
     {
@@ -6879,7 +6879,7 @@
       "source_location": "L136",
       "_origin": "ast",
       "id": "lib_canonservice_getaislessnapshot",
-      "community": 3,
+      "community": 2,
       "norm_label": "getaislessnapshot()"
     },
     {
@@ -6889,7 +6889,7 @@
       "source_location": "L140",
       "_origin": "ast",
       "id": "lib_canonservice_getcanonitemssnapshot",
-      "community": 3,
+      "community": 2,
       "norm_label": "getcanonitemssnapshot()"
     },
     {
@@ -6909,14 +6909,14 @@
       "source_location": "L179",
       "_origin": "ast",
       "id": "lib_canonservice_addcanonitem",
-      "community": 17,
+      "community": 3,
       "norm_label": "addcanonitem()"
     },
     {
       "label": "commitCanonItemUpdate()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L231",
+      "source_location": "L234",
       "_origin": "ast",
       "id": "lib_canonservice_commitcanonitemupdate",
       "community": 3,
@@ -6926,7 +6926,7 @@
       "label": "updateCanonItemName()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L235",
+      "source_location": "L238",
       "_origin": "ast",
       "id": "lib_canonservice_updatecanonitemname",
       "community": 3,
@@ -6936,7 +6936,7 @@
       "label": "updateCanonItemAisle()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L244",
+      "source_location": "L247",
       "_origin": "ast",
       "id": "lib_canonservice_updatecanonitemaisle",
       "community": 3,
@@ -6946,7 +6946,7 @@
       "label": "updateCanonItemSynonyms()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L253",
+      "source_location": "L256",
       "_origin": "ast",
       "id": "lib_canonservice_updatecanonitemsynonyms",
       "community": 3,
@@ -6956,7 +6956,7 @@
       "label": "updateCanonItemShoppingBehavior()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L262",
+      "source_location": "L265",
       "_origin": "ast",
       "id": "lib_canonservice_updatecanonitemshoppingbehavior",
       "community": 3,
@@ -6966,7 +6966,7 @@
       "label": "updateCanonItemThreshold()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L271",
+      "source_location": "L274",
       "_origin": "ast",
       "id": "lib_canonservice_updatecanonitemthreshold",
       "community": 3,
@@ -6976,7 +6976,7 @@
       "label": "approveCanonItemWithOverrides()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L281",
+      "source_location": "L284",
       "_origin": "ast",
       "id": "lib_canonservice_approvecanonitemwithoverrides",
       "community": 3,
@@ -6986,7 +6986,7 @@
       "label": "approveCanonItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L290",
+      "source_location": "L293",
       "_origin": "ast",
       "id": "lib_canonservice_approvecanonitems",
       "community": 7,
@@ -6996,17 +6996,17 @@
       "label": "splitMostRecentSynonym()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L303",
+      "source_location": "L306",
       "_origin": "ast",
       "id": "lib_canonservice_splitmostrecentsynonym",
-      "community": 3,
+      "community": 265,
       "norm_label": "splitmostrecentsynonym()"
     },
     {
       "label": "deleteCanonItem()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L321",
+      "source_location": "L324",
       "_origin": "ast",
       "id": "lib_canonservice_deletecanonitem",
       "community": 3,
@@ -7016,7 +7016,7 @@
       "label": "regenerateCanonIcon()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L332",
+      "source_location": "L335",
       "_origin": "ast",
       "id": "lib_canonservice_regeneratecanonicon",
       "community": 3,
@@ -7026,7 +7026,7 @@
       "label": "hideCanonIcon()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L341",
+      "source_location": "L344",
       "_origin": "ast",
       "id": "lib_canonservice_hidecanonicon",
       "community": 3,
@@ -7036,7 +7036,7 @@
       "label": "unhideCanonIcon()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L349",
+      "source_location": "L352",
       "_origin": "ast",
       "id": "lib_canonservice_unhidecanonicon",
       "community": 3,
@@ -7046,7 +7046,7 @@
       "label": "__resetCanonServiceForTest()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L355",
+      "source_location": "L358",
       "_origin": "ast",
       "id": "lib_canonservice_resetcanonservicefortest",
       "community": 3,
@@ -7069,7 +7069,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "lib_chatservice_getchatsessionssnapshot",
-      "community": 8,
+      "community": 42,
       "norm_label": "getchatsessionssnapshot()"
     },
     {
@@ -7156,7 +7156,7 @@
       "label": "persistSession()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L113",
+      "source_location": "L116",
       "_origin": "ast",
       "id": "lib_chatservice_persistsession",
       "community": 42,
@@ -7166,17 +7166,17 @@
       "label": "removeSession()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L123",
+      "source_location": "L126",
       "_origin": "ast",
       "id": "lib_chatservice_removesession",
-      "community": 42,
+      "community": 8,
       "norm_label": "removesession()"
     },
     {
       "label": "sendMessage()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L133",
+      "source_location": "L136",
       "_origin": "ast",
       "id": "lib_chatservice_sendmessage",
       "community": 42,
@@ -7300,7 +7300,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_e2ehooks",
-      "community": 8,
+      "community": 2,
       "norm_label": "e2ehooks.ts"
     },
     {
@@ -7310,7 +7310,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "lib_e2ehooks_installe2ehooks",
-      "community": 8,
+      "community": 49,
       "norm_label": "installe2ehooks()"
     },
     {
@@ -7584,13 +7584,33 @@
       "norm_label": "reportsubscriptionerror()"
     },
     {
+      "label": "reportWriteError()",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L43",
+      "_origin": "ast",
+      "id": "lib_errorreporting_reportwriteerror",
+      "community": 8,
+      "norm_label": "reportwriteerror()"
+    },
+    {
+      "label": "reportIfFailed()",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L56",
+      "_origin": "ast",
+      "id": "lib_errorreporting_reportiffailed",
+      "community": 8,
+      "norm_label": "reportiffailed()"
+    },
+    {
       "label": "authProvider",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/firebase.ts",
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_firebase_authprovider",
-      "community": 50,
+      "community": 10,
       "norm_label": "authprovider"
     },
     {
@@ -8140,7 +8160,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "lib_membersservice_reordermembers",
-      "community": 8,
+      "community": 10,
       "norm_label": "reordermembers()"
     },
     {
@@ -8240,7 +8260,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "lib_observability_tagsession",
-      "community": 49,
+      "community": 25,
       "norm_label": "tagsession()"
     },
     {
@@ -8290,7 +8310,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_pwa",
-      "community": 8,
+      "community": 49,
       "norm_label": "pwa.ts"
     },
     {
@@ -8300,7 +8320,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "lib_pwa_registerserviceworker",
-      "community": 8,
+      "community": 49,
       "norm_label": "registerserviceworker()"
     },
     {
@@ -8310,7 +8330,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_pwa_setupupdateflow",
-      "community": 8,
+      "community": 49,
       "norm_label": "setupupdateflow()"
     },
     {
@@ -8330,7 +8350,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "lib_recipeservice_getrecipessnapshot",
-      "community": 8,
+      "community": 24,
       "norm_label": "getrecipessnapshot()"
     },
     {
@@ -8467,7 +8487,7 @@
       "label": "matchIngredient()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L230",
+      "source_location": "L234",
       "_origin": "ast",
       "id": "lib_recipeservice_matchingredient",
       "community": 24,
@@ -8477,17 +8497,17 @@
       "label": "removeRecipe()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L259",
+      "source_location": "L263",
       "_origin": "ast",
       "id": "lib_recipeservice_removerecipe",
-      "community": 24,
+      "community": 8,
       "norm_label": "removerecipe()"
     },
     {
       "label": "quantityToNumber()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L268",
+      "source_location": "L272",
       "_origin": "ast",
       "id": "lib_recipeservice_quantitytonumber",
       "community": 24,
@@ -8497,7 +8517,7 @@
       "label": "_itemIds",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L274",
+      "source_location": "L278",
       "_origin": "ast",
       "id": "lib_recipeservice_itemids",
       "community": 24,
@@ -8507,17 +8527,17 @@
       "label": "RecipeAddRow",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L281",
+      "source_location": "L285",
       "_origin": "ast",
       "id": "lib_recipeservice_recipeaddrow",
-      "community": 24,
+      "community": 157,
       "norm_label": "recipeaddrow"
     },
     {
       "label": "scaledAmountUnit()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L298",
+      "source_location": "L302",
       "_origin": "ast",
       "id": "lib_recipeservice_scaledamountunit",
       "community": 24,
@@ -8527,7 +8547,7 @@
       "label": "buildRecipeAddPlan()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L309",
+      "source_location": "L313",
       "_origin": "ast",
       "id": "lib_recipeservice_buildrecipeaddplan",
       "community": 24,
@@ -8537,10 +8557,10 @@
       "label": "commitRecipeAddPlan()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L350",
+      "source_location": "L354",
       "_origin": "ast",
       "id": "lib_recipeservice_commitrecipeaddplan",
-      "community": 108,
+      "community": 8,
       "norm_label": "commitrecipeaddplan()"
     },
     {
@@ -8614,10 +8634,20 @@
       "norm_label": "geterrorreporter()"
     },
     {
+      "label": "reportFirstWriteFailure()",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L77",
+      "_origin": "ast",
+      "id": "lib_shoppinglistservice_svelte_reportfirstwritefailure",
+      "community": 8,
+      "norm_label": "reportfirstwritefailure()"
+    },
+    {
       "label": "markLoaded()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L79",
+      "source_location": "L90",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_markloaded",
       "community": 8,
@@ -8627,7 +8657,7 @@
       "label": "setActiveListId()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L90",
+      "source_location": "L101",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_setactivelistid",
       "community": 8,
@@ -8637,7 +8667,7 @@
       "label": "initShoppingListSync()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L107",
+      "source_location": "L118",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_initshoppinglistsync",
       "community": 8,
@@ -8647,17 +8677,17 @@
       "label": "addList()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L144",
+      "source_location": "L155",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_addlist",
-      "community": 141,
+      "community": 8,
       "norm_label": "addlist()"
     },
     {
       "label": "renameListById()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L158",
+      "source_location": "L173",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_renamelistbyid",
       "community": 8,
@@ -8667,7 +8697,7 @@
       "label": "removeList()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L169",
+      "source_location": "L184",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_removelist",
       "community": 8,
@@ -8677,7 +8707,7 @@
       "label": "changeDefaultList()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L177",
+      "source_location": "L192",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_changedefaultlist",
       "community": 8,
@@ -8687,17 +8717,17 @@
       "label": "addItemToList()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L187",
+      "source_location": "L202",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_additemtolist",
-      "community": 10,
+      "community": 8,
       "norm_label": "additemtolist()"
     },
     {
       "label": "updateItemRawText()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L204",
+      "source_location": "L219",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_updateitemrawtext",
       "community": 8,
@@ -8707,7 +8737,7 @@
       "label": "updateItemAmountUnit()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L217",
+      "source_location": "L232",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_updateitemamountunit",
       "community": 8,
@@ -8717,7 +8747,7 @@
       "label": "updateItemNotes()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L231",
+      "source_location": "L246",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_updateitemnotes",
       "community": 8,
@@ -8727,7 +8757,7 @@
       "label": "toggleItemChecked()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L244",
+      "source_location": "L259",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_toggleitemchecked",
       "community": 8,
@@ -8737,7 +8767,7 @@
       "label": "confirmItemNeeded()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L260",
+      "source_location": "L275",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_confirmitemneeded",
       "community": 8,
@@ -8747,7 +8777,7 @@
       "label": "confirmItemsNeeded()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L274",
+      "source_location": "L289",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_confirmitemsneeded",
       "community": 8,
@@ -8757,7 +8787,7 @@
       "label": "checkItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L289",
+      "source_location": "L305",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_checkitems",
       "community": 8,
@@ -8767,7 +8797,7 @@
       "label": "uncheckItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L301",
+      "source_location": "L318",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_uncheckitems",
       "community": 8,
@@ -8777,7 +8807,7 @@
       "label": "removeItem()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L313",
+      "source_location": "L331",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_removeitem",
       "community": 8,
@@ -8787,7 +8817,7 @@
       "label": "removeItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L323",
+      "source_location": "L341",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_removeitems",
       "community": 8,
@@ -8797,7 +8827,7 @@
       "label": "clearChecked()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L330",
+      "source_location": "L348",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_clearchecked",
       "community": 8,
@@ -8807,7 +8837,7 @@
       "label": "moveSelectedItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L337",
+      "source_location": "L355",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_moveselecteditems",
       "community": 8,
@@ -8817,7 +8847,7 @@
       "label": "getShoppingListsSnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L351",
+      "source_location": "L372",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_getshoppinglistssnapshot",
       "community": 8,
@@ -8827,7 +8857,7 @@
       "label": "getDefaultListIdSnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L355",
+      "source_location": "L376",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_getdefaultlistidsnapshot",
       "community": 8,
@@ -8837,7 +8867,7 @@
       "label": "getItemsSnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L359",
+      "source_location": "L380",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_getitemssnapshot",
       "community": 8,
@@ -8847,10 +8877,10 @@
       "label": "__resetShoppingListServiceForTest()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L365",
+      "source_location": "L386",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_resetshoppinglistservicefortest",
-      "community": 8,
+      "community": 10,
       "norm_label": "__resetshoppinglistservicefortest()"
     },
     {
@@ -8861,7 +8891,7 @@
       "_origin": "ast",
       "confidence": "EXTRACTED",
       "id": "lib_titlecase",
-      "community": 20,
+      "community": 50,
       "norm_label": "../../lib/titlecase.js"
     },
     {
@@ -8871,7 +8901,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_titlecase_titlecase",
-      "community": 20,
+      "community": 50,
       "norm_label": "titlecase()"
     },
     {
@@ -8981,7 +9011,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "apps_web_pwa_src_main_ts_src_main",
-      "community": 8,
+      "community": 49,
       "norm_label": "main.ts"
     },
     {
@@ -9052,7 +9082,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "admin_adminmealplanpage",
-      "community": 20,
+      "community": 50,
       "norm_label": "adminmealplanpage.svelte"
     },
     {
@@ -9062,7 +9092,7 @@
       "source_location": "L95",
       "_origin": "ast",
       "id": "admin_adminmealplanpage_each",
-      "community": 20,
+      "community": 50,
       "norm_label": "#each()"
     },
     {
@@ -9073,7 +9103,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "mealplan_mealdayeditor",
-      "community": 20,
+      "community": 50,
       "norm_label": "./mealdayeditor.svelte"
     },
     {
@@ -9144,7 +9174,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_aislemanagementpage",
-      "community": 20,
+      "community": 50,
       "norm_label": "aislemanagementpage.svelte"
     },
     {
@@ -9154,7 +9184,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canoncreatepage",
-      "community": 20,
+      "community": 33,
       "norm_label": "canoncreatepage.svelte"
     },
     {
@@ -9164,7 +9194,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canondetailpage",
-      "community": 20,
+      "community": 50,
       "norm_label": "canondetailpage.svelte"
     },
     {
@@ -9174,7 +9204,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "shared_types",
-      "community": 20,
+      "community": 50,
       "norm_label": "@salt/shared-types"
     },
     {
@@ -9275,7 +9305,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "canon_canonlistrow",
-      "community": 20,
+      "community": 50,
       "norm_label": "canonlistrow.svelte"
     },
     {
@@ -9615,7 +9645,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "home_homepage",
-      "community": 20,
+      "community": 50,
       "norm_label": "homepage.svelte"
     },
     {
@@ -9635,7 +9665,7 @@
       "source_location": "L127",
       "_origin": "ast",
       "id": "mealplan_mealdayeditor_each",
-      "community": 20,
+      "community": 50,
       "norm_label": "#each()"
     },
     {
@@ -9655,7 +9685,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "mealplan_mealplanweekpage",
-      "community": 20,
+      "community": 50,
       "norm_label": "mealplanweekpage.svelte"
     },
     {
@@ -9666,7 +9696,7 @@
       "_origin": "ast",
       "confidence": "EXTRACTED",
       "id": "recipes_recipeaddtolistsheet",
-      "community": 20,
+      "community": 50,
       "norm_label": "./recipeaddtolistsheet.svelte"
     },
     {
@@ -10066,7 +10096,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shopping_shoppinglistpage",
-      "community": 20,
+      "community": 162,
       "norm_label": "shoppinglistpage.svelte"
     },
     {
@@ -10076,7 +10106,7 @@
       "source_location": "L885",
       "_origin": "ast",
       "id": "shopping_shoppinglistpage_each",
-      "community": 20,
+      "community": 162,
       "norm_label": "#each()"
     },
     {
@@ -10096,7 +10126,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shopping_shoppinglistsmanagepage",
-      "community": 20,
+      "community": 33,
       "norm_label": "shoppinglistsmanagepage.svelte"
     },
     {
@@ -10356,7 +10386,7 @@
       "source_location": "L60",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_walkthroughcapture",
-      "community": 3,
+      "community": 141,
       "norm_label": "walkthroughcapture()"
     },
     {
@@ -10576,7 +10606,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test",
-      "community": 66,
+      "community": 162,
       "norm_label": "shoppinglistpage.danglingcanon.test.ts"
     },
     {
@@ -10586,7 +10616,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_mockcanonitems_mockaisles_mocklists_mockitems_mockdefaultlistid_mockloading",
-      "community": 66,
+      "community": 162,
       "norm_label": "{ mockcanonitems, mockaisles, mocklists, mockitems, mockdefaultlistid, mockloading }"
     },
     {
@@ -10596,7 +10626,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_canonitem",
-      "community": 66,
+      "community": 162,
       "norm_label": "canonitem()"
     },
     {
@@ -10606,7 +10636,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_item",
-      "community": 66,
+      "community": 162,
       "norm_label": "item()"
     },
     {
@@ -10616,7 +10646,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test",
-      "community": 66,
+      "community": 162,
       "norm_label": "shoppinglistpage.icon.test.ts"
     },
     {
@@ -10626,7 +10656,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_mockcanonitems_mockaisles_mocklists_mockitems_mockdefaultlistid_mockloading",
-      "community": 66,
+      "community": 162,
       "norm_label": "{ mockcanonitems, mockaisles, mocklists, mockitems, mockdefaultlistid, mockloading }"
     },
     {
@@ -10636,7 +10666,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_canonitem",
-      "community": 66,
+      "community": 162,
       "norm_label": "canonitem()"
     },
     {
@@ -10646,7 +10676,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_item",
-      "community": 66,
+      "community": 162,
       "norm_label": "item()"
     },
     {
@@ -10678,6 +10708,76 @@
       "id": "tests_aimodelcatalogservice_test_catalog",
       "community": 37,
       "norm_label": "catalog"
+    },
+    {
+      "label": "canonService.errorReporting.test.ts",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "tests_canonservice_errorreporting_test",
+      "community": 3,
+      "norm_label": "canonservice.errorreporting.test.ts"
+    },
+    {
+      "label": "{ reportSpy, gatedReport }",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "tests_canonservice_errorreporting_test_reportspy_gatedreport",
+      "community": 3,
+      "norm_label": "{ reportspy, gatedreport }"
+    },
+    {
+      "label": "fs",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L50",
+      "_origin": "ast",
+      "id": "tests_canonservice_errorreporting_test_fs",
+      "community": 3,
+      "norm_label": "fs"
+    },
+    {
+      "label": "STORAGE_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L52",
+      "_origin": "ast",
+      "id": "tests_canonservice_errorreporting_test_storage_err",
+      "community": 3,
+      "norm_label": "storage_err"
+    },
+    {
+      "label": "SYNC_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L53",
+      "_origin": "ast",
+      "id": "tests_canonservice_errorreporting_test_sync_err",
+      "community": 3,
+      "norm_label": "sync_err"
+    },
+    {
+      "label": "NETWORK_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L54",
+      "_origin": "ast",
+      "id": "tests_canonservice_errorreporting_test_network_err",
+      "community": 3,
+      "norm_label": "network_err"
+    },
+    {
+      "label": "NOTFOUND_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L55",
+      "_origin": "ast",
+      "id": "tests_canonservice_errorreporting_test_notfound_err",
+      "community": 3,
+      "norm_label": "notfound_err"
     },
     {
       "label": "canonService.icon.test.ts",
@@ -10716,7 +10816,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test",
-      "community": 3,
+      "community": 2,
       "norm_label": "canonservice.sync.test.ts"
     },
     {
@@ -10726,7 +10826,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_fs",
-      "community": 3,
+      "community": 2,
       "norm_label": "fs"
     },
     {
@@ -10736,7 +10836,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_makeitem",
-      "community": 3,
+      "community": 2,
       "norm_label": "makeitem()"
     },
     {
@@ -10746,7 +10846,7 @@
       "source_location": "L57",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_makeaisle",
-      "community": 3,
+      "community": 2,
       "norm_label": "makeaisle()"
     },
     {
@@ -10756,7 +10856,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_itemscb",
-      "community": 3,
+      "community": 2,
       "norm_label": "itemscb"
     },
     {
@@ -10766,7 +10866,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_aislescb",
-      "community": 3,
+      "community": 2,
       "norm_label": "aislescb"
     },
     {
@@ -10776,8 +10876,88 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_wiresubscriptions",
-      "community": 3,
+      "community": 2,
       "norm_label": "wiresubscriptions()"
+    },
+    {
+      "label": "chatService.errorReporting.test.ts",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "tests_chatservice_errorreporting_test",
+      "community": 42,
+      "norm_label": "chatservice.errorreporting.test.ts"
+    },
+    {
+      "label": "{ reportSpy }",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L7",
+      "_origin": "ast",
+      "id": "tests_chatservice_errorreporting_test_reportspy",
+      "community": 42,
+      "norm_label": "{ reportspy }"
+    },
+    {
+      "label": "fs",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L39",
+      "_origin": "ast",
+      "id": "tests_chatservice_errorreporting_test_fs",
+      "community": 42,
+      "norm_label": "fs"
+    },
+    {
+      "label": "STORAGE_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L41",
+      "_origin": "ast",
+      "id": "tests_chatservice_errorreporting_test_storage_err",
+      "community": 42,
+      "norm_label": "storage_err"
+    },
+    {
+      "label": "SYNC_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L42",
+      "_origin": "ast",
+      "id": "tests_chatservice_errorreporting_test_sync_err",
+      "community": 42,
+      "norm_label": "sync_err"
+    },
+    {
+      "label": "NETWORK_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L43",
+      "_origin": "ast",
+      "id": "tests_chatservice_errorreporting_test_network_err",
+      "community": 42,
+      "norm_label": "network_err"
+    },
+    {
+      "label": "AUTH_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L44",
+      "_origin": "ast",
+      "id": "tests_chatservice_errorreporting_test_auth_err",
+      "community": 42,
+      "norm_label": "auth_err"
+    },
+    {
+      "label": "makeSession()",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L46",
+      "_origin": "ast",
+      "id": "tests_chatservice_errorreporting_test_makesession",
+      "community": 42,
+      "norm_label": "makesession()"
     },
     {
       "label": "equipmentService.sync.test.ts",
@@ -11150,6 +11330,106 @@
       "norm_label": "parsedingredient"
     },
     {
+      "label": "recipeService.errorReporting.test.ts",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "tests_recipeservice_errorreporting_test",
+      "community": 157,
+      "norm_label": "recipeservice.errorreporting.test.ts"
+    },
+    {
+      "label": "{ reportSpy }",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L7",
+      "_origin": "ast",
+      "id": "tests_recipeservice_errorreporting_test_reportspy",
+      "community": 157,
+      "norm_label": "{ reportspy }"
+    },
+    {
+      "label": "{ mockGetCanonItemsSnapshot }",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L33",
+      "_origin": "ast",
+      "id": "tests_recipeservice_errorreporting_test_mockgetcanonitemssnapshot",
+      "community": 157,
+      "norm_label": "{ mockgetcanonitemssnapshot }"
+    },
+    {
+      "label": "fs",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L50",
+      "_origin": "ast",
+      "id": "tests_recipeservice_errorreporting_test_fs",
+      "community": 157,
+      "norm_label": "fs"
+    },
+    {
+      "label": "STORAGE_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L52",
+      "_origin": "ast",
+      "id": "tests_recipeservice_errorreporting_test_storage_err",
+      "community": 157,
+      "norm_label": "storage_err"
+    },
+    {
+      "label": "SYNC_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L53",
+      "_origin": "ast",
+      "id": "tests_recipeservice_errorreporting_test_sync_err",
+      "community": 157,
+      "norm_label": "sync_err"
+    },
+    {
+      "label": "NETWORK_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L54",
+      "_origin": "ast",
+      "id": "tests_recipeservice_errorreporting_test_network_err",
+      "community": 157,
+      "norm_label": "network_err"
+    },
+    {
+      "label": "CONFLICT_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L55",
+      "_origin": "ast",
+      "id": "tests_recipeservice_errorreporting_test_conflict_err",
+      "community": 157,
+      "norm_label": "conflict_err"
+    },
+    {
+      "label": "makeRecipe()",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L57",
+      "_origin": "ast",
+      "id": "tests_recipeservice_errorreporting_test_makerecipe",
+      "community": 157,
+      "norm_label": "makerecipe()"
+    },
+    {
+      "label": "makeIngredient()",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L79",
+      "_origin": "ast",
+      "id": "tests_recipeservice_errorreporting_test_makeingredient",
+      "community": 157,
+      "norm_label": "makeingredient()"
+    },
+    {
       "label": "recipeService.matchIngredient.test.ts",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.matchIngredient.test.ts",
@@ -11218,6 +11498,76 @@
       "id": "apps_web_pwa_tests_setup_ts_tests_setup",
       "community": 200,
       "norm_label": "setup.ts"
+    },
+    {
+      "label": "shoppingListService.errorReporting.test.ts",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "tests_shoppinglistservice_errorreporting_test",
+      "community": 10,
+      "norm_label": "shoppinglistservice.errorreporting.test.ts"
+    },
+    {
+      "label": "{ reportSpy }",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L6",
+      "_origin": "ast",
+      "id": "tests_shoppinglistservice_errorreporting_test_reportspy",
+      "community": 10,
+      "norm_label": "{ reportspy }"
+    },
+    {
+      "label": "fs",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L53",
+      "_origin": "ast",
+      "id": "tests_shoppinglistservice_errorreporting_test_fs",
+      "community": 10,
+      "norm_label": "fs"
+    },
+    {
+      "label": "STORAGE_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L55",
+      "_origin": "ast",
+      "id": "tests_shoppinglistservice_errorreporting_test_storage_err",
+      "community": 10,
+      "norm_label": "storage_err"
+    },
+    {
+      "label": "SYNC_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L56",
+      "_origin": "ast",
+      "id": "tests_shoppinglistservice_errorreporting_test_sync_err",
+      "community": 10,
+      "norm_label": "sync_err"
+    },
+    {
+      "label": "NETWORK_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L57",
+      "_origin": "ast",
+      "id": "tests_shoppinglistservice_errorreporting_test_network_err",
+      "community": 10,
+      "norm_label": "network_err"
+    },
+    {
+      "label": "VALIDATION_ERR",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L58",
+      "_origin": "ast",
+      "id": "tests_shoppinglistservice_errorreporting_test_validation_err",
+      "community": 10,
+      "norm_label": "validation_err"
     },
     {
       "label": "shoppingListService.manualSource.test.ts",
@@ -12492,7 +12842,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_aislesubscription",
-      "community": 3,
+      "community": 141,
       "norm_label": "aislesubscription.ts"
     },
     {
@@ -12502,7 +12852,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_aislesubscription_subscribeaisles",
-      "community": 3,
+      "community": 141,
       "norm_label": "subscribeaisles()"
     },
     {
@@ -12512,7 +12862,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "src_aislesubscription_saveaisles",
-      "community": 3,
+      "community": 2,
       "norm_label": "saveaisles()"
     },
     {
@@ -12522,7 +12872,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_appsettingssync",
-      "community": 1,
+      "community": 141,
       "norm_label": "appsettingssync.ts"
     },
     {
@@ -12542,7 +12892,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_appsettingssync_saveappsettings",
-      "community": 47,
+      "community": 141,
       "norm_label": "saveappsettings()"
     },
     {
@@ -12612,7 +12962,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "src_auth_createfirebaseauth",
-      "community": 50,
+      "community": 117,
       "norm_label": "createfirebaseauth()"
     },
     {
@@ -12682,7 +13032,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_canonmatching",
-      "community": 64,
+      "community": 1,
       "norm_label": "canonmatching.ts"
     },
     {
@@ -12692,7 +13042,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "src_canonmatching_wireresult",
-      "community": 64,
+      "community": 1,
       "norm_label": "wireresult"
     },
     {
@@ -12702,7 +13052,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "src_canonmatching_callmatchorcreate",
-      "community": 64,
+      "community": 3,
       "norm_label": "callmatchorcreate()"
     },
     {
@@ -12712,7 +13062,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_canonmatching_wirebatchresult",
-      "community": 64,
+      "community": 1,
       "norm_label": "wirebatchresult"
     },
     {
@@ -12742,7 +13092,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_canonsubscription",
-      "community": 1,
+      "community": 141,
       "norm_label": "canonsubscription.ts"
     },
     {
@@ -12752,7 +13102,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_canonsubscription_subscribecanonitems",
-      "community": 3,
+      "community": 141,
       "norm_label": "subscribecanonitems()"
     },
     {
@@ -12762,7 +13112,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "src_canonsubscription_upsertcanonitem",
-      "community": 3,
+      "community": 2,
       "norm_label": "upsertcanonitem()"
     },
     {
@@ -12772,7 +13122,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "src_canonsubscription_deletecanonitem",
-      "community": 3,
+      "community": 141,
       "norm_label": "deletecanonitem()"
     },
     {
@@ -12822,7 +13172,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_chatsessionsubscription",
-      "community": 1,
+      "community": 141,
       "norm_label": "chatsessionsubscription.ts"
     },
     {
@@ -12832,7 +13182,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_expiresat",
-      "community": 42,
+      "community": 141,
       "norm_label": "expiresat()"
     },
     {
@@ -12842,7 +13192,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_subscribechatsessions",
-      "community": 42,
+      "community": 141,
       "norm_label": "subscribechatsessions()"
     },
     {
@@ -12862,7 +13212,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_savechatsession",
-      "community": 42,
+      "community": 141,
       "norm_label": "savechatsession()"
     },
     {
@@ -12872,7 +13222,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_deletechatsession",
-      "community": 42,
+      "community": 141,
       "norm_label": "deletechatsession()"
     },
     {
@@ -12882,7 +13232,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_devsettingssync",
-      "community": 1,
+      "community": 141,
       "norm_label": "devsettingssync.ts"
     },
     {
@@ -12902,7 +13252,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_devsettingssync_savedevsettings",
-      "community": 107,
+      "community": 141,
       "norm_label": "savedevsettings()"
     },
     {
@@ -13002,7 +13352,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_equipmentmanifestsubscription",
-      "community": 9,
+      "community": 141,
       "norm_label": "equipmentmanifestsubscription.ts"
     },
     {
@@ -13012,7 +13362,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_equipmentmanifestsubscription_subscribeequipmentmanifest",
-      "community": 9,
+      "community": 141,
       "norm_label": "subscribeequipmentmanifest()"
     },
     {
@@ -13032,7 +13382,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_firestoreerrors",
-      "community": 1,
+      "community": 141,
       "norm_label": "firestoreerrors.ts"
     },
     {
@@ -13092,7 +13442,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "src_init_appcheckconfig",
-      "community": 50,
+      "community": 117,
       "norm_label": "appcheckconfig"
     },
     {
@@ -13122,7 +13472,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_mealplansync",
-      "community": 0,
+      "community": 141,
       "norm_label": "mealplansync.ts"
     },
     {
@@ -13162,7 +13512,7 @@
       "source_location": "L93",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplanconfig",
-      "community": 0,
+      "community": 141,
       "norm_label": "savemealplanconfig()"
     },
     {
@@ -13172,7 +13522,7 @@
       "source_location": "L105",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplantemplate",
-      "community": 0,
+      "community": 141,
       "norm_label": "savemealplantemplate()"
     },
     {
@@ -13182,7 +13532,7 @@
       "source_location": "L118",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplanweek",
-      "community": 0,
+      "community": 141,
       "norm_label": "savemealplanweek()"
     },
     {
@@ -13192,7 +13542,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_memberssubscription",
-      "community": 1,
+      "community": 141,
       "norm_label": "memberssubscription.ts"
     },
     {
@@ -13202,7 +13552,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "src_memberssubscription_subscribemembers",
-      "community": 10,
+      "community": 141,
       "norm_label": "subscribemembers()"
     },
     {
@@ -13222,7 +13572,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "src_memberssubscription_deletemember",
-      "community": 10,
+      "community": 141,
       "norm_label": "deletemember()"
     },
     {
@@ -13282,7 +13632,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "src_recipesubscription_subscriberecipes",
-      "community": 141,
+      "community": 24,
       "norm_label": "subscriberecipes()"
     },
     {
@@ -13322,7 +13672,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription",
-      "community": 141,
+      "community": 8,
       "norm_label": "shoppinglistitemsubscription.ts"
     },
     {
@@ -13332,7 +13682,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_subscribeshoppinglistitems",
-      "community": 141,
+      "community": 8,
       "norm_label": "subscribeshoppinglistitems()"
     },
     {
@@ -13342,7 +13692,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_listshoppinglistitems",
-      "community": 141,
+      "community": 8,
       "norm_label": "listshoppinglistitems()"
     },
     {
@@ -13352,7 +13702,7 @@
       "source_location": "L71",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_saveshoppinglistitem",
-      "community": 141,
+      "community": 8,
       "norm_label": "saveshoppinglistitem()"
     },
     {
@@ -13362,7 +13712,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_deleteshoppinglistitem",
-      "community": 141,
+      "community": 8,
       "norm_label": "deleteshoppinglistitem()"
     },
     {
@@ -13372,7 +13722,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_deleteshoppinglistitems",
-      "community": 141,
+      "community": 8,
       "norm_label": "deleteshoppinglistitems()"
     },
     {
@@ -13382,7 +13732,7 @@
       "source_location": "L114",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_moveshoppinglistitems",
-      "community": 141,
+      "community": 8,
       "norm_label": "moveshoppinglistitems()"
     },
     {
@@ -13452,7 +13802,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription",
-      "community": 1,
+      "community": 141,
       "norm_label": "shoppinglistsconfigsubscription.ts"
     },
     {
@@ -13462,7 +13812,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription_subscribeshoppinglistsconfig",
-      "community": 3,
+      "community": 141,
       "norm_label": "subscribeshoppinglistsconfig()"
     },
     {
@@ -13892,7 +14242,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test",
-      "community": 3,
+      "community": 141,
       "norm_label": "realtimesubscriptions.emulator.test.ts"
     },
     {
@@ -13902,7 +14252,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_writer_firestore_port",
-      "community": 3,
+      "community": 141,
       "norm_label": "writer_firestore_port"
     },
     {
@@ -13912,7 +14262,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_makeitem",
-      "community": 3,
+      "community": 141,
       "norm_label": "makeitem()"
     },
     {
@@ -13922,7 +14272,7 @@
       "source_location": "L80",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_makeaisle",
-      "community": 3,
+      "community": 141,
       "norm_label": "makeaisle()"
     },
     {
@@ -13932,7 +14282,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_createwriterapp",
-      "community": 3,
+      "community": 141,
       "norm_label": "createwriterapp()"
     },
     {
@@ -13942,7 +14292,7 @@
       "source_location": "L490",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_delay",
-      "community": 3,
+      "community": 141,
       "norm_label": "delay()"
     },
     {
@@ -13952,7 +14302,7 @@
       "source_location": "L494",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_waitfor",
-      "community": 3,
+      "community": 141,
       "norm_label": "waitfor()"
     },
     {
@@ -13962,7 +14312,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_recipesubscription_test",
-      "community": 141,
+      "community": 279,
       "norm_label": "recipesubscription.test.ts"
     },
     {
@@ -13972,7 +14322,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdeletedoc_mockgetdoc_mockdoc_mockcollection_mockgetfirestore",
-      "community": 141,
+      "community": 279,
       "norm_label": "{\n  mockunsubscribe,\n  mockonsnapshot,\n  mocksetdoc,\n  mockdeletedoc,\n  mockgetdoc,\n  mockdoc,\n  mockcollection,\n  mockgetfirestore,\n}"
     },
     {
@@ -13982,7 +14332,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_snapdoc",
-      "community": 141,
+      "community": 279,
       "norm_label": "snapdoc"
     },
     {
@@ -13992,7 +14342,7 @@
       "source_location": "L47",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_collectioncallback",
-      "community": 141,
+      "community": 279,
       "norm_label": "collectioncallback"
     },
     {
@@ -14002,7 +14352,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_errorcallback",
-      "community": 141,
+      "community": 279,
       "norm_label": "errorcallback"
     },
     {
@@ -14012,7 +14362,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_recipe",
-      "community": 141,
+      "community": 279,
       "norm_label": "recipe"
     },
     {
@@ -14022,7 +14372,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test",
-      "community": 141,
+      "community": 8,
       "norm_label": "shoppinglistitemsubscription.test.ts"
     },
     {
@@ -14032,7 +14382,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdeletedoc_mockgetdocs_mockdoc_mockcollection_mockgetfirestore_mockwritebatch_mockbatchdelete_mockbatchset_mockbatchcommit",
-      "community": 141,
+      "community": 8,
       "norm_label": "{\n  mockunsubscribe,\n  mockonsnapshot,\n  mocksetdoc,\n  mockdeletedoc,\n  mockgetdocs,\n  mockdoc,\n  mockcollection,\n  mockgetfirestore,\n  mockwritebatch,\n  mockbatchdelete,\n  mockbatchset,\n  mockbatchcommit,\n}"
     },
     {
@@ -14042,7 +14392,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_snapcallback",
-      "community": 141,
+      "community": 8,
       "norm_label": "snapcallback"
     },
     {
@@ -14052,7 +14402,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_errorcallback",
-      "community": 141,
+      "community": 8,
       "norm_label": "errorcallback"
     },
     {
@@ -14062,7 +14412,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_item_1",
-      "community": 141,
+      "community": 8,
       "norm_label": "item_1"
     },
     {
@@ -14072,7 +14422,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_item_2",
-      "community": 141,
+      "community": 8,
       "norm_label": "item_2"
     },
     {
@@ -14132,7 +14482,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test",
-      "community": 66,
+      "community": 141,
       "norm_label": "shoppinglistsconfigsubscription.test.ts"
     },
     {
@@ -14142,7 +14492,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockgetdoc_mockdoc_mockgetfirestore",
-      "community": 66,
+      "community": 141,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockgetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -14152,7 +14502,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test_snapcallback",
-      "community": 66,
+      "community": 141,
       "norm_label": "snapcallback"
     },
     {
@@ -14162,7 +14512,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test_errorcallback",
-      "community": 66,
+      "community": 141,
       "norm_label": "errorcallback"
     },
     {
@@ -14172,7 +14522,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test_config",
-      "community": 66,
+      "community": 141,
       "norm_label": "config"
     },
     {
@@ -15822,7 +16172,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "commands_createaisle_createaisleinput",
-      "community": 11,
+      "community": 64,
       "norm_label": "createaisleinput"
     },
     {
@@ -15832,7 +16182,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createaisle_createaisle",
-      "community": 3,
+      "community": 2,
       "norm_label": "createaisle()"
     },
     {
@@ -15852,7 +16202,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "commands_createaislesbulk_createaislesbulkinput",
-      "community": 11,
+      "community": 64,
       "norm_label": "createaislesbulkinput"
     },
     {
@@ -15862,7 +16212,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createaislesbulk_createaislesbulk",
-      "community": 3,
+      "community": 2,
       "norm_label": "createaislesbulk()"
     },
     {
@@ -15892,7 +16242,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "commands_createcanonitem_createcanonitem",
-      "community": 17,
+      "community": 265,
       "norm_label": "createcanonitem()"
     },
     {
@@ -15912,7 +16262,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_deleteaisles_deleteaislesinput",
-      "community": 11,
+      "community": 64,
       "norm_label": "deleteaislesinput"
     },
     {
@@ -15922,7 +16272,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_deleteaisles_deleteaisles",
-      "community": 1,
+      "community": 281,
       "norm_label": "deleteaisles()"
     },
     {
@@ -15942,7 +16292,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateinput",
-      "community": 64,
+      "community": 95,
       "norm_label": "matchorcreateinput"
     },
     {
@@ -15952,7 +16302,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateresult",
-      "community": 64,
+      "community": 3,
       "norm_label": "matchorcreateresult"
     },
     {
@@ -15962,7 +16312,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateports",
-      "community": 275,
+      "community": 64,
       "norm_label": "matchorcreateports"
     },
     {
@@ -16152,7 +16502,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_mergeaisles",
-      "community": 1,
+      "community": 64,
       "norm_label": "mergeaisles.ts"
     },
     {
@@ -16162,7 +16512,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_mergeaisles_itemmergechoice",
-      "community": 11,
+      "community": 64,
       "norm_label": "itemmergechoice"
     },
     {
@@ -16172,7 +16522,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "commands_mergeaisles_peritemmergechoice",
-      "community": 11,
+      "community": 64,
       "norm_label": "peritemmergechoice"
     },
     {
@@ -16182,7 +16532,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "commands_mergeaisles_mergeaislesinput",
-      "community": 3,
+      "community": 64,
       "norm_label": "mergeaislesinput"
     },
     {
@@ -16192,7 +16542,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "commands_mergeaisles_mergeaisles",
-      "community": 1,
+      "community": 266,
       "norm_label": "mergeaisles()"
     },
     {
@@ -16202,7 +16552,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_mergecanonitems",
-      "community": 11,
+      "community": 116,
       "norm_label": "mergecanonitems.ts"
     },
     {
@@ -16212,7 +16562,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "commands_mergecanonitems_mergecanonitems",
-      "community": 11,
+      "community": 116,
       "norm_label": "mergecanonitems()"
     },
     {
@@ -16222,7 +16572,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "commands_mergecanonitems_unionsynonyms",
-      "community": 11,
+      "community": 116,
       "norm_label": "unionsynonyms()"
     },
     {
@@ -16242,7 +16592,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_renameaisle_renameaisleinput",
-      "community": 11,
+      "community": 64,
       "norm_label": "renameaisleinput"
     },
     {
@@ -16252,7 +16602,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_renameaisle_renameaisle",
-      "community": 1,
+      "community": 2,
       "norm_label": "renameaisle()"
     },
     {
@@ -16272,7 +16622,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_renamecanonitem_renamecanonitem",
-      "community": 3,
+      "community": 11,
       "norm_label": "renamecanonitem()"
     },
     {
@@ -16292,7 +16642,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_reorderaisles_reorderaislesinput",
-      "community": 11,
+      "community": 64,
       "norm_label": "reorderaislesinput"
     },
     {
@@ -16302,7 +16652,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_reorderaisles_reorderaisles",
-      "community": 1,
+      "community": 2,
       "norm_label": "reorderaisles()"
     },
     {
@@ -16312,7 +16662,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_resolvecanonconflict",
-      "community": 11,
+      "community": 116,
       "norm_label": "resolvecanonconflict.ts"
     },
     {
@@ -16322,7 +16672,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "commands_resolvecanonconflict_conflictstrategy",
-      "community": 11,
+      "community": 116,
       "norm_label": "conflictstrategy"
     },
     {
@@ -16332,7 +16682,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_resolvecanonconflict_resolvecanonconflict",
-      "community": 11,
+      "community": 116,
       "norm_label": "resolvecanonconflict()"
     },
     {
@@ -16352,7 +16702,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setcanonitemaisle_setcanonitemaisle",
-      "community": 3,
+      "community": 11,
       "norm_label": "setcanonitemaisle()"
     },
     {
@@ -16372,7 +16722,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setcanonitemshoppingfields_setcanonitemshoppingbehavior",
-      "community": 3,
+      "community": 11,
       "norm_label": "setcanonitemshoppingbehavior()"
     },
     {
@@ -16382,7 +16732,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "commands_setcanonitemshoppingfields_setcanonitemthreshold",
-      "community": 3,
+      "community": 11,
       "norm_label": "setcanonitemthreshold()"
     },
     {
@@ -16402,7 +16752,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setcanonitemsynonyms_setcanonitemsynonyms",
-      "community": 3,
+      "community": 11,
       "norm_label": "setcanonitemsynonyms()"
     },
     {
@@ -16492,7 +16842,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_matchcandidate",
-      "community": 11,
+      "community": 64,
       "norm_label": "matchcandidate.ts"
     },
     {
@@ -16502,7 +16852,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "entities_matchcandidate_matchstage",
-      "community": 11,
+      "community": 64,
       "norm_label": "matchstage"
     },
     {
@@ -16512,7 +16862,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_matchcandidate_matchcandidate",
-      "community": 11,
+      "community": 64,
       "norm_label": "matchcandidate"
     },
     {
@@ -16532,7 +16882,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_matchlogentry_candidatelog",
-      "community": 17,
+      "community": 32,
       "norm_label": "candidatelog"
     },
     {
@@ -16592,7 +16942,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_index",
-      "community": 11,
+      "community": 64,
       "norm_label": "index.ts"
     },
     {
@@ -16622,7 +16972,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_canonarbitrationport",
-      "community": 11,
+      "community": 64,
       "norm_label": "canonarbitrationport.ts"
     },
     {
@@ -16632,7 +16982,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_canonarbitrationport_arbitrationresult",
-      "community": 11,
+      "community": 64,
       "norm_label": "arbitrationresult"
     },
     {
@@ -16642,7 +16992,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "ports_canonarbitrationport_arbitrationrequest",
-      "community": 11,
+      "community": 64,
       "norm_label": "arbitrationrequest"
     },
     {
@@ -16652,7 +17002,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "ports_canonarbitrationport_canonarbitrationport",
-      "community": 275,
+      "community": 64,
       "norm_label": "canonarbitrationport"
     },
     {
@@ -16662,7 +17012,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_canonlocalstoreport",
-      "community": 1,
+      "community": 64,
       "norm_label": "canonlocalstoreport.ts"
     },
     {
@@ -16672,7 +17022,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_canonlocalstoreport_canonlocalstoreport",
-      "community": 1,
+      "community": 64,
       "norm_label": "canonlocalstoreport"
     },
     {
@@ -16682,7 +17032,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_canonlookupport",
-      "community": 11,
+      "community": 64,
       "norm_label": "canonlookupport.ts"
     },
     {
@@ -16692,7 +17042,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "ports_canonlookupport_canonlookupport",
-      "community": 11,
+      "community": 64,
       "norm_label": "canonlookupport"
     },
     {
@@ -16742,7 +17092,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_matchloggingport",
-      "community": 275,
+      "community": 64,
       "norm_label": "matchloggingport.ts"
     },
     {
@@ -16752,7 +17102,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "ports_matchloggingport_matchloggingport",
-      "community": 275,
+      "community": 64,
       "norm_label": "matchloggingport"
     },
     {
@@ -16762,7 +17112,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_canonicon",
-      "community": 11,
+      "community": 64,
       "norm_label": "canonicon.ts"
     },
     {
@@ -16772,7 +17122,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "queries_canonicon_iscanoniconrenderable",
-      "community": 11,
+      "community": 64,
       "norm_label": "iscanoniconrenderable()"
     },
     {
@@ -16782,7 +17132,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_createcanonlookup",
-      "community": 11,
+      "community": 64,
       "norm_label": "createcanonlookup.ts"
     },
     {
@@ -16792,7 +17142,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "queries_createcanonlookup_createcanonlookup",
-      "community": 11,
+      "community": 64,
       "norm_label": "createcanonlookup()"
     },
     {
@@ -16822,7 +17172,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_findclosestmatch",
-      "community": 17,
+      "community": 32,
       "norm_label": "findclosestmatch.ts"
     },
     {
@@ -16832,7 +17182,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "queries_findclosestmatch_findclosestmatchresult",
-      "community": 11,
+      "community": 64,
       "norm_label": "findclosestmatchresult"
     },
     {
@@ -16862,7 +17212,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "queries_getaisleusage_getaisleusage",
-      "community": 1,
+      "community": 11,
       "norm_label": "getaisleusage()"
     },
     {
@@ -17062,7 +17412,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_synonymmatch",
-      "community": 17,
+      "community": 11,
       "norm_label": "synonymmatch.ts"
     },
     {
@@ -17072,7 +17422,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "queries_synonymmatch_synonymmatch",
-      "community": 17,
+      "community": 11,
       "norm_label": "synonymmatch()"
     },
     {
@@ -17112,7 +17462,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addaccessory",
-      "community": 9,
+      "community": 1,
       "norm_label": "addaccessory.ts"
     },
     {
@@ -17122,7 +17472,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_addaccessory_addaccessoryinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "addaccessoryinput"
     },
     {
@@ -17142,7 +17492,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addequipment",
-      "community": 9,
+      "community": 1,
       "norm_label": "addequipment.ts"
     },
     {
@@ -17152,7 +17502,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_addequipment_addequipmentinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "addequipmentinput"
     },
     {
@@ -17172,7 +17522,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addrule",
-      "community": 9,
+      "community": 1,
       "norm_label": "addrule.ts"
     },
     {
@@ -17182,7 +17532,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_addrule_addruleinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "addruleinput"
     },
     {
@@ -17202,7 +17552,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_editrule",
-      "community": 9,
+      "community": 1,
       "norm_label": "editrule.ts"
     },
     {
@@ -17212,7 +17562,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_editrule_editruleinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "editruleinput"
     },
     {
@@ -17232,7 +17582,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removeaccessory",
-      "community": 9,
+      "community": 1,
       "norm_label": "removeaccessory.ts"
     },
     {
@@ -17242,7 +17592,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removeaccessory_removeaccessoryinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "removeaccessoryinput"
     },
     {
@@ -17262,7 +17612,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removeequipment",
-      "community": 9,
+      "community": 1,
       "norm_label": "removeequipment.ts"
     },
     {
@@ -17272,7 +17622,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removeequipment_removeequipmentinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "removeequipmentinput"
     },
     {
@@ -17292,7 +17642,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removerule",
-      "community": 9,
+      "community": 1,
       "norm_label": "removerule.ts"
     },
     {
@@ -17302,7 +17652,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removerule_removeruleinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "removeruleinput"
     },
     {
@@ -17322,7 +17672,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_renameequipment",
-      "community": 9,
+      "community": 1,
       "norm_label": "renameequipment.ts"
     },
     {
@@ -17332,7 +17682,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_renameequipment_renameequipmentinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "renameequipmentinput"
     },
     {
@@ -17352,7 +17702,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_setaccessoryowned",
-      "community": 9,
+      "community": 1,
       "norm_label": "setaccessoryowned.ts"
     },
     {
@@ -17362,7 +17712,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setaccessoryowned_setaccessoryownedinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "setaccessoryownedinput"
     },
     {
@@ -17382,7 +17732,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentitem",
-      "community": 9,
+      "community": 1,
       "norm_label": "equipmentitem.ts"
     },
     {
@@ -17392,7 +17742,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentitem_accessory",
-      "community": 9,
+      "community": 1,
       "norm_label": "accessory"
     },
     {
@@ -17402,7 +17752,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "entities_equipmentitem_equipmentitem",
-      "community": 9,
+      "community": 1,
       "norm_label": "equipmentitem"
     },
     {
@@ -17412,7 +17762,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentmanifest",
-      "community": 9,
+      "community": 1,
       "norm_label": "equipmentmanifest.ts"
     },
     {
@@ -17422,7 +17772,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_equipmentmanifest_equipmentmanifest",
-      "community": 9,
+      "community": 1,
       "norm_label": "equipmentmanifest"
     },
     {
@@ -17432,7 +17782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "equipment_index",
-      "community": 9,
+      "community": 1,
       "norm_label": "index.ts"
     },
     {
@@ -17442,7 +17792,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_equipmentmanifestport",
-      "community": 9,
+      "community": 1,
       "norm_label": "equipmentmanifestport.ts"
     },
     {
@@ -17452,7 +17802,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_equipmentmanifestport_equipmentmanifestport",
-      "community": 9,
+      "community": 1,
       "norm_label": "equipmentmanifestport"
     },
     {
@@ -18322,7 +18672,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "queries_ingredients_flatteningredients",
-      "community": 36,
+      "community": 52,
       "norm_label": "flatteningredients()"
     },
     {
@@ -20242,7 +20592,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_createlist",
-      "community": 1,
+      "community": 66,
       "norm_label": "createlist.ts"
     },
     {
@@ -20252,7 +20602,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_createlist_createlistinput",
-      "community": 4,
+      "community": 66,
       "norm_label": "createlistinput"
     },
     {
@@ -20292,7 +20642,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "commands_deleteitem_deleteitem",
-      "community": 8,
+      "community": 4,
       "norm_label": "deleteitem()"
     },
     {
@@ -20382,7 +20732,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_edititemnotes_edititemnotes",
-      "community": 8,
+      "community": 4,
       "norm_label": "edititemnotes()"
     },
     {
@@ -20412,7 +20762,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_edititemrawtext_edititemrawtext",
-      "community": 8,
+      "community": 4,
       "norm_label": "edititemrawtext()"
     },
     {
@@ -20452,7 +20802,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "commands_moveitems_moveitems",
-      "community": 8,
+      "community": 4,
       "norm_label": "moveitems()"
     },
     {
@@ -20462,7 +20812,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_renamelist",
-      "community": 1,
+      "community": 66,
       "norm_label": "renamelist.ts"
     },
     {
@@ -20472,7 +20822,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_renamelist_renamelistinput",
-      "community": 4,
+      "community": 66,
       "norm_label": "renamelistinput"
     },
     {
@@ -20652,7 +21002,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_entryparseport",
-      "community": 83,
+      "community": 4,
       "norm_label": "entryparseport.ts"
     },
     {
@@ -20662,7 +21012,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "ports_entryparseport_entryparseport",
-      "community": 83,
+      "community": 4,
       "norm_label": "entryparseport"
     },
     {
@@ -20972,7 +21322,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "queries_parseentry_parsedentry",
-      "community": 83,
+      "community": 4,
       "norm_label": "parsedentry"
     },
     {
@@ -21072,7 +21422,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_recipeitemadddefault",
-      "community": 4,
+      "community": 24,
       "norm_label": "recipeitemadddefault.ts"
     },
     {
@@ -21082,7 +21432,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "queries_recipeitemadddefault_recipeitemadddefault",
-      "community": 4,
+      "community": 24,
       "norm_label": "recipeitemadddefault"
     },
     {
@@ -21092,7 +21442,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_resolveitemdisplayname",
-      "community": 83,
+      "community": 4,
       "norm_label": "resolveitemdisplayname.ts"
     },
     {
@@ -21102,7 +21452,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "queries_resolveitemdisplayname_resolveitemdisplayname",
-      "community": 83,
+      "community": 4,
       "norm_label": "resolveitemdisplayname()"
     },
     {
@@ -21172,7 +21522,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canonicon_test",
-      "community": 11,
+      "community": 64,
       "norm_label": "canonicon.test.ts"
     },
     {
@@ -21182,7 +21532,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canonitem_schema_test",
-      "community": 17,
+      "community": 265,
       "norm_label": "canonitem.schema.test.ts"
     },
     {
@@ -21192,7 +21542,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_canonitem_schema_test_counterids",
-      "community": 17,
+      "community": 265,
       "norm_label": "counterids()"
     },
     {
@@ -21352,7 +21702,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_createcanonitem_test",
-      "community": 17,
+      "community": 265,
       "norm_label": "createcanonitem.test.ts"
     },
     {
@@ -21362,7 +21712,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_createcanonitem_test_counterids",
-      "community": 17,
+      "community": 265,
       "norm_label": "counterids()"
     },
     {
@@ -21382,7 +21732,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_createcanonlookup_test_seed",
-      "community": 64,
+      "community": 95,
       "norm_label": "seed"
     },
     {
@@ -21402,7 +21752,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_deleteaisles_test",
-      "community": 1,
+      "community": 281,
       "norm_label": "deleteaisles.test.ts"
     },
     {
@@ -21412,7 +21762,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_deleteaisles_test_makeaislestore",
-      "community": 1,
+      "community": 281,
       "norm_label": "makeaislestore()"
     },
     {
@@ -21422,7 +21772,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "canon_deleteaisles_test_makecanonstore",
-      "community": 1,
+      "community": 281,
       "norm_label": "makecanonstore()"
     },
     {
@@ -21432,7 +21782,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "canon_deleteaisles_test_canonitem",
-      "community": 1,
+      "community": 281,
       "norm_label": "canonitem()"
     },
     {
@@ -21522,7 +21872,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_findclosestmatch_test",
-      "community": 17,
+      "community": 11,
       "norm_label": "findclosestmatch.test.ts"
     },
     {
@@ -21532,7 +21882,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_findclosestmatch_test_item",
-      "community": 17,
+      "community": 11,
       "norm_label": "item()"
     },
     {
@@ -21542,7 +21892,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "canon_findclosestmatch_test_catalog",
-      "community": 17,
+      "community": 11,
       "norm_label": "catalog"
     },
     {
@@ -21552,7 +21902,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_getaisleusage_test",
-      "community": 1,
+      "community": 11,
       "norm_label": "getaisleusage.test.ts"
     },
     {
@@ -21562,7 +21912,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_getaisleusage_test_makeaislestore",
-      "community": 1,
+      "community": 11,
       "norm_label": "makeaislestore()"
     },
     {
@@ -21572,7 +21922,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "canon_getaisleusage_test_makecanonstore",
-      "community": 1,
+      "community": 11,
       "norm_label": "makecanonstore()"
     },
     {
@@ -21582,7 +21932,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "canon_getaisleusage_test_canonitem",
-      "community": 1,
+      "community": 11,
       "norm_label": "canonitem()"
     },
     {
@@ -21782,7 +22132,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test",
-      "community": 64,
+      "community": 95,
       "norm_label": "matchorcreatebatch.test.ts"
     },
     {
@@ -21792,7 +22142,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_canonitem",
-      "community": 64,
+      "community": 95,
       "norm_label": "canonitem()"
     },
     {
@@ -21802,7 +22152,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_makeids",
-      "community": 64,
+      "community": 95,
       "norm_label": "makeids()"
     },
     {
@@ -21812,7 +22162,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_makestore",
-      "community": 64,
+      "community": 95,
       "norm_label": "makestore()"
     },
     {
@@ -21822,7 +22172,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_makeaislestore",
-      "community": 64,
+      "community": 95,
       "norm_label": "makeaislestore()"
     },
     {
@@ -21832,7 +22182,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_ex",
-      "community": 64,
+      "community": 95,
       "norm_label": "ex"
     },
     {
@@ -21842,7 +22192,7 @@
       "source_location": "L56",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_cosine",
-      "community": 64,
+      "community": 95,
       "norm_label": "cosine()"
     },
     {
@@ -21852,7 +22202,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_failembedding",
-      "community": 64,
+      "community": 95,
       "norm_label": "failembedding()"
     },
     {
@@ -21862,7 +22212,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_nomatcharbitration",
-      "community": 64,
+      "community": 95,
       "norm_label": "nomatcharbitration()"
     },
     {
@@ -21872,7 +22222,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_makeports",
-      "community": 64,
+      "community": 95,
       "norm_label": "makeports()"
     },
     {
@@ -21882,7 +22232,7 @@
       "source_location": "L111",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_shape",
-      "community": 64,
+      "community": 95,
       "norm_label": "shape"
     },
     {
@@ -21892,7 +22242,7 @@
       "source_location": "L133",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_runcombined",
-      "community": 64,
+      "community": 95,
       "norm_label": "runcombined()"
     },
     {
@@ -21902,7 +22252,7 @@
       "source_location": "L140",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_runsequential",
-      "community": 64,
+      "community": 95,
       "norm_label": "runsequential()"
     },
     {
@@ -21912,7 +22262,7 @@
       "source_location": "L154",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_normalizeids",
-      "community": 64,
+      "community": 95,
       "norm_label": "normalizeids()"
     },
     {
@@ -21922,7 +22272,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_mergeaisles_test",
-      "community": 1,
+      "community": 266,
       "norm_label": "mergeaisles.test.ts"
     },
     {
@@ -21932,7 +22282,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_makeaislestore",
-      "community": 1,
+      "community": 266,
       "norm_label": "makeaislestore()"
     },
     {
@@ -21942,7 +22292,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_makecanonstore",
-      "community": 1,
+      "community": 266,
       "norm_label": "makecanonstore()"
     },
     {
@@ -21952,7 +22302,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_canonitem",
-      "community": 1,
+      "community": 266,
       "norm_label": "canonitem()"
     },
     {
@@ -21962,7 +22312,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_aisles",
-      "community": 1,
+      "community": 266,
       "norm_label": "aisles"
     },
     {
@@ -21972,7 +22322,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_mergecanonitems_test",
-      "community": 11,
+      "community": 116,
       "norm_label": "mergecanonitems.test.ts"
     },
     {
@@ -21982,7 +22332,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_mergecanonitems_test_item",
-      "community": 11,
+      "community": 116,
       "norm_label": "item()"
     },
     {
@@ -22092,7 +22442,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test",
-      "community": 11,
+      "community": 116,
       "norm_label": "resolvecanonconflict.test.ts"
     },
     {
@@ -22102,7 +22452,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test_item",
-      "community": 11,
+      "community": 116,
       "norm_label": "item()"
     },
     {
@@ -22112,7 +22462,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test_local",
-      "community": 11,
+      "community": 116,
       "norm_label": "local"
     },
     {
@@ -22122,7 +22472,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test_remote",
-      "community": 11,
+      "community": 116,
       "norm_label": "remote"
     },
     {
@@ -22222,7 +22572,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test",
-      "community": 116,
+      "community": 32,
       "norm_label": "summarizematchlog.test.ts"
     },
     {
@@ -22232,7 +22582,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makestage",
-      "community": 116,
+      "community": 32,
       "norm_label": "makestage()"
     },
     {
@@ -22242,7 +22592,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makeentry",
-      "community": 116,
+      "community": 32,
       "norm_label": "makeentry()"
     },
     {
@@ -22252,7 +22602,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makearbitration",
-      "community": 116,
+      "community": 32,
       "norm_label": "makearbitration()"
     },
     {
@@ -22262,7 +22612,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_synonymmatch_test",
-      "community": 17,
+      "community": 11,
       "norm_label": "synonymmatch.test.ts"
     },
     {
@@ -22272,7 +22622,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_synonymmatch_test_items",
-      "community": 17,
+      "community": 11,
       "norm_label": "items"
     },
     {
@@ -22412,7 +22762,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "recipe_clearingredientmatch_test",
-      "community": 52,
+      "community": 36,
       "norm_label": "clearingredientmatch.test.ts"
     },
     {
@@ -22422,7 +22772,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "recipe_clearingredientmatch_test_matchedingredient",
-      "community": 52,
+      "community": 36,
       "norm_label": "matchedingredient()"
     },
     {
@@ -22462,7 +22812,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_commands_test",
-      "community": 8,
+      "community": 4,
       "norm_label": "commands.test.ts"
     },
     {
@@ -22472,7 +22822,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeids",
-      "community": 8,
+      "community": 4,
       "norm_label": "makeids()"
     },
     {
@@ -22482,7 +22832,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makelist",
-      "community": 8,
+      "community": 4,
       "norm_label": "makelist()"
     },
     {
@@ -22492,7 +22842,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeconfig",
-      "community": 8,
+      "community": 4,
       "norm_label": "makeconfig()"
     },
     {
@@ -22502,7 +22852,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeitem",
-      "community": 8,
+      "community": 4,
       "norm_label": "makeitem()"
     },
     {
@@ -22592,7 +22942,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_recipeitemadddefault_test",
-      "community": 4,
+      "community": 24,
       "norm_label": "recipeitemadddefault.test.ts"
     },
     {
@@ -22602,7 +22952,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_resolveitemdisplayname_test",
-      "community": 83,
+      "community": 4,
       "norm_label": "resolveitemdisplayname.test.ts"
     },
     {
@@ -22612,7 +22962,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "shoppinglist_resolveitemdisplayname_test_makeitem",
-      "community": 83,
+      "community": 4,
       "norm_label": "makeitem()"
     },
     {
@@ -25035,7 +25385,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_variants",
-      "community": 23,
+      "community": 27,
       "norm_label": "variants.ts"
     },
     {
@@ -25418,7 +25768,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "checkbox_checkbox_types",
-      "community": 26,
+      "community": 27,
       "norm_label": "checkbox.types.ts"
     },
     {
@@ -25428,7 +25778,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "checkbox_checkbox_types_checkedstate",
-      "community": 26,
+      "community": 27,
       "norm_label": "checkedstate"
     },
     {
@@ -25438,7 +25788,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "checkbox_checkbox_types_checkboxprops",
-      "community": 26,
+      "community": 27,
       "norm_label": "checkboxprops"
     },
     {
@@ -25448,7 +25798,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "checkbox_checkbox_variants",
-      "community": 26,
+      "community": 27,
       "norm_label": "checkbox.variants.ts"
     },
     {
@@ -25458,7 +25808,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "checkbox_checkbox_variants_checkboxrootvariants",
-      "community": 26,
+      "community": 27,
       "norm_label": "checkboxrootvariants"
     },
     {
@@ -25468,7 +25818,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "checkbox_index",
-      "community": 26,
+      "community": 27,
       "norm_label": "index.ts"
     },
     {
@@ -25709,7 +26059,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "combobox_combobox_variants",
-      "community": 95,
+      "community": 27,
       "norm_label": "combobox.variants.ts"
     },
     {
@@ -25719,7 +26069,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxinputvariants",
-      "community": 95,
+      "community": 27,
       "norm_label": "comboboxinputvariants"
     },
     {
@@ -25729,7 +26079,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxtriggervariants",
-      "community": 95,
+      "community": 27,
       "norm_label": "comboboxtriggervariants"
     },
     {
@@ -25739,7 +26089,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxcontentvariants",
-      "community": 95,
+      "community": 27,
       "norm_label": "comboboxcontentvariants"
     },
     {
@@ -25749,7 +26099,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxitemvariants",
-      "community": 95,
+      "community": 27,
       "norm_label": "comboboxitemvariants"
     },
     {
@@ -25759,7 +26109,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxcreatevariants",
-      "community": 95,
+      "community": 27,
       "norm_label": "comboboxcreatevariants"
     },
     {
@@ -25800,7 +26150,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "dom",
-      "community": 18,
+      "community": 14,
       "norm_label": "@floating-ui/dom"
     },
     {
@@ -26149,7 +26499,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_dialog_variants",
-      "community": 23,
+      "community": 27,
       "norm_label": "dialog.variants.ts"
     },
     {
@@ -26159,7 +26509,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "dialog_dialog_variants_dialogcontentvariants",
-      "community": 23,
+      "community": 27,
       "norm_label": "dialogcontentvariants"
     },
     {
@@ -26802,7 +27152,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_popover",
-      "community": 23,
+      "community": 150,
       "norm_label": "popover.svelte"
     },
     {
@@ -26812,7 +27162,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_headless_popover_headless_svelte",
-      "community": 23,
+      "community": 150,
       "norm_label": "../../headless/popover.headless.svelte"
     },
     {
@@ -26822,7 +27172,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_popover_popover_types",
-      "community": 23,
+      "community": 150,
       "norm_label": "./popover.types"
     },
     {
@@ -26832,7 +27182,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_popover_types",
-      "community": 23,
+      "community": 150,
       "norm_label": "popover.types.ts"
     },
     {
@@ -26842,7 +27192,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "popover_popover_types_popoverprops",
-      "community": 23,
+      "community": 150,
       "norm_label": "popoverprops"
     },
     {
@@ -26852,7 +27202,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "popover_popover_types_popovercontentprops",
-      "community": 23,
+      "community": 150,
       "norm_label": "popovercontentprops"
     },
     {
@@ -26862,7 +27212,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "popover_popover_types_popoverpartprops",
-      "community": 23,
+      "community": 150,
       "norm_label": "popoverpartprops"
     },
     {
@@ -26882,7 +27232,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_popovercontent",
-      "community": 23,
+      "community": 150,
       "norm_label": "popovercontent.svelte"
     },
     {
@@ -26892,7 +27242,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_popover_popover_variants",
-      "community": 23,
+      "community": 150,
       "norm_label": "./popover.variants"
     },
     {
@@ -26902,7 +27252,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_popovertrigger",
-      "community": 23,
+      "community": 150,
       "norm_label": "popovertrigger.svelte"
     },
     {
@@ -26912,7 +27262,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_index",
-      "community": 23,
+      "community": 150,
       "norm_label": "index.ts"
     },
     {
@@ -27725,7 +28075,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "sheet_sheettrigger",
-      "community": 23,
+      "community": 38,
       "norm_label": "sheettrigger.svelte"
     },
     {
@@ -28696,7 +29046,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltip",
-      "community": 2,
+      "community": 23,
       "norm_label": "tooltip.svelte"
     },
     {
@@ -28706,7 +29056,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "tooltip_tooltip_state",
-      "community": 2,
+      "community": 23,
       "norm_label": "state"
     },
     {
@@ -28716,7 +29066,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "tooltip_tooltip_handleopenchange",
-      "community": 2,
+      "community": 23,
       "norm_label": "handleopenchange()"
     },
     {
@@ -28726,7 +29076,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_headless_tooltip_headless_svelte",
-      "community": 2,
+      "community": 23,
       "norm_label": "../../headless/tooltip.headless.svelte"
     },
     {
@@ -28736,7 +29086,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_tooltip_tooltip_types",
-      "community": 2,
+      "community": 23,
       "norm_label": "./tooltip.types"
     },
     {
@@ -28746,7 +29096,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltip_types",
-      "community": 2,
+      "community": 23,
       "norm_label": "tooltip.types.ts"
     },
     {
@@ -28756,7 +29106,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "tooltip_tooltip_types_tooltipproviderprops",
-      "community": 2,
+      "community": 23,
       "norm_label": "tooltipproviderprops"
     },
     {
@@ -28766,7 +29116,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "tooltip_tooltip_types_tooltipprops",
-      "community": 2,
+      "community": 23,
       "norm_label": "tooltipprops"
     },
     {
@@ -28776,7 +29126,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "tooltip_tooltip_types_tooltipcontentprops",
-      "community": 2,
+      "community": 23,
       "norm_label": "tooltipcontentprops"
     },
     {
@@ -28786,7 +29136,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "tooltip_tooltip_types_tooltippartprops",
-      "community": 2,
+      "community": 23,
       "norm_label": "tooltippartprops"
     },
     {
@@ -28806,7 +29156,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltipcontent",
-      "community": 2,
+      "community": 23,
       "norm_label": "tooltipcontent.svelte"
     },
     {
@@ -28816,7 +29166,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_tooltip_tooltip_variants",
-      "community": 2,
+      "community": 23,
       "norm_label": "./tooltip.variants"
     },
     {
@@ -28826,7 +29176,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltipprovider",
-      "community": 2,
+      "community": 23,
       "norm_label": "tooltipprovider.svelte"
     },
     {
@@ -28836,7 +29186,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltiptrigger",
-      "community": 2,
+      "community": 23,
       "norm_label": "tooltiptrigger.svelte"
     },
     {
@@ -28846,7 +29196,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_index",
-      "community": 2,
+      "community": 23,
       "norm_label": "index.ts"
     },
     {
@@ -29569,7 +29919,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_popover_test",
-      "community": 23,
+      "community": 150,
       "norm_label": "popover.test.ts"
     },
     {
@@ -29819,7 +30169,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_tooltip_test",
-      "community": 2,
+      "community": 23,
       "norm_label": "tooltip.test.ts"
     },
     {
@@ -32685,7 +33035,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_foundations",
-      "community": 310,
+      "community": 273,
       "norm_label": "1. foundations"
     },
     {
@@ -32695,7 +33045,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_1_technology_stack",
-      "community": 310,
+      "community": 273,
       "norm_label": "1.1 technology stack"
     },
     {
@@ -32705,7 +33055,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_2_boundaries",
-      "community": 310,
+      "community": 273,
       "norm_label": "1.2 boundaries"
     },
     {
@@ -32715,7 +33065,7 @@
       "source_location": "L85",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_3_package_surface",
-      "community": 310,
+      "community": 273,
       "norm_label": "1.3 package surface"
     },
     {
@@ -32725,7 +33075,7 @@
       "source_location": "L137",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_4_event_naming_rule",
-      "community": 310,
+      "community": 273,
       "norm_label": "1.4 event naming rule"
     },
     {
@@ -32735,7 +33085,7 @@
       "source_location": "L147",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_5_spec_versioning_amendment_rule",
-      "community": 310,
+      "community": 273,
       "norm_label": "1.5 spec versioning & amendment rule"
     },
     {
@@ -32885,7 +33235,7 @@
       "source_location": "L383",
       "_origin": "ast",
       "id": "design_ui_spec_v02_3_5_helpers",
-      "community": 318,
+      "community": 299,
       "norm_label": "3.5 helpers"
     },
     {
@@ -32895,7 +33245,7 @@
       "source_location": "L385",
       "_origin": "ast",
       "id": "design_ui_spec_v02_src_lib_cn_ts",
-      "community": 318,
+      "community": 299,
       "norm_label": "`src/lib/cn.ts`"
     },
     {
@@ -32905,7 +33255,7 @@
       "source_location": "L396",
       "_origin": "ast",
       "id": "design_ui_spec_v02_src_lib_useid_ts",
-      "community": 318,
+      "community": 299,
       "norm_label": "`src/lib/useid.ts`"
     },
     {
@@ -32915,7 +33265,7 @@
       "source_location": "L409",
       "_origin": "ast",
       "id": "design_ui_spec_v02_src_lib_context_ts",
-      "community": 318,
+      "community": 299,
       "norm_label": "`src/lib/context.ts`"
     },
     {
@@ -32925,7 +33275,7 @@
       "source_location": "L432",
       "_origin": "ast",
       "id": "design_ui_spec_v02_src_lib_variants_ts",
-      "community": 318,
+      "community": 299,
       "norm_label": "`src/lib/variants.ts`"
     },
     {
@@ -33035,7 +33385,7 @@
       "source_location": "L669",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_styling_system",
-      "community": 312,
+      "community": 311,
       "norm_label": "4. styling system"
     },
     {
@@ -33105,7 +33455,7 @@
       "source_location": "L721",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_2_focus_ring",
-      "community": 312,
+      "community": 311,
       "norm_label": "4.2 focus ring"
     },
     {
@@ -33115,7 +33465,7 @@
       "source_location": "L735",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_3_disabled_loading",
-      "community": 312,
+      "community": 311,
       "norm_label": "4.3 disabled + loading"
     },
     {
@@ -33125,7 +33475,7 @@
       "source_location": "L737",
       "_origin": "ast",
       "id": "design_ui_spec_v02_disabled_terminal_state_no_interaction",
-      "community": 312,
+      "community": 311,
       "norm_label": "disabled (terminal state \u2014 no interaction)"
     },
     {
@@ -33135,7 +33485,7 @@
       "source_location": "L744",
       "_origin": "ast",
       "id": "design_ui_spec_v02_loading_transient_state_disables_interaction_without_terminal_semantics",
-      "community": 312,
+      "community": 311,
       "norm_label": "loading (transient state \u2014 disables interaction without terminal semantics)"
     },
     {
@@ -33145,7 +33495,7 @@
       "source_location": "L755",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_4_shared_size_scale",
-      "community": 313,
+      "community": 311,
       "norm_label": "4.4 shared size scale"
     },
     {
@@ -33155,7 +33505,7 @@
       "source_location": "L759",
       "_origin": "ast",
       "id": "design_ui_spec_v02_field_size_scale_textfield_textarea_frame_button",
-      "community": 313,
+      "community": 311,
       "norm_label": "field size scale (textfield, textarea frame, button)"
     },
     {
@@ -33165,7 +33515,7 @@
       "source_location": "L767",
       "_origin": "ast",
       "id": "design_ui_spec_v02_control_size_scale_checkbox_switch",
-      "community": 313,
+      "community": 311,
       "norm_label": "control size scale (checkbox, switch)"
     },
     {
@@ -33175,7 +33525,7 @@
       "source_location": "L775",
       "_origin": "ast",
       "id": "design_ui_spec_v02_dialog_size_scale",
-      "community": 313,
+      "community": 311,
       "norm_label": "dialog size scale"
     },
     {
@@ -33185,7 +33535,7 @@
       "source_location": "L785",
       "_origin": "ast",
       "id": "design_ui_spec_v02_text_size_scale_text_primitive",
-      "community": 313,
+      "community": 311,
       "norm_label": "text size scale (text primitive)"
     },
     {
@@ -33195,7 +33545,7 @@
       "source_location": "L793",
       "_origin": "ast",
       "id": "design_ui_spec_v02_icon_spinner_sizes",
-      "community": 313,
+      "community": 311,
       "norm_label": "icon / spinner sizes"
     },
     {
@@ -33205,7 +33555,7 @@
       "source_location": "L799",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_5_dark_mode",
-      "community": 312,
+      "community": 311,
       "norm_label": "4.5 dark mode"
     },
     {
@@ -33585,7 +33935,7 @@
       "source_location": "L1177",
       "_origin": "ast",
       "id": "design_ui_spec_v02_8_5_switch",
-      "community": 320,
+      "community": 283,
       "norm_label": "8.5 switch"
     },
     {
@@ -33595,7 +33945,7 @@
       "source_location": "L1179",
       "_origin": "ast",
       "id": "design_ui_spec_v02_props_1179",
-      "community": 320,
+      "community": 283,
       "norm_label": "props"
     },
     {
@@ -33605,7 +33955,7 @@
       "source_location": "L1195",
       "_origin": "ast",
       "id": "design_ui_spec_v02_events_1195",
-      "community": 320,
+      "community": 283,
       "norm_label": "events"
     },
     {
@@ -33615,7 +33965,7 @@
       "source_location": "L1199",
       "_origin": "ast",
       "id": "design_ui_spec_v02_accessibility_1199",
-      "community": 320,
+      "community": 283,
       "norm_label": "accessibility"
     },
     {
@@ -33625,7 +33975,7 @@
       "source_location": "L1205",
       "_origin": "ast",
       "id": "design_ui_spec_v02_styling_1205",
-      "community": 320,
+      "community": 283,
       "norm_label": "styling"
     },
     {
@@ -33985,7 +34335,7 @@
       "source_location": "L1462",
       "_origin": "ast",
       "id": "design_ui_spec_v02_8_13_layout_primitives_stack_inline_grid_divider",
-      "community": 319,
+      "community": 283,
       "norm_label": "8.13 layout primitives \u2014 stack / inline / grid / divider"
     },
     {
@@ -33995,7 +34345,7 @@
       "source_location": "L1464",
       "_origin": "ast",
       "id": "design_ui_spec_v02_stack",
-      "community": 319,
+      "community": 283,
       "norm_label": "stack"
     },
     {
@@ -34005,7 +34355,7 @@
       "source_location": "L1475",
       "_origin": "ast",
       "id": "design_ui_spec_v02_inline",
-      "community": 319,
+      "community": 283,
       "norm_label": "inline"
     },
     {
@@ -34015,7 +34365,7 @@
       "source_location": "L1479",
       "_origin": "ast",
       "id": "design_ui_spec_v02_grid",
-      "community": 319,
+      "community": 283,
       "norm_label": "grid"
     },
     {
@@ -34025,7 +34375,7 @@
       "source_location": "L1489",
       "_origin": "ast",
       "id": "design_ui_spec_v02_divider",
-      "community": 319,
+      "community": 283,
       "norm_label": "divider"
     },
     {
@@ -50948,6 +51298,17 @@
       "relation": "imports_from",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L44",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "lib_auth_svelte",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/tests/shoppingListService.manualSource.test.ts",
       "source_location": "L33",
       "weight": 1.0,
@@ -52025,9 +52386,9 @@
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_canonservice",
-      "target": "lib_errorreporting",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting"
     },
     {
       "relation": "imports",
@@ -52037,7 +52398,29 @@
       "source_location": "L42",
       "weight": 1.0,
       "source": "lib_canonservice",
-      "target": "lib_errorreporting_reportsubscriptionerror",
+      "target": "lib_errorreporting_reportiffailed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/canonService.ts",
+      "source_location": "L42",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "lib_canonservice",
+      "target": "lib_errorreporting_reportsubscriptionerror"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/canonService.ts",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "lib_canonservice",
+      "target": "lib_errorreporting_reportwriteerror",
       "confidence_score": 1.0
     },
     {
@@ -52313,6 +52696,17 @@
       "confidence_score": 1.0,
       "source": "tests_canondetailpage_test",
       "target": "lib_canonservice"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "tests_canonservice_errorreporting_test",
+      "target": "lib_canonservice",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -53101,9 +53495,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L38",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte",
-      "target": "lib_errorreporting",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting"
     },
     {
       "relation": "imports",
@@ -53113,7 +53507,29 @@
       "source_location": "L38",
       "weight": 1.0,
       "source": "lib_shoppinglistservice_svelte",
-      "target": "lib_errorreporting_reportsubscriptionerror",
+      "target": "lib_errorreporting_reportiffailed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L38",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "lib_shoppinglistservice_svelte",
+      "target": "lib_errorreporting_reportsubscriptionerror"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte",
+      "target": "lib_errorreporting_reportwriteerror",
       "confidence_score": 1.0
     },
     {
@@ -53382,6 +53798,16 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L77",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte",
+      "target": "lib_shoppinglistservice_svelte_reportfirstwritefailure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L364",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -53641,6 +54067,17 @@
       "confidence_score": 1.0,
       "source": "shopping_shoppinglistsmanagepage",
       "target": "lib_shoppinglistservice_svelte"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "lib_shoppinglistservice_svelte",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -53978,6 +54415,17 @@
       "confidence_score": 1.0,
       "source": "tests_membersservice_sync_test",
       "target": "lib_membersservice"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "lib_membersservice",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -54868,9 +55316,9 @@
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
       "source_location": "L11",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_recipeservice",
-      "target": "lib_errorreporting",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting"
     },
     {
       "relation": "imports",
@@ -54880,8 +55328,19 @@
       "source_location": "L11",
       "weight": 1.0,
       "source": "lib_recipeservice",
-      "target": "lib_errorreporting_reportsubscriptionerror",
+      "target": "lib_errorreporting_reportiffailed",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/recipeService.ts",
+      "source_location": "L11",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "lib_recipeservice",
+      "target": "lib_errorreporting_reportsubscriptionerror"
     },
     {
       "relation": "contains",
@@ -55347,6 +55806,17 @@
       "relation": "imports_from",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "lib_recipeservice",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/tests/recipeService.matchIngredient.test.ts",
       "source_location": "L19",
       "weight": 1.0,
@@ -55507,9 +55977,9 @@
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_chatservice",
-      "target": "lib_errorreporting",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting"
     },
     {
       "relation": "imports",
@@ -55519,7 +55989,29 @@
       "source_location": "L9",
       "weight": 1.0,
       "source": "lib_chatservice",
-      "target": "lib_errorreporting_reportsubscriptionerror",
+      "target": "lib_errorreporting_reportiffailed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/chatService.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "lib_chatservice",
+      "target": "lib_errorreporting_reportsubscriptionerror"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/chatService.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "lib_chatservice",
+      "target": "lib_errorreporting_reportwriteerror",
       "confidence_score": 1.0
     },
     {
@@ -55639,6 +56131,17 @@
       "confidence_score": 1.0,
       "source": "recipes_recipeviewpage",
       "target": "lib_chatservice"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "lib_chatservice",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -57540,6 +58043,17 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L44",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "lib_auth_svelte_auth",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/tests/shoppingListService.manualSource.test.ts",
       "source_location": "L33",
       "weight": 1.0,
@@ -57651,11 +58165,55 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
+      "source_location": "L226",
+      "weight": 1.0,
+      "source": "lib_canonservice_addcanonitem",
+      "target": "lib_canonservice_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/canonService.ts",
+      "source_location": "L325",
+      "weight": 1.0,
+      "source": "lib_canonservice_deletecanonitem",
+      "target": "lib_canonservice_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/canonService.ts",
       "source_location": "L150",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "lib_canonservice_initcanonsync",
       "target": "lib_canonservice_geterrorreporter"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/canonService.ts",
+      "source_location": "L339",
+      "weight": 1.0,
+      "source": "lib_canonservice_regeneratecanonicon",
+      "target": "lib_canonservice_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/canonService.ts",
+      "source_location": "L353",
+      "weight": 1.0,
+      "source": "lib_canonservice_unhidecanonicon",
+      "target": "lib_canonservice_geterrorreporter",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports",
@@ -57773,6 +58331,17 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
+      "source_location": "L226",
+      "weight": 1.0,
+      "source": "lib_canonservice_addcanonitem",
+      "target": "lib_errorreporting_reportwriteerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/canonService.ts",
       "source_location": "L194",
       "weight": 1.0,
       "source": "lib_canonservice_addcanonitem",
@@ -57821,6 +58390,17 @@
       "confidence_score": 1.0,
       "source": "tests_canoncreatepage_test",
       "target": "lib_canonservice_addcanonitem"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "tests_canonservice_errorreporting_test",
+      "target": "lib_canonservice_addcanonitem",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -58076,6 +58656,17 @@
       "target": "src_canonsubscription_upsertcanonitem"
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/canonService.ts",
+      "source_location": "L325",
+      "weight": 1.0,
+      "source": "lib_canonservice_deletecanonitem",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -58090,12 +58681,34 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "tests_canonservice_errorreporting_test",
+      "target": "lib_canonservice_deletecanonitem",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/tests/canonService.sync.test.ts",
       "source_location": "L22",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "tests_canonservice_sync_test",
       "target": "lib_canonservice_deletecanonitem"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/canonService.ts",
+      "source_location": "L339",
+      "weight": 1.0,
+      "source": "lib_canonservice_regeneratecanonicon",
+      "target": "lib_errorreporting_reportiffailed"
     },
     {
       "relation": "calls",
@@ -58118,6 +58731,17 @@
       "confidence_score": 1.0,
       "source": "tests_canondetailpage_icon_test",
       "target": "lib_canonservice_regeneratecanonicon"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "tests_canonservice_errorreporting_test",
+      "target": "lib_canonservice_regeneratecanonicon",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports",
@@ -58169,6 +58793,17 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
+      "source_location": "L353",
+      "weight": 1.0,
+      "source": "lib_canonservice_unhidecanonicon",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/canonService.ts",
       "source_location": "L349",
       "weight": 1.0,
       "source": "lib_canonservice_unhidecanonicon",
@@ -58189,12 +58824,34 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "tests_canonservice_errorreporting_test",
+      "target": "lib_canonservice_unhidecanonicon",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/tests/canonService.icon.test.ts",
       "source_location": "L21",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "tests_canonservice_icon_test",
       "target": "lib_canonservice_unhidecanonicon"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "tests_canonservice_errorreporting_test",
+      "target": "lib_canonservice_resetcanonservicefortest",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports",
@@ -58234,11 +58891,55 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
+      "source_location": "L110",
+      "weight": 1.0,
+      "source": "lib_chatservice_createchatsession",
+      "target": "lib_chatservice_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/chatService.ts",
       "source_location": "L65",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "lib_chatservice_initchatsync",
       "target": "lib_chatservice_geterrorreporter"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/chatService.ts",
+      "source_location": "L123",
+      "weight": 1.0,
+      "source": "lib_chatservice_persistsession",
+      "target": "lib_chatservice_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/chatService.ts",
+      "source_location": "L129",
+      "weight": 1.0,
+      "source": "lib_chatservice_removesession",
+      "target": "lib_chatservice_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/chatService.ts",
+      "source_location": "L172",
+      "weight": 1.0,
+      "source": "lib_chatservice_sendmessage",
+      "target": "lib_chatservice_geterrorreporter",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -58323,10 +59024,43 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
+      "source_location": "L110",
+      "weight": 1.0,
+      "source": "lib_chatservice_createchatsession",
+      "target": "lib_errorreporting_reportwriteerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/chatService.ts",
       "source_location": "L107",
       "weight": 1.0,
       "source": "lib_chatservice_createchatsession",
       "target": "src_chatsessionsubscription_savechatsession"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "lib_chatservice_createchatsession",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/chatService.ts",
+      "source_location": "L123",
+      "weight": 1.0,
+      "source": "lib_chatservice_persistsession",
+      "target": "lib_errorreporting_reportiffailed"
     },
     {
       "relation": "calls",
@@ -58351,6 +59085,28 @@
       "target": "lib_chatservice_persistsession"
     },
     {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "lib_chatservice_persistsession",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/chatService.ts",
+      "source_location": "L129",
+      "weight": 1.0,
+      "source": "lib_chatservice_removesession",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
@@ -58360,6 +59116,28 @@
       "weight": 1.0,
       "source": "lib_chatservice_removesession",
       "target": "src_chatsessionsubscription_deletechatsession"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "lib_chatservice_removesession",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/chatService.ts",
+      "source_location": "L172",
+      "weight": 1.0,
+      "source": "lib_chatservice_sendmessage",
+      "target": "lib_errorreporting_reportwriteerror"
     },
     {
       "relation": "calls",
@@ -58382,6 +59160,17 @@
       "weight": 1.0,
       "source": "lib_chatservice_sendmessage",
       "target": "src_chatcallables_streamchefchat"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "lib_chatservice_sendmessage",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -59398,10 +60187,30 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
-      "source_location": "L19",
+      "source_location": "L56",
       "weight": 1.0,
       "source": "lib_errorreporting",
-      "target": "lib_errorreporting_reportsubscriptionerror",
+      "target": "lib_errorreporting_reportiffailed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L19",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "lib_errorreporting",
+      "target": "lib_errorreporting_reportsubscriptionerror"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L43",
+      "weight": 1.0,
+      "source": "lib_errorreporting",
+      "target": "lib_errorreporting_reportwriteerror",
       "confidence_score": 1.0
     },
     {
@@ -59411,9 +60220,9 @@
       "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_errorreporting",
-      "target": "src_authtransition_isauthtransitioning",
-      "confidence_score": 1.0
+      "target": "src_authtransition_isauthtransitioning"
     },
     {
       "relation": "imports",
@@ -59422,8 +60231,30 @@
       "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_errorreporting",
-      "target": "src_errorreportingport_errorreportingport",
+      "target": "src_errorreportingport_errorreportingport"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "lib_errorreporting",
+      "target": "src_index_domainerror"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "lib_errorreporting",
+      "target": "src_index_readresult",
       "confidence_score": 1.0
     },
     {
@@ -59434,7 +60265,7 @@
       "source_location": "L2",
       "weight": 1.0,
       "source": "lib_errorreporting",
-      "target": "src_index_domainerror",
+      "target": "src_index_result",
       "confidence_score": 1.0
     },
     {
@@ -59444,9 +60275,9 @@
       "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
       "source_location": "L11",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_errorreporting_test",
-      "target": "lib_errorreporting",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting"
     },
     {
       "relation": "calls",
@@ -59466,8 +60297,261 @@
       "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
       "source_location": "L11",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_errorreporting_test",
-      "target": "lib_errorreporting_reportsubscriptionerror",
+      "target": "lib_errorreporting_reportsubscriptionerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L61",
+      "weight": 1.0,
+      "source": "lib_errorreporting_reportiffailed",
+      "target": "lib_errorreporting_reportwriteerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L162",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_addlist",
+      "target": "lib_errorreporting_reportwriteerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L80",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_reportfirstwritefailure",
+      "target": "lib_errorreporting_reportwriteerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "tests_errorreporting_test",
+      "target": "lib_errorreporting_reportwriteerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/recipeService.ts",
+      "source_location": "L201",
+      "weight": 1.0,
+      "source": "lib_recipeservice_canonicaliseingredients",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/recipeService.ts",
+      "source_location": "L395",
+      "weight": 1.0,
+      "source": "lib_recipeservice_commitrecipeaddplan",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/recipeService.ts",
+      "source_location": "L238",
+      "weight": 1.0,
+      "source": "lib_recipeservice_matchingredient",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/recipeService.ts",
+      "source_location": "L114",
+      "weight": 1.0,
+      "source": "lib_recipeservice_persistrecipe",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/recipeService.ts",
+      "source_location": "L267",
+      "weight": 1.0,
+      "source": "lib_recipeservice_removerecipe",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L216",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_additemtolist",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L197",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_changedefaultlist",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L352",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_clearchecked",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L284",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_confirmitemneeded",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L364",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_moveselecteditems",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L338",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_removeitem",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L345",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_removeitems",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L189",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_removelist",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L181",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_renamelistbyid",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L270",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_toggleitemchecked",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L243",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_updateitemamountunit",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L256",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_updateitemnotes",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L229",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_updateitemrawtext",
+      "target": "lib_errorreporting_reportiffailed"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "tests_errorreporting_test",
+      "target": "lib_errorreporting_reportiffailed",
       "confidence_score": 1.0
     },
     {
@@ -60772,6 +61856,17 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "lib_membersservice_resetmembersservicefortest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/tests/shoppingListService.manualSource.test.ts",
       "source_location": "L34",
       "weight": 1.0,
@@ -61038,11 +62133,66 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
+      "source_location": "L201",
+      "weight": 1.0,
+      "source": "lib_recipeservice_canonicaliseingredients",
+      "target": "lib_recipeservice_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/recipeService.ts",
+      "source_location": "L395",
+      "weight": 1.0,
+      "source": "lib_recipeservice_commitrecipeaddplan",
+      "target": "lib_recipeservice_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/recipeService.ts",
       "source_location": "L91",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "lib_recipeservice_initrecipesync",
       "target": "lib_recipeservice_geterrorreporter"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/recipeService.ts",
+      "source_location": "L238",
+      "weight": 1.0,
+      "source": "lib_recipeservice_matchingredient",
+      "target": "lib_recipeservice_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/recipeService.ts",
+      "source_location": "L114",
+      "weight": 1.0,
+      "source": "lib_recipeservice_persistrecipe",
+      "target": "lib_recipeservice_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/recipeService.ts",
+      "source_location": "L267",
+      "weight": 1.0,
+      "source": "lib_recipeservice_removerecipe",
+      "target": "lib_recipeservice_geterrorreporter",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -61087,6 +62237,17 @@
       "confidence_score": 1.0,
       "source": "tests_recipeeditpage_matchrow_test",
       "target": "lib_recipeservice_persistrecipe"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "lib_recipeservice_persistrecipe",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -61144,6 +62305,17 @@
       "target": "lib_recipeservice_canonicaliseingredients"
     },
     {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "lib_recipeservice_canonicaliseingredients",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
@@ -61180,12 +62352,34 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "lib_recipeservice_matchingredient",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/tests/recipeService.matchIngredient.test.ts",
       "source_location": "L19",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "tests_recipeservice_matchingredient_test",
       "target": "lib_recipeservice_matchingredient"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "lib_recipeservice_removerecipe",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -61197,6 +62391,17 @@
       "confidence_score": 1.0,
       "source": "lib_recipeservice_scaledamountunit",
       "target": "lib_recipeservice_quantitytonumber"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "lib_recipeservice_recipeaddrow",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -61265,6 +62470,72 @@
       "target": "lib_recipeservice_commitrecipeaddplan"
     },
     {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "lib_recipeservice_commitrecipeaddplan",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L216",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_additemtolist",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L162",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_addlist",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L197",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_changedefaultlist",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L352",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_clearchecked",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L284",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_confirmitemneeded",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
@@ -61280,11 +62551,154 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L365",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_moveselecteditems",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L338",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_removeitem",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L345",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_removeitems",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L189",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_removelist",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L181",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_renamelistbyid",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L80",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_reportfirstwritefailure",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L93",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_setactivelistid",
       "target": "lib_shoppinglistservice_svelte_geterrorreporter"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L270",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_toggleitemchecked",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L243",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_updateitemamountunit",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L256",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_updateitemnotes",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L229",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_updateitemrawtext",
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L315",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_checkitems",
+      "target": "lib_shoppinglistservice_svelte_reportfirstwritefailure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L302",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_confirmitemsneeded",
+      "target": "lib_shoppinglistservice_svelte_reportfirstwritefailure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L328",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte_uncheckitems",
+      "target": "lib_shoppinglistservice_svelte_reportfirstwritefailure",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -61351,6 +62765,17 @@
       "weight": 1.0,
       "source": "lib_shoppinglistservice_svelte_addlist",
       "target": "src_shoppinglistsubscription_createshoppinglist"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "lib_shoppinglistservice_svelte_addlist",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -61450,6 +62875,17 @@
       "weight": 1.0,
       "source": "lib_shoppinglistservice_svelte_additemtolist",
       "target": "src_shoppinglistitemsubscription_saveshoppinglistitem"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "lib_shoppinglistservice_svelte_additemtolist",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports",
@@ -61628,6 +63064,17 @@
       "target": "src_shoppinglistitemsubscription_deleteshoppinglistitems"
     },
     {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "lib_shoppinglistservice_svelte_removeitems",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
@@ -61659,6 +63106,17 @@
       "weight": 1.0,
       "source": "lib_shoppinglistservice_svelte_moveselecteditems",
       "target": "src_shoppinglistitemsubscription_moveshoppinglistitems"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "lib_shoppinglistservice_svelte_resetshoppinglistservicefortest",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -62332,6 +63790,17 @@
       "confidence_score": 1.0,
       "source": "tests_appsettingssync_test",
       "target": "schemas"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "schemas",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -64061,6 +65530,77 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "tests_canonservice_errorreporting_test",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "tests_canonservice_errorreporting_test",
+      "target": "tests_canonservice_errorreporting_test_fs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L54",
+      "weight": 1.0,
+      "source": "tests_canonservice_errorreporting_test",
+      "target": "tests_canonservice_errorreporting_test_network_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L55",
+      "weight": 1.0,
+      "source": "tests_canonservice_errorreporting_test",
+      "target": "tests_canonservice_errorreporting_test_notfound_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "tests_canonservice_errorreporting_test",
+      "target": "tests_canonservice_errorreporting_test_reportspy_gatedreport",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L52",
+      "weight": 1.0,
+      "source": "tests_canonservice_errorreporting_test",
+      "target": "tests_canonservice_errorreporting_test_storage_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "tests_canonservice_errorreporting_test",
+      "target": "tests_canonservice_errorreporting_test_sync_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/tests/canonService.icon.test.ts",
       "source_location": "L2",
       "weight": 1.0,
@@ -64174,6 +65714,87 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L44",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "tests_chatservice_errorreporting_test_auth_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "tests_chatservice_errorreporting_test_fs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "tests_chatservice_errorreporting_test_makesession",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L43",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "tests_chatservice_errorreporting_test_network_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "tests_chatservice_errorreporting_test_reportspy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "tests_chatservice_errorreporting_test_storage_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "tests_chatservice_errorreporting_test",
+      "target": "tests_chatservice_errorreporting_test_sync_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/tests/equipmentService.sync.test.ts",
       "source_location": "L3",
       "weight": 1.0,
@@ -64260,9 +65881,9 @@
       "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_errorreporting_test",
-      "target": "src_errorreportingport_errorreportingport",
-      "confidence_score": 1.0
+      "target": "src_errorreportingport_errorreportingport"
     },
     {
       "relation": "imports",
@@ -64271,8 +65892,19 @@
       "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_errorreporting_test",
-      "target": "src_index_domainerror",
+      "target": "src_index_domainerror"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
+      "source_location": "L16",
+      "weight": 1.0,
+      "source": "tests_errorreporting_test",
+      "target": "src_index_readresult",
       "confidence_score": 1.0
     },
     {
@@ -64281,9 +65913,9 @@
       "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
       "source_location": "L6",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_errorreporting_test",
-      "target": "tests_errorreporting_test_isauthtransitioning",
-      "confidence_score": 1.0
+      "target": "tests_errorreporting_test_isauthtransitioning"
     },
     {
       "relation": "imports",
@@ -64726,6 +66358,140 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "entities_ingredient_ingredient",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "entities_ingredient_ingredientgroup",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "entities_recipe_recipe",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L55",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "tests_recipeservice_errorreporting_test_conflict_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "tests_recipeservice_errorreporting_test_fs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L79",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "tests_recipeservice_errorreporting_test_makeingredient",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L57",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "tests_recipeservice_errorreporting_test_makerecipe",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L33",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "tests_recipeservice_errorreporting_test_mockgetcanonitemssnapshot",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L54",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "tests_recipeservice_errorreporting_test_network_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "tests_recipeservice_errorreporting_test_reportspy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L52",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "tests_recipeservice_errorreporting_test_storage_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "tests_recipeservice_errorreporting_test",
+      "target": "tests_recipeservice_errorreporting_test_sync_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/tests/recipeService.matchIngredient.test.ts",
       "source_location": "L2",
       "weight": 1.0,
@@ -64793,6 +66559,77 @@
       "confidence_score": 1.0,
       "source": "tests_recipeservice_matchingredient_test",
       "target": "tests_recipeservice_matchingredient_test_parsegroup"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "tests_shoppinglistservice_errorreporting_test_fs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L57",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "tests_shoppinglistservice_errorreporting_test_network_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "tests_shoppinglistservice_errorreporting_test_reportspy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L55",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "tests_shoppinglistservice_errorreporting_test_storage_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "tests_shoppinglistservice_errorreporting_test_sync_err",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
+      "source_location": "L58",
+      "weight": 1.0,
+      "source": "tests_shoppinglistservice_errorreporting_test",
+      "target": "tests_shoppinglistservice_errorreporting_test_validation_err",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports",
@@ -66462,9 +68299,9 @@
       "source_file": "packages/adapters/firebase-sync/src/auth.ts",
       "source_location": "L55",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "src_auth",
-      "target": "src_auth_reportauthfailure",
-      "confidence_score": 1.0
+      "target": "src_auth_reportauthfailure"
     },
     {
       "relation": "contains",
@@ -66493,9 +68330,9 @@
       "source_file": "packages/adapters/firebase-sync/src/auth.ts",
       "source_location": "L15",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "src_auth",
-      "target": "src_authtransition",
-      "confidence_score": 1.0
+      "target": "src_authtransition"
     },
     {
       "relation": "imports",
@@ -66504,9 +68341,9 @@
       "source_file": "packages/adapters/firebase-sync/src/auth.ts",
       "source_location": "L15",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "src_auth",
-      "target": "src_authtransition_isauthtransitioning",
-      "confidence_score": 1.0
+      "target": "src_authtransition_isauthtransitioning"
     },
     {
       "relation": "imports",
@@ -66515,9 +68352,9 @@
       "source_file": "packages/adapters/firebase-sync/src/auth.ts",
       "source_location": "L15",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "src_auth",
-      "target": "src_authtransition_setauthtransitioning",
-      "confidence_score": 1.0
+      "target": "src_authtransition_setauthtransitioning"
     },
     {
       "relation": "imports",
@@ -66581,9 +68418,9 @@
       "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
       "source_location": "L27",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_authtransition_test",
-      "target": "src_auth",
-      "confidence_score": 1.0
+      "target": "src_auth"
     },
     {
       "relation": "imports",
@@ -66614,9 +68451,9 @@
       "source_file": "packages/adapters/firebase-sync/src/auth.ts",
       "source_location": "L60",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "src_auth_reportauthfailure",
-      "target": "src_authtransition_isauthtransitioning",
-      "confidence_score": 1.0
+      "target": "src_authtransition_isauthtransitioning"
     },
     {
       "relation": "re_exports",
@@ -66636,9 +68473,9 @@
       "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
       "source_location": "L27",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_authtransition_test",
-      "target": "src_auth_createfirebaseauth",
-      "confidence_score": 1.0
+      "target": "src_auth_createfirebaseauth"
     },
     {
       "relation": "re_exports",
@@ -66647,9 +68484,9 @@
       "source_file": "packages/adapters/firebase-sync/src/index.ts",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "packages_adapters_firebase_sync_src_index_ts_src_index",
-      "target": "src_authtransition",
-      "confidence_score": 1.0
+      "target": "src_authtransition"
     },
     {
       "relation": "contains",
@@ -66657,9 +68494,9 @@
       "source_file": "packages/adapters/firebase-sync/src/authTransition.ts",
       "source_location": "L25",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "src_authtransition",
-      "target": "src_authtransition_isauthtransitioning",
-      "confidence_score": 1.0
+      "target": "src_authtransition_isauthtransitioning"
     },
     {
       "relation": "contains",
@@ -66667,9 +68504,9 @@
       "source_file": "packages/adapters/firebase-sync/src/authTransition.ts",
       "source_location": "L21",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "src_authtransition",
-      "target": "src_authtransition_setauthtransitioning",
-      "confidence_score": 1.0
+      "target": "src_authtransition_setauthtransitioning"
     },
     {
       "relation": "imports_from",
@@ -66678,9 +68515,9 @@
       "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
       "source_location": "L28",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_authtransition_test",
-      "target": "src_authtransition",
-      "confidence_score": 1.0
+      "target": "src_authtransition"
     },
     {
       "relation": "imports",
@@ -66689,9 +68526,9 @@
       "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
       "source_location": "L28",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_authtransition_test",
-      "target": "src_authtransition_setauthtransitioning",
-      "confidence_score": 1.0
+      "target": "src_authtransition_setauthtransitioning"
     },
     {
       "relation": "re_exports",
@@ -66700,9 +68537,9 @@
       "source_file": "packages/adapters/firebase-sync/src/index.ts",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "packages_adapters_firebase_sync_src_index_ts_src_index",
-      "target": "src_authtransition_isauthtransitioning",
-      "confidence_score": 1.0
+      "target": "src_authtransition_isauthtransitioning"
     },
     {
       "relation": "imports",
@@ -66711,9 +68548,9 @@
       "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
       "source_location": "L28",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_authtransition_test",
-      "target": "src_authtransition_isauthtransitioning",
-      "confidence_score": 1.0
+      "target": "src_authtransition_isauthtransitioning"
     },
     {
       "relation": "re_exports",
@@ -70130,9 +71967,9 @@
       "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_authtransition_test",
-      "target": "src_errorreportingport_errorreportingport",
-      "confidence_score": 1.0
+      "target": "src_errorreportingport_errorreportingport"
     },
     {
       "relation": "contains",
@@ -70140,9 +71977,9 @@
       "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
       "source_location": "L30",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_authtransition_test",
-      "target": "tests_authtransition_test_fbautherror",
-      "confidence_score": 1.0
+      "target": "tests_authtransition_test_fbautherror"
     },
     {
       "relation": "contains",
@@ -70150,9 +71987,9 @@
       "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_authtransition_test",
-      "target": "tests_authtransition_test_fbsignout",
-      "confidence_score": 1.0
+      "target": "tests_authtransition_test_fbsignout"
     },
     {
       "relation": "contains",
@@ -70160,9 +71997,9 @@
       "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
       "source_location": "L8",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_authtransition_test",
-      "target": "tests_authtransition_test_sendsigninlinktoemail",
-      "confidence_score": 1.0
+      "target": "tests_authtransition_test_sendsigninlinktoemail"
     },
     {
       "relation": "contains",
@@ -70170,9 +72007,9 @@
       "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_authtransition_test",
-      "target": "tests_authtransition_test_signinwithemaillink",
-      "confidence_score": 1.0
+      "target": "tests_authtransition_test_signinwithemaillink"
     },
     {
       "relation": "contains",
@@ -71289,9 +73126,9 @@
       "source_file": "packages/adapters/observability/src/index.ts",
       "source_location": "L36",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "packages_adapters_observability_src_index_ts_src_index",
-      "target": "shared_reportablecategory",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory"
     },
     {
       "relation": "re_exports",
@@ -71300,9 +73137,9 @@
       "source_file": "packages/adapters/observability/src/index.ts",
       "source_location": "L36",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "packages_adapters_observability_src_index_ts_src_index",
-      "target": "shared_reportablecategory_isreportablecategory",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory_isreportablecategory"
     },
     {
       "relation": "re_exports",
@@ -71817,9 +73654,9 @@
       "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
       "source_location": "L21",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_posthogerrorreportingadapter_test",
-      "target": "src_init_initobservability",
-      "confidence_score": 1.0
+      "target": "src_init_initobservability"
     },
     {
       "relation": "imports",
@@ -71861,9 +73698,9 @@
       "source_file": "packages/adapters/observability/src/posthogErrorReportingAdapter.ts",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "src_posthogerrorreportingadapter",
-      "target": "shared_reportablecategory",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory"
     },
     {
       "relation": "imports",
@@ -71872,9 +73709,9 @@
       "source_file": "packages/adapters/observability/src/posthogErrorReportingAdapter.ts",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "src_posthogerrorreportingadapter",
-      "target": "shared_reportablecategory_isreportablecategory",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory_isreportablecategory"
     },
     {
       "relation": "imports",
@@ -71904,9 +73741,9 @@
       "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
       "source_location": "L22",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_posthogerrorreportingadapter_test",
-      "target": "src_posthogerrorreportingadapter",
-      "confidence_score": 1.0
+      "target": "src_posthogerrorreportingadapter"
     },
     {
       "relation": "imports",
@@ -71915,9 +73752,9 @@
       "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
       "source_location": "L22",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_posthogerrorreportingadapter_test",
-      "target": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter",
-      "confidence_score": 1.0
+      "target": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter"
     },
     {
       "relation": "imports",
@@ -72266,9 +74103,9 @@
       "source_file": "packages/adapters/observability/src/server/index.ts",
       "source_location": "L50",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "server_index",
-      "target": "shared_reportablecategory",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory"
     },
     {
       "relation": "re_exports",
@@ -72277,9 +74114,9 @@
       "source_file": "packages/adapters/observability/src/server/index.ts",
       "source_location": "L50",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "server_index",
-      "target": "shared_reportablecategory_isreportablecategory",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory_isreportablecategory"
     },
     {
       "relation": "contains",
@@ -72851,9 +74688,9 @@
       "source_file": "packages/adapters/observability/src/shared/reportableCategory.ts",
       "source_location": "L29",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "shared_reportablecategory",
-      "target": "shared_reportablecategory_isreportablecategory",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory_isreportablecategory"
     },
     {
       "relation": "contains",
@@ -72861,9 +74698,9 @@
       "source_file": "packages/adapters/observability/src/shared/reportableCategory.ts",
       "source_location": "L22",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "shared_reportablecategory",
-      "target": "shared_reportablecategory_suppressed_categories",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory_suppressed_categories"
     },
     {
       "relation": "imports",
@@ -72872,9 +74709,9 @@
       "source_file": "packages/adapters/observability/src/shared/reportableCategory.ts",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "shared_reportablecategory",
-      "target": "src_index_domainerror",
-      "confidence_score": 1.0
+      "target": "src_index_domainerror"
     },
     {
       "relation": "imports_from",
@@ -72883,9 +74720,9 @@
       "source_file": "packages/adapters/observability/tests/reportableCategory.test.ts",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportablecategory_test",
-      "target": "shared_reportablecategory",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory"
     },
     {
       "relation": "imports",
@@ -72894,9 +74731,9 @@
       "source_file": "packages/adapters/observability/tests/reportableCategory.test.ts",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportablecategory_test",
-      "target": "shared_reportablecategory_isreportablecategory",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory_isreportablecategory"
     },
     {
       "relation": "imports",
@@ -72926,9 +74763,9 @@
       "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_posthogerrorreportingadapter_test",
-      "target": "src_index_domainerror",
-      "confidence_score": 1.0
+      "target": "src_index_domainerror"
     },
     {
       "relation": "contains",
@@ -72936,9 +74773,9 @@
       "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_posthogerrorreportingadapter_test",
-      "target": "tests_posthogerrorreportingadapter_test_captureexception_init",
-      "confidence_score": 1.0
+      "target": "tests_posthogerrorreportingadapter_test_captureexception_init"
     },
     {
       "relation": "imports",
@@ -72947,9 +74784,9 @@
       "source_file": "packages/adapters/observability/tests/reportableCategory.test.ts",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportablecategory_test",
-      "target": "src_index_domainerror",
-      "confidence_score": 1.0
+      "target": "src_index_domainerror"
     },
     {
       "relation": "contains",
@@ -73319,9 +75156,9 @@
       "source_file": "packages/domain/src/ErrorReportingPort.ts",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "src_errorreportingport",
-      "target": "src_index_domainerror",
-      "confidence_score": 1.0
+      "target": "src_index_domainerror"
     },
     {
       "relation": "re_exports",
@@ -109915,9 +111752,9 @@
       "source_file": "CLAUDE.md",
       "source_location": "L63",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
-      "target": "claude_observability_error_reporting_conventions",
-      "confidence_score": 1.0
+      "target": "claude_observability_error_reporting_conventions"
     },
     {
       "relation": "contains",
@@ -116586,5 +118423,5 @@
       "source_file": ".claude/commands/spec.md"
     }
   ],
-  "built_at_commit": "fd895d5989d2ae19cfc48cdc1f421de5b2e96542"
+  "built_at_commit": "77a9c480e5c1c67a15b137ead51ffe3f9fa136af"
 }

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -851,7 +851,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_serverarbitration",
-      "community": 7,
+      "community": 75,
       "norm_label": "serverarbitration.ts"
     },
     {
@@ -891,7 +891,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_serverentryparse",
-      "community": 96,
+      "community": 73,
       "norm_label": "serverentryparse.ts"
     },
     {
@@ -901,7 +901,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "adapters_serverentryparse_createserverentryparseadapter",
-      "community": 75,
+      "community": 73,
       "norm_label": "createserverentryparseadapter()"
     },
     {
@@ -1601,7 +1601,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_dev",
-      "community": 161,
+      "community": 75,
       "norm_label": "dev.ts"
     },
     {
@@ -1611,7 +1611,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_arbitratecanon",
-      "community": 161,
+      "community": 75,
       "norm_label": "arbitratecanon.ts"
     },
     {
@@ -1621,7 +1621,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "flows_arbitratecanon_arbitrationresultschema",
-      "community": 161,
+      "community": 75,
       "norm_label": "arbitrationresultschema"
     },
     {
@@ -1631,7 +1631,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "flows_arbitratecanon_arbitratecanonflow",
-      "community": 161,
+      "community": 75,
       "norm_label": "arbitratecanonflow"
     },
     {
@@ -1641,7 +1641,7 @@
       "source_location": "L101",
       "_origin": "ast",
       "id": "flows_arbitratecanon_buildprompt",
-      "community": 161,
+      "community": 75,
       "norm_label": "buildprompt()"
     },
     {
@@ -1791,7 +1791,7 @@
       "source_location": "L99",
       "_origin": "ast",
       "id": "flows_chefchat_chefchatflow",
-      "community": 34,
+      "community": 161,
       "norm_label": "chefchatflow"
     },
     {
@@ -1821,7 +1821,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "flows_embedtext_embedtextflow",
-      "community": 29,
+      "community": 161,
       "norm_label": "embedtextflow"
     },
     {
@@ -1991,7 +1991,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_generatechattitle",
-      "community": 161,
+      "community": 96,
       "norm_label": "generatechattitle.ts"
     },
     {
@@ -2001,7 +2001,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "flows_generatechattitle_inputschema",
-      "community": 161,
+      "community": 96,
       "norm_label": "inputschema"
     },
     {
@@ -2011,7 +2011,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "flows_generatechattitle_generatechattitleflow",
-      "community": 34,
+      "community": 96,
       "norm_label": "generatechattitleflow"
     },
     {
@@ -2031,7 +2031,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "flows_identifyequipment_identifyequipmentflow",
-      "community": 34,
+      "community": 161,
       "norm_label": "identifyequipmentflow"
     },
     {
@@ -2111,7 +2111,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_parseentry",
-      "community": 161,
+      "community": 73,
       "norm_label": "parseentry.ts"
     },
     {
@@ -2121,7 +2121,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "flows_parseentry_parseentryinputschema",
-      "community": 161,
+      "community": 73,
       "norm_label": "parseentryinputschema"
     },
     {
@@ -2131,7 +2131,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "flows_parseentry_parseentryflow",
-      "community": 161,
+      "community": 73,
       "norm_label": "parseentryflow"
     },
     {
@@ -2141,7 +2141,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "flows_parseentry_buildprompt",
-      "community": 161,
+      "community": 73,
       "norm_label": "buildprompt()"
     },
     {
@@ -2451,7 +2451,7 @@
       "source_location": "L345",
       "_origin": "ast",
       "id": "src_index_reportunexpected",
-      "community": 29,
+      "community": 34,
       "norm_label": "reportunexpected()"
     },
     {
@@ -2481,7 +2481,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "observability_reportservererror",
-      "community": 29,
+      "community": 34,
       "norm_label": "reportservererror.ts"
     },
     {
@@ -2491,7 +2491,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "observability_reportservererror_reporter",
-      "community": 29,
+      "community": 34,
       "norm_label": "reporter"
     },
     {
@@ -2511,7 +2511,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "observability_reportservererror_reportflowerror",
-      "community": 29,
+      "community": 34,
       "norm_label": "reportflowerror()"
     },
     {
@@ -2611,7 +2611,7 @@
       "source_location": "L205",
       "_origin": "ast",
       "id": "triggers_oncanonitemwritten_oncanonitemwritten",
-      "community": 34,
+      "community": 29,
       "norm_label": "oncanonitemwritten"
     },
     {
@@ -2621,7 +2621,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite",
-      "community": 75,
+      "community": 73,
       "norm_label": "onshoppinglistitemwrite.ts"
     },
     {
@@ -2631,7 +2631,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_geminiapikey",
-      "community": 75,
+      "community": 73,
       "norm_label": "geminiapikey"
     },
     {
@@ -2641,7 +2641,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_posthogapikey",
-      "community": 75,
+      "community": 73,
       "norm_label": "posthogapikey"
     },
     {
@@ -2651,7 +2651,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_lookscompound",
-      "community": 75,
+      "community": 73,
       "norm_label": "lookscompound()"
     },
     {
@@ -2661,7 +2661,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_onshoppinglistitemwrite",
-      "community": 75,
+      "community": 73,
       "norm_label": "onshoppinglistitemwrite"
     },
     {
@@ -2831,7 +2831,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_resolvemodel_test",
-      "community": 77,
+      "community": 51,
       "norm_label": "resolvemodel.test.ts"
     },
     {
@@ -2841,7 +2841,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "ai_resolvemodel_test_mockget",
-      "community": 77,
+      "community": 51,
       "norm_label": "mockget"
     },
     {
@@ -6425,7 +6425,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "boundary_tests_no_firebase_sync_internal",
-      "community": 64,
+      "community": 141,
       "norm_label": "no-firebase-sync-internal.ts"
     },
     {
@@ -6477,7 +6477,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_firebase",
-      "community": 66,
+      "community": 20,
       "norm_label": "firebase.ts"
     },
     {
@@ -7029,7 +7029,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "lib_canonservice_canonitems",
-      "community": 2,
+      "community": 3,
       "norm_label": "canonitems"
     },
     {
@@ -7039,7 +7039,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "lib_canonservice_aisles",
-      "community": 2,
+      "community": 3,
       "norm_label": "aisles"
     },
     {
@@ -7049,7 +7049,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "lib_canonservice_aisleusage",
-      "community": 2,
+      "community": 3,
       "norm_label": "aisleusage"
     },
     {
@@ -7059,7 +7059,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "lib_canonservice_isloadingaisles",
-      "community": 2,
+      "community": 3,
       "norm_label": "isloadingaisles"
     },
     {
@@ -7089,7 +7089,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "lib_canonservice_recomputeaisleusage",
-      "community": 8,
+      "community": 3,
       "norm_label": "recomputeaisleusage()"
     },
     {
@@ -7149,7 +7149,7 @@
       "source_location": "L179",
       "_origin": "ast",
       "id": "lib_canonservice_addcanonitem",
-      "community": 3,
+      "community": 17,
       "norm_label": "addcanonitem()"
     },
     {
@@ -7229,7 +7229,7 @@
       "source_location": "L293",
       "_origin": "ast",
       "id": "lib_canonservice_approvecanonitems",
-      "community": 33,
+      "community": 3,
       "norm_label": "approvecanonitems()"
     },
     {
@@ -7239,7 +7239,7 @@
       "source_location": "L306",
       "_origin": "ast",
       "id": "lib_canonservice_splitmostrecentsynonym",
-      "community": 2,
+      "community": 279,
       "norm_label": "splitmostrecentsynonym()"
     },
     {
@@ -7309,7 +7309,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "lib_chatservice_getchatsessionssnapshot",
-      "community": 8,
+      "community": 116,
       "norm_label": "getchatsessionssnapshot()"
     },
     {
@@ -7349,7 +7349,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "lib_chatservice_applysnapshot",
-      "community": 8,
+      "community": 42,
       "norm_label": "applysnapshot()"
     },
     {
@@ -7540,7 +7540,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_e2ehooks",
-      "community": 2,
+      "community": 116,
       "norm_label": "e2ehooks.ts"
     },
     {
@@ -7550,7 +7550,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "lib_e2ehooks_installe2ehooks",
-      "community": 2,
+      "community": 116,
       "norm_label": "installe2ehooks()"
     },
     {
@@ -7790,7 +7790,7 @@
       "source_location": "L304",
       "_origin": "ast",
       "id": "lib_equipmentservice_getequipmentsnapshot",
-      "community": 8,
+      "community": 116,
       "norm_label": "getequipmentsnapshot()"
     },
     {
@@ -7810,7 +7810,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_errorreporting",
-      "community": 117,
+      "community": 42,
       "norm_label": "errorreporting.ts"
     },
     {
@@ -7820,7 +7820,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "lib_errorreporting_reportsubscriptionerror",
-      "community": 117,
+      "community": 42,
       "norm_label": "reportsubscriptionerror()"
     },
     {
@@ -7840,7 +7840,7 @@
       "source_location": "L56",
       "_origin": "ast",
       "id": "lib_errorreporting_reportiffailed",
-      "community": 157,
+      "community": 8,
       "norm_label": "reportiffailed()"
     },
     {
@@ -7850,7 +7850,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_firebase_authprovider",
-      "community": 66,
+      "community": 20,
       "norm_label": "authprovider"
     },
     {
@@ -7960,7 +7960,7 @@
       "source_location": "L76",
       "_origin": "ast",
       "id": "lib_mealplanservice_firstdayofweek",
-      "community": 116,
+      "community": 0,
       "norm_label": "firstdayofweek"
     },
     {
@@ -7970,7 +7970,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "lib_mealplanservice_currentweek",
-      "community": 116,
+      "community": 0,
       "norm_label": "currentweek"
     },
     {
@@ -8060,7 +8060,7 @@
       "source_location": "L179",
       "_origin": "ast",
       "id": "lib_mealplanservice_currenttemplateobject",
-      "community": 1,
+      "community": 0,
       "norm_label": "currenttemplateobject()"
     },
     {
@@ -8080,7 +8080,7 @@
       "source_location": "L191",
       "_origin": "ast",
       "id": "lib_mealplanservice_persisttemplate",
-      "community": 1,
+      "community": 0,
       "norm_label": "persisttemplate()"
     },
     {
@@ -8100,7 +8100,7 @@
       "source_location": "L209",
       "_origin": "ast",
       "id": "lib_mealplanservice_setweekdaynote",
-      "community": 1,
+      "community": 0,
       "norm_label": "setweekdaynote()"
     },
     {
@@ -8110,7 +8110,7 @@
       "source_location": "L212",
       "_origin": "ast",
       "id": "lib_mealplanservice_setweekdaychefs",
-      "community": 1,
+      "community": 0,
       "norm_label": "setweekdaychefs()"
     },
     {
@@ -8120,7 +8120,7 @@
       "source_location": "L215",
       "_origin": "ast",
       "id": "lib_mealplanservice_setweekdayguests",
-      "community": 1,
+      "community": 0,
       "norm_label": "setweekdayguests()"
     },
     {
@@ -8150,7 +8150,7 @@
       "source_location": "L224",
       "_origin": "ast",
       "id": "lib_mealplanservice_setweekattendeehometime",
-      "community": 1,
+      "community": 0,
       "norm_label": "setweekattendeehometime()"
     },
     {
@@ -8160,7 +8160,7 @@
       "source_location": "L231",
       "_origin": "ast",
       "id": "lib_mealplanservice_setweekattendeenote",
-      "community": 1,
+      "community": 0,
       "norm_label": "setweekattendeenote()"
     },
     {
@@ -8170,7 +8170,7 @@
       "source_location": "L236",
       "_origin": "ast",
       "id": "lib_mealplanservice_savefirstdayofweek",
-      "community": 108,
+      "community": 0,
       "norm_label": "savefirstdayofweek()"
     },
     {
@@ -8180,7 +8180,7 @@
       "source_location": "L241",
       "_origin": "ast",
       "id": "lib_mealplanservice_settemplatedaynote",
-      "community": 1,
+      "community": 0,
       "norm_label": "settemplatedaynote()"
     },
     {
@@ -8190,7 +8190,7 @@
       "source_location": "L244",
       "_origin": "ast",
       "id": "lib_mealplanservice_settemplatedaychefs",
-      "community": 1,
+      "community": 0,
       "norm_label": "settemplatedaychefs()"
     },
     {
@@ -8200,7 +8200,7 @@
       "source_location": "L247",
       "_origin": "ast",
       "id": "lib_mealplanservice_settemplatedayguests",
-      "community": 1,
+      "community": 0,
       "norm_label": "settemplatedayguests()"
     },
     {
@@ -8220,7 +8220,7 @@
       "source_location": "L253",
       "_origin": "ast",
       "id": "lib_mealplanservice_removetemplateattendee",
-      "community": 1,
+      "community": 0,
       "norm_label": "removetemplateattendee()"
     },
     {
@@ -8230,7 +8230,7 @@
       "source_location": "L256",
       "_origin": "ast",
       "id": "lib_mealplanservice_settemplateattendeehometime",
-      "community": 1,
+      "community": 0,
       "norm_label": "settemplateattendeehometime()"
     },
     {
@@ -8240,7 +8240,7 @@
       "source_location": "L263",
       "_origin": "ast",
       "id": "lib_mealplanservice_settemplateattendeenote",
-      "community": 1,
+      "community": 0,
       "norm_label": "settemplateattendeenote()"
     },
     {
@@ -8260,7 +8260,7 @@
       "source_location": "L285",
       "_origin": "ast",
       "id": "lib_mealplanservice_seedmealplanconfig",
-      "community": 116,
+      "community": 0,
       "norm_label": "seedmealplanconfig()"
     },
     {
@@ -8270,7 +8270,7 @@
       "source_location": "L290",
       "_origin": "ast",
       "id": "lib_mealplanservice_seedmealplantemplate",
-      "community": 116,
+      "community": 0,
       "norm_label": "seedmealplantemplate()"
     },
     {
@@ -8280,7 +8280,7 @@
       "source_location": "L296",
       "_origin": "ast",
       "id": "lib_mealplanservice_seedmealplanweek",
-      "community": 116,
+      "community": 0,
       "norm_label": "seedmealplanweek()"
     },
     {
@@ -8330,7 +8330,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "lib_membersservice_findmemberbyemail",
-      "community": 10,
+      "community": 8,
       "norm_label": "findmemberbyemail()"
     },
     {
@@ -8400,7 +8400,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "lib_membersservice_reordermembers",
-      "community": 8,
+      "community": 10,
       "norm_label": "reordermembers()"
     },
     {
@@ -8550,7 +8550,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_pwa",
-      "community": 2,
+      "community": 116,
       "norm_label": "pwa.ts"
     },
     {
@@ -8560,7 +8560,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "lib_pwa_registerserviceworker",
-      "community": 2,
+      "community": 116,
       "norm_label": "registerserviceworker()"
     },
     {
@@ -8570,7 +8570,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_pwa_setupupdateflow",
-      "community": 2,
+      "community": 116,
       "norm_label": "setupupdateflow()"
     },
     {
@@ -8590,7 +8590,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "lib_recipeservice_getrecipessnapshot",
-      "community": 24,
+      "community": 116,
       "norm_label": "getrecipessnapshot()"
     },
     {
@@ -8610,7 +8610,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "lib_recipeservice_geterrorreporter",
-      "community": 157,
+      "community": 24,
       "norm_label": "geterrorreporter()"
     },
     {
@@ -8630,7 +8630,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "lib_recipeservice_applysnapshot",
-      "community": 8,
+      "community": 24,
       "norm_label": "applysnapshot()"
     },
     {
@@ -8640,7 +8640,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "lib_recipeservice_initrecipesync",
-      "community": 157,
+      "community": 24,
       "norm_label": "initrecipesync()"
     },
     {
@@ -8650,7 +8650,7 @@
       "source_location": "L109",
       "_origin": "ast",
       "id": "lib_recipeservice_persistrecipe",
-      "community": 157,
+      "community": 24,
       "norm_label": "persistrecipe()"
     },
     {
@@ -8690,7 +8690,7 @@
       "source_location": "L147",
       "_origin": "ast",
       "id": "lib_recipeservice_importrecipefromurl",
-      "community": 24,
+      "community": 51,
       "norm_label": "importrecipefromurl()"
     },
     {
@@ -8720,7 +8720,7 @@
       "source_location": "L177",
       "_origin": "ast",
       "id": "lib_recipeservice_canonicaliseingredients",
-      "community": 157,
+      "community": 24,
       "norm_label": "canonicaliseingredients()"
     },
     {
@@ -8730,7 +8730,7 @@
       "source_location": "L234",
       "_origin": "ast",
       "id": "lib_recipeservice_matchingredient",
-      "community": 157,
+      "community": 24,
       "norm_label": "matchingredient()"
     },
     {
@@ -8740,7 +8740,7 @@
       "source_location": "L263",
       "_origin": "ast",
       "id": "lib_recipeservice_removerecipe",
-      "community": 157,
+      "community": 8,
       "norm_label": "removerecipe()"
     },
     {
@@ -8800,7 +8800,7 @@
       "source_location": "L354",
       "_origin": "ast",
       "id": "lib_recipeservice_commitrecipeaddplan",
-      "community": 157,
+      "community": 8,
       "norm_label": "commitrecipeaddplan()"
     },
     {
@@ -8900,7 +8900,7 @@
       "source_location": "L101",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_setactivelistid",
-      "community": 93,
+      "community": 8,
       "norm_label": "setactivelistid()"
     },
     {
@@ -8910,7 +8910,7 @@
       "source_location": "L118",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_initshoppinglistsync",
-      "community": 141,
+      "community": 8,
       "norm_label": "initshoppinglistsync()"
     },
     {
@@ -9080,7 +9080,7 @@
       "source_location": "L358",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_moveselecteditems",
-      "community": 93,
+      "community": 8,
       "norm_label": "moveselecteditems()"
     },
     {
@@ -9120,7 +9120,7 @@
       "source_location": "L389",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_resetshoppinglistservicefortest",
-      "community": 10,
+      "community": 265,
       "norm_label": "__resetshoppinglistservicefortest()"
     },
     {
@@ -9211,7 +9211,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "types_e2e_d",
-      "community": 4,
+      "community": 51,
       "norm_label": "e2e.d.ts"
     },
     {
@@ -9221,7 +9221,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "types_e2e_d_seedcanoniteminput",
-      "community": 4,
+      "community": 51,
       "norm_label": "seedcanoniteminput"
     },
     {
@@ -9231,7 +9231,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "types_e2e_d_e2ebridge",
-      "community": 4,
+      "community": 51,
       "norm_label": "e2ebridge"
     },
     {
@@ -9241,7 +9241,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "types_e2e_d_window",
-      "community": 4,
+      "community": 51,
       "norm_label": "window"
     },
     {
@@ -9251,7 +9251,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "apps_web_pwa_src_main_ts_src_main",
-      "community": 2,
+      "community": 116,
       "norm_label": "main.ts"
     },
     {
@@ -9373,7 +9373,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "schemas",
-      "community": 77,
+      "community": 51,
       "norm_label": "@salt/domain/schemas"
     },
     {
@@ -9384,7 +9384,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "admin_modelcombofield",
-      "community": 50,
+      "community": 90,
       "norm_label": "modelcombofield.svelte"
     },
     {
@@ -9514,7 +9514,7 @@
       "source_location": "L111",
       "_origin": "ast",
       "id": "canon_canonlistpage_handlebulkapprove",
-      "community": 33,
+      "community": 3,
       "norm_label": "handlebulkapprove()"
     },
     {
@@ -10396,7 +10396,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_adminmealplanpage_test",
-      "community": 108,
+      "community": 0,
       "norm_label": "adminmealplanpage.test.ts"
     },
     {
@@ -10406,7 +10406,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "tests_adminmealplanpage_test_mockmembers_mockisloadingmembers_mocktemplate_mockfirstday_mockauth",
-      "community": 108,
+      "community": 0,
       "norm_label": "{ mockmembers, mockisloadingmembers, mocktemplate, mockfirstday, mockauth }"
     },
     {
@@ -10416,7 +10416,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "tests_adminmealplanpage_test_member",
-      "community": 108,
+      "community": 0,
       "norm_label": "member()"
     },
     {
@@ -10426,7 +10426,7 @@
       "source_location": "L71",
       "_origin": "ast",
       "id": "tests_adminmealplanpage_test_admin",
-      "community": 108,
+      "community": 0,
       "norm_label": "admin"
     },
     {
@@ -10626,7 +10626,7 @@
       "source_location": "L60",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_walkthroughcapture",
-      "community": 33,
+      "community": 141,
       "norm_label": "walkthroughcapture()"
     },
     {
@@ -10676,7 +10676,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_mealplanweekpage_test",
-      "community": 1,
+      "community": 0,
       "norm_label": "mealplanweekpage.test.ts"
     },
     {
@@ -10686,7 +10686,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_mealplanweekpage_test_mockmembers_mockweek_mockstart_mockloading",
-      "community": 1,
+      "community": 0,
       "norm_label": "{ mockmembers, mockweek, mockstart, mockloading }"
     },
     {
@@ -10696,7 +10696,7 @@
       "source_location": "L70",
       "_origin": "ast",
       "id": "tests_mealplanweekpage_test_expandday",
-      "community": 1,
+      "community": 0,
       "norm_label": "expandday()"
     },
     {
@@ -10706,7 +10706,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "tests_mealplanweekpage_test_member",
-      "community": 1,
+      "community": 0,
       "norm_label": "member()"
     },
     {
@@ -10716,7 +10716,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "tests_mealplanweekpage_test_alice",
-      "community": 1,
+      "community": 0,
       "norm_label": "alice"
     },
     {
@@ -10726,7 +10726,7 @@
       "source_location": "L88",
       "_origin": "ast",
       "id": "tests_mealplanweekpage_test_bob",
-      "community": 1,
+      "community": 0,
       "norm_label": "bob"
     },
     {
@@ -10846,7 +10846,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test",
-      "community": 4,
+      "community": 317,
       "norm_label": "shoppinglistpage.danglingcanon.test.ts"
     },
     {
@@ -10856,7 +10856,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_mockcanonitems_mockaisles_mocklists_mockitems_mockdefaultlistid_mockloading",
-      "community": 4,
+      "community": 317,
       "norm_label": "{ mockcanonitems, mockaisles, mocklists, mockitems, mockdefaultlistid, mockloading }"
     },
     {
@@ -10866,7 +10866,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_canonitem",
-      "community": 4,
+      "community": 317,
       "norm_label": "canonitem()"
     },
     {
@@ -10876,7 +10876,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_item",
-      "community": 4,
+      "community": 317,
       "norm_label": "item()"
     },
     {
@@ -10886,7 +10886,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test",
-      "community": 4,
+      "community": 318,
       "norm_label": "shoppinglistpage.icon.test.ts"
     },
     {
@@ -10896,7 +10896,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_mockcanonitems_mockaisles_mocklists_mockitems_mockdefaultlistid_mockloading",
-      "community": 4,
+      "community": 318,
       "norm_label": "{ mockcanonitems, mockaisles, mocklists, mockitems, mockdefaultlistid, mockloading }"
     },
     {
@@ -10906,7 +10906,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_canonitem",
-      "community": 4,
+      "community": 318,
       "norm_label": "canonitem()"
     },
     {
@@ -10916,7 +10916,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_item",
-      "community": 4,
+      "community": 318,
       "norm_label": "item()"
     },
     {
@@ -11056,7 +11056,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test",
-      "community": 2,
+      "community": 3,
       "norm_label": "canonservice.sync.test.ts"
     },
     {
@@ -11066,7 +11066,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_fs",
-      "community": 2,
+      "community": 3,
       "norm_label": "fs"
     },
     {
@@ -11076,7 +11076,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_makeitem",
-      "community": 2,
+      "community": 3,
       "norm_label": "makeitem()"
     },
     {
@@ -11086,7 +11086,7 @@
       "source_location": "L57",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_makeaisle",
-      "community": 2,
+      "community": 3,
       "norm_label": "makeaisle()"
     },
     {
@@ -11096,7 +11096,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_itemscb",
-      "community": 2,
+      "community": 3,
       "norm_label": "itemscb"
     },
     {
@@ -11106,7 +11106,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_aislescb",
-      "community": 2,
+      "community": 3,
       "norm_label": "aislescb"
     },
     {
@@ -11116,7 +11116,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_wiresubscriptions",
-      "community": 2,
+      "community": 3,
       "norm_label": "wiresubscriptions()"
     },
     {
@@ -11266,7 +11266,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_errorreporting_test",
-      "community": 117,
+      "community": 42,
       "norm_label": "errorreporting.test.ts"
     },
     {
@@ -11276,7 +11276,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "tests_errorreporting_test_isauthtransitioning",
-      "community": 117,
+      "community": 42,
       "norm_label": "isauthtransitioning"
     },
     {
@@ -11286,7 +11286,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test",
-      "community": 116,
+      "community": 0,
       "norm_label": "mealplanservice.sync.test.ts"
     },
     {
@@ -11296,7 +11296,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test_fs",
-      "community": 116,
+      "community": 0,
       "norm_label": "fs"
     },
     {
@@ -11306,7 +11306,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test_weekcb",
-      "community": 116,
+      "community": 0,
       "norm_label": "weekcb"
     },
     {
@@ -11316,7 +11316,7 @@
       "source_location": "L47",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test_configcb",
-      "community": 116,
+      "community": 0,
       "norm_label": "configcb"
     },
     {
@@ -11326,7 +11326,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test_templatecb",
-      "community": 116,
+      "community": 0,
       "norm_label": "templatecb"
     },
     {
@@ -11336,7 +11336,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test_config",
-      "community": 116,
+      "community": 0,
       "norm_label": "config"
     },
     {
@@ -11346,7 +11346,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "tests_mealplanservice_sync_test_wiresubscriptions",
-      "community": 116,
+      "community": 0,
       "norm_label": "wiresubscriptions()"
     },
     {
@@ -11406,7 +11406,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test",
-      "community": 24,
+      "community": 108,
       "norm_label": "recipeservice.addtolist.test.ts"
     },
     {
@@ -11416,7 +11416,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_mockgetcanonitemssnapshot",
-      "community": 24,
+      "community": 108,
       "norm_label": "{ mockgetcanonitemssnapshot }"
     },
     {
@@ -11426,7 +11426,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_fs",
-      "community": 24,
+      "community": 108,
       "norm_label": "fs"
     },
     {
@@ -11436,7 +11436,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_makecanonitem",
-      "community": 24,
+      "community": 108,
       "norm_label": "makecanonitem()"
     },
     {
@@ -11446,7 +11446,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_makegroup",
-      "community": 24,
+      "community": 108,
       "norm_label": "makegroup()"
     },
     {
@@ -11456,7 +11456,7 @@
       "source_location": "L59",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_makerecipe",
-      "community": 24,
+      "community": 108,
       "norm_label": "makerecipe()"
     },
     {
@@ -11466,7 +11466,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_gramingredient",
-      "community": 24,
+      "community": 108,
       "norm_label": "gramingredient"
     },
     {
@@ -11476,7 +11476,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_weightingredient",
-      "community": 24,
+      "community": 108,
       "norm_label": "weightingredient()"
     },
     {
@@ -11486,7 +11486,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_countingredient",
-      "community": 24,
+      "community": 108,
       "norm_label": "countingredient"
     },
     {
@@ -11496,7 +11496,7 @@
       "source_location": "L112",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_matchedingredient",
-      "community": 24,
+      "community": 108,
       "norm_label": "matchedingredient()"
     },
     {
@@ -11746,7 +11746,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test",
-      "community": 10,
+      "community": 265,
       "norm_label": "shoppinglistservice.errorreporting.test.ts"
     },
     {
@@ -11756,7 +11756,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test_reportspy",
-      "community": 10,
+      "community": 265,
       "norm_label": "{ reportspy }"
     },
     {
@@ -11766,7 +11766,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test_fs",
-      "community": 10,
+      "community": 265,
       "norm_label": "fs"
     },
     {
@@ -11776,7 +11776,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test_storage_err",
-      "community": 10,
+      "community": 265,
       "norm_label": "storage_err"
     },
     {
@@ -11786,7 +11786,7 @@
       "source_location": "L56",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test_sync_err",
-      "community": 10,
+      "community": 265,
       "norm_label": "sync_err"
     },
     {
@@ -11796,7 +11796,7 @@
       "source_location": "L57",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test_network_err",
-      "community": 10,
+      "community": 265,
       "norm_label": "network_err"
     },
     {
@@ -11806,7 +11806,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test_validation_err",
-      "community": 10,
+      "community": 265,
       "norm_label": "validation_err"
     },
     {
@@ -13082,7 +13082,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_aislesubscription",
-      "community": 64,
+      "community": 141,
       "norm_label": "aislesubscription.ts"
     },
     {
@@ -13092,7 +13092,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_aislesubscription_subscribeaisles",
-      "community": 3,
+      "community": 141,
       "norm_label": "subscribeaisles()"
     },
     {
@@ -13112,7 +13112,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_appsettingssync",
-      "community": 64,
+      "community": 51,
       "norm_label": "appsettingssync.ts"
     },
     {
@@ -13122,7 +13122,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "src_appsettingssync_subscribeappsettings",
-      "community": 47,
+      "community": 51,
       "norm_label": "subscribeappsettings()"
     },
     {
@@ -13132,7 +13132,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_appsettingssync_saveappsettings",
-      "community": 47,
+      "community": 51,
       "norm_label": "saveappsettings()"
     },
     {
@@ -13162,7 +13162,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "src_auth_connectauthemulatoronce",
-      "community": 66,
+      "community": 117,
       "norm_label": "connectauthemulatoronce()"
     },
     {
@@ -13202,7 +13202,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "src_auth_createfirebaseauth",
-      "community": 66,
+      "community": 20,
       "norm_label": "createfirebaseauth()"
     },
     {
@@ -13242,7 +13242,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_authorrecipecallable",
-      "community": 64,
+      "community": 93,
       "norm_label": "authorrecipecallable.ts"
     },
     {
@@ -13252,7 +13252,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "src_authorrecipecallable_classifyerror",
-      "community": 64,
+      "community": 93,
       "norm_label": "classifyerror()"
     },
     {
@@ -13262,7 +13262,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "src_authorrecipecallable_callauthorrecipe",
-      "community": 64,
+      "community": 93,
       "norm_label": "callauthorrecipe()"
     },
     {
@@ -13272,7 +13272,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_canonmatching",
-      "community": 95,
+      "community": 93,
       "norm_label": "canonmatching.ts"
     },
     {
@@ -13282,7 +13282,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "src_canonmatching_wireresult",
-      "community": 95,
+      "community": 93,
       "norm_label": "wireresult"
     },
     {
@@ -13292,7 +13292,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "src_canonmatching_callmatchorcreate",
-      "community": 3,
+      "community": 93,
       "norm_label": "callmatchorcreate()"
     },
     {
@@ -13302,7 +13302,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_canonmatching_wirebatchresult",
-      "community": 95,
+      "community": 93,
       "norm_label": "wirebatchresult"
     },
     {
@@ -13312,7 +13312,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "src_canonmatching_callcanonicaliserecipeingredients",
-      "community": 157,
+      "community": 24,
       "norm_label": "callcanonicaliserecipeingredients()"
     },
     {
@@ -13332,7 +13332,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_canonsubscription",
-      "community": 64,
+      "community": 141,
       "norm_label": "canonsubscription.ts"
     },
     {
@@ -13342,7 +13342,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_canonsubscription_subscribecanonitems",
-      "community": 3,
+      "community": 141,
       "norm_label": "subscribecanonitems()"
     },
     {
@@ -13372,7 +13372,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_chatcallables",
-      "community": 64,
+      "community": 93,
       "norm_label": "chatcallables.ts"
     },
     {
@@ -13382,7 +13382,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "src_chatcallables_geterr",
-      "community": 42,
+      "community": 93,
       "norm_label": "geterr()"
     },
     {
@@ -13392,7 +13392,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "src_chatcallables_callgeneratechattitle",
-      "community": 42,
+      "community": 93,
       "norm_label": "callgeneratechattitle()"
     },
     {
@@ -13402,7 +13402,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "src_chatcallables_streamchefchat",
-      "community": 42,
+      "community": 93,
       "norm_label": "streamchefchat()"
     },
     {
@@ -13412,7 +13412,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_chatsessionsubscription",
-      "community": 64,
+      "community": 93,
       "norm_label": "chatsessionsubscription.ts"
     },
     {
@@ -13422,7 +13422,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_expiresat",
-      "community": 42,
+      "community": 93,
       "norm_label": "expiresat()"
     },
     {
@@ -13452,7 +13452,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_savechatsession",
-      "community": 42,
+      "community": 93,
       "norm_label": "savechatsession()"
     },
     {
@@ -13462,7 +13462,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_deletechatsession",
-      "community": 42,
+      "community": 93,
       "norm_label": "deletechatsession()"
     },
     {
@@ -13502,7 +13502,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_e2eaistubsync",
-      "community": 66,
+      "community": 93,
       "norm_label": "e2eaistubsync.ts"
     },
     {
@@ -13512,7 +13512,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "src_e2eaistubsync_setaistub",
-      "community": 66,
+      "community": 93,
       "norm_label": "setaistub()"
     },
     {
@@ -13522,7 +13522,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_equipmentcallables",
-      "community": 66,
+      "community": 93,
       "norm_label": "equipmentcallables.ts"
     },
     {
@@ -13532,7 +13532,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "src_equipmentcallables_identifyequipmentcandidate",
-      "community": 66,
+      "community": 93,
       "norm_label": "identifyequipmentcandidate"
     },
     {
@@ -13542,7 +13542,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "src_equipmentcallables_identifyequipmentresult",
-      "community": 66,
+      "community": 93,
       "norm_label": "identifyequipmentresult"
     },
     {
@@ -13552,7 +13552,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "src_equipmentcallables_populateaccessory",
-      "community": 66,
+      "community": 93,
       "norm_label": "populateaccessory"
     },
     {
@@ -13562,7 +13562,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "src_equipmentcallables_populateequipmententryresult",
-      "community": 66,
+      "community": 93,
       "norm_label": "populateequipmententryresult"
     },
     {
@@ -13572,7 +13572,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "src_equipmentcallables_callidentifyequipment",
-      "community": 66,
+      "community": 93,
       "norm_label": "callidentifyequipment()"
     },
     {
@@ -13582,7 +13582,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "src_equipmentcallables_callpopulateequipmententry",
-      "community": 66,
+      "community": 93,
       "norm_label": "callpopulateequipmententry()"
     },
     {
@@ -13592,7 +13592,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_equipmentmanifestsubscription",
-      "community": 9,
+      "community": 93,
       "norm_label": "equipmentmanifestsubscription.ts"
     },
     {
@@ -13622,7 +13622,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_firestoreerrors",
-      "community": 64,
+      "community": 93,
       "norm_label": "firestoreerrors.ts"
     },
     {
@@ -13652,7 +13652,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_adapters_firebase_sync_src_index_ts_src_index",
-      "community": 66,
+      "community": 93,
       "norm_label": "index.ts"
     },
     {
@@ -13662,7 +13662,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_adapters_firebase_sync_src_init_ts_src_init",
-      "community": 66,
+      "community": 117,
       "norm_label": "init.ts"
     },
     {
@@ -13672,7 +13672,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "src_init_emulatorconnectedapps",
-      "community": 66,
+      "community": 117,
       "norm_label": "emulatorconnectedapps"
     },
     {
@@ -13682,7 +13682,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "src_init_appcheckconfig",
-      "community": 66,
+      "community": 20,
       "norm_label": "appcheckconfig"
     },
     {
@@ -13692,7 +13692,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "src_init_initfirebase",
-      "community": 66,
+      "community": 117,
       "norm_label": "initfirebase()"
     },
     {
@@ -13702,7 +13702,7 @@
       "source_location": "L96",
       "_origin": "ast",
       "id": "src_init_setfirestorenetwork",
-      "community": 66,
+      "community": 117,
       "norm_label": "setfirestorenetwork()"
     },
     {
@@ -13712,7 +13712,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_mealplansync",
-      "community": 64,
+      "community": 0,
       "norm_label": "mealplansync.ts"
     },
     {
@@ -13752,7 +13752,7 @@
       "source_location": "L93",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplanconfig",
-      "community": 108,
+      "community": 0,
       "norm_label": "savemealplanconfig()"
     },
     {
@@ -13762,7 +13762,7 @@
       "source_location": "L105",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplantemplate",
-      "community": 1,
+      "community": 0,
       "norm_label": "savemealplantemplate()"
     },
     {
@@ -13782,7 +13782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_memberssubscription",
-      "community": 64,
+      "community": 93,
       "norm_label": "memberssubscription.ts"
     },
     {
@@ -13792,7 +13792,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "src_memberssubscription_subscribemembers",
-      "community": 10,
+      "community": 93,
       "norm_label": "subscribemembers()"
     },
     {
@@ -13812,7 +13812,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "src_memberssubscription_deletemember",
-      "community": 10,
+      "community": 93,
       "norm_label": "deletemember()"
     },
     {
@@ -13822,7 +13822,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_recipecallables",
-      "community": 64,
+      "community": 51,
       "norm_label": "recipecallables.ts"
     },
     {
@@ -13842,7 +13842,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_recipecallables_classifyurlimporterror",
-      "community": 24,
+      "community": 51,
       "norm_label": "classifyurlimporterror()"
     },
     {
@@ -13852,7 +13852,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "src_recipecallables_callextractrecipefromurl",
-      "community": 24,
+      "community": 51,
       "norm_label": "callextractrecipefromurl()"
     },
     {
@@ -13862,7 +13862,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_recipesubscription",
-      "community": 279,
+      "community": 93,
       "norm_label": "recipesubscription.ts"
     },
     {
@@ -13872,7 +13872,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "src_recipesubscription_subscriberecipes",
-      "community": 279,
+      "community": 93,
       "norm_label": "subscriberecipes()"
     },
     {
@@ -13882,7 +13882,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "src_recipesubscription_loadrecipe",
-      "community": 279,
+      "community": 93,
       "norm_label": "loadrecipe()"
     },
     {
@@ -13892,7 +13892,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "src_recipesubscription_saverecipe",
-      "community": 279,
+      "community": 93,
       "norm_label": "saverecipe()"
     },
     {
@@ -13902,7 +13902,7 @@
       "source_location": "L73",
       "_origin": "ast",
       "id": "src_recipesubscription_deleterecipe",
-      "community": 279,
+      "community": 93,
       "norm_label": "deleterecipe()"
     },
     {
@@ -13952,7 +13952,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_deleteshoppinglistitem",
-      "community": 8,
+      "community": 93,
       "norm_label": "deleteshoppinglistitem()"
     },
     {
@@ -13982,7 +13982,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription",
-      "community": 64,
+      "community": 93,
       "norm_label": "shoppinglistsubscription.ts"
     },
     {
@@ -13992,7 +13992,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_subscribeshoppinglists",
-      "community": 141,
+      "community": 93,
       "norm_label": "subscribeshoppinglists()"
     },
     {
@@ -14002,7 +14002,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_listshoppinglists",
-      "community": 141,
+      "community": 93,
       "norm_label": "listshoppinglists()"
     },
     {
@@ -14012,7 +14012,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_createshoppinglist",
-      "community": 8,
+      "community": 93,
       "norm_label": "createshoppinglist()"
     },
     {
@@ -14022,7 +14022,7 @@
       "source_location": "L78",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_renameshoppinglist",
-      "community": 8,
+      "community": 93,
       "norm_label": "renameshoppinglist()"
     },
     {
@@ -14032,7 +14032,7 @@
       "source_location": "L92",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_deleteshoppinglist",
-      "community": 8,
+      "community": 93,
       "norm_label": "deleteshoppinglist()"
     },
     {
@@ -14042,7 +14042,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription",
-      "community": 64,
+      "community": 141,
       "norm_label": "shoppinglistsconfigsubscription.ts"
     },
     {
@@ -14072,7 +14072,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription_saveshoppinglistsconfig",
-      "community": 8,
+      "community": 141,
       "norm_label": "saveshoppinglistsconfig()"
     },
     {
@@ -14082,7 +14082,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_appsettingssync_test",
-      "community": 47,
+      "community": 51,
       "norm_label": "appsettingssync.test.ts"
     },
     {
@@ -14092,7 +14092,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdoc_mockgetfirestore",
-      "community": 47,
+      "community": 51,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -14102,7 +14102,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_snapcallback",
-      "community": 47,
+      "community": 51,
       "norm_label": "snapcallback"
     },
     {
@@ -14112,7 +14112,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_errorcallback",
-      "community": 47,
+      "community": 51,
       "norm_label": "errorcallback"
     },
     {
@@ -14172,7 +14172,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_emulatorhelpers",
-      "community": 141,
+      "community": 117,
       "norm_label": "emulatorhelpers.ts"
     },
     {
@@ -14182,7 +14182,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "tests_emulatorhelpers_initfirebaseemulator",
-      "community": 141,
+      "community": 117,
       "norm_label": "initfirebaseemulator()"
     },
     {
@@ -14192,7 +14192,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "tests_emulatorhelpers_resetdefaultapp",
-      "community": 141,
+      "community": 117,
       "norm_label": "resetdefaultapp()"
     },
     {
@@ -14202,7 +14202,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "tests_emulatorhelpers_clearfirestoreemulator",
-      "community": 141,
+      "community": 117,
       "norm_label": "clearfirestoreemulator()"
     },
     {
@@ -14352,7 +14352,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_mealplansync_test",
-      "community": 108,
+      "community": 0,
       "norm_label": "mealplansync.test.ts"
     },
     {
@@ -14362,7 +14362,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_mealplansync_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdoc_mockgetfirestore",
-      "community": 108,
+      "community": 0,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -14372,7 +14372,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "tests_mealplansync_test_snapcallback",
-      "community": 108,
+      "community": 0,
       "norm_label": "snapcallback"
     },
     {
@@ -14382,7 +14382,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "tests_mealplansync_test_errorcallback",
-      "community": 108,
+      "community": 0,
       "norm_label": "errorcallback"
     },
     {
@@ -14392,7 +14392,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "tests_mealplansync_test_config",
-      "community": 108,
+      "community": 0,
       "norm_label": "config"
     },
     {
@@ -14402,7 +14402,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "tests_mealplansync_test_template",
-      "community": 108,
+      "community": 0,
       "norm_label": "template"
     },
     {
@@ -14412,7 +14412,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "tests_mealplansync_test_week",
-      "community": 108,
+      "community": 0,
       "norm_label": "week"
     },
     {
@@ -14552,7 +14552,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_recipesubscription_test",
-      "community": 279,
+      "community": 93,
       "norm_label": "recipesubscription.test.ts"
     },
     {
@@ -14562,7 +14562,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdeletedoc_mockgetdoc_mockdoc_mockcollection_mockgetfirestore",
-      "community": 279,
+      "community": 93,
       "norm_label": "{\n  mockunsubscribe,\n  mockonsnapshot,\n  mocksetdoc,\n  mockdeletedoc,\n  mockgetdoc,\n  mockdoc,\n  mockcollection,\n  mockgetfirestore,\n}"
     },
     {
@@ -14572,7 +14572,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_snapdoc",
-      "community": 279,
+      "community": 93,
       "norm_label": "snapdoc"
     },
     {
@@ -14582,7 +14582,7 @@
       "source_location": "L47",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_collectioncallback",
-      "community": 279,
+      "community": 93,
       "norm_label": "collectioncallback"
     },
     {
@@ -14592,7 +14592,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_errorcallback",
-      "community": 279,
+      "community": 93,
       "norm_label": "errorcallback"
     },
     {
@@ -14602,7 +14602,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_recipe",
-      "community": 279,
+      "community": 93,
       "norm_label": "recipe"
     },
     {
@@ -14672,7 +14672,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistsubscription_test",
-      "community": 141,
+      "community": 93,
       "norm_label": "shoppinglistsubscription.test.ts"
     },
     {
@@ -14682,7 +14682,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_shoppinglistsubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdeletedoc_mockgetdocs_mockupdatedoc_mockdoc_mockcollection_mockgetfirestore",
-      "community": 141,
+      "community": 93,
       "norm_label": "{\n  mockunsubscribe,\n  mockonsnapshot,\n  mocksetdoc,\n  mockdeletedoc,\n  mockgetdocs,\n  mockupdatedoc,\n  mockdoc,\n  mockcollection,\n  mockgetfirestore,\n}"
     },
     {
@@ -14692,7 +14692,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "tests_shoppinglistsubscription_test_snapcallback",
-      "community": 141,
+      "community": 93,
       "norm_label": "snapcallback"
     },
     {
@@ -14702,7 +14702,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "tests_shoppinglistsubscription_test_errorcallback",
-      "community": 141,
+      "community": 93,
       "norm_label": "errorcallback"
     },
     {
@@ -14712,7 +14712,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "tests_shoppinglistsubscription_test_list_1",
-      "community": 141,
+      "community": 93,
       "norm_label": "list_1"
     },
     {
@@ -15289,7 +15289,7 @@
       "label": "createPosthogErrorReportingAdapter()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/posthogErrorReportingAdapter.ts",
-      "source_location": "L8",
+      "source_location": "L11",
       "_origin": "ast",
       "id": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter",
       "community": 49,
@@ -16402,7 +16402,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_buildmatchlog",
-      "community": 7,
+      "community": 32,
       "norm_label": "buildmatchlog.ts"
     },
     {
@@ -16412,7 +16412,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder",
-      "community": 7,
+      "community": 32,
       "norm_label": "matchlogbuilder"
     },
     {
@@ -16422,7 +16422,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_start",
-      "community": 7,
+      "community": 32,
       "norm_label": ".start()"
     },
     {
@@ -16432,7 +16432,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_setinputitemcount",
-      "community": 7,
+      "community": 32,
       "norm_label": ".setinputitemcount()"
     },
     {
@@ -16442,7 +16442,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_addstage",
-      "community": 7,
+      "community": 32,
       "norm_label": ".addstage()"
     },
     {
@@ -16452,7 +16452,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_setarbitration",
-      "community": 7,
+      "community": 32,
       "norm_label": ".setarbitration()"
     },
     {
@@ -16462,7 +16462,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_complete",
-      "community": 7,
+      "community": 32,
       "norm_label": ".complete()"
     },
     {
@@ -16492,7 +16492,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createaisle_createaisle",
-      "community": 64,
+      "community": 2,
       "norm_label": "createaisle()"
     },
     {
@@ -16522,7 +16522,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createaislesbulk_createaislesbulk",
-      "community": 64,
+      "community": 2,
       "norm_label": "createaislesbulk()"
     },
     {
@@ -16552,7 +16552,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "commands_createcanonitem_createcanonitem",
-      "community": 17,
+      "community": 279,
       "norm_label": "createcanonitem()"
     },
     {
@@ -16582,7 +16582,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_deleteaisles_deleteaisles",
-      "community": 64,
+      "community": 2,
       "norm_label": "deleteaisles()"
     },
     {
@@ -16612,7 +16612,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateresult",
-      "community": 95,
+      "community": 7,
       "norm_label": "matchorcreateresult"
     },
     {
@@ -16642,7 +16642,7 @@
       "source_location": "L88",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreatebatch",
-      "community": 95,
+      "community": 17,
       "norm_label": "matchorcreatebatch()"
     },
     {
@@ -16752,7 +16752,7 @@
       "source_location": "L500",
       "_origin": "ast",
       "id": "commands_matchorcreate_loadaisles",
-      "community": 95,
+      "community": 17,
       "norm_label": "loadaisles()"
     },
     {
@@ -16812,7 +16812,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_mergeaisles",
-      "community": 7,
+      "community": 64,
       "norm_label": "mergeaisles.ts"
     },
     {
@@ -16852,7 +16852,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "commands_mergeaisles_mergeaisles",
-      "community": 7,
+      "community": 286,
       "norm_label": "mergeaisles()"
     },
     {
@@ -16862,7 +16862,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_mergecanonitems",
-      "community": 11,
+      "community": 145,
       "norm_label": "mergecanonitems.ts"
     },
     {
@@ -16872,7 +16872,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "commands_mergecanonitems_mergecanonitems",
-      "community": 11,
+      "community": 145,
       "norm_label": "mergecanonitems()"
     },
     {
@@ -16882,7 +16882,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "commands_mergecanonitems_unionsynonyms",
-      "community": 11,
+      "community": 145,
       "norm_label": "unionsynonyms()"
     },
     {
@@ -16932,7 +16932,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_renamecanonitem_renamecanonitem",
-      "community": 3,
+      "community": 11,
       "norm_label": "renamecanonitem()"
     },
     {
@@ -16972,7 +16972,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_resolvecanonconflict",
-      "community": 11,
+      "community": 145,
       "norm_label": "resolvecanonconflict.ts"
     },
     {
@@ -16982,7 +16982,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "commands_resolvecanonconflict_conflictstrategy",
-      "community": 11,
+      "community": 145,
       "norm_label": "conflictstrategy"
     },
     {
@@ -16992,7 +16992,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_resolvecanonconflict_resolvecanonconflict",
-      "community": 11,
+      "community": 145,
       "norm_label": "resolvecanonconflict()"
     },
     {
@@ -17182,7 +17182,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_matchlogentry",
-      "community": 7,
+      "community": 32,
       "norm_label": "matchlogentry.ts"
     },
     {
@@ -17192,7 +17192,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_matchlogentry_candidatelog",
-      "community": 7,
+      "community": 32,
       "norm_label": "candidatelog"
     },
     {
@@ -17202,7 +17202,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "entities_matchlogentry_stageskipreason",
-      "community": 7,
+      "community": 32,
       "norm_label": "stageskipreason"
     },
     {
@@ -17212,7 +17212,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "entities_matchlogentry_stagelog",
-      "community": 7,
+      "community": 32,
       "norm_label": "stagelog"
     },
     {
@@ -17222,7 +17222,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "entities_matchlogentry_finaldecision",
-      "community": 7,
+      "community": 32,
       "norm_label": "finaldecision"
     },
     {
@@ -17232,7 +17232,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "entities_matchlogentry_arbitrationlog",
-      "community": 7,
+      "community": 32,
       "norm_label": "arbitrationlog"
     },
     {
@@ -17242,7 +17242,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "entities_matchlogentry_matchlogentry",
-      "community": 7,
+      "community": 32,
       "norm_label": "matchlogentry"
     },
     {
@@ -17402,7 +17402,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_matchloggingport",
-      "community": 7,
+      "community": 32,
       "norm_label": "matchloggingport.ts"
     },
     {
@@ -17412,7 +17412,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "ports_matchloggingport_matchloggingport",
-      "community": 7,
+      "community": 32,
       "norm_label": "matchloggingport"
     },
     {
@@ -17482,7 +17482,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_findclosestmatch",
-      "community": 7,
+      "community": 17,
       "norm_label": "findclosestmatch.ts"
     },
     {
@@ -17512,7 +17512,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_getaisleusage",
-      "community": 7,
+      "community": 64,
       "norm_label": "getaisleusage.ts"
     },
     {
@@ -17522,7 +17522,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "queries_getaisleusage_getaisleusage",
-      "community": 7,
+      "community": 64,
       "norm_label": "getaisleusage()"
     },
     {
@@ -17662,7 +17662,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_summarizematchlog",
-      "community": 7,
+      "community": 32,
       "norm_label": "summarizematchlog.ts"
     },
     {
@@ -17672,7 +17672,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "queries_summarizematchlog_matchlogsummary",
-      "community": 7,
+      "community": 32,
       "norm_label": "matchlogsummary"
     },
     {
@@ -17682,7 +17682,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "queries_summarizematchlog_nearmisscount",
-      "community": 7,
+      "community": 32,
       "norm_label": "nearmisscount()"
     },
     {
@@ -17692,7 +17692,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "queries_summarizematchlog_formatstage",
-      "community": 7,
+      "community": 32,
       "norm_label": "formatstage()"
     },
     {
@@ -17702,7 +17702,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "queries_summarizematchlog_formatarbitration",
-      "community": 7,
+      "community": 32,
       "norm_label": "formatarbitration()"
     },
     {
@@ -17712,7 +17712,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "queries_summarizematchlog_summarizematchlog",
-      "community": 7,
+      "community": 32,
       "norm_label": "summarizematchlog()"
     },
     {
@@ -17722,7 +17722,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_synonymmatch",
-      "community": 11,
+      "community": 17,
       "norm_label": "synonymmatch.ts"
     },
     {
@@ -17732,7 +17732,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "queries_synonymmatch_synonymmatch",
-      "community": 11,
+      "community": 17,
       "norm_label": "synonymmatch()"
     },
     {
@@ -17772,7 +17772,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addaccessory",
-      "community": 9,
+      "community": 1,
       "norm_label": "addaccessory.ts"
     },
     {
@@ -17782,7 +17782,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_addaccessory_addaccessoryinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "addaccessoryinput"
     },
     {
@@ -17802,7 +17802,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addequipment",
-      "community": 9,
+      "community": 1,
       "norm_label": "addequipment.ts"
     },
     {
@@ -17812,7 +17812,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_addequipment_addequipmentinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "addequipmentinput"
     },
     {
@@ -17832,7 +17832,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addrule",
-      "community": 9,
+      "community": 1,
       "norm_label": "addrule.ts"
     },
     {
@@ -17842,7 +17842,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_addrule_addruleinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "addruleinput"
     },
     {
@@ -17852,7 +17852,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_addrule_addrule",
-      "community": 9,
+      "community": 1,
       "norm_label": "addrule()"
     },
     {
@@ -17862,7 +17862,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_editrule",
-      "community": 9,
+      "community": 1,
       "norm_label": "editrule.ts"
     },
     {
@@ -17872,7 +17872,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_editrule_editruleinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "editruleinput"
     },
     {
@@ -17882,7 +17882,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "commands_editrule_editrule",
-      "community": 9,
+      "community": 1,
       "norm_label": "editrule()"
     },
     {
@@ -17892,7 +17892,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removeaccessory",
-      "community": 9,
+      "community": 1,
       "norm_label": "removeaccessory.ts"
     },
     {
@@ -17902,7 +17902,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removeaccessory_removeaccessoryinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "removeaccessoryinput"
     },
     {
@@ -17922,7 +17922,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removeequipment",
-      "community": 9,
+      "community": 1,
       "norm_label": "removeequipment.ts"
     },
     {
@@ -17932,7 +17932,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removeequipment_removeequipmentinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "removeequipmentinput"
     },
     {
@@ -17952,7 +17952,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removerule",
-      "community": 9,
+      "community": 1,
       "norm_label": "removerule.ts"
     },
     {
@@ -17962,7 +17962,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removerule_removeruleinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "removeruleinput"
     },
     {
@@ -17972,7 +17972,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_removerule_removerule",
-      "community": 9,
+      "community": 1,
       "norm_label": "removerule()"
     },
     {
@@ -17982,7 +17982,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_renameequipment",
-      "community": 9,
+      "community": 1,
       "norm_label": "renameequipment.ts"
     },
     {
@@ -17992,7 +17992,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_renameequipment_renameequipmentinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "renameequipmentinput"
     },
     {
@@ -18002,7 +18002,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_renameequipment_renameequipment",
-      "community": 9,
+      "community": 1,
       "norm_label": "renameequipment()"
     },
     {
@@ -18012,7 +18012,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_setaccessoryowned",
-      "community": 9,
+      "community": 1,
       "norm_label": "setaccessoryowned.ts"
     },
     {
@@ -18022,7 +18022,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setaccessoryowned_setaccessoryownedinput",
-      "community": 9,
+      "community": 1,
       "norm_label": "setaccessoryownedinput"
     },
     {
@@ -18042,7 +18042,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentitem",
-      "community": 9,
+      "community": 1,
       "norm_label": "equipmentitem.ts"
     },
     {
@@ -18052,7 +18052,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentitem_accessory",
-      "community": 9,
+      "community": 1,
       "norm_label": "accessory"
     },
     {
@@ -18062,7 +18062,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "entities_equipmentitem_equipmentitem",
-      "community": 9,
+      "community": 1,
       "norm_label": "equipmentitem"
     },
     {
@@ -18072,7 +18072,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentmanifest",
-      "community": 9,
+      "community": 1,
       "norm_label": "equipmentmanifest.ts"
     },
     {
@@ -18082,7 +18082,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_equipmentmanifest_equipmentmanifest",
-      "community": 9,
+      "community": 1,
       "norm_label": "equipmentmanifest"
     },
     {
@@ -18092,7 +18092,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "equipment_index",
-      "community": 9,
+      "community": 1,
       "norm_label": "index.ts"
     },
     {
@@ -18102,7 +18102,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_equipmentmanifestport",
-      "community": 9,
+      "community": 1,
       "norm_label": "equipmentmanifestport.ts"
     },
     {
@@ -18112,7 +18112,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_equipmentmanifestport_equipmentmanifestport",
-      "community": 9,
+      "community": 1,
       "norm_label": "equipmentmanifestport"
     },
     {
@@ -18152,7 +18152,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_daymutators",
-      "community": 1,
+      "community": 0,
       "norm_label": "daymutators.ts"
     },
     {
@@ -18162,7 +18162,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "commands_daymutators_daycontainer",
-      "community": 1,
+      "community": 0,
       "norm_label": "daycontainer"
     },
     {
@@ -18172,7 +18172,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_daymutators_withday",
-      "community": 1,
+      "community": 0,
       "norm_label": "withday()"
     },
     {
@@ -18182,7 +18182,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "commands_daymutators_withattendee",
-      "community": 1,
+      "community": 0,
       "norm_label": "withattendee()"
     },
     {
@@ -18192,7 +18192,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "commands_daymutators_setdaynote",
-      "community": 1,
+      "community": 0,
       "norm_label": "setdaynote()"
     },
     {
@@ -18202,7 +18202,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "commands_daymutators_setdaychefs",
-      "community": 1,
+      "community": 0,
       "norm_label": "setdaychefs()"
     },
     {
@@ -18212,7 +18212,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "commands_daymutators_setdayguests",
-      "community": 1,
+      "community": 0,
       "norm_label": "setdayguests()"
     },
     {
@@ -18232,7 +18232,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "commands_daymutators_removeattendee",
-      "community": 1,
+      "community": 0,
       "norm_label": "removeattendee()"
     },
     {
@@ -18242,7 +18242,7 @@
       "source_location": "L77",
       "_origin": "ast",
       "id": "commands_daymutators_setattendeehometime",
-      "community": 1,
+      "community": 0,
       "norm_label": "setattendeehometime()"
     },
     {
@@ -18252,7 +18252,7 @@
       "source_location": "L88",
       "_origin": "ast",
       "id": "commands_daymutators_setattendeenote",
-      "community": 1,
+      "community": 0,
       "norm_label": "setattendeenote()"
     },
     {
@@ -18262,7 +18262,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_emptyday",
-      "community": 32,
+      "community": 0,
       "norm_label": "emptyday.ts"
     },
     {
@@ -18272,7 +18272,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "commands_emptyday_emptyday",
-      "community": 32,
+      "community": 0,
       "norm_label": "emptyday()"
     },
     {
@@ -18282,7 +18282,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "commands_emptyday_emptytemplate",
-      "community": 108,
+      "community": 0,
       "norm_label": "emptytemplate()"
     },
     {
@@ -18292,7 +18292,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "commands_emptyday_emptyweek",
-      "community": 32,
+      "community": 0,
       "norm_label": "emptyweek()"
     },
     {
@@ -18302,7 +18302,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_instantiateweek",
-      "community": 32,
+      "community": 0,
       "norm_label": "instantiateweek.ts"
     },
     {
@@ -18312,7 +18312,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "commands_instantiateweek_cloneday",
-      "community": 32,
+      "community": 0,
       "norm_label": "cloneday()"
     },
     {
@@ -18322,7 +18322,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "commands_instantiateweek_instantiateweek",
-      "community": 32,
+      "community": 0,
       "norm_label": "instantiateweek()"
     },
     {
@@ -18332,7 +18332,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_day",
-      "community": 32,
+      "community": 0,
       "norm_label": "day.ts"
     },
     {
@@ -18342,7 +18342,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "entities_day_attendee",
-      "community": 32,
+      "community": 0,
       "norm_label": "attendee"
     },
     {
@@ -18352,7 +18352,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "entities_day_day",
-      "community": 32,
+      "community": 0,
       "norm_label": "day"
     },
     {
@@ -18362,7 +18362,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_mealplanconfig",
-      "community": 32,
+      "community": 0,
       "norm_label": "mealplanconfig.ts"
     },
     {
@@ -18372,7 +18372,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_mealplanconfig_mealplanconfig",
-      "community": 32,
+      "community": 0,
       "norm_label": "mealplanconfig"
     },
     {
@@ -18382,7 +18382,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_mealplantemplate",
-      "community": 32,
+      "community": 0,
       "norm_label": "mealplantemplate.ts"
     },
     {
@@ -18392,7 +18392,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "entities_mealplantemplate_mealplantemplate",
-      "community": 32,
+      "community": 0,
       "norm_label": "mealplantemplate"
     },
     {
@@ -18402,7 +18402,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_mealplanweek",
-      "community": 32,
+      "community": 0,
       "norm_label": "mealplanweek.ts"
     },
     {
@@ -18412,7 +18412,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "entities_mealplanweek_mealplanweek",
-      "community": 32,
+      "community": 0,
       "norm_label": "mealplanweek"
     },
     {
@@ -18422,7 +18422,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_weekday",
-      "community": 32,
+      "community": 0,
       "norm_label": "weekday.ts"
     },
     {
@@ -18432,7 +18432,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_weekday_weekday",
-      "community": 32,
+      "community": 0,
       "norm_label": "weekday"
     },
     {
@@ -18442,7 +18442,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "entities_weekday_weekdays",
-      "community": 32,
+      "community": 0,
       "norm_label": "weekdays"
     },
     {
@@ -18452,7 +18452,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "mealplan_index",
-      "community": 32,
+      "community": 0,
       "norm_label": "index.ts"
     },
     {
@@ -18462,7 +18462,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_weekdays",
-      "community": 32,
+      "community": 0,
       "norm_label": "weekdays.ts"
     },
     {
@@ -18472,7 +18472,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "queries_weekdays_weekday_index",
-      "community": 32,
+      "community": 0,
       "norm_label": "weekday_index"
     },
     {
@@ -18482,7 +18482,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "queries_weekdays_toutcdate",
-      "community": 32,
+      "community": 0,
       "norm_label": "toutcdate()"
     },
     {
@@ -18492,7 +18492,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "queries_weekdays_formatutc",
-      "community": 32,
+      "community": 0,
       "norm_label": "formatutc()"
     },
     {
@@ -18502,7 +18502,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "queries_weekdays_mondayfirstindex",
-      "community": 32,
+      "community": 0,
       "norm_label": "mondayfirstindex()"
     },
     {
@@ -18512,7 +18512,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "queries_weekdays_weekdayof",
-      "community": 32,
+      "community": 0,
       "norm_label": "weekdayof()"
     },
     {
@@ -18522,7 +18522,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "queries_weekdays_weekstartfor",
-      "community": 32,
+      "community": 0,
       "norm_label": "weekstartfor()"
     },
     {
@@ -18532,7 +18532,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "queries_weekdays_weekdates",
-      "community": 32,
+      "community": 0,
       "norm_label": "weekdates()"
     },
     {
@@ -18542,7 +18542,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_createmember",
-      "community": 51,
+      "community": 10,
       "norm_label": "createmember.ts"
     },
     {
@@ -18552,7 +18552,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "commands_createmember_creatememberinput",
-      "community": 51,
+      "community": 10,
       "norm_label": "creatememberinput"
     },
     {
@@ -18562,7 +18562,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "commands_createmember_createmember",
-      "community": 51,
+      "community": 10,
       "norm_label": "createmember()"
     },
     {
@@ -18572,7 +18572,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_normalisememberemail",
-      "community": 51,
+      "community": 10,
       "norm_label": "normalisememberemail.ts"
     },
     {
@@ -18582,7 +18582,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "commands_normalisememberemail_normalisememberemail",
-      "community": 51,
+      "community": 10,
       "norm_label": "normalisememberemail()"
     },
     {
@@ -18592,7 +18592,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_updatemember",
-      "community": 51,
+      "community": 10,
       "norm_label": "updatemember.ts"
     },
     {
@@ -18602,7 +18602,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_updatemember_updatememberpatch",
-      "community": 51,
+      "community": 10,
       "norm_label": "updatememberpatch"
     },
     {
@@ -18612,7 +18612,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "commands_updatemember_updatemember",
-      "community": 51,
+      "community": 10,
       "norm_label": "updatemember()"
     },
     {
@@ -18622,7 +18622,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_member",
-      "community": 51,
+      "community": 10,
       "norm_label": "member.ts"
     },
     {
@@ -18632,7 +18632,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "entities_member_member",
-      "community": 51,
+      "community": 10,
       "norm_label": "member"
     },
     {
@@ -18642,7 +18642,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "members_index",
-      "community": 51,
+      "community": 10,
       "norm_label": "index.ts"
     },
     {
@@ -18652,7 +18652,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_memberfirstname",
-      "community": 51,
+      "community": 10,
       "norm_label": "memberfirstname.ts"
     },
     {
@@ -18662,7 +18662,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "queries_memberfirstname_memberfirstname",
-      "community": 51,
+      "community": 10,
       "norm_label": "memberfirstname()"
     },
     {
@@ -18672,7 +18672,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_memberinitials",
-      "community": 51,
+      "community": 10,
       "norm_label": "memberinitials.ts"
     },
     {
@@ -18682,7 +18682,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "queries_memberinitials_memberinitials",
-      "community": 51,
+      "community": 10,
       "norm_label": "memberinitials()"
     },
     {
@@ -18692,7 +18692,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_sortmembers",
-      "community": 51,
+      "community": 10,
       "norm_label": "sortmembers.ts"
     },
     {
@@ -18702,7 +18702,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "queries_sortmembers_sortmembers",
-      "community": 51,
+      "community": 10,
       "norm_label": "sortmembers()"
     },
     {
@@ -20862,7 +20862,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_clearcheckeditems_clearcheckeditems",
-      "community": 8,
+      "community": 4,
       "norm_label": "clearcheckeditems()"
     },
     {
@@ -20892,7 +20892,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "commands_confirmitemneeded_confirmitemneeded",
-      "community": 8,
+      "community": 4,
       "norm_label": "confirmitemneeded()"
     },
     {
@@ -20922,7 +20922,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createlist_createlist",
-      "community": 8,
+      "community": 66,
       "norm_label": "createlist()"
     },
     {
@@ -20952,7 +20952,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "commands_deleteitem_deleteitem",
-      "community": 8,
+      "community": 4,
       "norm_label": "deleteitem()"
     },
     {
@@ -20962,7 +20962,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_deletelist",
-      "community": 4,
+      "community": 64,
       "norm_label": "deletelist.ts"
     },
     {
@@ -20982,7 +20982,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_deletelist_deletelist",
-      "community": 8,
+      "community": 66,
       "norm_label": "deletelist()"
     },
     {
@@ -21012,7 +21012,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "commands_edititemamountunit_edititemamountunit",
-      "community": 8,
+      "community": 4,
       "norm_label": "edititemamountunit()"
     },
     {
@@ -21042,7 +21042,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_edititemnotes_edititemnotes",
-      "community": 8,
+      "community": 4,
       "norm_label": "edititemnotes()"
     },
     {
@@ -21052,7 +21052,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_edititemrawtext",
-      "community": 64,
+      "community": 66,
       "norm_label": "edititemrawtext.ts"
     },
     {
@@ -21062,7 +21062,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_edititemrawtext_edititemrawtextinput",
-      "community": 4,
+      "community": 66,
       "norm_label": "edititemrawtextinput"
     },
     {
@@ -21072,7 +21072,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_edititemrawtext_edititemrawtext",
-      "community": 8,
+      "community": 66,
       "norm_label": "edititemrawtext()"
     },
     {
@@ -21112,7 +21112,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "commands_moveitems_moveitems",
-      "community": 93,
+      "community": 4,
       "norm_label": "moveitems()"
     },
     {
@@ -21142,7 +21142,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_renamelist_renamelist",
-      "community": 8,
+      "community": 66,
       "norm_label": "renamelist()"
     },
     {
@@ -21152,7 +21152,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_setdefaultlist",
-      "community": 4,
+      "community": 64,
       "norm_label": "setdefaultlist.ts"
     },
     {
@@ -21172,7 +21172,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_setdefaultlist_setdefaultlist",
-      "community": 8,
+      "community": 66,
       "norm_label": "setdefaultlist()"
     },
     {
@@ -21212,7 +21212,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglist",
-      "community": 4,
+      "community": 64,
       "norm_label": "shoppinglist.ts"
     },
     {
@@ -21222,7 +21222,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglist_shoppinglist",
-      "community": 4,
+      "community": 64,
       "norm_label": "shoppinglist"
     },
     {
@@ -21262,7 +21262,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglistsconfig",
-      "community": 4,
+      "community": 141,
       "norm_label": "shoppinglistsconfig.ts"
     },
     {
@@ -21272,7 +21272,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglistsconfig_shoppinglistsconfig",
-      "community": 4,
+      "community": 141,
       "norm_label": "shoppinglistsconfig"
     },
     {
@@ -21322,7 +21322,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "ports_entryparseport_entryparseport",
-      "community": 96,
+      "community": 83,
       "norm_label": "entryparseport"
     },
     {
@@ -21372,7 +21372,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_shoppinglistport",
-      "community": 4,
+      "community": 64,
       "norm_label": "shoppinglistport.ts"
     },
     {
@@ -21392,7 +21392,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_shoppinglistsconfigport",
-      "community": 4,
+      "community": 141,
       "norm_label": "shoppinglistsconfigport.ts"
     },
     {
@@ -21752,7 +21752,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_resolveitemdisplayname",
-      "community": 4,
+      "community": 83,
       "norm_label": "resolveitemdisplayname.ts"
     },
     {
@@ -21762,7 +21762,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "queries_resolveitemdisplayname_resolveitemdisplayname",
-      "community": 4,
+      "community": 83,
       "norm_label": "resolveitemdisplayname()"
     },
     {
@@ -21772,7 +21772,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_appsettings_schema_test",
-      "community": 77,
+      "community": 51,
       "norm_label": "appsettings.schema.test.ts"
     },
     {
@@ -21782,7 +21782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_matchlogbuilder_test",
-      "community": 7,
+      "community": 32,
       "norm_label": "matchlogbuilder.test.ts"
     },
     {
@@ -21792,7 +21792,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_matchlogbuilder_test_makestage",
-      "community": 7,
+      "community": 32,
       "norm_label": "makestage()"
     },
     {
@@ -21842,7 +21842,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canonitem_schema_test",
-      "community": 17,
+      "community": 279,
       "norm_label": "canonitem.schema.test.ts"
     },
     {
@@ -21852,7 +21852,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_canonitem_schema_test_counterids",
-      "community": 17,
+      "community": 279,
       "norm_label": "counterids()"
     },
     {
@@ -22012,7 +22012,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_createcanonitem_test",
-      "community": 17,
+      "community": 279,
       "norm_label": "createcanonitem.test.ts"
     },
     {
@@ -22022,7 +22022,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_createcanonitem_test_counterids",
-      "community": 17,
+      "community": 279,
       "norm_label": "counterids()"
     },
     {
@@ -22062,7 +22062,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_deleteaisles_test",
-      "community": 64,
+      "community": 2,
       "norm_label": "deleteaisles.test.ts"
     },
     {
@@ -22072,7 +22072,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_deleteaisles_test_makeaislestore",
-      "community": 64,
+      "community": 2,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22082,7 +22082,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "canon_deleteaisles_test_makecanonstore",
-      "community": 64,
+      "community": 2,
       "norm_label": "makecanonstore()"
     },
     {
@@ -22092,7 +22092,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "canon_deleteaisles_test_canonitem",
-      "community": 64,
+      "community": 2,
       "norm_label": "canonitem()"
     },
     {
@@ -22212,7 +22212,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_getaisleusage_test",
-      "community": 11,
+      "community": 64,
       "norm_label": "getaisleusage.test.ts"
     },
     {
@@ -22222,7 +22222,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_getaisleusage_test_makeaislestore",
-      "community": 11,
+      "community": 64,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22232,7 +22232,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "canon_getaisleusage_test_makecanonstore",
-      "community": 11,
+      "community": 64,
       "norm_label": "makecanonstore()"
     },
     {
@@ -22242,7 +22242,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "canon_getaisleusage_test_canonitem",
-      "community": 11,
+      "community": 64,
       "norm_label": "canonitem()"
     },
     {
@@ -22582,7 +22582,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_mergeaisles_test",
-      "community": 11,
+      "community": 286,
       "norm_label": "mergeaisles.test.ts"
     },
     {
@@ -22592,7 +22592,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_makeaislestore",
-      "community": 11,
+      "community": 286,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22602,7 +22602,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_makecanonstore",
-      "community": 11,
+      "community": 286,
       "norm_label": "makecanonstore()"
     },
     {
@@ -22612,7 +22612,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_canonitem",
-      "community": 11,
+      "community": 286,
       "norm_label": "canonitem()"
     },
     {
@@ -22622,7 +22622,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_aisles",
-      "community": 11,
+      "community": 286,
       "norm_label": "aisles"
     },
     {
@@ -22632,7 +22632,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_mergecanonitems_test",
-      "community": 11,
+      "community": 145,
       "norm_label": "mergecanonitems.test.ts"
     },
     {
@@ -22642,7 +22642,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_mergecanonitems_test_item",
-      "community": 11,
+      "community": 145,
       "norm_label": "item()"
     },
     {
@@ -22752,7 +22752,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test",
-      "community": 11,
+      "community": 145,
       "norm_label": "resolvecanonconflict.test.ts"
     },
     {
@@ -22762,7 +22762,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test_item",
-      "community": 11,
+      "community": 145,
       "norm_label": "item()"
     },
     {
@@ -22772,7 +22772,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test_local",
-      "community": 11,
+      "community": 145,
       "norm_label": "local"
     },
     {
@@ -22782,7 +22782,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test_remote",
-      "community": 11,
+      "community": 145,
       "norm_label": "remote"
     },
     {
@@ -22882,7 +22882,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test",
-      "community": 7,
+      "community": 32,
       "norm_label": "summarizematchlog.test.ts"
     },
     {
@@ -22892,7 +22892,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makestage",
-      "community": 7,
+      "community": 32,
       "norm_label": "makestage()"
     },
     {
@@ -22902,7 +22902,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makeentry",
-      "community": 7,
+      "community": 32,
       "norm_label": "makeentry()"
     },
     {
@@ -22912,7 +22912,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makearbitration",
-      "community": 7,
+      "community": 32,
       "norm_label": "makearbitration()"
     },
     {
@@ -22922,7 +22922,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_synonymmatch_test",
-      "community": 11,
+      "community": 17,
       "norm_label": "synonymmatch.test.ts"
     },
     {
@@ -22932,7 +22932,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_synonymmatch_test_items",
-      "community": 11,
+      "community": 17,
       "norm_label": "items"
     },
     {
@@ -22952,7 +22952,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_devsettings_schema_test",
-      "community": 77,
+      "community": 51,
       "norm_label": "devsettings.schema.test.ts"
     },
     {
@@ -22962,7 +22962,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "equipment_commands_test",
-      "community": 9,
+      "community": 1,
       "norm_label": "commands.test.ts"
     },
     {
@@ -22972,7 +22972,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "equipment_commands_test_makeids",
-      "community": 9,
+      "community": 1,
       "norm_label": "makeids()"
     },
     {
@@ -22982,7 +22982,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "equipment_commands_test_emptymanifest",
-      "community": 9,
+      "community": 1,
       "norm_label": "emptymanifest()"
     },
     {
@@ -22992,7 +22992,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "equipment_commands_test_manifestwith",
-      "community": 9,
+      "community": 1,
       "norm_label": "manifestwith()"
     },
     {
@@ -23002,7 +23002,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "equipment_commands_test_makeitem",
-      "community": 9,
+      "community": 1,
       "norm_label": "makeitem()"
     },
     {
@@ -23012,7 +23012,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "equipment_commands_test_makeaccessory",
-      "community": 9,
+      "community": 1,
       "norm_label": "makeaccessory()"
     },
     {
@@ -23022,7 +23022,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "mealplan_mealplan_test",
-      "community": 32,
+      "community": 0,
       "norm_label": "mealplan.test.ts"
     },
     {
@@ -23032,7 +23032,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "mealplan_mealplan_test_config",
-      "community": 32,
+      "community": 0,
       "norm_label": "config()"
     },
     {
@@ -23042,7 +23042,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "mealplan_mealplan_test_templatewithlabels",
-      "community": 32,
+      "community": 0,
       "norm_label": "templatewithlabels()"
     },
     {
@@ -23052,7 +23052,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "members_members_test",
-      "community": 51,
+      "community": 10,
       "norm_label": "members.test.ts"
     },
     {
@@ -23062,7 +23062,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "members_members_test_makemember",
-      "community": 51,
+      "community": 10,
       "norm_label": "makemember()"
     },
     {
@@ -23122,7 +23122,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_commands_test",
-      "community": 8,
+      "community": 66,
       "norm_label": "commands.test.ts"
     },
     {
@@ -23132,7 +23132,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeids",
-      "community": 8,
+      "community": 66,
       "norm_label": "makeids()"
     },
     {
@@ -23142,7 +23142,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makelist",
-      "community": 8,
+      "community": 66,
       "norm_label": "makelist()"
     },
     {
@@ -23152,7 +23152,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeconfig",
-      "community": 8,
+      "community": 66,
       "norm_label": "makeconfig()"
     },
     {
@@ -23162,7 +23162,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeitem",
-      "community": 8,
+      "community": 66,
       "norm_label": "makeitem()"
     },
     {
@@ -23262,7 +23262,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_resolveitemdisplayname_test",
-      "community": 4,
+      "community": 83,
       "norm_label": "resolveitemdisplayname.test.ts"
     },
     {
@@ -23272,7 +23272,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "shoppinglist_resolveitemdisplayname_test_makeitem",
-      "community": 4,
+      "community": 83,
       "norm_label": "makeitem()"
     },
     {
@@ -23472,7 +23472,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_types_src_index_ts_src_index",
-      "community": 64,
+      "community": 298,
       "norm_label": "index.ts"
     },
     {
@@ -23502,7 +23502,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "src_index_conflict",
-      "community": 64,
+      "community": 298,
       "norm_label": "conflict"
     },
     {
@@ -23522,7 +23522,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "src_index_writeresult",
-      "community": 64,
+      "community": 298,
       "norm_label": "writeresult"
     },
     {
@@ -23572,7 +23572,7 @@
       "source_location": "L92",
       "_origin": "ast",
       "id": "src_index_canonitemdto",
-      "community": 64,
+      "community": 298,
       "norm_label": "canonitemdto"
     },
     {
@@ -23582,7 +23582,7 @@
       "source_location": "L107",
       "_origin": "ast",
       "id": "src_index_aisledto",
-      "community": 64,
+      "community": 298,
       "norm_label": "aisledto"
     },
     {
@@ -23592,7 +23592,7 @@
       "source_location": "L113",
       "_origin": "ast",
       "id": "src_index_aislelistdto",
-      "community": 64,
+      "community": 298,
       "norm_label": "aislelistdto"
     },
     {
@@ -23602,7 +23602,7 @@
       "source_location": "L118",
       "_origin": "ast",
       "id": "src_index_errorcode",
-      "community": 64,
+      "community": 1,
       "norm_label": "errorcode"
     },
     {
@@ -34695,7 +34695,7 @@
       "source_location": "L1505",
       "_origin": "ast",
       "id": "design_ui_spec_v02_8_14_spinner",
-      "community": 283,
+      "community": 313,
       "norm_label": "8.14 spinner"
     },
     {
@@ -34705,7 +34705,7 @@
       "source_location": "L1507",
       "_origin": "ast",
       "id": "design_ui_spec_v02_props_1507",
-      "community": 283,
+      "community": 313,
       "norm_label": "props"
     },
     {
@@ -34715,7 +34715,7 @@
       "source_location": "L1515",
       "_origin": "ast",
       "id": "design_ui_spec_v02_accessibility_1515",
-      "community": 283,
+      "community": 313,
       "norm_label": "accessibility"
     },
     {
@@ -34725,7 +34725,7 @@
       "source_location": "L1520",
       "_origin": "ast",
       "id": "design_ui_spec_v02_styling_1520",
-      "community": 283,
+      "community": 313,
       "norm_label": "styling"
     },
     {
@@ -35665,7 +35665,7 @@
       "source_location": "L621",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_list_selection_createlistselection_selectablelist_selectallcheckbox_rowselectcheckbox",
-      "community": 73,
+      "community": 272,
       "norm_label": "10. list selection (`createlistselection` + `selectablelist` / `selectallcheckbox` / `rowselectcheckbox`)"
     },
     {
@@ -35675,7 +35675,7 @@
       "source_location": "L623",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_1_overview",
-      "community": 73,
+      "community": 272,
       "norm_label": "10.1 overview"
     },
     {
@@ -35685,7 +35685,7 @@
       "source_location": "L638",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_2_createlistselection_options",
-      "community": 73,
+      "community": 272,
       "norm_label": "10.2 `createlistselection(options)`"
     },
     {
@@ -35695,7 +35695,7 @@
       "source_location": "L664",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_3_component_props",
-      "community": 73,
+      "community": 272,
       "norm_label": "10.3 component props"
     },
     {
@@ -35705,7 +35705,7 @@
       "source_location": "L679",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_4_behaviour",
-      "community": 73,
+      "community": 272,
       "norm_label": "10.4 behaviour"
     },
     {
@@ -35715,7 +35715,7 @@
       "source_location": "L686",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_5_accessibility",
-      "community": 73,
+      "community": 272,
       "norm_label": "10.5 accessibility"
     },
     {
@@ -35725,7 +35725,7 @@
       "source_location": "L691",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_6_testing_requirements",
-      "community": 73,
+      "community": 272,
       "norm_label": "10.6 testing requirements"
     },
     {
@@ -35735,7 +35735,7 @@
       "source_location": "L700",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_editablerow_primitive",
-      "community": 272,
+      "community": 310,
       "norm_label": "11. editablerow (primitive)"
     },
     {
@@ -35745,7 +35745,7 @@
       "source_location": "L702",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_1_overview",
-      "community": 272,
+      "community": 310,
       "norm_label": "11.1 overview"
     },
     {
@@ -35755,7 +35755,7 @@
       "source_location": "L706",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_2_props",
-      "community": 272,
+      "community": 310,
       "norm_label": "11.2 props"
     },
     {
@@ -35765,7 +35765,7 @@
       "source_location": "L716",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_3_behaviour",
-      "community": 272,
+      "community": 310,
       "norm_label": "11.3 behaviour"
     },
     {
@@ -35775,7 +35775,7 @@
       "source_location": "L723",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_4_testing_requirements",
-      "community": 272,
+      "community": 310,
       "norm_label": "11.4 testing requirements"
     },
     {
@@ -35905,7 +35905,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_e2e_test_spec",
-      "community": 284,
+      "community": 291,
       "norm_label": "e2e-test-spec.md"
     },
     {
@@ -36045,7 +36045,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_e2e",
-      "community": 284,
+      "community": 291,
       "norm_label": "e2e.md"
     },
     {
@@ -36165,7 +36165,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_error_reporting_calibration_caught_error_reporting_calibration_note",
-      "community": 291,
+      "community": 312,
       "norm_label": "caught-error reporting \u2014 calibration note"
     },
     {
@@ -36175,27 +36175,37 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "docs_error_reporting_calibration_before_after_check_in_posthog_error_tracking",
-      "community": 291,
+      "community": 312,
       "norm_label": "before/after check in posthog error tracking"
+    },
+    {
+      "label": "Uncaught errors \u2014 separate, automatic path",
+      "file_type": "document",
+      "source_file": "docs/error-reporting-calibration.md",
+      "source_location": "L48",
+      "_origin": "ast",
+      "id": "docs_error_reporting_calibration_uncaught_errors_separate_automatic_path",
+      "community": 312,
+      "norm_label": "uncaught errors \u2014 separate, automatic path"
     },
     {
       "label": "Known, intentional asymmetries (NOT bugs)",
       "file_type": "document",
       "source_file": "docs/error-reporting-calibration.md",
-      "source_location": "L48",
+      "source_location": "L66",
       "_origin": "ast",
       "id": "docs_error_reporting_calibration_known_intentional_asymmetries_not_bugs",
-      "community": 291,
+      "community": 312,
       "norm_label": "known, intentional asymmetries (not bugs)"
     },
     {
       "label": "No raw user content in payloads",
       "file_type": "document",
       "source_file": "docs/error-reporting-calibration.md",
-      "source_location": "L66",
+      "source_location": "L84",
       "_origin": "ast",
       "id": "docs_error_reporting_calibration_no_raw_user_content_in_payloads",
-      "community": 291,
+      "community": 312,
       "norm_label": "no raw user content in payloads"
     },
     {
@@ -37102,7 +37112,7 @@
       "label": "8. Cloud Functions requirements",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L279",
+      "source_location": "L281",
       "_origin": "ast",
       "id": "docs_salt_architecture_8_cloud_functions_requirements",
       "community": 280,
@@ -37112,7 +37122,7 @@
       "label": "9. PWA (UI) requirements",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L310",
+      "source_location": "L312",
       "_origin": "ast",
       "id": "docs_salt_architecture_9_pwa_ui_requirements",
       "community": 280,
@@ -37122,7 +37132,7 @@
       "label": "10. Shared types requirements",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L330",
+      "source_location": "L332",
       "_origin": "ast",
       "id": "docs_salt_architecture_10_shared_types_requirements",
       "community": 280,
@@ -37132,7 +37142,7 @@
       "label": "11. Enforcement rules",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L345",
+      "source_location": "L347",
       "_origin": "ast",
       "id": "docs_salt_architecture_11_enforcement_rules",
       "community": 326,
@@ -37142,7 +37152,7 @@
       "label": "ESLint",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L347",
+      "source_location": "L349",
       "_origin": "ast",
       "id": "docs_salt_architecture_eslint",
       "community": 326,
@@ -37152,7 +37162,7 @@
       "label": "tsconfig",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L360",
+      "source_location": "L362",
       "_origin": "ast",
       "id": "docs_salt_architecture_tsconfig",
       "community": 326,
@@ -37162,7 +37172,7 @@
       "label": "Commit gateway",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L366",
+      "source_location": "L368",
       "_origin": "ast",
       "id": "docs_salt_architecture_commit_gateway",
       "community": 326,
@@ -37172,7 +37182,7 @@
       "label": "12. Testing strategy",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L383",
+      "source_location": "L385",
       "_origin": "ast",
       "id": "docs_salt_architecture_12_testing_strategy",
       "community": 316,
@@ -37182,7 +37192,7 @@
       "label": "Domain",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L385",
+      "source_location": "L387",
       "_origin": "ast",
       "id": "docs_salt_architecture_domain",
       "community": 316,
@@ -37192,7 +37202,7 @@
       "label": "firebase-sync",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L390",
+      "source_location": "L392",
       "_origin": "ast",
       "id": "docs_salt_architecture_firebase_sync",
       "community": 316,
@@ -37202,7 +37212,7 @@
       "label": "observability",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L395",
+      "source_location": "L397",
       "_origin": "ast",
       "id": "docs_salt_architecture_observability",
       "community": 316,
@@ -37212,7 +37222,7 @@
       "label": "Cloud Functions",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L400",
+      "source_location": "L402",
       "_origin": "ast",
       "id": "docs_salt_architecture_cloud_functions",
       "community": 316,
@@ -37222,7 +37232,7 @@
       "label": "UI",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L405",
+      "source_location": "L407",
       "_origin": "ast",
       "id": "docs_salt_architecture_ui",
       "community": 316,
@@ -37232,7 +37242,7 @@
       "label": "13. Deployment units",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L413",
+      "source_location": "L415",
       "_origin": "ast",
       "id": "docs_salt_architecture_13_deployment_units",
       "community": 280,
@@ -37242,7 +37252,7 @@
       "label": "14. Non-negotiables",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L425",
+      "source_location": "L427",
       "_origin": "ast",
       "id": "docs_salt_architecture_14_non_negotiables",
       "community": 280,
@@ -37355,7 +37365,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "lib_mealplanservice_mealplantemplate",
-      "community": 116,
+      "community": 0,
       "norm_label": "mealplantemplate"
     },
     {
@@ -37365,7 +37375,7 @@
       "source_location": "L70",
       "_origin": "ast",
       "id": "lib_mealplanservice_selectedstartdate",
-      "community": 116,
+      "community": 0,
       "norm_label": "selectedstartdate"
     },
     {
@@ -74477,9 +74487,9 @@
       "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
       "source_location": "L55",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_payloadscrubbing_test",
-      "target": "src_init_initobservability",
-      "confidence_score": 1.0
+      "target": "src_init_initobservability"
     },
     {
       "relation": "imports",
@@ -74499,9 +74509,9 @@
       "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
       "source_location": "L61",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportabilityparity_test",
-      "target": "src_init_initobservability",
-      "confidence_score": 1.0
+      "target": "src_init_initobservability"
     },
     {
       "relation": "imports",
@@ -74586,9 +74596,9 @@
       "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
       "source_location": "L57",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_payloadscrubbing_test",
-      "target": "src_posthogerrorreportingadapter",
-      "confidence_score": 1.0
+      "target": "src_posthogerrorreportingadapter"
     },
     {
       "relation": "imports_from",
@@ -74608,9 +74618,9 @@
       "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
       "source_location": "L63",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportabilityparity_test",
-      "target": "src_posthogerrorreportingadapter",
-      "confidence_score": 1.0
+      "target": "src_posthogerrorreportingadapter"
     },
     {
       "relation": "imports",
@@ -74619,9 +74629,9 @@
       "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
       "source_location": "L57",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_payloadscrubbing_test",
-      "target": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter",
-      "confidence_score": 1.0
+      "target": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter"
     },
     {
       "relation": "imports",
@@ -74641,9 +74651,9 @@
       "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
       "source_location": "L63",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportabilityparity_test",
-      "target": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter",
-      "confidence_score": 1.0
+      "target": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter"
     },
     {
       "relation": "imports",
@@ -75206,9 +75216,9 @@
       "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
       "source_location": "L56",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_payloadscrubbing_test",
-      "target": "server_init",
-      "confidence_score": 1.0
+      "target": "server_init"
     },
     {
       "relation": "imports_from",
@@ -75228,9 +75238,9 @@
       "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
       "source_location": "L62",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportabilityparity_test",
-      "target": "server_init",
-      "confidence_score": 1.0
+      "target": "server_init"
     },
     {
       "relation": "imports_from",
@@ -75250,9 +75260,9 @@
       "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
       "source_location": "L56",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_payloadscrubbing_test",
-      "target": "server_init_initserverobservability",
-      "confidence_score": 1.0
+      "target": "server_init_initserverobservability"
     },
     {
       "relation": "imports",
@@ -75272,9 +75282,9 @@
       "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
       "source_location": "L62",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportabilityparity_test",
-      "target": "server_init_initserverobservability",
-      "confidence_score": 1.0
+      "target": "server_init_initserverobservability"
     },
     {
       "relation": "calls",
@@ -75425,9 +75435,9 @@
       "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
       "source_location": "L58",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_payloadscrubbing_test",
-      "target": "server_posthogservererrorreportingadapter",
-      "confidence_score": 1.0
+      "target": "server_posthogservererrorreportingadapter"
     },
     {
       "relation": "imports_from",
@@ -75447,9 +75457,9 @@
       "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
       "source_location": "L64",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportabilityparity_test",
-      "target": "server_posthogservererrorreportingadapter",
-      "confidence_score": 1.0
+      "target": "server_posthogservererrorreportingadapter"
     },
     {
       "relation": "imports",
@@ -75458,9 +75468,9 @@
       "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
       "source_location": "L58",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_payloadscrubbing_test",
-      "target": "server_posthogservererrorreportingadapter_createposthogservererrorreportingadapter",
-      "confidence_score": 1.0
+      "target": "server_posthogservererrorreportingadapter_createposthogservererrorreportingadapter"
     },
     {
       "relation": "imports",
@@ -75480,9 +75490,9 @@
       "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
       "source_location": "L64",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportabilityparity_test",
-      "target": "server_posthogservererrorreportingadapter_createposthogservererrorreportingadapter",
-      "confidence_score": 1.0
+      "target": "server_posthogservererrorreportingadapter_createposthogservererrorreportingadapter"
     },
     {
       "relation": "imports",
@@ -75774,9 +75784,9 @@
       "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
       "source_location": "L65",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportabilityparity_test",
-      "target": "shared_reportablecategory",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory"
     },
     {
       "relation": "imports_from",
@@ -75796,9 +75806,9 @@
       "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
       "source_location": "L65",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportabilityparity_test",
-      "target": "shared_reportablecategory_isreportablecategory",
-      "confidence_score": 1.0
+      "target": "shared_reportablecategory_isreportablecategory"
     },
     {
       "relation": "imports",
@@ -75838,9 +75848,9 @@
       "source_file": "packages/adapters/observability/tests/payloadScrubbing.test.ts",
       "source_location": "L19",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_payloadscrubbing_test",
-      "target": "tests_payloadscrubbing_test_clientcapture_clientinit_servercapture_fakeposthog",
-      "confidence_score": 1.0
+      "target": "tests_payloadscrubbing_test_clientcapture_clientinit_servercapture_fakeposthog"
     },
     {
       "relation": "imports",
@@ -75891,9 +75901,9 @@
       "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportabilityparity_test",
-      "target": "src_index_domainerror",
-      "confidence_score": 1.0
+      "target": "src_index_domainerror"
     },
     {
       "relation": "contains",
@@ -75901,9 +75911,9 @@
       "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
       "source_location": "L25",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportabilityparity_test",
-      "target": "tests_reportabilityparity_test_clientcapture_clientinit_servercapture_fakeposthog",
-      "confidence_score": 1.0
+      "target": "tests_reportabilityparity_test_clientcapture_clientinit_servercapture_fakeposthog"
     },
     {
       "relation": "contains",
@@ -75911,9 +75921,9 @@
       "source_file": "packages/adapters/observability/tests/reportabilityParity.test.ts",
       "source_location": "L71",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_reportabilityparity_test",
-      "target": "tests_reportabilityparity_test_expected_report",
-      "confidence_score": 1.0
+      "target": "tests_reportabilityparity_test_expected_report"
     },
     {
       "relation": "imports",
@@ -116480,9 +116490,9 @@
       "source_file": "docs/error-reporting-calibration.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_error_reporting_calibration",
-      "target": "docs_error_reporting_calibration_caught_error_reporting_calibration_note",
-      "confidence_score": 1.0
+      "target": "docs_error_reporting_calibration_caught_error_reporting_calibration_note"
     },
     {
       "relation": "references",
@@ -116490,9 +116500,9 @@
       "source_file": "docs/error-reporting-calibration.md",
       "source_location": "L5",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_error_reporting_calibration",
-      "target": "docs_salt_architecture",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture"
     },
     {
       "relation": "contains",
@@ -116500,9 +116510,29 @@
       "source_file": "docs/error-reporting-calibration.md",
       "source_location": "L13",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_error_reporting_calibration_caught_error_reporting_calibration_note",
-      "target": "docs_error_reporting_calibration_before_after_check_in_posthog_error_tracking",
-      "confidence_score": 1.0
+      "target": "docs_error_reporting_calibration_before_after_check_in_posthog_error_tracking"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/error-reporting-calibration.md",
+      "source_location": "L48",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_error_reporting_calibration_caught_error_reporting_calibration_note",
+      "target": "docs_error_reporting_calibration_known_intentional_asymmetries_not_bugs"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/error-reporting-calibration.md",
+      "source_location": "L66",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_error_reporting_calibration_caught_error_reporting_calibration_note",
+      "target": "docs_error_reporting_calibration_no_raw_user_content_in_payloads"
     },
     {
       "relation": "contains",
@@ -116511,17 +116541,7 @@
       "source_location": "L48",
       "weight": 1.0,
       "source": "docs_error_reporting_calibration_caught_error_reporting_calibration_note",
-      "target": "docs_error_reporting_calibration_known_intentional_asymmetries_not_bugs",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/error-reporting-calibration.md",
-      "source_location": "L66",
-      "weight": 1.0,
-      "source": "docs_error_reporting_calibration_caught_error_reporting_calibration_note",
-      "target": "docs_error_reporting_calibration_no_raw_user_content_in_payloads",
+      "target": "docs_error_reporting_calibration_uncaught_errors_separate_automatic_path",
       "confidence_score": 1.0
     },
     {
@@ -119611,5 +119631,5 @@
       "source_file": ".claude/commands/spec.md"
     }
   ],
-  "built_at_commit": "192fd59019686b330ff04ccfaeee3769ed101388"
+  "built_at_commit": "585c82e89e2fbb11a94c1c45fb924101f1ef947b"
 }

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -661,7 +661,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_firestoreaislestore",
-      "community": 7,
+      "community": 1,
       "norm_label": "firestoreaislestore.ts"
     },
     {
@@ -671,7 +671,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "adapters_firestoreaislestore_classify",
-      "community": 7,
+      "community": 1,
       "norm_label": "classify()"
     },
     {
@@ -691,7 +691,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_firestorecanonstore",
-      "community": 7,
+      "community": 1,
       "norm_label": "firestorecanonstore.ts"
     },
     {
@@ -701,7 +701,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "adapters_firestorecanonstore_classify",
-      "community": 7,
+      "community": 1,
       "norm_label": "classify()"
     },
     {
@@ -771,7 +771,7 @@
       "source_location": "L98",
       "_origin": "ast",
       "id": "adapters_jsonldrecipe_jsonldrecipe",
-      "community": 68,
+      "community": 63,
       "norm_label": "jsonldrecipe"
     },
     {
@@ -851,7 +851,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_serverarbitration",
-      "community": 275,
+      "community": 1,
       "norm_label": "serverarbitration.ts"
     },
     {
@@ -871,7 +871,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_serverembedding",
-      "community": 49,
+      "community": 28,
       "norm_label": "serverembedding.ts"
     },
     {
@@ -1041,7 +1041,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_withaitimeout",
-      "community": 49,
+      "community": 29,
       "norm_label": "withaitimeout.ts"
     },
     {
@@ -1051,7 +1051,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "adapters_withaitimeout_aitimeouterror",
-      "community": 49,
+      "community": 29,
       "norm_label": "aitimeouterror"
     },
     {
@@ -1061,7 +1061,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "adapters_withaitimeout_aitimeouterror_constructor",
-      "community": 49,
+      "community": 29,
       "norm_label": ".constructor()"
     },
     {
@@ -1071,7 +1071,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "adapters_withaitimeout_withaitimeoutoptions",
-      "community": 49,
+      "community": 29,
       "norm_label": "withaitimeoutoptions"
     },
     {
@@ -1081,7 +1081,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "adapters_withaitimeout_racewithtimeout",
-      "community": 49,
+      "community": 29,
       "norm_label": "racewithtimeout()"
     },
     {
@@ -1091,7 +1091,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "adapters_withaitimeout_withaitimeout",
-      "community": 49,
+      "community": 29,
       "norm_label": "withaitimeout()"
     },
     {
@@ -1141,7 +1141,7 @@
       "source_location": "L72",
       "_origin": "ast",
       "id": "ai_fakemodel_aifakeenabled",
-      "community": 29,
+      "community": 28,
       "norm_label": "aifakeenabled()"
     },
     {
@@ -1191,7 +1191,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_listaimodels",
-      "community": 49,
+      "community": 61,
       "norm_label": "listaimodels.ts"
     },
     {
@@ -1201,7 +1201,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "ai_listaimodels_catalogmodelschema",
-      "community": 49,
+      "community": 61,
       "norm_label": "catalogmodelschema"
     },
     {
@@ -1211,7 +1211,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "ai_listaimodels_catalogresponseschema",
-      "community": 49,
+      "community": 61,
       "norm_label": "catalogresponseschema"
     },
     {
@@ -1221,7 +1221,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "ai_listaimodels_listaimodelsinputschema",
-      "community": 49,
+      "community": 61,
       "norm_label": "listaimodelsinputschema"
     },
     {
@@ -1231,7 +1231,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "ai_listaimodels_aicatalogmodel",
-      "community": 49,
+      "community": 61,
       "norm_label": "aicatalogmodel"
     },
     {
@@ -1241,7 +1241,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "ai_listaimodels_listaimodelsresult",
-      "community": 49,
+      "community": 61,
       "norm_label": "listaimodelsresult"
     },
     {
@@ -1251,7 +1251,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "ai_listaimodels_cacheentry",
-      "community": 49,
+      "community": 61,
       "norm_label": "cacheentry"
     },
     {
@@ -1261,7 +1261,7 @@
       "source_location": "L59",
       "_origin": "ast",
       "id": "ai_listaimodels_bareid",
-      "community": 49,
+      "community": 61,
       "norm_label": "bareid()"
     },
     {
@@ -1271,7 +1271,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "ai_listaimodels_fetchcatalog",
-      "community": 49,
+      "community": 61,
       "norm_label": "fetchcatalog()"
     },
     {
@@ -1281,7 +1281,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "ai_listaimodels_loadcatalog",
-      "community": 49,
+      "community": 61,
       "norm_label": "loadcatalog()"
     },
     {
@@ -1291,7 +1291,7 @@
       "source_location": "L114",
       "_origin": "ast",
       "id": "ai_listaimodels_handlelistaimodels",
-      "community": 49,
+      "community": 61,
       "norm_label": "handlelistaimodels()"
     },
     {
@@ -1301,7 +1301,7 @@
       "source_location": "L124",
       "_origin": "ast",
       "id": "ai_listaimodels_resetlistaimodelscachefortest",
-      "community": 49,
+      "community": 61,
       "norm_label": "__resetlistaimodelscachefortest()"
     },
     {
@@ -1401,7 +1401,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "ai_modelcapabilities_modelsupportsrole",
-      "community": 49,
+      "community": 61,
       "norm_label": "modelsupportsrole()"
     },
     {
@@ -1421,7 +1421,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_requireadmin",
-      "community": 49,
+      "community": 77,
       "norm_label": "requireadmin.ts"
     },
     {
@@ -1431,7 +1431,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "ai_requireadmin_requireadmin",
-      "community": 49,
+      "community": 77,
       "norm_label": "requireadmin()"
     },
     {
@@ -1441,7 +1441,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_resolvemodel",
-      "community": 95,
+      "community": 28,
       "norm_label": "resolvemodel.ts"
     },
     {
@@ -1451,7 +1451,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "ai_resolvemodel_cacheentry",
-      "community": 95,
+      "community": 28,
       "norm_label": "cacheentry"
     },
     {
@@ -1461,7 +1461,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "ai_resolvemodel_default_settings",
-      "community": 95,
+      "community": 28,
       "norm_label": "default_settings"
     },
     {
@@ -1471,7 +1471,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "ai_resolvemodel_loadsettings",
-      "community": 95,
+      "community": 28,
       "norm_label": "loadsettings()"
     },
     {
@@ -1481,7 +1481,7 @@
       "source_location": "L71",
       "_origin": "ast",
       "id": "ai_resolvemodel_resolvemodel",
-      "community": 95,
+      "community": 28,
       "norm_label": "resolvemodel()"
     },
     {
@@ -1491,7 +1491,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "ai_resolvemodel_resetresolvemodelcachefortest",
-      "community": 95,
+      "community": 28,
       "norm_label": "__resetresolvemodelcachefortest()"
     },
     {
@@ -1501,7 +1501,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_testmodel",
-      "community": 49,
+      "community": 77,
       "norm_label": "testmodel.ts"
     },
     {
@@ -1511,7 +1511,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "ai_testmodel_testmodelinputschema",
-      "community": 49,
+      "community": 77,
       "norm_label": "testmodelinputschema"
     },
     {
@@ -1521,7 +1521,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "ai_testmodel_testmodelresult",
-      "community": 49,
+      "community": 77,
       "norm_label": "testmodelresult"
     },
     {
@@ -1531,7 +1531,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "ai_testmodel_probe",
-      "community": 49,
+      "community": 77,
       "norm_label": "probe()"
     },
     {
@@ -1541,7 +1541,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "ai_testmodel_handletestmodel",
-      "community": 49,
+      "community": 77,
       "norm_label": "handletestmodel()"
     },
     {
@@ -1591,7 +1591,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_dev",
-      "community": 95,
+      "community": 28,
       "norm_label": "dev.ts"
     },
     {
@@ -1601,7 +1601,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_arbitratecanon",
-      "community": 95,
+      "community": 28,
       "norm_label": "arbitratecanon.ts"
     },
     {
@@ -1611,7 +1611,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "flows_arbitratecanon_arbitrationresultschema",
-      "community": 95,
+      "community": 28,
       "norm_label": "arbitrationresultschema"
     },
     {
@@ -1621,7 +1621,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "flows_arbitratecanon_arbitratecanonflow",
-      "community": 95,
+      "community": 28,
       "norm_label": "arbitratecanonflow"
     },
     {
@@ -1631,7 +1631,7 @@
       "source_location": "L101",
       "_origin": "ast",
       "id": "flows_arbitratecanon_buildprompt",
-      "community": 95,
+      "community": 28,
       "norm_label": "buildprompt()"
     },
     {
@@ -1641,7 +1641,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "assets_canoniconseed",
-      "community": 95,
+      "community": 29,
       "norm_label": "canoniconseed.ts"
     },
     {
@@ -1651,7 +1651,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "assets_canoniconseed_loadcanoniconseed",
-      "community": 95,
+      "community": 29,
       "norm_label": "loadcanoniconseed()"
     },
     {
@@ -1681,7 +1681,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "flows_authorrecipe_authorrecipeflow",
-      "community": 34,
+      "community": 68,
       "norm_label": "authorrecipeflow"
     },
     {
@@ -1701,7 +1701,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_canonicaliserecipeingredients",
-      "community": 68,
+      "community": 75,
       "norm_label": "canonicaliserecipeingredients.ts"
     },
     {
@@ -1711,7 +1711,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "flows_canonicaliserecipeingredients_itemresultschema",
-      "community": 68,
+      "community": 75,
       "norm_label": "itemresultschema"
     },
     {
@@ -1721,7 +1721,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "flows_canonicaliserecipeingredients_outputschema",
-      "community": 68,
+      "community": 75,
       "norm_label": "outputschema"
     },
     {
@@ -1791,7 +1791,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_embedtext",
-      "community": 95,
+      "community": 28,
       "norm_label": "embedtext.ts"
     },
     {
@@ -1801,7 +1801,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "flows_embedtext_fake_embedding",
-      "community": 95,
+      "community": 28,
       "norm_label": "fake_embedding"
     },
     {
@@ -1811,7 +1811,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "flows_embedtext_embedtextflow",
-      "community": 49,
+      "community": 28,
       "norm_label": "embedtextflow"
     },
     {
@@ -1831,7 +1831,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_urlimporterror",
-      "community": 34,
+      "community": 68,
       "norm_label": "urlimporterror"
     },
     {
@@ -1841,7 +1841,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_urlimporterror_constructor",
-      "community": 34,
+      "community": 68,
       "norm_label": ".constructor()"
     },
     {
@@ -1921,7 +1921,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_generatecanonicon",
-      "community": 95,
+      "community": 29,
       "norm_label": "generatecanonicon.ts"
     },
     {
@@ -1931,7 +1931,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "flows_generatecanonicon_buildiconprompt",
-      "community": 95,
+      "community": 29,
       "norm_label": "buildiconprompt()"
     },
     {
@@ -1941,7 +1941,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "flows_generatecanonicon_parsedataurl",
-      "community": 95,
+      "community": 29,
       "norm_label": "parsedataurl()"
     },
     {
@@ -1951,7 +1951,7 @@
       "source_location": "L47",
       "_origin": "ast",
       "id": "flows_generatecanonicon_generatecanoniconinputschema",
-      "community": 95,
+      "community": 29,
       "norm_label": "generatecanoniconinputschema"
     },
     {
@@ -1961,7 +1961,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "flows_generatecanonicon_generatecanoniconoutputschema",
-      "community": 95,
+      "community": 29,
       "norm_label": "generatecanoniconoutputschema"
     },
     {
@@ -2001,7 +2001,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "flows_generatechattitle_generatechattitleflow",
-      "community": 28,
+      "community": 34,
       "norm_label": "generatechattitleflow"
     },
     {
@@ -2021,7 +2021,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "flows_identifyequipment_identifyequipmentflow",
-      "community": 28,
+      "community": 34,
       "norm_label": "identifyequipmentflow"
     },
     {
@@ -2141,7 +2141,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_parserecipeingredients",
-      "community": 68,
+      "community": 28,
       "norm_label": "parserecipeingredients.ts"
     },
     {
@@ -2161,7 +2161,7 @@
       "source_location": "L71",
       "_origin": "ast",
       "id": "flows_parserecipeingredients_system_instructions",
-      "community": 68,
+      "community": 28,
       "norm_label": "system_instructions"
     },
     {
@@ -2181,7 +2181,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "flows_populateequipmententry_populateequipmententryflow",
-      "community": 28,
+      "community": 34,
       "norm_label": "populateequipmententryflow"
     },
     {
@@ -2201,7 +2201,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_genkit",
-      "community": 68,
+      "community": 28,
       "norm_label": "genkit.ts"
     },
     {
@@ -2211,7 +2211,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "src_genkit_ai",
-      "community": 68,
+      "community": 28,
       "norm_label": "ai"
     },
     {
@@ -2481,7 +2481,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "triggers_oncanonitemwritten_maybegenerateembedding",
-      "community": 49,
+      "community": 29,
       "norm_label": "maybegenerateembedding()"
     },
     {
@@ -2761,7 +2761,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_resolvemodel_test",
-      "community": 266,
+      "community": 77,
       "norm_label": "resolvemodel.test.ts"
     },
     {
@@ -2771,7 +2771,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "ai_resolvemodel_test_mockget",
-      "community": 266,
+      "community": 77,
       "norm_label": "mockget"
     },
     {
@@ -5970,7 +5970,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "apps_web_pwa_src_app_svelte_src_app",
-      "community": 50,
+      "community": 51,
       "norm_label": "app.svelte"
     },
     {
@@ -5980,7 +5980,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "src_app_needsapprovalcount",
-      "community": 50,
+      "community": 51,
       "norm_label": "needsapprovalcount"
     },
     {
@@ -5990,7 +5990,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "src_app_decoratednavitems",
-      "community": 50,
+      "community": 51,
       "norm_label": "decoratednavitems"
     },
     {
@@ -6033,7 +6033,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_nav",
-      "community": 50,
+      "community": 51,
       "norm_label": "nav.ts"
     },
     {
@@ -6055,7 +6055,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_toaststore",
-      "community": 20,
+      "community": 33,
       "norm_label": "../../lib/toaststore.js"
     },
     {
@@ -6175,7 +6175,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "dev_sessionoverlay",
-      "community": 50,
+      "community": 51,
       "norm_label": "sessionoverlay.svelte"
     },
     {
@@ -6185,7 +6185,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "boundary_tests_no_firebase_sync_internal",
-      "community": 2,
+      "community": 1,
       "norm_label": "no-firebase-sync-internal.ts"
     },
     {
@@ -6237,7 +6237,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_firebase",
-      "community": 82,
+      "community": 50,
       "norm_label": "firebase.ts"
     },
     {
@@ -6439,7 +6439,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "lib_aisleservice_addaisle",
-      "community": 2,
+      "community": 3,
       "norm_label": "addaisle()"
     },
     {
@@ -6449,7 +6449,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "lib_aisleservice_addaislesbulk",
-      "community": 2,
+      "community": 3,
       "norm_label": "addaislesbulk()"
     },
     {
@@ -6459,7 +6459,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_aisleservice_renameaisle",
-      "community": 2,
+      "community": 3,
       "norm_label": "renameaisle()"
     },
     {
@@ -6469,7 +6469,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "lib_aisleservice_reorderaisles",
-      "community": 2,
+      "community": 3,
       "norm_label": "reorderaisles()"
     },
     {
@@ -6479,7 +6479,7 @@
       "source_location": "L68",
       "_origin": "ast",
       "id": "lib_aisleservice_deleteaisles",
-      "community": 2,
+      "community": 3,
       "norm_label": "deleteaisles()"
     },
     {
@@ -6489,7 +6489,7 @@
       "source_location": "L82",
       "_origin": "ast",
       "id": "lib_aisleservice_mergeaisles",
-      "community": 2,
+      "community": 3,
       "norm_label": "mergeaisles()"
     },
     {
@@ -6786,7 +6786,7 @@
       "label": "canonItems",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L48",
+      "source_location": "L49",
       "_origin": "ast",
       "id": "lib_canonservice_canonitems",
       "community": 3,
@@ -6796,7 +6796,7 @@
       "label": "aisles",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L51",
+      "source_location": "L52",
       "_origin": "ast",
       "id": "lib_canonservice_aisles",
       "community": 3,
@@ -6806,7 +6806,7 @@
       "label": "aisleUsage",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L54",
+      "source_location": "L55",
       "_origin": "ast",
       "id": "lib_canonservice_aisleusage",
       "community": 3,
@@ -6816,7 +6816,7 @@
       "label": "isLoadingAisles",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L57",
+      "source_location": "L58",
       "_origin": "ast",
       "id": "lib_canonservice_isloadingaisles",
       "community": 3,
@@ -6826,17 +6826,17 @@
       "label": "getErrorReporter()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L62",
+      "source_location": "L63",
       "_origin": "ast",
       "id": "lib_canonservice_geterrorreporter",
-      "community": 2,
+      "community": 3,
       "norm_label": "geterrorreporter()"
     },
     {
       "label": "markLoaded()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L72",
+      "source_location": "L73",
       "_origin": "ast",
       "id": "lib_canonservice_markloaded",
       "community": 3,
@@ -6846,7 +6846,7 @@
       "label": "recomputeAisleUsage()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L80",
+      "source_location": "L81",
       "_origin": "ast",
       "id": "lib_canonservice_recomputeaisleusage",
       "community": 8,
@@ -6856,57 +6856,57 @@
       "label": "memAisleStore()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L96",
+      "source_location": "L97",
       "_origin": "ast",
       "id": "lib_canonservice_memaislestore",
-      "community": 2,
+      "community": 3,
       "norm_label": "memaislestore()"
     },
     {
       "label": "memCanonStore()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L110",
+      "source_location": "L111",
       "_origin": "ast",
       "id": "lib_canonservice_memcanonstore",
-      "community": 2,
+      "community": 3,
       "norm_label": "memcanonstore()"
     },
     {
       "label": "getAislesSnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L135",
+      "source_location": "L136",
       "_origin": "ast",
       "id": "lib_canonservice_getaislessnapshot",
-      "community": 2,
+      "community": 3,
       "norm_label": "getaislessnapshot()"
     },
     {
       "label": "getCanonItemsSnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L139",
+      "source_location": "L140",
       "_origin": "ast",
       "id": "lib_canonservice_getcanonitemssnapshot",
-      "community": 24,
+      "community": 3,
       "norm_label": "getcanonitemssnapshot()"
     },
     {
       "label": "initCanonSync()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L145",
+      "source_location": "L146",
       "_origin": "ast",
       "id": "lib_canonservice_initcanonsync",
-      "community": 2,
+      "community": 3,
       "norm_label": "initcanonsync()"
     },
     {
       "label": "addCanonItem()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L178",
+      "source_location": "L179",
       "_origin": "ast",
       "id": "lib_canonservice_addcanonitem",
       "community": 17,
@@ -6916,7 +6916,7 @@
       "label": "commitCanonItemUpdate()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L230",
+      "source_location": "L231",
       "_origin": "ast",
       "id": "lib_canonservice_commitcanonitemupdate",
       "community": 3,
@@ -6926,7 +6926,7 @@
       "label": "updateCanonItemName()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L234",
+      "source_location": "L235",
       "_origin": "ast",
       "id": "lib_canonservice_updatecanonitemname",
       "community": 3,
@@ -6936,7 +6936,7 @@
       "label": "updateCanonItemAisle()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L243",
+      "source_location": "L244",
       "_origin": "ast",
       "id": "lib_canonservice_updatecanonitemaisle",
       "community": 3,
@@ -6946,7 +6946,7 @@
       "label": "updateCanonItemSynonyms()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L252",
+      "source_location": "L253",
       "_origin": "ast",
       "id": "lib_canonservice_updatecanonitemsynonyms",
       "community": 3,
@@ -6956,7 +6956,7 @@
       "label": "updateCanonItemShoppingBehavior()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L261",
+      "source_location": "L262",
       "_origin": "ast",
       "id": "lib_canonservice_updatecanonitemshoppingbehavior",
       "community": 3,
@@ -6966,7 +6966,7 @@
       "label": "updateCanonItemThreshold()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L270",
+      "source_location": "L271",
       "_origin": "ast",
       "id": "lib_canonservice_updatecanonitemthreshold",
       "community": 3,
@@ -6976,7 +6976,7 @@
       "label": "approveCanonItemWithOverrides()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L280",
+      "source_location": "L281",
       "_origin": "ast",
       "id": "lib_canonservice_approvecanonitemwithoverrides",
       "community": 3,
@@ -6986,17 +6986,17 @@
       "label": "approveCanonItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L289",
+      "source_location": "L290",
       "_origin": "ast",
       "id": "lib_canonservice_approvecanonitems",
-      "community": 33,
+      "community": 7,
       "norm_label": "approvecanonitems()"
     },
     {
       "label": "splitMostRecentSynonym()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L302",
+      "source_location": "L303",
       "_origin": "ast",
       "id": "lib_canonservice_splitmostrecentsynonym",
       "community": 3,
@@ -7006,7 +7006,7 @@
       "label": "deleteCanonItem()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L320",
+      "source_location": "L321",
       "_origin": "ast",
       "id": "lib_canonservice_deletecanonitem",
       "community": 3,
@@ -7016,7 +7016,7 @@
       "label": "regenerateCanonIcon()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L331",
+      "source_location": "L332",
       "_origin": "ast",
       "id": "lib_canonservice_regeneratecanonicon",
       "community": 3,
@@ -7026,7 +7026,7 @@
       "label": "hideCanonIcon()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L340",
+      "source_location": "L341",
       "_origin": "ast",
       "id": "lib_canonservice_hidecanonicon",
       "community": 3,
@@ -7036,7 +7036,7 @@
       "label": "unhideCanonIcon()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L348",
+      "source_location": "L349",
       "_origin": "ast",
       "id": "lib_canonservice_unhidecanonicon",
       "community": 3,
@@ -7046,7 +7046,7 @@
       "label": "__resetCanonServiceForTest()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
-      "source_location": "L354",
+      "source_location": "L355",
       "_origin": "ast",
       "id": "lib_canonservice_resetcanonservicefortest",
       "community": 3,
@@ -7056,7 +7056,7 @@
       "label": "sessions",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L19",
+      "source_location": "L20",
       "_origin": "ast",
       "id": "lib_chatservice_sessions",
       "community": 42,
@@ -7066,7 +7066,7 @@
       "label": "getChatSessionsSnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L26",
+      "source_location": "L27",
       "_origin": "ast",
       "id": "lib_chatservice_getchatsessionssnapshot",
       "community": 8,
@@ -7076,7 +7076,7 @@
       "label": "isLoadingSessions",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L31",
+      "source_location": "L32",
       "_origin": "ast",
       "id": "lib_chatservice_isloadingsessions",
       "community": 42,
@@ -7086,7 +7086,7 @@
       "label": "getErrorReporter()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L34",
+      "source_location": "L35",
       "_origin": "ast",
       "id": "lib_chatservice_geterrorreporter",
       "community": 42,
@@ -7096,7 +7096,7 @@
       "label": "latestLocalEdit",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L40",
+      "source_location": "L41",
       "_origin": "ast",
       "id": "lib_chatservice_latestlocaledit",
       "community": 42,
@@ -7106,7 +7106,7 @@
       "label": "applySnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L42",
+      "source_location": "L43",
       "_origin": "ast",
       "id": "lib_chatservice_applysnapshot",
       "community": 42,
@@ -7116,7 +7116,7 @@
       "label": "initChatSync()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L63",
+      "source_location": "L64",
       "_origin": "ast",
       "id": "lib_chatservice_initchatsync",
       "community": 42,
@@ -7126,7 +7126,7 @@
       "label": "now()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L80",
+      "source_location": "L81",
       "_origin": "ast",
       "id": "lib_chatservice_now",
       "community": 42,
@@ -7136,7 +7136,7 @@
       "label": "newSession()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L84",
+      "source_location": "L85",
       "_origin": "ast",
       "id": "lib_chatservice_newsession",
       "community": 42,
@@ -7146,7 +7146,7 @@
       "label": "createChatSession()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L99",
+      "source_location": "L100",
       "_origin": "ast",
       "id": "lib_chatservice_createchatsession",
       "community": 42,
@@ -7156,7 +7156,7 @@
       "label": "persistSession()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L112",
+      "source_location": "L113",
       "_origin": "ast",
       "id": "lib_chatservice_persistsession",
       "community": 42,
@@ -7166,7 +7166,7 @@
       "label": "removeSession()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L122",
+      "source_location": "L123",
       "_origin": "ast",
       "id": "lib_chatservice_removesession",
       "community": 42,
@@ -7176,7 +7176,7 @@
       "label": "sendMessage()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
-      "source_location": "L132",
+      "source_location": "L133",
       "_origin": "ast",
       "id": "lib_chatservice_sendmessage",
       "community": 42,
@@ -7220,7 +7220,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "observability",
-      "community": 50,
+      "community": 51,
       "norm_label": "$lib/observability"
     },
     {
@@ -7310,7 +7310,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "lib_e2ehooks_installe2ehooks",
-      "community": 317,
+      "community": 8,
       "norm_label": "installe2ehooks()"
     },
     {
@@ -7564,13 +7564,33 @@
       "norm_label": "seedequipmentmanifest()"
     },
     {
+      "label": "errorReporting.ts",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "lib_errorreporting",
+      "community": 117,
+      "norm_label": "errorreporting.ts"
+    },
+    {
+      "label": "reportSubscriptionError()",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L19",
+      "_origin": "ast",
+      "id": "lib_errorreporting_reportsubscriptionerror",
+      "community": 117,
+      "norm_label": "reportsubscriptionerror()"
+    },
+    {
       "label": "authProvider",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/firebase.ts",
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_firebase_authprovider",
-      "community": 82,
+      "community": 50,
       "norm_label": "authprovider"
     },
     {
@@ -8050,7 +8070,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "lib_membersservice_findmemberbyemail",
-      "community": 8,
+      "community": 10,
       "norm_label": "findmemberbyemail()"
     },
     {
@@ -8120,7 +8140,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "lib_membersservice_reordermembers",
-      "community": 10,
+      "community": 8,
       "norm_label": "reordermembers()"
     },
     {
@@ -8140,7 +8160,7 @@
       "source_location": "L126",
       "_origin": "ast",
       "id": "lib_membersservice_getmemberssnapshot",
-      "community": 116,
+      "community": 10,
       "norm_label": "getmemberssnapshot()"
     },
     {
@@ -8160,7 +8180,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "lib_nav_navitems",
-      "community": 50,
+      "community": 51,
       "norm_label": "navitems"
     },
     {
@@ -8170,7 +8190,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "lib_nav_adminnavitem",
-      "community": 50,
+      "community": 51,
       "norm_label": "adminnavitem"
     },
     {
@@ -8180,7 +8200,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_observability",
-      "community": 25,
+      "community": 49,
       "norm_label": "observability.ts"
     },
     {
@@ -8190,7 +8210,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "lib_observability_phkey",
-      "community": 25,
+      "community": 49,
       "norm_label": "_phkey"
     },
     {
@@ -8200,7 +8220,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "lib_observability_identifyuser",
-      "community": 25,
+      "community": 49,
       "norm_label": "identifyuser()"
     },
     {
@@ -8210,7 +8230,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "lib_observability_identifyanonymous",
-      "community": 25,
+      "community": 49,
       "norm_label": "identifyanonymous()"
     },
     {
@@ -8220,7 +8240,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "lib_observability_tagsession",
-      "community": 25,
+      "community": 49,
       "norm_label": "tagsession()"
     },
     {
@@ -8230,7 +8250,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "lib_observability_getsessionurl",
-      "community": 25,
+      "community": 49,
       "norm_label": "getsessionurl()"
     },
     {
@@ -8240,7 +8260,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_observability_startsession",
-      "community": 25,
+      "community": 49,
       "norm_label": "startsession()"
     },
     {
@@ -8250,7 +8270,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "lib_observability_stopsession",
-      "community": 25,
+      "community": 49,
       "norm_label": "stopsession()"
     },
     {
@@ -8260,7 +8280,7 @@
       "source_location": "L56",
       "_origin": "ast",
       "id": "lib_observability_issessionactive",
-      "community": 25,
+      "community": 49,
       "norm_label": "issessionactive()"
     },
     {
@@ -8270,7 +8290,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_pwa",
-      "community": 317,
+      "community": 8,
       "norm_label": "pwa.ts"
     },
     {
@@ -8280,7 +8300,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "lib_pwa_registerserviceworker",
-      "community": 317,
+      "community": 8,
       "norm_label": "registerserviceworker()"
     },
     {
@@ -8290,14 +8310,14 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_pwa_setupupdateflow",
-      "community": 317,
+      "community": 8,
       "norm_label": "setupupdateflow()"
     },
     {
       "label": "recipes",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L35",
+      "source_location": "L36",
       "_origin": "ast",
       "id": "lib_recipeservice_recipes",
       "community": 24,
@@ -8307,7 +8327,7 @@
       "label": "getRecipesSnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L40",
+      "source_location": "L41",
       "_origin": "ast",
       "id": "lib_recipeservice_getrecipessnapshot",
       "community": 8,
@@ -8317,7 +8337,7 @@
       "label": "isLoadingRecipes",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L45",
+      "source_location": "L46",
       "_origin": "ast",
       "id": "lib_recipeservice_isloadingrecipes",
       "community": 24,
@@ -8327,7 +8347,7 @@
       "label": "getErrorReporter()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L50",
+      "source_location": "L51",
       "_origin": "ast",
       "id": "lib_recipeservice_geterrorreporter",
       "community": 24,
@@ -8337,7 +8357,7 @@
       "label": "latestLocalEdit",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L61",
+      "source_location": "L62",
       "_origin": "ast",
       "id": "lib_recipeservice_latestlocaledit",
       "community": 24,
@@ -8347,7 +8367,7 @@
       "label": "applySnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L63",
+      "source_location": "L64",
       "_origin": "ast",
       "id": "lib_recipeservice_applysnapshot",
       "community": 24,
@@ -8357,7 +8377,7 @@
       "label": "initRecipeSync()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L89",
+      "source_location": "L90",
       "_origin": "ast",
       "id": "lib_recipeservice_initrecipesync",
       "community": 24,
@@ -8367,7 +8387,7 @@
       "label": "persistRecipe()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L108",
+      "source_location": "L109",
       "_origin": "ast",
       "id": "lib_recipeservice_persistrecipe",
       "community": 24,
@@ -8377,7 +8397,7 @@
       "label": "parseIngredients()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L116",
+      "source_location": "L117",
       "_origin": "ast",
       "id": "lib_recipeservice_parseingredients",
       "community": 24,
@@ -8387,7 +8407,7 @@
       "label": "URL_IMPORT_COPY",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L131",
+      "source_location": "L132",
       "_origin": "ast",
       "id": "lib_recipeservice_url_import_copy",
       "community": 24,
@@ -8397,7 +8417,7 @@
       "label": "urlImportMessage()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L139",
+      "source_location": "L140",
       "_origin": "ast",
       "id": "lib_recipeservice_urlimportmessage",
       "community": 24,
@@ -8407,7 +8427,7 @@
       "label": "importRecipeFromUrl()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L146",
+      "source_location": "L147",
       "_origin": "ast",
       "id": "lib_recipeservice_importrecipefromurl",
       "community": 24,
@@ -8417,7 +8437,7 @@
       "label": "stashImportedDraft()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L163",
+      "source_location": "L164",
       "_origin": "ast",
       "id": "lib_recipeservice_stashimporteddraft",
       "community": 24,
@@ -8427,7 +8447,7 @@
       "label": "takeImportedDraft()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L167",
+      "source_location": "L168",
       "_origin": "ast",
       "id": "lib_recipeservice_takeimporteddraft",
       "community": 24,
@@ -8437,7 +8457,7 @@
       "label": "canonicaliseIngredients()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L176",
+      "source_location": "L177",
       "_origin": "ast",
       "id": "lib_recipeservice_canonicaliseingredients",
       "community": 24,
@@ -8447,7 +8467,7 @@
       "label": "matchIngredient()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L229",
+      "source_location": "L230",
       "_origin": "ast",
       "id": "lib_recipeservice_matchingredient",
       "community": 24,
@@ -8457,7 +8477,7 @@
       "label": "removeRecipe()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L258",
+      "source_location": "L259",
       "_origin": "ast",
       "id": "lib_recipeservice_removerecipe",
       "community": 24,
@@ -8467,7 +8487,7 @@
       "label": "quantityToNumber()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L267",
+      "source_location": "L268",
       "_origin": "ast",
       "id": "lib_recipeservice_quantitytonumber",
       "community": 24,
@@ -8477,7 +8497,7 @@
       "label": "_itemIds",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L273",
+      "source_location": "L274",
       "_origin": "ast",
       "id": "lib_recipeservice_itemids",
       "community": 24,
@@ -8487,7 +8507,7 @@
       "label": "RecipeAddRow",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L280",
+      "source_location": "L281",
       "_origin": "ast",
       "id": "lib_recipeservice_recipeaddrow",
       "community": 24,
@@ -8497,7 +8517,7 @@
       "label": "scaledAmountUnit()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L297",
+      "source_location": "L298",
       "_origin": "ast",
       "id": "lib_recipeservice_scaledamountunit",
       "community": 24,
@@ -8507,7 +8527,7 @@
       "label": "buildRecipeAddPlan()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L308",
+      "source_location": "L309",
       "_origin": "ast",
       "id": "lib_recipeservice_buildrecipeaddplan",
       "community": 24,
@@ -8517,17 +8537,17 @@
       "label": "commitRecipeAddPlan()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
-      "source_location": "L349",
+      "source_location": "L350",
       "_origin": "ast",
       "id": "lib_recipeservice_commitrecipeaddplan",
-      "community": 8,
+      "community": 108,
       "norm_label": "commitrecipeaddplan()"
     },
     {
       "label": "ids",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L41",
+      "source_location": "L42",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_ids",
       "community": 8,
@@ -8537,7 +8557,7 @@
       "label": "lists",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L49",
+      "source_location": "L50",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_lists",
       "community": 8,
@@ -8547,7 +8567,7 @@
       "label": "defaultListId",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L53",
+      "source_location": "L54",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_defaultlistid",
       "community": 8,
@@ -8557,7 +8577,7 @@
       "label": "activeListId",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L56",
+      "source_location": "L57",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_activelistid",
       "community": 8,
@@ -8567,7 +8587,7 @@
       "label": "itemsForActiveList",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L59",
+      "source_location": "L60",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_itemsforactivelist",
       "community": 8,
@@ -8577,7 +8597,7 @@
       "label": "isLoadingShoppingList",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L62",
+      "source_location": "L63",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_isloadingshoppinglist",
       "community": 8,
@@ -8587,7 +8607,7 @@
       "label": "getErrorReporter()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L67",
+      "source_location": "L68",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_geterrorreporter",
       "community": 8,
@@ -8597,7 +8617,7 @@
       "label": "markLoaded()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L78",
+      "source_location": "L79",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_markloaded",
       "community": 8,
@@ -8607,7 +8627,7 @@
       "label": "setActiveListId()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L89",
+      "source_location": "L90",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_setactivelistid",
       "community": 8,
@@ -8617,27 +8637,27 @@
       "label": "initShoppingListSync()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L106",
+      "source_location": "L107",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_initshoppinglistsync",
-      "community": 285,
+      "community": 8,
       "norm_label": "initshoppinglistsync()"
     },
     {
       "label": "addList()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L143",
+      "source_location": "L144",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_addlist",
-      "community": 8,
+      "community": 141,
       "norm_label": "addlist()"
     },
     {
       "label": "renameListById()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L157",
+      "source_location": "L158",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_renamelistbyid",
       "community": 8,
@@ -8647,7 +8667,7 @@
       "label": "removeList()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L168",
+      "source_location": "L169",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_removelist",
       "community": 8,
@@ -8657,7 +8677,7 @@
       "label": "changeDefaultList()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L176",
+      "source_location": "L177",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_changedefaultlist",
       "community": 8,
@@ -8667,17 +8687,17 @@
       "label": "addItemToList()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L186",
+      "source_location": "L187",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_additemtolist",
-      "community": 8,
+      "community": 10,
       "norm_label": "additemtolist()"
     },
     {
       "label": "updateItemRawText()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L203",
+      "source_location": "L204",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_updateitemrawtext",
       "community": 8,
@@ -8687,7 +8707,7 @@
       "label": "updateItemAmountUnit()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L216",
+      "source_location": "L217",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_updateitemamountunit",
       "community": 8,
@@ -8697,7 +8717,7 @@
       "label": "updateItemNotes()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L230",
+      "source_location": "L231",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_updateitemnotes",
       "community": 8,
@@ -8707,7 +8727,7 @@
       "label": "toggleItemChecked()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L243",
+      "source_location": "L244",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_toggleitemchecked",
       "community": 8,
@@ -8717,7 +8737,7 @@
       "label": "confirmItemNeeded()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L259",
+      "source_location": "L260",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_confirmitemneeded",
       "community": 8,
@@ -8727,7 +8747,7 @@
       "label": "confirmItemsNeeded()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L273",
+      "source_location": "L274",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_confirmitemsneeded",
       "community": 8,
@@ -8737,7 +8757,7 @@
       "label": "checkItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L288",
+      "source_location": "L289",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_checkitems",
       "community": 8,
@@ -8747,7 +8767,7 @@
       "label": "uncheckItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L300",
+      "source_location": "L301",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_uncheckitems",
       "community": 8,
@@ -8757,7 +8777,7 @@
       "label": "removeItem()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L312",
+      "source_location": "L313",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_removeitem",
       "community": 8,
@@ -8767,17 +8787,17 @@
       "label": "removeItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L322",
+      "source_location": "L323",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_removeitems",
-      "community": 141,
+      "community": 8,
       "norm_label": "removeitems()"
     },
     {
       "label": "clearChecked()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L329",
+      "source_location": "L330",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_clearchecked",
       "community": 8,
@@ -8787,7 +8807,7 @@
       "label": "moveSelectedItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L336",
+      "source_location": "L337",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_moveselecteditems",
       "community": 8,
@@ -8797,7 +8817,7 @@
       "label": "getShoppingListsSnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L350",
+      "source_location": "L351",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_getshoppinglistssnapshot",
       "community": 8,
@@ -8807,7 +8827,7 @@
       "label": "getDefaultListIdSnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L354",
+      "source_location": "L355",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_getdefaultlistidsnapshot",
       "community": 8,
@@ -8817,7 +8837,7 @@
       "label": "getItemsSnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L358",
+      "source_location": "L359",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_getitemssnapshot",
       "community": 8,
@@ -8827,7 +8847,7 @@
       "label": "__resetShoppingListServiceForTest()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L364",
+      "source_location": "L365",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_resetshoppinglistservicefortest",
       "community": 8,
@@ -8861,7 +8881,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "lib_toaststore_toastactionconfig",
-      "community": 20,
+      "community": 33,
       "norm_label": "toastactionconfig"
     },
     {
@@ -8871,7 +8891,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "lib_toaststore_toastitem",
-      "community": 20,
+      "community": 33,
       "norm_label": "toastitem"
     },
     {
@@ -8881,7 +8901,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "lib_toaststore_addtoastoptions",
-      "community": 20,
+      "community": 33,
       "norm_label": "addtoastoptions"
     },
     {
@@ -8891,7 +8911,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "lib_toaststore_toasts",
-      "community": 20,
+      "community": 33,
       "norm_label": "toasts"
     },
     {
@@ -8911,7 +8931,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "lib_toaststore_dismisstoast",
-      "community": 20,
+      "community": 33,
       "norm_label": "dismisstoast()"
     },
     {
@@ -8921,7 +8941,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "types_e2e_d",
-      "community": 164,
+      "community": 66,
       "norm_label": "e2e.d.ts"
     },
     {
@@ -8931,7 +8951,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "types_e2e_d_seedcanoniteminput",
-      "community": 164,
+      "community": 66,
       "norm_label": "seedcanoniteminput"
     },
     {
@@ -8941,7 +8961,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "types_e2e_d_e2ebridge",
-      "community": 164,
+      "community": 66,
       "norm_label": "e2ebridge"
     },
     {
@@ -8951,7 +8971,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "types_e2e_d_window",
-      "community": 164,
+      "community": 66,
       "norm_label": "window"
     },
     {
@@ -8961,7 +8981,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "apps_web_pwa_src_main_ts_src_main",
-      "community": 317,
+      "community": 8,
       "norm_label": "main.ts"
     },
     {
@@ -9083,7 +9103,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "schemas",
-      "community": 266,
+      "community": 77,
       "norm_label": "@salt/domain/schemas"
     },
     {
@@ -9114,7 +9134,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "firebase_sync",
-      "community": 90,
+      "community": 20,
       "norm_label": "@salt/firebase-sync"
     },
     {
@@ -9164,7 +9184,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canonlistpage",
-      "community": 33,
+      "community": 7,
       "norm_label": "canonlistpage.svelte"
     },
     {
@@ -9174,7 +9194,7 @@
       "source_location": "L88",
       "_origin": "ast",
       "id": "canon_canonlistpage_topapprovalitems",
-      "community": 33,
+      "community": 7,
       "norm_label": "topapprovalitems"
     },
     {
@@ -9184,7 +9204,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "canon_canonlistpage_allvisibleids",
-      "community": 33,
+      "community": 7,
       "norm_label": "allvisibleids"
     },
     {
@@ -9194,7 +9214,7 @@
       "source_location": "L98",
       "_origin": "ast",
       "id": "canon_canonlistpage_selection",
-      "community": 33,
+      "community": 7,
       "norm_label": "selection"
     },
     {
@@ -9204,7 +9224,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "canon_canonlistpage_selectedapprovalids",
-      "community": 33,
+      "community": 7,
       "norm_label": "selectedapprovalids"
     },
     {
@@ -9214,7 +9234,7 @@
       "source_location": "L107",
       "_origin": "ast",
       "id": "canon_canonlistpage_selectpending",
-      "community": 33,
+      "community": 7,
       "norm_label": "selectpending()"
     },
     {
@@ -9224,7 +9244,7 @@
       "source_location": "L111",
       "_origin": "ast",
       "id": "canon_canonlistpage_handlebulkapprove",
-      "community": 33,
+      "community": 7,
       "norm_label": "handlebulkapprove()"
     },
     {
@@ -9244,7 +9264,7 @@
       "source_location": "L128",
       "_origin": "ast",
       "id": "canon_canonlistpage_handlebulkdelete",
-      "community": 33,
+      "community": 7,
       "norm_label": "handlebulkdelete()"
     },
     {
@@ -10306,7 +10326,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test",
-      "community": 9,
+      "community": 33,
       "norm_label": "equipmentcapturepage.test.ts"
     },
     {
@@ -10316,7 +10336,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_mockisloadingequipment",
-      "community": 9,
+      "community": 33,
       "norm_label": "{ mockisloadingequipment }"
     },
     {
@@ -10326,7 +10346,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_makemanifest",
-      "community": 9,
+      "community": 33,
       "norm_label": "makemanifest()"
     },
     {
@@ -10336,7 +10356,7 @@
       "source_location": "L60",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_walkthroughcapture",
-      "community": 2,
+      "community": 3,
       "norm_label": "walkthroughcapture()"
     },
     {
@@ -10556,7 +10576,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test",
-      "community": 161,
+      "community": 66,
       "norm_label": "shoppinglistpage.danglingcanon.test.ts"
     },
     {
@@ -10566,7 +10586,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_mockcanonitems_mockaisles_mocklists_mockitems_mockdefaultlistid_mockloading",
-      "community": 161,
+      "community": 66,
       "norm_label": "{ mockcanonitems, mockaisles, mocklists, mockitems, mockdefaultlistid, mockloading }"
     },
     {
@@ -10576,7 +10596,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_canonitem",
-      "community": 161,
+      "community": 66,
       "norm_label": "canonitem()"
     },
     {
@@ -10586,7 +10606,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_item",
-      "community": 161,
+      "community": 66,
       "norm_label": "item()"
     },
     {
@@ -10596,7 +10616,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test",
-      "community": 162,
+      "community": 66,
       "norm_label": "shoppinglistpage.icon.test.ts"
     },
     {
@@ -10606,7 +10626,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_mockcanonitems_mockaisles_mocklists_mockitems_mockdefaultlistid_mockloading",
-      "community": 162,
+      "community": 66,
       "norm_label": "{ mockcanonitems, mockaisles, mocklists, mockitems, mockdefaultlistid, mockloading }"
     },
     {
@@ -10616,7 +10636,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_canonitem",
-      "community": 162,
+      "community": 66,
       "norm_label": "canonitem()"
     },
     {
@@ -10626,7 +10646,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_item",
-      "community": 162,
+      "community": 66,
       "norm_label": "item()"
     },
     {
@@ -10673,7 +10693,7 @@
       "label": "fs",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/canonService.icon.test.ts",
-      "source_location": "L28",
+      "source_location": "L29",
       "_origin": "ast",
       "id": "tests_canonservice_icon_test_fs",
       "community": 3,
@@ -10683,7 +10703,7 @@
       "label": "makeItem()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/canonService.icon.test.ts",
-      "source_location": "L30",
+      "source_location": "L31",
       "_origin": "ast",
       "id": "tests_canonservice_icon_test_makeitem",
       "community": 3,
@@ -10703,7 +10723,7 @@
       "label": "fs",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/canonService.sync.test.ts",
-      "source_location": "L39",
+      "source_location": "L40",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_fs",
       "community": 3,
@@ -10713,7 +10733,7 @@
       "label": "makeItem()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/canonService.sync.test.ts",
-      "source_location": "L41",
+      "source_location": "L42",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_makeitem",
       "community": 3,
@@ -10723,7 +10743,7 @@
       "label": "makeAisle()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/canonService.sync.test.ts",
-      "source_location": "L56",
+      "source_location": "L57",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_makeaisle",
       "community": 3,
@@ -10733,7 +10753,7 @@
       "label": "ItemsCb",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/canonService.sync.test.ts",
-      "source_location": "L62",
+      "source_location": "L63",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_itemscb",
       "community": 3,
@@ -10743,7 +10763,7 @@
       "label": "AislesCb",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/canonService.sync.test.ts",
-      "source_location": "L63",
+      "source_location": "L64",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_aislescb",
       "community": 3,
@@ -10753,7 +10773,7 @@
       "label": "wireSubscriptions()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/canonService.sync.test.ts",
-      "source_location": "L65",
+      "source_location": "L66",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_wiresubscriptions",
       "community": 3,
@@ -10818,6 +10838,26 @@
       "id": "tests_equipmentservice_sync_test_hydrateempty",
       "community": 9,
       "norm_label": "hydrateempty()"
+    },
+    {
+      "label": "errorReporting.test.ts",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "tests_errorreporting_test",
+      "community": 117,
+      "norm_label": "errorreporting.test.ts"
+    },
+    {
+      "label": "isAuthTransitioning",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
+      "source_location": "L6",
+      "_origin": "ast",
+      "id": "tests_errorreporting_test_isauthtransitioning",
+      "community": 117,
+      "norm_label": "isauthtransitioning"
     },
     {
       "label": "mealPlanService.sync.test.ts",
@@ -10953,7 +10993,7 @@
       "label": "{ mockGetCanonItemsSnapshot }",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.addToList.test.ts",
-      "source_location": "L19",
+      "source_location": "L20",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_mockgetcanonitemssnapshot",
       "community": 108,
@@ -10963,7 +11003,7 @@
       "label": "fs",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.addToList.test.ts",
-      "source_location": "L30",
+      "source_location": "L31",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_fs",
       "community": 108,
@@ -10973,7 +11013,7 @@
       "label": "makeCanonItem()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.addToList.test.ts",
-      "source_location": "L34",
+      "source_location": "L35",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_makecanonitem",
       "community": 108,
@@ -10983,7 +11023,7 @@
       "label": "makeGroup()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.addToList.test.ts",
-      "source_location": "L54",
+      "source_location": "L55",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_makegroup",
       "community": 108,
@@ -10993,7 +11033,7 @@
       "label": "makeRecipe()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.addToList.test.ts",
-      "source_location": "L58",
+      "source_location": "L59",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_makerecipe",
       "community": 108,
@@ -11003,7 +11043,7 @@
       "label": "gramIngredient",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.addToList.test.ts",
-      "source_location": "L80",
+      "source_location": "L81",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_gramingredient",
       "community": 108,
@@ -11013,7 +11053,7 @@
       "label": "weightIngredient()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.addToList.test.ts",
-      "source_location": "L89",
+      "source_location": "L90",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_weightingredient",
       "community": 108,
@@ -11023,7 +11063,7 @@
       "label": "countIngredient",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.addToList.test.ts",
-      "source_location": "L102",
+      "source_location": "L103",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_countingredient",
       "community": 108,
@@ -11033,7 +11073,7 @@
       "label": "matchedIngredient()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.addToList.test.ts",
-      "source_location": "L111",
+      "source_location": "L112",
       "_origin": "ast",
       "id": "tests_recipeservice_addtolist_test_matchedingredient",
       "community": 108,
@@ -11053,7 +11093,7 @@
       "label": "{ mockGetCanonItemsSnapshot }",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.canonicalise.test.ts",
-      "source_location": "L18",
+      "source_location": "L19",
       "_origin": "ast",
       "id": "tests_recipeservice_canonicalise_test_mockgetcanonitemssnapshot",
       "community": 137,
@@ -11063,7 +11103,7 @@
       "label": "fs",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.canonicalise.test.ts",
-      "source_location": "L29",
+      "source_location": "L30",
       "_origin": "ast",
       "id": "tests_recipeservice_canonicalise_test_fs",
       "community": 137,
@@ -11073,7 +11113,7 @@
       "label": "makeCanonItem()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.canonicalise.test.ts",
-      "source_location": "L33",
+      "source_location": "L34",
       "_origin": "ast",
       "id": "tests_recipeservice_canonicalise_test_makecanonitem",
       "community": 137,
@@ -11083,7 +11123,7 @@
       "label": "makeRecipe()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.canonicalise.test.ts",
-      "source_location": "L47",
+      "source_location": "L48",
       "_origin": "ast",
       "id": "tests_recipeservice_canonicalise_test_makerecipe",
       "community": 137,
@@ -11093,7 +11133,7 @@
       "label": "makeGroup()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.canonicalise.test.ts",
-      "source_location": "L69",
+      "source_location": "L70",
       "_origin": "ast",
       "id": "tests_recipeservice_canonicalise_test_makegroup",
       "community": 137,
@@ -11103,7 +11143,7 @@
       "label": "parsedIngredient",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.canonicalise.test.ts",
-      "source_location": "L73",
+      "source_location": "L74",
       "_origin": "ast",
       "id": "tests_recipeservice_canonicalise_test_parsedingredient",
       "community": 137,
@@ -11123,7 +11163,7 @@
       "label": "fs",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.matchIngredient.test.ts",
-      "source_location": "L21",
+      "source_location": "L22",
       "_origin": "ast",
       "id": "tests_recipeservice_matchingredient_test_fs",
       "community": 144,
@@ -11133,7 +11173,7 @@
       "label": "makePendingIngredient()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.matchIngredient.test.ts",
-      "source_location": "L25",
+      "source_location": "L26",
       "_origin": "ast",
       "id": "tests_recipeservice_matchingredient_test_makependingingredient",
       "community": 144,
@@ -11143,7 +11183,7 @@
       "label": "parsedFlour",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.matchIngredient.test.ts",
-      "source_location": "L37",
+      "source_location": "L38",
       "_origin": "ast",
       "id": "tests_recipeservice_matchingredient_test_parsedflour",
       "community": 144,
@@ -11153,7 +11193,7 @@
       "label": "parseGroup",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.matchIngredient.test.ts",
-      "source_location": "L46",
+      "source_location": "L47",
       "_origin": "ast",
       "id": "tests_recipeservice_matchingredient_test_parsegroup",
       "community": 144,
@@ -11163,7 +11203,7 @@
       "label": "makeCanonItem()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/recipeService.matchIngredient.test.ts",
-      "source_location": "L52",
+      "source_location": "L53",
       "_origin": "ast",
       "id": "tests_recipeservice_matchingredient_test_makecanonitem",
       "community": 144,
@@ -11193,7 +11233,7 @@
       "label": "fs",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/shoppingListService.manualSource.test.ts",
-      "source_location": "L37",
+      "source_location": "L38",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_manualsource_test_fs",
       "community": 10,
@@ -11203,7 +11243,7 @@
       "label": "member()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/shoppingListService.manualSource.test.ts",
-      "source_location": "L39",
+      "source_location": "L40",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_manualsource_test_member",
       "community": 10,
@@ -11213,7 +11253,7 @@
       "label": "savedItem()",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/shoppingListService.manualSource.test.ts",
-      "source_location": "L52",
+      "source_location": "L53",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_manualsource_test_saveditem",
       "community": 10,
@@ -12452,7 +12492,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_aislesubscription",
-      "community": 141,
+      "community": 3,
       "norm_label": "aislesubscription.ts"
     },
     {
@@ -12462,17 +12502,17 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_aislesubscription_subscribeaisles",
-      "community": 2,
+      "community": 3,
       "norm_label": "subscribeaisles()"
     },
     {
       "label": "saveAisles()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/aisleSubscription.ts",
-      "source_location": "L34",
+      "source_location": "L36",
       "_origin": "ast",
       "id": "src_aislesubscription_saveaisles",
-      "community": 2,
+      "community": 3,
       "norm_label": "saveaisles()"
     },
     {
@@ -12482,7 +12522,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_appsettingssync",
-      "community": 266,
+      "community": 1,
       "norm_label": "appsettingssync.ts"
     },
     {
@@ -12492,7 +12532,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "src_appsettingssync_subscribeappsettings",
-      "community": 266,
+      "community": 47,
       "norm_label": "subscribeappsettings()"
     },
     {
@@ -12502,7 +12542,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_appsettingssync_saveappsettings",
-      "community": 266,
+      "community": 47,
       "norm_label": "saveappsettings()"
     },
     {
@@ -12519,7 +12559,7 @@
       "label": "authEmulatorConnected",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/auth.ts",
-      "source_location": "L19",
+      "source_location": "L20",
       "_origin": "ast",
       "id": "src_auth_authemulatorconnected",
       "community": 117,
@@ -12529,17 +12569,17 @@
       "label": "connectAuthEmulatorOnce()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/auth.ts",
-      "source_location": "L23",
+      "source_location": "L24",
       "_origin": "ast",
       "id": "src_auth_connectauthemulatoronce",
-      "community": 82,
+      "community": 117,
       "norm_label": "connectauthemulatoronce()"
     },
     {
       "label": "toUser()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/auth.ts",
-      "source_location": "L31",
+      "source_location": "L32",
       "_origin": "ast",
       "id": "src_auth_touser",
       "community": 117,
@@ -12549,21 +12589,61 @@
       "label": "toAuthError()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/auth.ts",
-      "source_location": "L37",
+      "source_location": "L38",
       "_origin": "ast",
       "id": "src_auth_toautherror",
       "community": 117,
       "norm_label": "toautherror()"
     },
     {
+      "label": "reportAuthFailure()",
+      "file_type": "code",
+      "source_file": "packages/adapters/firebase-sync/src/auth.ts",
+      "source_location": "L55",
+      "_origin": "ast",
+      "id": "src_auth_reportauthfailure",
+      "community": 117,
+      "norm_label": "reportauthfailure()"
+    },
+    {
       "label": "createFirebaseAuth()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/auth.ts",
-      "source_location": "L48",
+      "source_location": "L64",
       "_origin": "ast",
       "id": "src_auth_createfirebaseauth",
-      "community": 82,
+      "community": 50,
       "norm_label": "createfirebaseauth()"
+    },
+    {
+      "label": "authTransition.ts",
+      "file_type": "code",
+      "source_file": "packages/adapters/firebase-sync/src/authTransition.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "src_authtransition",
+      "community": 117,
+      "norm_label": "authtransition.ts"
+    },
+    {
+      "label": "setAuthTransitioning()",
+      "file_type": "code",
+      "source_file": "packages/adapters/firebase-sync/src/authTransition.ts",
+      "source_location": "L21",
+      "_origin": "ast",
+      "id": "src_authtransition_setauthtransitioning",
+      "community": 117,
+      "norm_label": "setauthtransitioning()"
+    },
+    {
+      "label": "isAuthTransitioning()",
+      "file_type": "code",
+      "source_file": "packages/adapters/firebase-sync/src/authTransition.ts",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "src_authtransition_isauthtransitioning",
+      "community": 117,
+      "norm_label": "isauthtransitioning()"
     },
     {
       "label": "authorRecipeCallable.ts",
@@ -12572,7 +12652,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_authorrecipecallable",
-      "community": 7,
+      "community": 1,
       "norm_label": "authorrecipecallable.ts"
     },
     {
@@ -12582,7 +12662,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "src_authorrecipecallable_classifyerror",
-      "community": 7,
+      "community": 1,
       "norm_label": "classifyerror()"
     },
     {
@@ -12592,7 +12672,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "src_authorrecipecallable_callauthorrecipe",
-      "community": 7,
+      "community": 1,
       "norm_label": "callauthorrecipe()"
     },
     {
@@ -12602,7 +12682,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_canonmatching",
-      "community": 3,
+      "community": 64,
       "norm_label": "canonmatching.ts"
     },
     {
@@ -12612,7 +12692,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "src_canonmatching_wireresult",
-      "community": 3,
+      "community": 64,
       "norm_label": "wireresult"
     },
     {
@@ -12622,7 +12702,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "src_canonmatching_callmatchorcreate",
-      "community": 3,
+      "community": 64,
       "norm_label": "callmatchorcreate()"
     },
     {
@@ -12632,7 +12712,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_canonmatching_wirebatchresult",
-      "community": 3,
+      "community": 64,
       "norm_label": "wirebatchresult"
     },
     {
@@ -12662,7 +12742,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_canonsubscription",
-      "community": 2,
+      "community": 1,
       "norm_label": "canonsubscription.ts"
     },
     {
@@ -12672,27 +12752,27 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_canonsubscription_subscribecanonitems",
-      "community": 2,
+      "community": 3,
       "norm_label": "subscribecanonitems()"
     },
     {
       "label": "upsertCanonItem()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/canonSubscription.ts",
-      "source_location": "L34",
+      "source_location": "L38",
       "_origin": "ast",
       "id": "src_canonsubscription_upsertcanonitem",
-      "community": 2,
+      "community": 3,
       "norm_label": "upsertcanonitem()"
     },
     {
       "label": "deleteCanonItem()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/canonSubscription.ts",
-      "source_location": "L39",
+      "source_location": "L43",
       "_origin": "ast",
       "id": "src_canonsubscription_deletecanonitem",
-      "community": 2,
+      "community": 3,
       "norm_label": "deletecanonitem()"
     },
     {
@@ -12742,7 +12822,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_chatsessionsubscription",
-      "community": 42,
+      "community": 1,
       "norm_label": "chatsessionsubscription.ts"
     },
     {
@@ -12769,17 +12849,17 @@
       "label": "loadChatSession()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/chatSessionSubscription.ts",
-      "source_location": "L57",
+      "source_location": "L59",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_loadchatsession",
-      "community": 42,
+      "community": 141,
       "norm_label": "loadchatsession()"
     },
     {
       "label": "saveChatSession()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/chatSessionSubscription.ts",
-      "source_location": "L72",
+      "source_location": "L74",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_savechatsession",
       "community": 42,
@@ -12789,7 +12869,7 @@
       "label": "deleteChatSession()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/chatSessionSubscription.ts",
-      "source_location": "L85",
+      "source_location": "L87",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_deletechatsession",
       "community": 42,
@@ -12802,7 +12882,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_devsettingssync",
-      "community": 141,
+      "community": 1,
       "norm_label": "devsettingssync.ts"
     },
     {
@@ -12832,7 +12912,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_e2eaistubsync",
-      "community": 72,
+      "community": 141,
       "norm_label": "e2eaistubsync.ts"
     },
     {
@@ -12842,7 +12922,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "src_e2eaistubsync_setaistub",
-      "community": 72,
+      "community": 141,
       "norm_label": "setaistub()"
     },
     {
@@ -12852,7 +12932,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_equipmentcallables",
-      "community": 72,
+      "community": 141,
       "norm_label": "equipmentcallables.ts"
     },
     {
@@ -12862,7 +12942,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "src_equipmentcallables_identifyequipmentcandidate",
-      "community": 72,
+      "community": 141,
       "norm_label": "identifyequipmentcandidate"
     },
     {
@@ -12872,7 +12952,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "src_equipmentcallables_identifyequipmentresult",
-      "community": 72,
+      "community": 141,
       "norm_label": "identifyequipmentresult"
     },
     {
@@ -12882,7 +12962,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "src_equipmentcallables_populateaccessory",
-      "community": 72,
+      "community": 141,
       "norm_label": "populateaccessory"
     },
     {
@@ -12892,7 +12972,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "src_equipmentcallables_populateequipmententryresult",
-      "community": 72,
+      "community": 141,
       "norm_label": "populateequipmententryresult"
     },
     {
@@ -12902,7 +12982,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "src_equipmentcallables_callidentifyequipment",
-      "community": 9,
+      "community": 141,
       "norm_label": "callidentifyequipment()"
     },
     {
@@ -12912,7 +12992,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "src_equipmentcallables_callpopulateequipmententry",
-      "community": 9,
+      "community": 141,
       "norm_label": "callpopulateequipmententry()"
     },
     {
@@ -12922,7 +13002,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_equipmentmanifestsubscription",
-      "community": 266,
+      "community": 9,
       "norm_label": "equipmentmanifestsubscription.ts"
     },
     {
@@ -12932,7 +13012,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_equipmentmanifestsubscription_subscribeequipmentmanifest",
-      "community": 266,
+      "community": 9,
       "norm_label": "subscribeequipmentmanifest()"
     },
     {
@@ -12952,7 +13032,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_firestoreerrors",
-      "community": 141,
+      "community": 1,
       "norm_label": "firestoreerrors.ts"
     },
     {
@@ -12982,7 +13062,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_adapters_firebase_sync_src_index_ts_src_index",
-      "community": 72,
+      "community": 141,
       "norm_label": "index.ts"
     },
     {
@@ -12992,7 +13072,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_adapters_firebase_sync_src_init_ts_src_init",
-      "community": 82,
+      "community": 117,
       "norm_label": "init.ts"
     },
     {
@@ -13002,7 +13082,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "src_init_emulatorconnectedapps",
-      "community": 82,
+      "community": 117,
       "norm_label": "emulatorconnectedapps"
     },
     {
@@ -13012,7 +13092,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "src_init_appcheckconfig",
-      "community": 82,
+      "community": 50,
       "norm_label": "appcheckconfig"
     },
     {
@@ -13022,7 +13102,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "src_init_initfirebase",
-      "community": 82,
+      "community": 117,
       "norm_label": "initfirebase()"
     },
     {
@@ -13032,7 +13112,7 @@
       "source_location": "L96",
       "_origin": "ast",
       "id": "src_init_setfirestorenetwork",
-      "community": 82,
+      "community": 117,
       "norm_label": "setfirestorenetwork()"
     },
     {
@@ -13042,7 +13122,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_mealplansync",
-      "community": 72,
+      "community": 0,
       "norm_label": "mealplansync.ts"
     },
     {
@@ -13052,7 +13132,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "src_mealplansync_subscribemealplanconfig",
-      "community": 72,
+      "community": 0,
       "norm_label": "subscribemealplanconfig()"
     },
     {
@@ -13062,7 +13142,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "src_mealplansync_subscribemealplantemplate",
-      "community": 72,
+      "community": 0,
       "norm_label": "subscribemealplantemplate()"
     },
     {
@@ -13072,7 +13152,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "src_mealplansync_subscribemealplanweek",
-      "community": 72,
+      "community": 0,
       "norm_label": "subscribemealplanweek()"
     },
     {
@@ -13082,7 +13162,7 @@
       "source_location": "L93",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplanconfig",
-      "community": 72,
+      "community": 0,
       "norm_label": "savemealplanconfig()"
     },
     {
@@ -13092,7 +13172,7 @@
       "source_location": "L105",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplantemplate",
-      "community": 72,
+      "community": 0,
       "norm_label": "savemealplantemplate()"
     },
     {
@@ -13102,7 +13182,7 @@
       "source_location": "L118",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplanweek",
-      "community": 72,
+      "community": 0,
       "norm_label": "savemealplanweek()"
     },
     {
@@ -13112,7 +13192,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_memberssubscription",
-      "community": 286,
+      "community": 1,
       "norm_label": "memberssubscription.ts"
     },
     {
@@ -13122,7 +13202,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "src_memberssubscription_subscribemembers",
-      "community": 286,
+      "community": 10,
       "norm_label": "subscribemembers()"
     },
     {
@@ -13132,7 +13212,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_memberssubscription_upsertmember",
-      "community": 286,
+      "community": 10,
       "norm_label": "upsertmember()"
     },
     {
@@ -13142,7 +13222,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "src_memberssubscription_deletemember",
-      "community": 286,
+      "community": 10,
       "norm_label": "deletemember()"
     },
     {
@@ -13152,7 +13232,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_recipecallables",
-      "community": 7,
+      "community": 1,
       "norm_label": "recipecallables.ts"
     },
     {
@@ -13192,7 +13272,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_recipesubscription",
-      "community": 281,
+      "community": 141,
       "norm_label": "recipesubscription.ts"
     },
     {
@@ -13202,37 +13282,37 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "src_recipesubscription_subscriberecipes",
-      "community": 281,
+      "community": 141,
       "norm_label": "subscriberecipes()"
     },
     {
       "label": "loadRecipe()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/recipeSubscription.ts",
-      "source_location": "L47",
+      "source_location": "L49",
       "_origin": "ast",
       "id": "src_recipesubscription_loadrecipe",
-      "community": 281,
+      "community": 141,
       "norm_label": "loadrecipe()"
     },
     {
       "label": "saveRecipe()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/recipeSubscription.ts",
-      "source_location": "L61",
+      "source_location": "L63",
       "_origin": "ast",
       "id": "src_recipesubscription_saverecipe",
-      "community": 281,
+      "community": 141,
       "norm_label": "saverecipe()"
     },
     {
       "label": "deleteRecipe()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/recipeSubscription.ts",
-      "source_location": "L71",
+      "source_location": "L73",
       "_origin": "ast",
       "id": "src_recipesubscription_deleterecipe",
-      "community": 281,
+      "community": 141,
       "norm_label": "deleterecipe()"
     },
     {
@@ -13259,7 +13339,7 @@
       "label": "listShoppingListItems()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/shoppingListItemSubscription.ts",
-      "source_location": "L48",
+      "source_location": "L50",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_listshoppinglistitems",
       "community": 141,
@@ -13269,17 +13349,17 @@
       "label": "saveShoppingListItem()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/shoppingListItemSubscription.ts",
-      "source_location": "L69",
+      "source_location": "L71",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_saveshoppinglistitem",
-      "community": 8,
+      "community": 141,
       "norm_label": "saveshoppinglistitem()"
     },
     {
       "label": "deleteShoppingListItem()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/shoppingListItemSubscription.ts",
-      "source_location": "L82",
+      "source_location": "L84",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_deleteshoppinglistitem",
       "community": 141,
@@ -13289,7 +13369,7 @@
       "label": "deleteShoppingListItems()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/shoppingListItemSubscription.ts",
-      "source_location": "L95",
+      "source_location": "L97",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_deleteshoppinglistitems",
       "community": 141,
@@ -13299,7 +13379,7 @@
       "label": "moveShoppingListItems()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/shoppingListItemSubscription.ts",
-      "source_location": "L112",
+      "source_location": "L114",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_moveshoppinglistitems",
       "community": 141,
@@ -13312,7 +13392,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription",
-      "community": 282,
+      "community": 141,
       "norm_label": "shoppinglistsubscription.ts"
     },
     {
@@ -13322,47 +13402,47 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_subscribeshoppinglists",
-      "community": 282,
+      "community": 141,
       "norm_label": "subscribeshoppinglists()"
     },
     {
       "label": "listShoppingLists()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/shoppingListSubscription.ts",
-      "source_location": "L43",
+      "source_location": "L45",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_listshoppinglists",
-      "community": 282,
+      "community": 141,
       "norm_label": "listshoppinglists()"
     },
     {
       "label": "createShoppingList()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/shoppingListSubscription.ts",
-      "source_location": "L64",
+      "source_location": "L66",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_createshoppinglist",
-      "community": 282,
+      "community": 141,
       "norm_label": "createshoppinglist()"
     },
     {
       "label": "renameShoppingList()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/shoppingListSubscription.ts",
-      "source_location": "L76",
+      "source_location": "L78",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_renameshoppinglist",
-      "community": 282,
+      "community": 141,
       "norm_label": "renameshoppinglist()"
     },
     {
       "label": "deleteShoppingList()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/shoppingListSubscription.ts",
-      "source_location": "L90",
+      "source_location": "L92",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_deleteshoppinglist",
-      "community": 282,
+      "community": 141,
       "norm_label": "deleteshoppinglist()"
     },
     {
@@ -13372,7 +13452,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription",
-      "community": 285,
+      "community": 1,
       "norm_label": "shoppinglistsconfigsubscription.ts"
     },
     {
@@ -13382,27 +13462,27 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription_subscribeshoppinglistsconfig",
-      "community": 285,
+      "community": 3,
       "norm_label": "subscribeshoppinglistsconfig()"
     },
     {
       "label": "loadShoppingListsConfig()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/shoppingListsConfigSubscription.ts",
-      "source_location": "L35",
+      "source_location": "L37",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription_loadshoppinglistsconfig",
-      "community": 285,
+      "community": 141,
       "norm_label": "loadshoppinglistsconfig()"
     },
     {
       "label": "saveShoppingListsConfig()",
       "file_type": "code",
       "source_file": "packages/adapters/firebase-sync/src/shoppingListsConfigSubscription.ts",
-      "source_location": "L50",
+      "source_location": "L52",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription_saveshoppinglistsconfig",
-      "community": 285,
+      "community": 141,
       "norm_label": "saveshoppinglistsconfig()"
     },
     {
@@ -13412,7 +13492,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_appsettingssync_test",
-      "community": 266,
+      "community": 47,
       "norm_label": "appsettingssync.test.ts"
     },
     {
@@ -13422,7 +13502,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdoc_mockgetfirestore",
-      "community": 266,
+      "community": 47,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -13432,7 +13512,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_snapcallback",
-      "community": 266,
+      "community": 47,
       "norm_label": "snapcallback"
     },
     {
@@ -13442,8 +13522,58 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_errorcallback",
-      "community": 266,
+      "community": 47,
       "norm_label": "errorcallback"
+    },
+    {
+      "label": "authTransition.test.ts",
+      "file_type": "code",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "tests_authtransition_test",
+      "community": 117,
+      "norm_label": "authtransition.test.ts"
+    },
+    {
+      "label": "sendSignInLinkToEmail",
+      "file_type": "code",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L8",
+      "_origin": "ast",
+      "id": "tests_authtransition_test_sendsigninlinktoemail",
+      "community": 117,
+      "norm_label": "sendsigninlinktoemail"
+    },
+    {
+      "label": "signInWithEmailLink",
+      "file_type": "code",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "tests_authtransition_test_signinwithemaillink",
+      "community": 117,
+      "norm_label": "signinwithemaillink"
+    },
+    {
+      "label": "fbSignOut",
+      "file_type": "code",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L10",
+      "_origin": "ast",
+      "id": "tests_authtransition_test_fbsignout",
+      "community": 117,
+      "norm_label": "fbsignout"
+    },
+    {
+      "label": "fbAuthError()",
+      "file_type": "code",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L30",
+      "_origin": "ast",
+      "id": "tests_authtransition_test_fbautherror",
+      "community": 117,
+      "norm_label": "fbautherror()"
     },
     {
       "label": "emulatorHelpers.ts",
@@ -13452,7 +13582,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_emulatorhelpers",
-      "community": 82,
+      "community": 117,
       "norm_label": "emulatorhelpers.ts"
     },
     {
@@ -13462,7 +13592,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "tests_emulatorhelpers_initfirebaseemulator",
-      "community": 82,
+      "community": 117,
       "norm_label": "initfirebaseemulator()"
     },
     {
@@ -13472,7 +13602,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "tests_emulatorhelpers_resetdefaultapp",
-      "community": 82,
+      "community": 117,
       "norm_label": "resetdefaultapp()"
     },
     {
@@ -13482,7 +13612,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "tests_emulatorhelpers_clearfirestoreemulator",
-      "community": 82,
+      "community": 117,
       "norm_label": "clearfirestoreemulator()"
     },
     {
@@ -13492,7 +13622,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_equipmentmanifestsubscription_test",
-      "community": 266,
+      "community": 9,
       "norm_label": "equipmentmanifestsubscription.test.ts"
     },
     {
@@ -13502,7 +13632,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_equipmentmanifestsubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdoc_mockgetfirestore",
-      "community": 266,
+      "community": 9,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -13512,7 +13642,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "tests_equipmentmanifestsubscription_test_snapcallback",
-      "community": 266,
+      "community": 9,
       "norm_label": "snapcallback"
     },
     {
@@ -13522,7 +13652,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "tests_equipmentmanifestsubscription_test_errorcallback",
-      "community": 266,
+      "community": 9,
       "norm_label": "errorcallback"
     },
     {
@@ -13632,7 +13762,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_mealplansync_test",
-      "community": 72,
+      "community": 0,
       "norm_label": "mealplansync.test.ts"
     },
     {
@@ -13642,7 +13772,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_mealplansync_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdoc_mockgetfirestore",
-      "community": 72,
+      "community": 0,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -13652,7 +13782,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "tests_mealplansync_test_snapcallback",
-      "community": 72,
+      "community": 0,
       "norm_label": "snapcallback"
     },
     {
@@ -13662,7 +13792,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "tests_mealplansync_test_errorcallback",
-      "community": 72,
+      "community": 0,
       "norm_label": "errorcallback"
     },
     {
@@ -13672,7 +13802,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "tests_mealplansync_test_config",
-      "community": 72,
+      "community": 0,
       "norm_label": "config"
     },
     {
@@ -13682,7 +13812,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "tests_mealplansync_test_template",
-      "community": 72,
+      "community": 0,
       "norm_label": "template"
     },
     {
@@ -13692,7 +13822,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "tests_mealplansync_test_week",
-      "community": 72,
+      "community": 0,
       "norm_label": "week"
     },
     {
@@ -13702,7 +13832,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_memberssubscription_test",
-      "community": 286,
+      "community": 10,
       "norm_label": "memberssubscription.test.ts"
     },
     {
@@ -13712,7 +13842,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "tests_memberssubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdeletedoc_mockdoc_mockcollection_mockgetfirestore",
-      "community": 286,
+      "community": 10,
       "norm_label": "{\n  mockunsubscribe,\n  mockonsnapshot,\n  mocksetdoc,\n  mockdeletedoc,\n  mockdoc,\n  mockcollection,\n  mockgetfirestore,\n}"
     },
     {
@@ -13722,7 +13852,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "tests_memberssubscription_test_snapcallback",
-      "community": 286,
+      "community": 10,
       "norm_label": "snapcallback"
     },
     {
@@ -13732,7 +13862,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "tests_memberssubscription_test_errorcallback",
-      "community": 286,
+      "community": 10,
       "norm_label": "errorcallback"
     },
     {
@@ -13742,7 +13872,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "tests_memberssubscription_test_validmemberdata",
-      "community": 286,
+      "community": 10,
       "norm_label": "validmemberdata()"
     },
     {
@@ -13752,7 +13882,7 @@
       "source_location": "L54",
       "_origin": "ast",
       "id": "tests_memberssubscription_test_member",
-      "community": 286,
+      "community": 10,
       "norm_label": "member()"
     },
     {
@@ -13762,7 +13892,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test",
-      "community": 2,
+      "community": 3,
       "norm_label": "realtimesubscriptions.emulator.test.ts"
     },
     {
@@ -13772,7 +13902,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_writer_firestore_port",
-      "community": 2,
+      "community": 3,
       "norm_label": "writer_firestore_port"
     },
     {
@@ -13782,7 +13912,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_makeitem",
-      "community": 2,
+      "community": 3,
       "norm_label": "makeitem()"
     },
     {
@@ -13792,7 +13922,7 @@
       "source_location": "L80",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_makeaisle",
-      "community": 2,
+      "community": 3,
       "norm_label": "makeaisle()"
     },
     {
@@ -13802,7 +13932,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_createwriterapp",
-      "community": 2,
+      "community": 3,
       "norm_label": "createwriterapp()"
     },
     {
@@ -13812,7 +13942,7 @@
       "source_location": "L490",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_delay",
-      "community": 2,
+      "community": 3,
       "norm_label": "delay()"
     },
     {
@@ -13822,7 +13952,7 @@
       "source_location": "L494",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_waitfor",
-      "community": 2,
+      "community": 3,
       "norm_label": "waitfor()"
     },
     {
@@ -13832,7 +13962,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_recipesubscription_test",
-      "community": 281,
+      "community": 141,
       "norm_label": "recipesubscription.test.ts"
     },
     {
@@ -13842,7 +13972,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdeletedoc_mockgetdoc_mockdoc_mockcollection_mockgetfirestore",
-      "community": 281,
+      "community": 141,
       "norm_label": "{\n  mockunsubscribe,\n  mockonsnapshot,\n  mocksetdoc,\n  mockdeletedoc,\n  mockgetdoc,\n  mockdoc,\n  mockcollection,\n  mockgetfirestore,\n}"
     },
     {
@@ -13852,7 +13982,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_snapdoc",
-      "community": 281,
+      "community": 141,
       "norm_label": "snapdoc"
     },
     {
@@ -13862,7 +13992,7 @@
       "source_location": "L47",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_collectioncallback",
-      "community": 281,
+      "community": 141,
       "norm_label": "collectioncallback"
     },
     {
@@ -13872,7 +14002,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_errorcallback",
-      "community": 281,
+      "community": 141,
       "norm_label": "errorcallback"
     },
     {
@@ -13882,7 +14012,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "tests_recipesubscription_test_recipe",
-      "community": 281,
+      "community": 141,
       "norm_label": "recipe"
     },
     {
@@ -13952,7 +14082,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistsubscription_test",
-      "community": 282,
+      "community": 141,
       "norm_label": "shoppinglistsubscription.test.ts"
     },
     {
@@ -13962,7 +14092,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_shoppinglistsubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdeletedoc_mockgetdocs_mockupdatedoc_mockdoc_mockcollection_mockgetfirestore",
-      "community": 282,
+      "community": 141,
       "norm_label": "{\n  mockunsubscribe,\n  mockonsnapshot,\n  mocksetdoc,\n  mockdeletedoc,\n  mockgetdocs,\n  mockupdatedoc,\n  mockdoc,\n  mockcollection,\n  mockgetfirestore,\n}"
     },
     {
@@ -13972,7 +14102,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "tests_shoppinglistsubscription_test_snapcallback",
-      "community": 282,
+      "community": 141,
       "norm_label": "snapcallback"
     },
     {
@@ -13982,7 +14112,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "tests_shoppinglistsubscription_test_errorcallback",
-      "community": 282,
+      "community": 141,
       "norm_label": "errorcallback"
     },
     {
@@ -13992,7 +14122,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "tests_shoppinglistsubscription_test_list_1",
-      "community": 282,
+      "community": 141,
       "norm_label": "list_1"
     },
     {
@@ -14002,7 +14132,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test",
-      "community": 285,
+      "community": 66,
       "norm_label": "shoppinglistsconfigsubscription.test.ts"
     },
     {
@@ -14012,7 +14142,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockgetdoc_mockdoc_mockgetfirestore",
-      "community": 285,
+      "community": 66,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockgetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -14022,7 +14152,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test_snapcallback",
-      "community": 285,
+      "community": 66,
       "norm_label": "snapcallback"
     },
     {
@@ -14032,7 +14162,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test_errorcallback",
-      "community": 285,
+      "community": 66,
       "norm_label": "errorcallback"
     },
     {
@@ -14042,7 +14172,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test_config",
-      "community": 285,
+      "community": 66,
       "norm_label": "config"
     },
     {
@@ -14522,7 +14652,7 @@
       "source_location": "L109",
       "_origin": "ast",
       "id": "src_init_observabilityspan",
-      "community": 93,
+      "community": 25,
       "norm_label": "observabilityspan"
     },
     {
@@ -14562,17 +14692,17 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_posthogerrorreportingadapter",
-      "community": 25,
+      "community": 72,
       "norm_label": "posthogerrorreportingadapter.ts"
     },
     {
       "label": "createPosthogErrorReportingAdapter()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/posthogErrorReportingAdapter.ts",
-      "source_location": "L4",
+      "source_location": "L8",
       "_origin": "ast",
       "id": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter",
-      "community": 25,
+      "community": 72,
       "norm_label": "createposthogerrorreportingadapter()"
     },
     {
@@ -14966,6 +15096,36 @@
       "norm_label": "tocanonmatchevent()"
     },
     {
+      "label": "reportableCategory.ts",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/src/shared/reportableCategory.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "shared_reportablecategory",
+      "community": 72,
+      "norm_label": "reportablecategory.ts"
+    },
+    {
+      "label": "SUPPRESSED_CATEGORIES",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/src/shared/reportableCategory.ts",
+      "source_location": "L22",
+      "_origin": "ast",
+      "id": "shared_reportablecategory_suppressed_categories",
+      "community": 72,
+      "norm_label": "suppressed_categories"
+    },
+    {
+      "label": "isReportableCategory()",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/src/shared/reportableCategory.ts",
+      "source_location": "L29",
+      "_origin": "ast",
+      "id": "shared_reportablecategory_isreportablecategory",
+      "community": 72,
+      "norm_label": "isreportablecategory()"
+    },
+    {
       "label": "matchLogParity.test.ts",
       "file_type": "code",
       "source_file": "packages/adapters/observability/tests/matchLogParity.test.ts",
@@ -14984,6 +15144,36 @@
       "id": "tests_matchlogparity_test_fixture",
       "community": 93,
       "norm_label": "fixture"
+    },
+    {
+      "label": "posthogErrorReportingAdapter.test.ts",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "tests_posthogerrorreportingadapter_test",
+      "community": 72,
+      "norm_label": "posthogerrorreportingadapter.test.ts"
+    },
+    {
+      "label": "{ captureException, init }",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
+      "source_location": "L7",
+      "_origin": "ast",
+      "id": "tests_posthogerrorreportingadapter_test_captureexception_init",
+      "community": 72,
+      "norm_label": "{ captureexception, init }"
+    },
+    {
+      "label": "reportableCategory.test.ts",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/tests/reportableCategory.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "tests_reportablecategory_test",
+      "community": 72,
+      "norm_label": "reportablecategory.test.ts"
     },
     {
       "label": "runWithExtractedTraceContext.test.ts",
@@ -15379,7 +15569,7 @@
       "label": "ErrorReportingPort",
       "file_type": "code",
       "source_file": "packages/domain/src/ErrorReportingPort.ts",
-      "source_location": "L1",
+      "source_location": "L9",
       "_origin": "ast",
       "id": "src_errorreportingport_errorreportingport",
       "community": 117,
@@ -15552,7 +15742,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_buildmatchlog",
-      "community": 17,
+      "community": 32,
       "norm_label": "buildmatchlog.ts"
     },
     {
@@ -15562,7 +15752,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder",
-      "community": 17,
+      "community": 32,
       "norm_label": "matchlogbuilder"
     },
     {
@@ -15572,7 +15762,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_start",
-      "community": 17,
+      "community": 32,
       "norm_label": ".start()"
     },
     {
@@ -15582,7 +15772,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_setinputitemcount",
-      "community": 17,
+      "community": 32,
       "norm_label": ".setinputitemcount()"
     },
     {
@@ -15592,7 +15782,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_addstage",
-      "community": 17,
+      "community": 32,
       "norm_label": ".addstage()"
     },
     {
@@ -15602,7 +15792,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_setarbitration",
-      "community": 17,
+      "community": 32,
       "norm_label": ".setarbitration()"
     },
     {
@@ -15612,7 +15802,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "commands_buildmatchlog_matchlogbuilder_complete",
-      "community": 17,
+      "community": 32,
       "norm_label": ".complete()"
     },
     {
@@ -15632,7 +15822,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "commands_createaisle_createaisleinput",
-      "community": 1,
+      "community": 11,
       "norm_label": "createaisleinput"
     },
     {
@@ -15642,7 +15832,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createaisle_createaisle",
-      "community": 1,
+      "community": 3,
       "norm_label": "createaisle()"
     },
     {
@@ -15662,7 +15852,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "commands_createaislesbulk_createaislesbulkinput",
-      "community": 1,
+      "community": 11,
       "norm_label": "createaislesbulkinput"
     },
     {
@@ -15672,7 +15862,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createaislesbulk_createaislesbulk",
-      "community": 1,
+      "community": 3,
       "norm_label": "createaislesbulk()"
     },
     {
@@ -15702,7 +15892,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "commands_createcanonitem_createcanonitem",
-      "community": 3,
+      "community": 17,
       "norm_label": "createcanonitem()"
     },
     {
@@ -15722,7 +15912,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_deleteaisles_deleteaislesinput",
-      "community": 1,
+      "community": 11,
       "norm_label": "deleteaislesinput"
     },
     {
@@ -15752,7 +15942,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateinput",
-      "community": 3,
+      "community": 64,
       "norm_label": "matchorcreateinput"
     },
     {
@@ -15762,7 +15952,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateresult",
-      "community": 3,
+      "community": 64,
       "norm_label": "matchorcreateresult"
     },
     {
@@ -15772,7 +15962,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateports",
-      "community": 1,
+      "community": 275,
       "norm_label": "matchorcreateports"
     },
     {
@@ -15782,7 +15972,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreate",
-      "community": 64,
+      "community": 17,
       "norm_label": "matchorcreate()"
     },
     {
@@ -15792,7 +15982,7 @@
       "source_location": "L88",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreatebatch",
-      "community": 51,
+      "community": 17,
       "norm_label": "matchorcreatebatch()"
     },
     {
@@ -15902,7 +16092,7 @@
       "source_location": "L500",
       "_origin": "ast",
       "id": "commands_matchorcreate_loadaisles",
-      "community": 51,
+      "community": 17,
       "norm_label": "loadaisles()"
     },
     {
@@ -15972,7 +16162,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_mergeaisles_itemmergechoice",
-      "community": 1,
+      "community": 11,
       "norm_label": "itemmergechoice"
     },
     {
@@ -15982,7 +16172,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "commands_mergeaisles_peritemmergechoice",
-      "community": 1,
+      "community": 11,
       "norm_label": "peritemmergechoice"
     },
     {
@@ -15992,7 +16182,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "commands_mergeaisles_mergeaislesinput",
-      "community": 1,
+      "community": 3,
       "norm_label": "mergeaislesinput"
     },
     {
@@ -16052,7 +16242,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_renameaisle_renameaisleinput",
-      "community": 1,
+      "community": 11,
       "norm_label": "renameaisleinput"
     },
     {
@@ -16072,7 +16262,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_renamecanonitem",
-      "community": 7,
+      "community": 11,
       "norm_label": "renamecanonitem.ts"
     },
     {
@@ -16102,7 +16292,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_reorderaisles_reorderaislesinput",
-      "community": 1,
+      "community": 11,
       "norm_label": "reorderaislesinput"
     },
     {
@@ -16162,7 +16352,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setcanonitemaisle_setcanonitemaisle",
-      "community": 11,
+      "community": 3,
       "norm_label": "setcanonitemaisle()"
     },
     {
@@ -16182,7 +16372,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setcanonitemshoppingfields_setcanonitemshoppingbehavior",
-      "community": 11,
+      "community": 3,
       "norm_label": "setcanonitemshoppingbehavior()"
     },
     {
@@ -16192,7 +16382,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "commands_setcanonitemshoppingfields_setcanonitemthreshold",
-      "community": 11,
+      "community": 3,
       "norm_label": "setcanonitemthreshold()"
     },
     {
@@ -16212,7 +16402,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setcanonitemsynonyms_setcanonitemsynonyms",
-      "community": 11,
+      "community": 3,
       "norm_label": "setcanonitemsynonyms()"
     },
     {
@@ -16302,7 +16492,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_matchcandidate",
-      "community": 275,
+      "community": 11,
       "norm_label": "matchcandidate.ts"
     },
     {
@@ -16312,7 +16502,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "entities_matchcandidate_matchstage",
-      "community": 275,
+      "community": 11,
       "norm_label": "matchstage"
     },
     {
@@ -16322,7 +16512,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_matchcandidate_matchcandidate",
-      "community": 275,
+      "community": 11,
       "norm_label": "matchcandidate"
     },
     {
@@ -16332,7 +16522,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_matchlogentry",
-      "community": 17,
+      "community": 32,
       "norm_label": "matchlogentry.ts"
     },
     {
@@ -16352,7 +16542,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "entities_matchlogentry_stageskipreason",
-      "community": 17,
+      "community": 32,
       "norm_label": "stageskipreason"
     },
     {
@@ -16362,7 +16552,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "entities_matchlogentry_stagelog",
-      "community": 17,
+      "community": 32,
       "norm_label": "stagelog"
     },
     {
@@ -16372,7 +16562,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "entities_matchlogentry_finaldecision",
-      "community": 17,
+      "community": 32,
       "norm_label": "finaldecision"
     },
     {
@@ -16382,7 +16572,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "entities_matchlogentry_arbitrationlog",
-      "community": 17,
+      "community": 32,
       "norm_label": "arbitrationlog"
     },
     {
@@ -16402,7 +16592,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_index",
-      "community": 1,
+      "community": 11,
       "norm_label": "index.ts"
     },
     {
@@ -16432,7 +16622,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_canonarbitrationport",
-      "community": 275,
+      "community": 11,
       "norm_label": "canonarbitrationport.ts"
     },
     {
@@ -16442,7 +16632,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_canonarbitrationport_arbitrationresult",
-      "community": 275,
+      "community": 11,
       "norm_label": "arbitrationresult"
     },
     {
@@ -16452,7 +16642,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "ports_canonarbitrationport_arbitrationrequest",
-      "community": 275,
+      "community": 11,
       "norm_label": "arbitrationrequest"
     },
     {
@@ -16492,7 +16682,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_canonlookupport",
-      "community": 275,
+      "community": 11,
       "norm_label": "canonlookupport.ts"
     },
     {
@@ -16502,7 +16692,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "ports_canonlookupport_canonlookupport",
-      "community": 275,
+      "community": 11,
       "norm_label": "canonlookupport"
     },
     {
@@ -16552,7 +16742,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_matchloggingport",
-      "community": 1,
+      "community": 275,
       "norm_label": "matchloggingport.ts"
     },
     {
@@ -16562,7 +16752,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "ports_matchloggingport_matchloggingport",
-      "community": 1,
+      "community": 275,
       "norm_label": "matchloggingport"
     },
     {
@@ -16572,7 +16762,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_canonicon",
-      "community": 1,
+      "community": 11,
       "norm_label": "canonicon.ts"
     },
     {
@@ -16582,7 +16772,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "queries_canonicon_iscanoniconrenderable",
-      "community": 1,
+      "community": 11,
       "norm_label": "iscanoniconrenderable()"
     },
     {
@@ -16592,7 +16782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_createcanonlookup",
-      "community": 275,
+      "community": 11,
       "norm_label": "createcanonlookup.ts"
     },
     {
@@ -16602,7 +16792,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "queries_createcanonlookup_createcanonlookup",
-      "community": 275,
+      "community": 11,
       "norm_label": "createcanonlookup()"
     },
     {
@@ -16642,7 +16832,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "queries_findclosestmatch_findclosestmatchresult",
-      "community": 275,
+      "community": 11,
       "norm_label": "findclosestmatchresult"
     },
     {
@@ -16922,7 +17112,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addaccessory",
-      "community": 7,
+      "community": 9,
       "norm_label": "addaccessory.ts"
     },
     {
@@ -16932,7 +17122,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_addaccessory_addaccessoryinput",
-      "community": 7,
+      "community": 9,
       "norm_label": "addaccessoryinput"
     },
     {
@@ -16952,7 +17142,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addequipment",
-      "community": 7,
+      "community": 9,
       "norm_label": "addequipment.ts"
     },
     {
@@ -16962,7 +17152,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_addequipment_addequipmentinput",
-      "community": 7,
+      "community": 9,
       "norm_label": "addequipmentinput"
     },
     {
@@ -16982,7 +17172,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addrule",
-      "community": 7,
+      "community": 9,
       "norm_label": "addrule.ts"
     },
     {
@@ -16992,7 +17182,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_addrule_addruleinput",
-      "community": 7,
+      "community": 9,
       "norm_label": "addruleinput"
     },
     {
@@ -17012,7 +17202,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_editrule",
-      "community": 7,
+      "community": 9,
       "norm_label": "editrule.ts"
     },
     {
@@ -17022,7 +17212,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_editrule_editruleinput",
-      "community": 7,
+      "community": 9,
       "norm_label": "editruleinput"
     },
     {
@@ -17042,7 +17232,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removeaccessory",
-      "community": 7,
+      "community": 9,
       "norm_label": "removeaccessory.ts"
     },
     {
@@ -17052,7 +17242,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removeaccessory_removeaccessoryinput",
-      "community": 7,
+      "community": 9,
       "norm_label": "removeaccessoryinput"
     },
     {
@@ -17072,7 +17262,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removeequipment",
-      "community": 7,
+      "community": 9,
       "norm_label": "removeequipment.ts"
     },
     {
@@ -17082,7 +17272,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removeequipment_removeequipmentinput",
-      "community": 7,
+      "community": 9,
       "norm_label": "removeequipmentinput"
     },
     {
@@ -17102,7 +17292,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removerule",
-      "community": 7,
+      "community": 9,
       "norm_label": "removerule.ts"
     },
     {
@@ -17112,7 +17302,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removerule_removeruleinput",
-      "community": 7,
+      "community": 9,
       "norm_label": "removeruleinput"
     },
     {
@@ -17132,7 +17322,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_renameequipment",
-      "community": 7,
+      "community": 9,
       "norm_label": "renameequipment.ts"
     },
     {
@@ -17142,7 +17332,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_renameequipment_renameequipmentinput",
-      "community": 7,
+      "community": 9,
       "norm_label": "renameequipmentinput"
     },
     {
@@ -17162,7 +17352,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_setaccessoryowned",
-      "community": 7,
+      "community": 9,
       "norm_label": "setaccessoryowned.ts"
     },
     {
@@ -17172,7 +17362,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setaccessoryowned_setaccessoryownedinput",
-      "community": 7,
+      "community": 9,
       "norm_label": "setaccessoryownedinput"
     },
     {
@@ -17192,7 +17382,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentitem",
-      "community": 7,
+      "community": 9,
       "norm_label": "equipmentitem.ts"
     },
     {
@@ -17202,7 +17392,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentitem_accessory",
-      "community": 7,
+      "community": 9,
       "norm_label": "accessory"
     },
     {
@@ -17212,7 +17402,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "entities_equipmentitem_equipmentitem",
-      "community": 7,
+      "community": 9,
       "norm_label": "equipmentitem"
     },
     {
@@ -17222,7 +17412,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentmanifest",
-      "community": 7,
+      "community": 9,
       "norm_label": "equipmentmanifest.ts"
     },
     {
@@ -17232,7 +17422,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_equipmentmanifest_equipmentmanifest",
-      "community": 7,
+      "community": 9,
       "norm_label": "equipmentmanifest"
     },
     {
@@ -17242,7 +17432,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "equipment_index",
-      "community": 7,
+      "community": 9,
       "norm_label": "index.ts"
     },
     {
@@ -17252,7 +17442,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_equipmentmanifestport",
-      "community": 7,
+      "community": 9,
       "norm_label": "equipmentmanifestport.ts"
     },
     {
@@ -17262,7 +17452,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_equipmentmanifestport_equipmentmanifestport",
-      "community": 7,
+      "community": 9,
       "norm_label": "equipmentmanifestport"
     },
     {
@@ -17692,7 +17882,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_createmember",
-      "community": 116,
+      "community": 10,
       "norm_label": "createmember.ts"
     },
     {
@@ -17702,7 +17892,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "commands_createmember_creatememberinput",
-      "community": 116,
+      "community": 10,
       "norm_label": "creatememberinput"
     },
     {
@@ -17712,7 +17902,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "commands_createmember_createmember",
-      "community": 116,
+      "community": 10,
       "norm_label": "createmember()"
     },
     {
@@ -17722,7 +17912,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_normalisememberemail",
-      "community": 116,
+      "community": 10,
       "norm_label": "normalisememberemail.ts"
     },
     {
@@ -17732,7 +17922,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "commands_normalisememberemail_normalisememberemail",
-      "community": 116,
+      "community": 10,
       "norm_label": "normalisememberemail()"
     },
     {
@@ -17742,7 +17932,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_updatemember",
-      "community": 116,
+      "community": 10,
       "norm_label": "updatemember.ts"
     },
     {
@@ -17752,7 +17942,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_updatemember_updatememberpatch",
-      "community": 116,
+      "community": 10,
       "norm_label": "updatememberpatch"
     },
     {
@@ -17762,7 +17952,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "commands_updatemember_updatemember",
-      "community": 116,
+      "community": 10,
       "norm_label": "updatemember()"
     },
     {
@@ -17772,7 +17962,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_member",
-      "community": 116,
+      "community": 10,
       "norm_label": "member.ts"
     },
     {
@@ -17782,7 +17972,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "entities_member_member",
-      "community": 116,
+      "community": 10,
       "norm_label": "member"
     },
     {
@@ -17792,7 +17982,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "members_index",
-      "community": 116,
+      "community": 10,
       "norm_label": "index.ts"
     },
     {
@@ -17802,7 +17992,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_memberfirstname",
-      "community": 116,
+      "community": 10,
       "norm_label": "memberfirstname.ts"
     },
     {
@@ -17812,7 +18002,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "queries_memberfirstname_memberfirstname",
-      "community": 116,
+      "community": 10,
       "norm_label": "memberfirstname()"
     },
     {
@@ -17822,7 +18012,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_memberinitials",
-      "community": 116,
+      "community": 10,
       "norm_label": "memberinitials.ts"
     },
     {
@@ -17832,7 +18022,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "queries_memberinitials_memberinitials",
-      "community": 116,
+      "community": 10,
       "norm_label": "memberinitials()"
     },
     {
@@ -17842,7 +18032,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_sortmembers",
-      "community": 116,
+      "community": 10,
       "norm_label": "sortmembers.ts"
     },
     {
@@ -17852,7 +18042,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "queries_sortmembers_sortmembers",
-      "community": 116,
+      "community": 10,
       "norm_label": "sortmembers()"
     },
     {
@@ -20002,7 +20192,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_clearcheckeditems",
-      "community": 66,
+      "community": 4,
       "norm_label": "clearcheckeditems.ts"
     },
     {
@@ -20012,7 +20202,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_clearcheckeditems_clearcheckeditems",
-      "community": 66,
+      "community": 4,
       "norm_label": "clearcheckeditems()"
     },
     {
@@ -20022,7 +20212,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_confirmitemneeded",
-      "community": 66,
+      "community": 4,
       "norm_label": "confirmitemneeded.ts"
     },
     {
@@ -20032,7 +20222,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_confirmitemneeded_confirmitemneededinput",
-      "community": 66,
+      "community": 4,
       "norm_label": "confirmitemneededinput"
     },
     {
@@ -20042,7 +20232,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "commands_confirmitemneeded_confirmitemneeded",
-      "community": 66,
+      "community": 4,
       "norm_label": "confirmitemneeded()"
     },
     {
@@ -20052,7 +20242,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_createlist",
-      "community": 66,
+      "community": 1,
       "norm_label": "createlist.ts"
     },
     {
@@ -20062,7 +20252,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_createlist_createlistinput",
-      "community": 66,
+      "community": 4,
       "norm_label": "createlistinput"
     },
     {
@@ -20072,7 +20262,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createlist_createlist",
-      "community": 66,
+      "community": 8,
       "norm_label": "createlist()"
     },
     {
@@ -20132,7 +20322,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_deletelist_deletelist",
-      "community": 66,
+      "community": 8,
       "norm_label": "deletelist()"
     },
     {
@@ -20272,7 +20462,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_renamelist",
-      "community": 66,
+      "community": 1,
       "norm_label": "renamelist.ts"
     },
     {
@@ -20282,7 +20472,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_renamelist_renamelistinput",
-      "community": 66,
+      "community": 4,
       "norm_label": "renamelistinput"
     },
     {
@@ -20292,7 +20482,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_renamelist_renamelist",
-      "community": 66,
+      "community": 8,
       "norm_label": "renamelist()"
     },
     {
@@ -20452,7 +20642,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_index",
-      "community": 66,
+      "community": 4,
       "norm_label": "index.ts"
     },
     {
@@ -20462,7 +20652,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_entryparseport",
-      "community": 96,
+      "community": 83,
       "norm_label": "entryparseport.ts"
     },
     {
@@ -20472,7 +20662,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "ports_entryparseport_entryparseport",
-      "community": 96,
+      "community": 83,
       "norm_label": "entryparseport"
     },
     {
@@ -20562,7 +20752,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle",
-      "community": 265,
+      "community": 4,
       "norm_label": "groupitemsbyaisle.ts"
     },
     {
@@ -20572,7 +20762,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_canoninfo",
-      "community": 265,
+      "community": 4,
       "norm_label": "canoninfo"
     },
     {
@@ -20582,7 +20772,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_aisleinfo",
-      "community": 265,
+      "community": 4,
       "norm_label": "aisleinfo"
     },
     {
@@ -20592,7 +20782,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_othercontributor",
-      "community": 265,
+      "community": 4,
       "norm_label": "othercontributor"
     },
     {
@@ -20602,7 +20792,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_otherbucket",
-      "community": 265,
+      "community": 4,
       "norm_label": "otherbucket"
     },
     {
@@ -20622,7 +20812,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_amountsubtotal",
-      "community": 265,
+      "community": 4,
       "norm_label": "amountsubtotal"
     },
     {
@@ -20632,7 +20822,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_aislerow",
-      "community": 265,
+      "community": 4,
       "norm_label": "aislerow"
     },
     {
@@ -20642,7 +20832,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_aislegroup",
-      "community": 265,
+      "community": 4,
       "norm_label": "aislegroup"
     },
     {
@@ -20652,7 +20842,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_groupedshoppinglist",
-      "community": 265,
+      "community": 4,
       "norm_label": "groupedshoppinglist"
     },
     {
@@ -20662,7 +20852,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_groupitemsoptions",
-      "community": 265,
+      "community": 4,
       "norm_label": "groupitemsoptions"
     },
     {
@@ -20672,7 +20862,7 @@
       "source_location": "L75",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_isrecipesourced",
-      "community": 265,
+      "community": 4,
       "norm_label": "isrecipesourced()"
     },
     {
@@ -20682,7 +20872,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_buildsubtotals",
-      "community": 265,
+      "community": 4,
       "norm_label": "buildsubtotals()"
     },
     {
@@ -20692,7 +20882,7 @@
       "source_location": "L98",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_makerow",
-      "community": 265,
+      "community": 4,
       "norm_label": "makerow()"
     },
     {
@@ -20702,7 +20892,7 @@
       "source_location": "L112",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_rowcreatedat",
-      "community": 265,
+      "community": 4,
       "norm_label": "rowcreatedat()"
     },
     {
@@ -20712,7 +20902,7 @@
       "source_location": "L119",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_groupitemsbyaisle",
-      "community": 265,
+      "community": 4,
       "norm_label": "groupitemsbyaisle()"
     },
     {
@@ -20782,7 +20972,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "queries_parseentry_parsedentry",
-      "community": 96,
+      "community": 83,
       "norm_label": "parsedentry"
     },
     {
@@ -20882,7 +21072,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_recipeitemadddefault",
-      "community": 66,
+      "community": 4,
       "norm_label": "recipeitemadddefault.ts"
     },
     {
@@ -20892,7 +21082,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "queries_recipeitemadddefault_recipeitemadddefault",
-      "community": 66,
+      "community": 4,
       "norm_label": "recipeitemadddefault"
     },
     {
@@ -20922,7 +21112,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_appsettings_schema_test",
-      "community": 266,
+      "community": 77,
       "norm_label": "appsettings.schema.test.ts"
     },
     {
@@ -20932,7 +21122,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_matchlogbuilder_test",
-      "community": 17,
+      "community": 32,
       "norm_label": "matchlogbuilder.test.ts"
     },
     {
@@ -20942,7 +21132,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_matchlogbuilder_test_makestage",
-      "community": 17,
+      "community": 32,
       "norm_label": "makestage()"
     },
     {
@@ -20982,7 +21172,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canonicon_test",
-      "community": 1,
+      "community": 11,
       "norm_label": "canonicon.test.ts"
     },
     {
@@ -20992,7 +21182,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canonitem_schema_test",
-      "community": 3,
+      "community": 17,
       "norm_label": "canonitem.schema.test.ts"
     },
     {
@@ -21002,7 +21192,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_canonitem_schema_test_counterids",
-      "community": 3,
+      "community": 17,
       "norm_label": "counterids()"
     },
     {
@@ -21012,7 +21202,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_clientfastpathparity_integration_test",
-      "community": 64,
+      "community": 17,
       "norm_label": "clientfastpathparity.integration.test.ts"
     },
     {
@@ -21022,7 +21212,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "canon_clientfastpathparity_integration_test_canonitem",
-      "community": 64,
+      "community": 17,
       "norm_label": "canonitem()"
     },
     {
@@ -21032,7 +21222,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "canon_clientfastpathparity_integration_test_makestore",
-      "community": 64,
+      "community": 17,
       "norm_label": "makestore()"
     },
     {
@@ -21042,7 +21232,7 @@
       "source_location": "L59",
       "_origin": "ast",
       "id": "canon_clientfastpathparity_integration_test_aislestore",
-      "community": 64,
+      "community": 17,
       "norm_label": "aislestore"
     },
     {
@@ -21052,7 +21242,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "canon_clientfastpathparity_integration_test_failingembedding",
-      "community": 64,
+      "community": 17,
       "norm_label": "failingembedding"
     },
     {
@@ -21062,7 +21252,7 @@
       "source_location": "L73",
       "_origin": "ast",
       "id": "canon_clientfastpathparity_integration_test_failingarbitration",
-      "community": 64,
+      "community": 17,
       "norm_label": "failingarbitration"
     },
     {
@@ -21072,7 +21262,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "canon_clientfastpathparity_integration_test_ids",
-      "community": 64,
+      "community": 17,
       "norm_label": "ids"
     },
     {
@@ -21092,7 +21282,7 @@
       "source_location": "L99",
       "_origin": "ast",
       "id": "canon_clientfastpathparity_integration_test_runcfpath",
-      "community": 64,
+      "community": 17,
       "norm_label": "runcfpath()"
     },
     {
@@ -21162,7 +21352,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_createcanonitem_test",
-      "community": 3,
+      "community": 17,
       "norm_label": "createcanonitem.test.ts"
     },
     {
@@ -21172,7 +21362,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_createcanonitem_test_counterids",
-      "community": 3,
+      "community": 17,
       "norm_label": "counterids()"
     },
     {
@@ -21182,7 +21372,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_createcanonlookup_test",
-      "community": 7,
+      "community": 1,
       "norm_label": "createcanonlookup.test.ts"
     },
     {
@@ -21192,7 +21382,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_createcanonlookup_test_seed",
-      "community": 51,
+      "community": 64,
       "norm_label": "seed"
     },
     {
@@ -21202,7 +21392,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "canon_createcanonlookup_test_fakestore",
-      "community": 7,
+      "community": 1,
       "norm_label": "fakestore()"
     },
     {
@@ -21332,7 +21522,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_findclosestmatch_test",
-      "community": 11,
+      "community": 17,
       "norm_label": "findclosestmatch.test.ts"
     },
     {
@@ -21342,7 +21532,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_findclosestmatch_test_item",
-      "community": 11,
+      "community": 17,
       "norm_label": "item()"
     },
     {
@@ -21352,7 +21542,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "canon_findclosestmatch_test_catalog",
-      "community": 11,
+      "community": 17,
       "norm_label": "catalog"
     },
     {
@@ -21432,7 +21622,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_matchorcreate_test",
-      "community": 64,
+      "community": 275,
       "norm_label": "matchorcreate.test.ts"
     },
     {
@@ -21442,7 +21632,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_canonitem",
-      "community": 64,
+      "community": 275,
       "norm_label": "canonitem()"
     },
     {
@@ -21452,7 +21642,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_makeids",
-      "community": 64,
+      "community": 275,
       "norm_label": "makeids()"
     },
     {
@@ -21462,7 +21652,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_makestore",
-      "community": 64,
+      "community": 275,
       "norm_label": "makestore()"
     },
     {
@@ -21472,7 +21662,7 @@
       "source_location": "L57",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_makeaislestore",
-      "community": 64,
+      "community": 275,
       "norm_label": "makeaislestore()"
     },
     {
@@ -21482,7 +21672,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_makeaislestorewithaisles",
-      "community": 64,
+      "community": 275,
       "norm_label": "makeaislestorewithaisles()"
     },
     {
@@ -21492,7 +21682,7 @@
       "source_location": "L73",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_ex",
-      "community": 64,
+      "community": 275,
       "norm_label": "ex"
     },
     {
@@ -21502,7 +21692,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_ey",
-      "community": 64,
+      "community": 275,
       "norm_label": "ey"
     },
     {
@@ -21512,7 +21702,7 @@
       "source_location": "L76",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_cosine",
-      "community": 64,
+      "community": 275,
       "norm_label": "cosine()"
     },
     {
@@ -21522,7 +21712,7 @@
       "source_location": "L89",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_makeembedding",
-      "community": 64,
+      "community": 275,
       "norm_label": "makeembedding()"
     },
     {
@@ -21532,7 +21722,7 @@
       "source_location": "L96",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_failembedding",
-      "community": 64,
+      "community": 275,
       "norm_label": "failembedding()"
     },
     {
@@ -21542,7 +21732,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_nomatcharbitration",
-      "community": 64,
+      "community": 275,
       "norm_label": "nomatcharbitration()"
     },
     {
@@ -21552,7 +21742,7 @@
       "source_location": "L110",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_newarbitration",
-      "community": 64,
+      "community": 275,
       "norm_label": "newarbitration()"
     },
     {
@@ -21562,7 +21752,7 @@
       "source_location": "L119",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_matcharbitration",
-      "community": 64,
+      "community": 275,
       "norm_label": "matcharbitration()"
     },
     {
@@ -21572,7 +21762,7 @@
       "source_location": "L134",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_errorarbitration",
-      "community": 64,
+      "community": 275,
       "norm_label": "errorarbitration()"
     },
     {
@@ -21582,7 +21772,7 @@
       "source_location": "L143",
       "_origin": "ast",
       "id": "canon_matchorcreate_test_makepipeline",
-      "community": 64,
+      "community": 275,
       "norm_label": "makepipeline()"
     },
     {
@@ -21592,7 +21782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test",
-      "community": 51,
+      "community": 64,
       "norm_label": "matchorcreatebatch.test.ts"
     },
     {
@@ -21602,7 +21792,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_canonitem",
-      "community": 51,
+      "community": 64,
       "norm_label": "canonitem()"
     },
     {
@@ -21612,7 +21802,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_makeids",
-      "community": 51,
+      "community": 64,
       "norm_label": "makeids()"
     },
     {
@@ -21622,7 +21812,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_makestore",
-      "community": 51,
+      "community": 64,
       "norm_label": "makestore()"
     },
     {
@@ -21632,7 +21822,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_makeaislestore",
-      "community": 51,
+      "community": 64,
       "norm_label": "makeaislestore()"
     },
     {
@@ -21642,7 +21832,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_ex",
-      "community": 51,
+      "community": 64,
       "norm_label": "ex"
     },
     {
@@ -21652,7 +21842,7 @@
       "source_location": "L56",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_cosine",
-      "community": 51,
+      "community": 64,
       "norm_label": "cosine()"
     },
     {
@@ -21662,7 +21852,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_failembedding",
-      "community": 51,
+      "community": 64,
       "norm_label": "failembedding()"
     },
     {
@@ -21672,7 +21862,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_nomatcharbitration",
-      "community": 51,
+      "community": 64,
       "norm_label": "nomatcharbitration()"
     },
     {
@@ -21682,7 +21872,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_makeports",
-      "community": 51,
+      "community": 64,
       "norm_label": "makeports()"
     },
     {
@@ -21692,7 +21882,7 @@
       "source_location": "L111",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_shape",
-      "community": 51,
+      "community": 64,
       "norm_label": "shape"
     },
     {
@@ -21702,7 +21892,7 @@
       "source_location": "L133",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_runcombined",
-      "community": 51,
+      "community": 64,
       "norm_label": "runcombined()"
     },
     {
@@ -21712,7 +21902,7 @@
       "source_location": "L140",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_runsequential",
-      "community": 51,
+      "community": 64,
       "norm_label": "runsequential()"
     },
     {
@@ -21722,7 +21912,7 @@
       "source_location": "L154",
       "_origin": "ast",
       "id": "canon_matchorcreatebatch_test_normalizeids",
-      "community": 51,
+      "community": 64,
       "norm_label": "normalizeids()"
     },
     {
@@ -21852,7 +22042,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_renamecanonitem_test",
-      "community": 3,
+      "community": 11,
       "norm_label": "renamecanonitem.test.ts"
     },
     {
@@ -21862,7 +22052,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_renamecanonitem_test_item",
-      "community": 3,
+      "community": 11,
       "norm_label": "item()"
     },
     {
@@ -22032,7 +22222,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test",
-      "community": 93,
+      "community": 116,
       "norm_label": "summarizematchlog.test.ts"
     },
     {
@@ -22042,7 +22232,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makestage",
-      "community": 93,
+      "community": 116,
       "norm_label": "makestage()"
     },
     {
@@ -22052,7 +22242,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makeentry",
-      "community": 93,
+      "community": 116,
       "norm_label": "makeentry()"
     },
     {
@@ -22062,7 +22252,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makearbitration",
-      "community": 93,
+      "community": 116,
       "norm_label": "makearbitration()"
     },
     {
@@ -22102,7 +22292,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_devsettings_schema_test",
-      "community": 266,
+      "community": 77,
       "norm_label": "devsettings.schema.test.ts"
     },
     {
@@ -22202,7 +22392,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "members_members_test",
-      "community": 116,
+      "community": 10,
       "norm_label": "members.test.ts"
     },
     {
@@ -22212,7 +22402,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "members_members_test_makemember",
-      "community": 116,
+      "community": 10,
       "norm_label": "makemember()"
     },
     {
@@ -22272,7 +22462,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_commands_test",
-      "community": 66,
+      "community": 8,
       "norm_label": "commands.test.ts"
     },
     {
@@ -22282,7 +22472,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeids",
-      "community": 66,
+      "community": 8,
       "norm_label": "makeids()"
     },
     {
@@ -22292,7 +22482,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makelist",
-      "community": 66,
+      "community": 8,
       "norm_label": "makelist()"
     },
     {
@@ -22302,7 +22492,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeconfig",
-      "community": 66,
+      "community": 8,
       "norm_label": "makeconfig()"
     },
     {
@@ -22312,7 +22502,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeitem",
-      "community": 66,
+      "community": 8,
       "norm_label": "makeitem()"
     },
     {
@@ -22322,7 +22512,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_groupitemsbyaisle_test",
-      "community": 265,
+      "community": 4,
       "norm_label": "groupitemsbyaisle.test.ts"
     },
     {
@@ -22332,7 +22522,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "shoppinglist_groupitemsbyaisle_test_makeitem",
-      "community": 265,
+      "community": 4,
       "norm_label": "makeitem()"
     },
     {
@@ -22342,7 +22532,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "shoppinglist_groupitemsbyaisle_test_makecanonmap",
-      "community": 265,
+      "community": 4,
       "norm_label": "makecanonmap()"
     },
     {
@@ -22352,7 +22542,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "shoppinglist_groupitemsbyaisle_test_aisles",
-      "community": 265,
+      "community": 4,
       "norm_label": "aisles"
     },
     {
@@ -22402,7 +22592,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_recipeitemadddefault_test",
-      "community": 66,
+      "community": 4,
       "norm_label": "recipeitemadddefault.test.ts"
     },
     {
@@ -22622,7 +22812,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_types_src_index_ts_src_index",
-      "community": 7,
+      "community": 1,
       "norm_label": "index.ts"
     },
     {
@@ -22632,7 +22822,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "src_index_success",
-      "community": 7,
+      "community": 1,
       "norm_label": "success"
     },
     {
@@ -22642,7 +22832,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "src_index_failure",
-      "community": 7,
+      "community": 1,
       "norm_label": "failure"
     },
     {
@@ -22652,7 +22842,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "src_index_conflict",
-      "community": 7,
+      "community": 1,
       "norm_label": "conflict"
     },
     {
@@ -22662,7 +22852,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "src_index_readresult",
-      "community": 7,
+      "community": 1,
       "norm_label": "readresult"
     },
     {
@@ -22672,7 +22862,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "src_index_writeresult",
-      "community": 7,
+      "community": 1,
       "norm_label": "writeresult"
     },
     {
@@ -22692,7 +22882,7 @@
       "source_location": "L54",
       "_origin": "ast",
       "id": "src_index_domainerror",
-      "community": 7,
+      "community": 1,
       "norm_label": "domainerror"
     },
     {
@@ -22722,7 +22912,7 @@
       "source_location": "L92",
       "_origin": "ast",
       "id": "src_index_canonitemdto",
-      "community": 7,
+      "community": 1,
       "norm_label": "canonitemdto"
     },
     {
@@ -22732,7 +22922,7 @@
       "source_location": "L107",
       "_origin": "ast",
       "id": "src_index_aisledto",
-      "community": 7,
+      "community": 1,
       "norm_label": "aisledto"
     },
     {
@@ -22742,7 +22932,7 @@
       "source_location": "L113",
       "_origin": "ast",
       "id": "src_index_aislelistdto",
-      "community": 7,
+      "community": 1,
       "norm_label": "aislelistdto"
     },
     {
@@ -22752,7 +22942,7 @@
       "source_location": "L118",
       "_origin": "ast",
       "id": "src_index_errorcode",
-      "community": 7,
+      "community": 1,
       "norm_label": "errorcode"
     },
     {
@@ -24845,7 +25035,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_variants",
-      "community": 27,
+      "community": 23,
       "norm_label": "variants.ts"
     },
     {
@@ -25228,7 +25418,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "checkbox_checkbox_types",
-      "community": 27,
+      "community": 26,
       "norm_label": "checkbox.types.ts"
     },
     {
@@ -25238,7 +25428,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "checkbox_checkbox_types_checkedstate",
-      "community": 27,
+      "community": 26,
       "norm_label": "checkedstate"
     },
     {
@@ -25248,7 +25438,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "checkbox_checkbox_types_checkboxprops",
-      "community": 27,
+      "community": 26,
       "norm_label": "checkboxprops"
     },
     {
@@ -25258,7 +25448,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "checkbox_checkbox_variants",
-      "community": 27,
+      "community": 26,
       "norm_label": "checkbox.variants.ts"
     },
     {
@@ -25268,7 +25458,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "checkbox_checkbox_variants_checkboxrootvariants",
-      "community": 27,
+      "community": 26,
       "norm_label": "checkboxrootvariants"
     },
     {
@@ -25278,7 +25468,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "checkbox_index",
-      "community": 27,
+      "community": 26,
       "norm_label": "index.ts"
     },
     {
@@ -25519,7 +25709,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "combobox_combobox_variants",
-      "community": 27,
+      "community": 95,
       "norm_label": "combobox.variants.ts"
     },
     {
@@ -25529,7 +25719,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxinputvariants",
-      "community": 27,
+      "community": 95,
       "norm_label": "comboboxinputvariants"
     },
     {
@@ -25539,7 +25729,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxtriggervariants",
-      "community": 27,
+      "community": 95,
       "norm_label": "comboboxtriggervariants"
     },
     {
@@ -25549,7 +25739,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxcontentvariants",
-      "community": 27,
+      "community": 95,
       "norm_label": "comboboxcontentvariants"
     },
     {
@@ -25559,7 +25749,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxitemvariants",
-      "community": 27,
+      "community": 95,
       "norm_label": "comboboxitemvariants"
     },
     {
@@ -25569,7 +25759,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "combobox_combobox_variants_comboboxcreatevariants",
-      "community": 27,
+      "community": 95,
       "norm_label": "comboboxcreatevariants"
     },
     {
@@ -25959,7 +26149,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_dialog_variants",
-      "community": 27,
+      "community": 23,
       "norm_label": "dialog.variants.ts"
     },
     {
@@ -25969,7 +26159,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "dialog_dialog_variants_dialogcontentvariants",
-      "community": 27,
+      "community": 23,
       "norm_label": "dialogcontentvariants"
     },
     {
@@ -26582,7 +26772,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "markdown_markdown",
-      "community": 13,
+      "community": 40,
       "norm_label": "markdown.svelte"
     },
     {
@@ -26602,7 +26792,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "gfm",
-      "community": 13,
+      "community": 40,
       "norm_label": "svelte-exmarkdown/gfm"
     },
     {
@@ -26612,7 +26802,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_popover",
-      "community": 279,
+      "community": 23,
       "norm_label": "popover.svelte"
     },
     {
@@ -26622,7 +26812,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_headless_popover_headless_svelte",
-      "community": 279,
+      "community": 23,
       "norm_label": "../../headless/popover.headless.svelte"
     },
     {
@@ -26632,7 +26822,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_popover_popover_types",
-      "community": 279,
+      "community": 23,
       "norm_label": "./popover.types"
     },
     {
@@ -26642,7 +26832,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_popover_types",
-      "community": 279,
+      "community": 23,
       "norm_label": "popover.types.ts"
     },
     {
@@ -26652,7 +26842,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "popover_popover_types_popoverprops",
-      "community": 279,
+      "community": 23,
       "norm_label": "popoverprops"
     },
     {
@@ -26662,7 +26852,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "popover_popover_types_popovercontentprops",
-      "community": 279,
+      "community": 23,
       "norm_label": "popovercontentprops"
     },
     {
@@ -26672,7 +26862,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "popover_popover_types_popoverpartprops",
-      "community": 279,
+      "community": 23,
       "norm_label": "popoverpartprops"
     },
     {
@@ -26692,7 +26882,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_popovercontent",
-      "community": 279,
+      "community": 23,
       "norm_label": "popovercontent.svelte"
     },
     {
@@ -26702,7 +26892,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_popover_popover_variants",
-      "community": 279,
+      "community": 23,
       "norm_label": "./popover.variants"
     },
     {
@@ -26712,7 +26902,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_popovertrigger",
-      "community": 279,
+      "community": 23,
       "norm_label": "popovertrigger.svelte"
     },
     {
@@ -26722,7 +26912,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_index",
-      "community": 279,
+      "community": 23,
       "norm_label": "index.ts"
     },
     {
@@ -27535,7 +27725,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "sheet_sheettrigger",
-      "community": 38,
+      "community": 23,
       "norm_label": "sheettrigger.svelte"
     },
     {
@@ -28506,7 +28696,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltip",
-      "community": 23,
+      "community": 2,
       "norm_label": "tooltip.svelte"
     },
     {
@@ -28516,7 +28706,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "tooltip_tooltip_state",
-      "community": 23,
+      "community": 2,
       "norm_label": "state"
     },
     {
@@ -28526,7 +28716,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "tooltip_tooltip_handleopenchange",
-      "community": 23,
+      "community": 2,
       "norm_label": "handleopenchange()"
     },
     {
@@ -28536,7 +28726,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_headless_tooltip_headless_svelte",
-      "community": 23,
+      "community": 2,
       "norm_label": "../../headless/tooltip.headless.svelte"
     },
     {
@@ -28546,7 +28736,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_tooltip_tooltip_types",
-      "community": 23,
+      "community": 2,
       "norm_label": "./tooltip.types"
     },
     {
@@ -28556,7 +28746,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltip_types",
-      "community": 23,
+      "community": 2,
       "norm_label": "tooltip.types.ts"
     },
     {
@@ -28566,7 +28756,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "tooltip_tooltip_types_tooltipproviderprops",
-      "community": 23,
+      "community": 2,
       "norm_label": "tooltipproviderprops"
     },
     {
@@ -28576,7 +28766,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "tooltip_tooltip_types_tooltipprops",
-      "community": 23,
+      "community": 2,
       "norm_label": "tooltipprops"
     },
     {
@@ -28586,7 +28776,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "tooltip_tooltip_types_tooltipcontentprops",
-      "community": 23,
+      "community": 2,
       "norm_label": "tooltipcontentprops"
     },
     {
@@ -28596,7 +28786,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "tooltip_tooltip_types_tooltippartprops",
-      "community": 23,
+      "community": 2,
       "norm_label": "tooltippartprops"
     },
     {
@@ -28616,7 +28806,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltipcontent",
-      "community": 23,
+      "community": 2,
       "norm_label": "tooltipcontent.svelte"
     },
     {
@@ -28626,7 +28816,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_tooltip_tooltip_variants",
-      "community": 23,
+      "community": 2,
       "norm_label": "./tooltip.variants"
     },
     {
@@ -28636,7 +28826,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltipprovider",
-      "community": 23,
+      "community": 2,
       "norm_label": "tooltipprovider.svelte"
     },
     {
@@ -28646,7 +28836,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_tooltiptrigger",
-      "community": 23,
+      "community": 2,
       "norm_label": "tooltiptrigger.svelte"
     },
     {
@@ -28656,7 +28846,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tooltip_index",
-      "community": 23,
+      "community": 2,
       "norm_label": "index.ts"
     },
     {
@@ -29379,7 +29569,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_popover_test",
-      "community": 279,
+      "community": 23,
       "norm_label": "popover.test.ts"
     },
     {
@@ -29629,7 +29819,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_tooltip_test",
-      "community": 23,
+      "community": 2,
       "norm_label": "tooltip.test.ts"
     },
     {
@@ -29921,46 +30111,6 @@
       "norm_label": "cut-release.sh script"
     },
     {
-      "label": "export-prod-firestore.mjs",
-      "file_type": "code",
-      "source_file": "scripts/export-prod-firestore.mjs",
-      "source_location": "L1",
-      "_origin": "ast",
-      "id": "scripts_export_prod_firestore",
-      "community": 157,
-      "norm_label": "export-prod-firestore.mjs"
-    },
-    {
-      "label": "run()",
-      "file_type": "code",
-      "source_file": "scripts/export-prod-firestore.mjs",
-      "source_location": "L25",
-      "_origin": "ast",
-      "id": "scripts_export_prod_firestore_run",
-      "community": 157,
-      "norm_label": "run()"
-    },
-    {
-      "label": "commandExists()",
-      "file_type": "code",
-      "source_file": "scripts/export-prod-firestore.mjs",
-      "source_location": "L29",
-      "_origin": "ast",
-      "id": "scripts_export_prod_firestore_commandexists",
-      "community": 157,
-      "norm_label": "commandexists()"
-    },
-    {
-      "label": "stamp",
-      "file_type": "code",
-      "source_file": "scripts/export-prod-firestore.mjs",
-      "source_location": "L65",
-      "_origin": "ast",
-      "id": "scripts_export_prod_firestore_stamp",
-      "community": 157,
-      "norm_label": "stamp"
-    },
-    {
       "label": "free-ports.mjs",
       "file_type": "code",
       "source_file": "scripts/free-ports.mjs",
@@ -30077,56 +30227,6 @@
       "id": "users_daniel_projects_saltv2_scripts_grant_callable_invokers_sh__entry",
       "community": 194,
       "norm_label": "grant-callable-invokers.sh script"
-    },
-    {
-      "label": "restore-staging-from-prod.mjs",
-      "file_type": "code",
-      "source_file": "scripts/restore-staging-from-prod.mjs",
-      "source_location": "L1",
-      "_origin": "ast",
-      "id": "scripts_restore_staging_from_prod",
-      "community": 150,
-      "norm_label": "restore-staging-from-prod.mjs"
-    },
-    {
-      "label": "run()",
-      "file_type": "code",
-      "source_file": "scripts/restore-staging-from-prod.mjs",
-      "source_location": "L36",
-      "_origin": "ast",
-      "id": "scripts_restore_staging_from_prod_run",
-      "community": 150,
-      "norm_label": "run()"
-    },
-    {
-      "label": "commandExists()",
-      "file_type": "code",
-      "source_file": "scripts/restore-staging-from-prod.mjs",
-      "source_location": "L40",
-      "_origin": "ast",
-      "id": "scripts_restore_staging_from_prod_commandexists",
-      "community": 150,
-      "norm_label": "commandexists()"
-    },
-    {
-      "label": "ask()",
-      "file_type": "code",
-      "source_file": "scripts/restore-staging-from-prod.mjs",
-      "source_location": "L49",
-      "_origin": "ast",
-      "id": "scripts_restore_staging_from_prod_ask",
-      "community": 150,
-      "norm_label": "ask()"
-    },
-    {
-      "label": "exportPath",
-      "file_type": "code",
-      "source_file": "scripts/restore-staging-from-prod.mjs",
-      "source_location": "L72",
-      "_origin": "ast",
-      "id": "scripts_restore_staging_from_prod_exportpath",
-      "community": 150,
-      "norm_label": "exportpath"
     },
     {
       "label": "stop-emulators.mjs",
@@ -32009,10 +32109,20 @@
       "norm_label": "zod schema conventions"
     },
     {
-      "label": "Enforcement",
+      "label": "Observability / error-reporting conventions",
       "file_type": "document",
       "source_file": "CLAUDE.md",
       "source_location": "L63",
+      "_origin": "ast",
+      "id": "claude_observability_error_reporting_conventions",
+      "community": 48,
+      "norm_label": "observability / error-reporting conventions"
+    },
+    {
+      "label": "Enforcement",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L72",
       "_origin": "ast",
       "id": "claude_enforcement",
       "community": 48,
@@ -32022,7 +32132,7 @@
       "label": "Package names",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L71",
+      "source_location": "L80",
       "_origin": "ast",
       "id": "claude_package_names",
       "community": 48,
@@ -32032,7 +32142,7 @@
       "label": "graphify",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L84",
+      "source_location": "L93",
       "_origin": "ast",
       "id": "claude_graphify",
       "community": 48,
@@ -32397,86 +32507,6 @@
       "id": "docs_canon_icons_proven_prompt_verbatim_reproduce_exactly",
       "community": 267,
       "norm_label": "proven prompt (verbatim \u2014 reproduce exactly)"
-    },
-    {
-      "label": "data-refresh.md",
-      "file_type": "document",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L1",
-      "_origin": "ast",
-      "id": "docs_data_refresh",
-      "community": 298,
-      "norm_label": "data-refresh.md"
-    },
-    {
-      "label": "Refreshing staging with prod data",
-      "file_type": "document",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L1",
-      "_origin": "ast",
-      "id": "docs_data_refresh_refreshing_staging_with_prod_data",
-      "community": 298,
-      "norm_label": "refreshing staging with prod data"
-    },
-    {
-      "label": "Why managed export/import (and not a copy script)",
-      "file_type": "document",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L13",
-      "_origin": "ast",
-      "id": "docs_data_refresh_why_managed_export_import_and_not_a_copy_script",
-      "community": 298,
-      "norm_label": "why managed export/import (and not a copy script)"
-    },
-    {
-      "label": "One-time setup",
-      "file_type": "document",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L24",
-      "_origin": "ast",
-      "id": "docs_data_refresh_one_time_setup",
-      "community": 298,
-      "norm_label": "one-time setup"
-    },
-    {
-      "label": "Usage",
-      "file_type": "document",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L59",
-      "_origin": "ast",
-      "id": "docs_data_refresh_usage",
-      "community": 298,
-      "norm_label": "usage"
-    },
-    {
-      "label": "Safety",
-      "file_type": "document",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L66",
-      "_origin": "ast",
-      "id": "docs_data_refresh_safety",
-      "community": 298,
-      "norm_label": "safety"
-    },
-    {
-      "label": "After a restore \u2014 re-apply staging-only config",
-      "file_type": "document",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L73",
-      "_origin": "ast",
-      "id": "docs_data_refresh_after_a_restore_re_apply_staging_only_config",
-      "community": 298,
-      "norm_label": "after a restore \u2014 re-apply staging-only config"
-    },
-    {
-      "label": "Scope",
-      "file_type": "document",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L88",
-      "_origin": "ast",
-      "id": "docs_data_refresh_scope",
-      "community": 298,
-      "norm_label": "scope"
     },
     {
       "label": "design.md",
@@ -34975,7 +35005,7 @@
       "source_location": "L621",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_list_selection_createlistselection_selectablelist_selectallcheckbox_rowselectcheckbox",
-      "community": 272,
+      "community": 73,
       "norm_label": "10. list selection (`createlistselection` + `selectablelist` / `selectallcheckbox` / `rowselectcheckbox`)"
     },
     {
@@ -34985,7 +35015,7 @@
       "source_location": "L623",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_1_overview",
-      "community": 272,
+      "community": 73,
       "norm_label": "10.1 overview"
     },
     {
@@ -34995,7 +35025,7 @@
       "source_location": "L638",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_2_createlistselection_options",
-      "community": 272,
+      "community": 73,
       "norm_label": "10.2 `createlistselection(options)`"
     },
     {
@@ -35005,7 +35035,7 @@
       "source_location": "L664",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_3_component_props",
-      "community": 272,
+      "community": 73,
       "norm_label": "10.3 component props"
     },
     {
@@ -35015,7 +35045,7 @@
       "source_location": "L679",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_4_behaviour",
-      "community": 272,
+      "community": 73,
       "norm_label": "10.4 behaviour"
     },
     {
@@ -35025,7 +35055,7 @@
       "source_location": "L686",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_5_accessibility",
-      "community": 272,
+      "community": 73,
       "norm_label": "10.5 accessibility"
     },
     {
@@ -35035,7 +35065,7 @@
       "source_location": "L691",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_6_testing_requirements",
-      "community": 272,
+      "community": 73,
       "norm_label": "10.6 testing requirements"
     },
     {
@@ -35045,7 +35075,7 @@
       "source_location": "L700",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_editablerow_primitive",
-      "community": 321,
+      "community": 272,
       "norm_label": "11. editablerow (primitive)"
     },
     {
@@ -35055,7 +35085,7 @@
       "source_location": "L702",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_1_overview",
-      "community": 321,
+      "community": 272,
       "norm_label": "11.1 overview"
     },
     {
@@ -35065,7 +35095,7 @@
       "source_location": "L706",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_2_props",
-      "community": 321,
+      "community": 272,
       "norm_label": "11.2 props"
     },
     {
@@ -35075,7 +35105,7 @@
       "source_location": "L716",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_3_behaviour",
-      "community": 321,
+      "community": 272,
       "norm_label": "11.3 behaviour"
     },
     {
@@ -35085,7 +35115,7 @@
       "source_location": "L723",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_4_testing_requirements",
-      "community": 321,
+      "community": 272,
       "norm_label": "11.4 testing requirements"
     },
     {
@@ -35505,7 +35535,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_by_stage_narrative",
-      "community": 71,
+      "community": 82,
       "norm_label": "stage-by-stage narrative"
     },
     {
@@ -35515,7 +35545,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_1_exact_name_match",
-      "community": 71,
+      "community": 82,
       "norm_label": "stage 1 \u2014 exact name match"
     },
     {
@@ -35525,7 +35555,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_2_token_overlap",
-      "community": 71,
+      "community": 82,
       "norm_label": "stage 2 \u2014 token overlap"
     },
     {
@@ -35535,7 +35565,7 @@
       "source_location": "L91",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_3_synonym_exact_match",
-      "community": 71,
+      "community": 82,
       "norm_label": "stage 3 \u2014 synonym exact match"
     },
     {
@@ -35545,7 +35575,7 @@
       "source_location": "L95",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_4_string_similarity_levenshtein",
-      "community": 71,
+      "community": 82,
       "norm_label": "stage 4 \u2014 string similarity (levenshtein)"
     },
     {
@@ -35555,7 +35585,7 @@
       "source_location": "L99",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_5_embedding_cosine",
-      "community": 71,
+      "community": 82,
       "norm_label": "stage 5 \u2014 embedding cosine"
     },
     {
@@ -35565,7 +35595,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_6_merged_shortlist_ai_arbitration",
-      "community": 71,
+      "community": 82,
       "norm_label": "stage 6 \u2014 merged shortlist + ai arbitration"
     },
     {
@@ -35972,7 +36002,7 @@
       "label": "Cross-module seams (already shipped, awaiting this module)",
       "file_type": "document",
       "source_file": "docs/recipe-module.md",
-      "source_location": "L158",
+      "source_location": "L162",
       "_origin": "ast",
       "id": "docs_recipe_module_cross_module_seams_already_shipped_awaiting_this_module",
       "community": 76,
@@ -35982,7 +36012,7 @@
       "label": "Architecture placement",
       "file_type": "document",
       "source_file": "docs/recipe-module.md",
-      "source_location": "L166",
+      "source_location": "L170",
       "_origin": "ast",
       "id": "docs_recipe_module_architecture_placement",
       "community": 76,
@@ -35992,7 +36022,7 @@
       "label": "Access & admin",
       "file_type": "document",
       "source_file": "docs/recipe-module.md",
-      "source_location": "L177",
+      "source_location": "L181",
       "_origin": "ast",
       "id": "docs_recipe_module_access_admin",
       "community": 76,
@@ -36002,7 +36032,7 @@
       "label": "Deferred: the AI-generation epic (own issue + design session)",
       "file_type": "document",
       "source_file": "docs/recipe-module.md",
-      "source_location": "L182",
+      "source_location": "L186",
       "_origin": "ast",
       "id": "docs_recipe_module_deferred_the_ai_generation_epic_own_issue_design_session",
       "community": 76,
@@ -36362,7 +36392,7 @@
       "label": "8. Cloud Functions requirements",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L254",
+      "source_location": "L277",
       "_origin": "ast",
       "id": "docs_salt_architecture_8_cloud_functions_requirements",
       "community": 280,
@@ -36372,7 +36402,7 @@
       "label": "9. PWA (UI) requirements",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L285",
+      "source_location": "L308",
       "_origin": "ast",
       "id": "docs_salt_architecture_9_pwa_ui_requirements",
       "community": 280,
@@ -36382,7 +36412,7 @@
       "label": "10. Shared types requirements",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L305",
+      "source_location": "L328",
       "_origin": "ast",
       "id": "docs_salt_architecture_10_shared_types_requirements",
       "community": 280,
@@ -36392,7 +36422,7 @@
       "label": "11. Enforcement rules",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L320",
+      "source_location": "L343",
       "_origin": "ast",
       "id": "docs_salt_architecture_11_enforcement_rules",
       "community": 326,
@@ -36402,7 +36432,7 @@
       "label": "ESLint",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L322",
+      "source_location": "L345",
       "_origin": "ast",
       "id": "docs_salt_architecture_eslint",
       "community": 326,
@@ -36412,7 +36442,7 @@
       "label": "tsconfig",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L335",
+      "source_location": "L358",
       "_origin": "ast",
       "id": "docs_salt_architecture_tsconfig",
       "community": 326,
@@ -36422,7 +36452,7 @@
       "label": "Commit gateway",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L341",
+      "source_location": "L364",
       "_origin": "ast",
       "id": "docs_salt_architecture_commit_gateway",
       "community": 326,
@@ -36432,7 +36462,7 @@
       "label": "12. Testing strategy",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L358",
+      "source_location": "L381",
       "_origin": "ast",
       "id": "docs_salt_architecture_12_testing_strategy",
       "community": 316,
@@ -36442,7 +36472,7 @@
       "label": "Domain",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L360",
+      "source_location": "L383",
       "_origin": "ast",
       "id": "docs_salt_architecture_domain",
       "community": 316,
@@ -36452,7 +36482,7 @@
       "label": "firebase-sync",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L365",
+      "source_location": "L388",
       "_origin": "ast",
       "id": "docs_salt_architecture_firebase_sync",
       "community": 316,
@@ -36462,7 +36492,7 @@
       "label": "observability",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L370",
+      "source_location": "L393",
       "_origin": "ast",
       "id": "docs_salt_architecture_observability",
       "community": 316,
@@ -36472,7 +36502,7 @@
       "label": "Cloud Functions",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L375",
+      "source_location": "L398",
       "_origin": "ast",
       "id": "docs_salt_architecture_cloud_functions",
       "community": 316,
@@ -36482,7 +36512,7 @@
       "label": "UI",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L380",
+      "source_location": "L403",
       "_origin": "ast",
       "id": "docs_salt_architecture_ui",
       "community": 316,
@@ -36492,7 +36522,7 @@
       "label": "13. Deployment units",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L388",
+      "source_location": "L411",
       "_origin": "ast",
       "id": "docs_salt_architecture_13_deployment_units",
       "community": 280,
@@ -36502,7 +36532,7 @@
       "label": "14. Non-negotiables",
       "file_type": "document",
       "source_file": "docs/salt-architecture.md",
-      "source_location": "L400",
+      "source_location": "L423",
       "_origin": "ast",
       "id": "docs_salt_architecture_14_non_negotiables",
       "community": 280,
@@ -37789,7 +37819,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 73,
+      "community": 97,
       "norm_label": "no indexeddb / firestore persistentlocalcache rule",
       "id": "claude_no_idb_firestore_cache"
     },
@@ -37815,7 +37845,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 73,
+      "community": 48,
       "norm_label": "last-write-wins per document",
       "id": "claude_lww_per_document"
     },
@@ -37854,7 +37884,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 73,
+      "community": 65,
       "norm_label": "observability dual subpath (browser vs server)",
       "id": "claude_observability_dual_subpath"
     },
@@ -37867,7 +37897,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 48,
+      "community": 295,
       "norm_label": "boundary enforcement (lint/typecheck/ci)",
       "id": "claude_boundary_enforcement"
     },
@@ -37997,7 +38027,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 89,
+      "community": 53,
       "norm_label": "prod -> staging firestore refresh flow",
       "id": "data_refresh_prod_to_staging_refresh"
     },
@@ -38023,7 +38053,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 89,
+      "community": 53,
       "norm_label": "task pilot sidebar tasks",
       "id": "data_refresh_task_pilot"
     },
@@ -38036,7 +38066,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 89,
+      "community": 53,
       "norm_label": "staging-only hard refuse safety guard",
       "id": "data_refresh_staging_hard_refuse"
     },
@@ -38049,7 +38079,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 89,
+      "community": 53,
       "norm_label": "cross-project import iam (objectviewer + legacybucketreader)",
       "id": "data_refresh_cross_project_iam"
     },
@@ -38088,7 +38118,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 48,
+      "community": 295,
       "norm_label": "provenance header convention",
       "id": "design_ui_spec_v02_provenance_header"
     },
@@ -38335,7 +38365,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 73,
+      "community": 97,
       "norm_label": "realtime cross-tab convergence (long-poll settle)",
       "id": "e2e_test_spec_realtime_convergence"
     },
@@ -38673,7 +38703,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 89,
+      "community": 53,
       "norm_label": "firebase project aliases (default/staging/production)",
       "id": "releases_firebase_projects"
     },
@@ -38725,7 +38755,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 73,
+      "community": 65,
       "norm_label": "posthog project per deploy target",
       "id": "releases_posthog_project_per_env"
     },
@@ -38738,7 +38768,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 89,
       "norm_label": "dev/staging share one google ai studio project",
       "id": "releases_gemini_shared_ai_studio"
     },
@@ -38751,7 +38781,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 73,
+      "community": 97,
       "norm_label": "salt 2.0 architecture contract (prose)",
       "id": "salt_architecture_architecture_contract_doc"
     },
@@ -38777,7 +38807,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 73,
+      "community": 48,
       "norm_label": "schema evolution / end-of-greenfield",
       "id": "salt_architecture_schema_evolution_greenfield"
     },
@@ -38790,7 +38820,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 48,
+      "community": 97,
       "norm_label": "allowed import dependency graph",
       "id": "salt_architecture_dependency_graph"
     },
@@ -38803,7 +38833,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 73,
+      "community": 97,
       "norm_label": "pre-auth localstorage narrow exception",
       "id": "salt_architecture_localstorage_exception"
     },
@@ -38816,7 +38846,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 73,
+      "community": 97,
       "norm_label": "adapter error contract (success/failure/conflict)",
       "id": "salt_architecture_adapter_error_contract"
     },
@@ -38842,7 +38872,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 73,
+      "community": 97,
       "norm_label": "firebase-sync adapter",
       "id": "salt_architecture_firebase_sync_adapter"
     },
@@ -38855,7 +38885,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 73,
+      "community": 65,
       "norm_label": "observability adapter (dual subpath)",
       "id": "salt_architecture_observability_adapter"
     },
@@ -38881,7 +38911,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 73,
+      "community": 97,
       "norm_label": "chatsessions owner-scoped exception",
       "id": "salt_architecture_chat_sessions_owner_scoped"
     },
@@ -38894,7 +38924,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 89,
       "norm_label": "admin-managed model selection (resolvemodel/ai_flow_roles)",
       "id": "salt_architecture_resolve_model_roles"
     },
@@ -38920,7 +38950,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 73,
+      "community": 97,
       "norm_label": "firestore persistentlocalcache offline layer",
       "id": "salt_architecture_persistent_local_cache"
     },
@@ -38933,7 +38963,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 48,
+      "community": 97,
       "norm_label": "enforcement rules (eslint/tsconfig/commit gateway)",
       "id": "salt_architecture_enforcement_rules"
     },
@@ -44558,9 +44588,9 @@
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
       "source_location": "L60",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "triggers_oncanonitemwritten",
-      "target": "triggers_oncanonitemwritten_iconneedsgeneration",
-      "confidence_score": 1.0
+      "target": "triggers_oncanonitemwritten_iconneedsgeneration"
     },
     {
       "relation": "contains",
@@ -44630,9 +44660,9 @@
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
       "source_location": "L85",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "triggers_oncanonitemwritten_maybegenerateicon",
-      "target": "triggers_oncanonitemwritten_iconneedsgeneration",
-      "confidence_score": 1.0
+      "target": "triggers_oncanonitemwritten_iconneedsgeneration"
     },
     {
       "relation": "calls",
@@ -51989,6 +52019,28 @@
       "target": "lib_canonservice_updatecanonitemthreshold"
     },
     {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/canonService.ts",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "lib_canonservice",
+      "target": "lib_errorreporting",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/canonService.ts",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "lib_canonservice",
+      "target": "lib_errorreporting_reportsubscriptionerror",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -53041,6 +53093,28 @@
       "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte",
       "target": "lib_auth_svelte_auth"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte",
+      "target": "lib_errorreporting",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "lib_shoppinglistservice_svelte",
+      "target": "lib_errorreporting_reportsubscriptionerror",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -54788,6 +54862,28 @@
       "target": "lib_canonservice_getcanonitemssnapshot"
     },
     {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/recipeService.ts",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "lib_recipeservice",
+      "target": "lib_errorreporting",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/recipeService.ts",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "lib_recipeservice",
+      "target": "lib_errorreporting_reportsubscriptionerror",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
@@ -55403,6 +55499,28 @@
       "confidence_score": 1.0,
       "source": "lib_chatservice",
       "target": "lib_chatservice_sessions"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/chatService.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "lib_chatservice",
+      "target": "lib_errorreporting",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/chatService.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "lib_chatservice",
+      "target": "lib_errorreporting_reportsubscriptionerror",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -59275,6 +59393,82 @@
       "weight": 1.0,
       "source": "lib_equipmentservice_seedequipmentmanifest",
       "target": "src_equipmentmanifestsubscription_saveequipmentmanifest"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L19",
+      "weight": 1.0,
+      "source": "lib_errorreporting",
+      "target": "lib_errorreporting_reportsubscriptionerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "lib_errorreporting",
+      "target": "src_authtransition_isauthtransitioning",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "lib_errorreporting",
+      "target": "src_errorreportingport_errorreportingport",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "lib_errorreporting",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "tests_errorreporting_test",
+      "target": "lib_errorreporting",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
+      "source_location": "L24",
+      "weight": 1.0,
+      "source": "lib_errorreporting_reportsubscriptionerror",
+      "target": "src_authtransition_isauthtransitioning"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "tests_errorreporting_test",
+      "target": "lib_errorreporting_reportsubscriptionerror",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -64063,6 +64257,38 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "tests_errorreporting_test",
+      "target": "src_errorreportingport_errorreportingport",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "tests_errorreporting_test",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "tests_errorreporting_test",
+      "target": "tests_errorreporting_test_isauthtransitioning",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/tests/mealPlanService.sync.test.ts",
       "source_location": "L3",
       "weight": 1.0,
@@ -66234,6 +66460,16 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/adapters/firebase-sync/src/auth.ts",
+      "source_location": "L55",
+      "weight": 1.0,
+      "source": "src_auth",
+      "target": "src_auth_reportauthfailure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/src/auth.ts",
       "source_location": "L37",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -66249,6 +66485,39 @@
       "confidence_score": 1.0,
       "source": "src_auth",
       "target": "src_auth_touser"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/src/auth.ts",
+      "source_location": "L15",
+      "weight": 1.0,
+      "source": "src_auth",
+      "target": "src_authtransition",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/src/auth.ts",
+      "source_location": "L15",
+      "weight": 1.0,
+      "source": "src_auth",
+      "target": "src_authtransition_isauthtransitioning",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/src/auth.ts",
+      "source_location": "L15",
+      "weight": 1.0,
+      "source": "src_auth",
+      "target": "src_authtransition_setauthtransitioning",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports",
@@ -66306,6 +66575,17 @@
       "target": "src_index_success"
     },
     {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L27",
+      "weight": 1.0,
+      "source": "tests_authtransition_test",
+      "target": "src_auth",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -66328,6 +66608,17 @@
       "target": "src_auth_connectauthemulatoronce"
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/src/auth.ts",
+      "source_location": "L60",
+      "weight": 1.0,
+      "source": "src_auth_reportauthfailure",
+      "target": "src_authtransition_isauthtransitioning",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "re_exports",
       "context": "re-export",
       "confidence": "EXTRACTED",
@@ -66337,6 +66628,92 @@
       "confidence_score": 1.0,
       "source": "packages_adapters_firebase_sync_src_index_ts_src_index",
       "target": "src_auth_createfirebaseauth"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L27",
+      "weight": 1.0,
+      "source": "tests_authtransition_test",
+      "target": "src_auth_createfirebaseauth",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "re_exports",
+      "context": "export",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/src/index.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "packages_adapters_firebase_sync_src_index_ts_src_index",
+      "target": "src_authtransition",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/src/authTransition.ts",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "src_authtransition",
+      "target": "src_authtransition_isauthtransitioning",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/src/authTransition.ts",
+      "source_location": "L21",
+      "weight": 1.0,
+      "source": "src_authtransition",
+      "target": "src_authtransition_setauthtransitioning",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L28",
+      "weight": 1.0,
+      "source": "tests_authtransition_test",
+      "target": "src_authtransition",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L28",
+      "weight": 1.0,
+      "source": "tests_authtransition_test",
+      "target": "src_authtransition_setauthtransitioning",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "re_exports",
+      "context": "re-export",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/src/index.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "packages_adapters_firebase_sync_src_index_ts_src_index",
+      "target": "src_authtransition_isauthtransitioning",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L28",
+      "weight": 1.0,
+      "source": "tests_authtransition_test",
+      "target": "src_authtransition_isauthtransitioning",
+      "confidence_score": 1.0
     },
     {
       "relation": "re_exports",
@@ -69747,6 +70124,57 @@
       "target": "tests_appsettingssync_test_snapcallback"
     },
     {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "tests_authtransition_test",
+      "target": "src_errorreportingport_errorreportingport",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "tests_authtransition_test",
+      "target": "tests_authtransition_test_fbautherror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L10",
+      "weight": 1.0,
+      "source": "tests_authtransition_test",
+      "target": "tests_authtransition_test_fbsignout",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L8",
+      "weight": 1.0,
+      "source": "tests_authtransition_test",
+      "target": "tests_authtransition_test_sendsigninlinktoemail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/firebase-sync/tests/authTransition.test.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "tests_authtransition_test",
+      "target": "tests_authtransition_test_signinwithemaillink",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/adapters/firebase-sync/tests/emulatorHelpers.ts",
@@ -70856,6 +71284,28 @@
     },
     {
       "relation": "re_exports",
+      "context": "export",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/index.ts",
+      "source_location": "L36",
+      "weight": 1.0,
+      "source": "packages_adapters_observability_src_index_ts_src_index",
+      "target": "shared_reportablecategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "re_exports",
+      "context": "re-export",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/index.ts",
+      "source_location": "L36",
+      "weight": 1.0,
+      "source": "packages_adapters_observability_src_index_ts_src_index",
+      "target": "shared_reportablecategory_isreportablecategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "re_exports",
       "context": "re-export",
       "confidence": "EXTRACTED",
       "source_file": "packages/adapters/observability/src/index.ts",
@@ -71364,6 +71814,17 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
+      "source_location": "L21",
+      "weight": 1.0,
+      "source": "tests_posthogerrorreportingadapter_test",
+      "target": "src_init_initobservability",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "packages/adapters/observability/src/sessionTagging.ts",
       "source_location": "L1",
       "weight": 1.0,
@@ -71394,6 +71855,28 @@
       "target": "src_init_observabilityspan"
     },
     {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/posthogErrorReportingAdapter.ts",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_posthogerrorreportingadapter",
+      "target": "shared_reportablecategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/posthogErrorReportingAdapter.ts",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_posthogerrorreportingadapter",
+      "target": "shared_reportablecategory_isreportablecategory",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -71413,6 +71896,28 @@
       "confidence_score": 1.0,
       "source": "src_posthogerrorreportingadapter",
       "target": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "tests_posthogerrorreportingadapter_test",
+      "target": "src_posthogerrorreportingadapter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "tests_posthogerrorreportingadapter_test",
+      "target": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports",
@@ -71753,6 +72258,28 @@
       "confidence_score": 1.0,
       "source": "server_index",
       "target": "shared_matchoutcomeevent_tocanonmatchevent"
+    },
+    {
+      "relation": "re_exports",
+      "context": "export",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/server/index.ts",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "server_index",
+      "target": "shared_reportablecategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "re_exports",
+      "context": "re-export",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/server/index.ts",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "server_index",
+      "target": "shared_reportablecategory_isreportablecategory",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -72319,6 +72846,59 @@
       "target": "shared_matchoutcomeevent_tocanonmatchevent"
     },
     {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/shared/reportableCategory.ts",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "shared_reportablecategory",
+      "target": "shared_reportablecategory_isreportablecategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/shared/reportableCategory.ts",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "shared_reportablecategory",
+      "target": "shared_reportablecategory_suppressed_categories",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/shared/reportableCategory.ts",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "shared_reportablecategory",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportableCategory.test.ts",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "tests_reportablecategory_test",
+      "target": "shared_reportablecategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportableCategory.test.ts",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "tests_reportablecategory_test",
+      "target": "shared_reportablecategory_isreportablecategory",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -72338,6 +72918,38 @@
       "confidence_score": 1.0,
       "source": "tests_matchlogparity_test",
       "target": "tests_matchlogparity_test_fixture"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "tests_posthogerrorreportingadapter_test",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "tests_posthogerrorreportingadapter_test",
+      "target": "tests_posthogerrorreportingadapter_test_captureexception_init",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/reportableCategory.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "tests_reportablecategory_test",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -72699,6 +73311,17 @@
       "confidence_score": 1.0,
       "source": "src_errorreportingport",
       "target": "src_errorreportingport_errorreportingport"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/domain/src/ErrorReportingPort.ts",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "src_errorreportingport",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
     },
     {
       "relation": "re_exports",
@@ -106868,36 +107491,6 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "scripts/export-prod-firestore.mjs",
-      "source_location": "L29",
-      "weight": 1.0,
-      "confidence_score": 1.0,
-      "source": "scripts_export_prod_firestore",
-      "target": "scripts_export_prod_firestore_commandexists"
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "scripts/export-prod-firestore.mjs",
-      "source_location": "L25",
-      "weight": 1.0,
-      "confidence_score": 1.0,
-      "source": "scripts_export_prod_firestore",
-      "target": "scripts_export_prod_firestore_run"
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "scripts/export-prod-firestore.mjs",
-      "source_location": "L65",
-      "weight": 1.0,
-      "confidence_score": 1.0,
-      "source": "scripts_export_prod_firestore",
-      "target": "scripts_export_prod_firestore_stamp"
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
       "source_file": "scripts/free-ports.mjs",
       "source_location": "L58",
       "weight": 1.0,
@@ -106984,46 +107577,6 @@
       "confidence_score": 1.0,
       "source": "users_daniel_projects_saltv2_scripts_grant_callable_invokers_sh",
       "target": "users_daniel_projects_saltv2_scripts_grant_callable_invokers_sh__entry"
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "scripts/restore-staging-from-prod.mjs",
-      "source_location": "L49",
-      "weight": 1.0,
-      "confidence_score": 1.0,
-      "source": "scripts_restore_staging_from_prod",
-      "target": "scripts_restore_staging_from_prod_ask"
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "scripts/restore-staging-from-prod.mjs",
-      "source_location": "L40",
-      "weight": 1.0,
-      "confidence_score": 1.0,
-      "source": "scripts_restore_staging_from_prod",
-      "target": "scripts_restore_staging_from_prod_commandexists"
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "scripts/restore-staging-from-prod.mjs",
-      "source_location": "L72",
-      "weight": 1.0,
-      "confidence_score": 1.0,
-      "source": "scripts_restore_staging_from_prod",
-      "target": "scripts_restore_staging_from_prod_exportpath"
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "scripts/restore-staging-from-prod.mjs",
-      "source_location": "L36",
-      "weight": 1.0,
-      "confidence_score": 1.0,
-      "source": "scripts_restore_staging_from_prod",
-      "target": "scripts_restore_staging_from_prod_run"
     },
     {
       "relation": "contains",
@@ -108572,9 +109125,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect",
-      "target": "commands_defect_defect_spec",
-      "confidence_score": 1.0
+      "target": "commands_defect_defect_spec"
     },
     {
       "relation": "contains",
@@ -108582,9 +109135,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L63",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_defect_spec",
-      "target": "commands_defect_architecture_notes_constraints",
-      "confidence_score": 1.0
+      "target": "commands_defect_architecture_notes_constraints"
     },
     {
       "relation": "contains",
@@ -108592,9 +109145,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L59",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_defect_spec",
-      "target": "commands_defect_blast_radius",
-      "confidence_score": 1.0
+      "target": "commands_defect_blast_radius"
     },
     {
       "relation": "contains",
@@ -108602,9 +109155,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L94",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_defect_spec",
-      "target": "commands_defect_definition_of_done",
-      "confidence_score": 1.0
+      "target": "commands_defect_definition_of_done"
     },
     {
       "relation": "references",
@@ -108622,9 +109175,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L48",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_defect_spec",
-      "target": "commands_defect_observed_vs_expected",
-      "confidence_score": 1.0
+      "target": "commands_defect_observed_vs_expected"
     },
     {
       "relation": "contains",
@@ -108632,9 +109185,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L68",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_defect_spec",
-      "target": "commands_defect_open_questions_decisions",
-      "confidence_score": 1.0
+      "target": "commands_defect_open_questions_decisions"
     },
     {
       "relation": "contains",
@@ -108642,9 +109195,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L75",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_defect_spec",
-      "target": "commands_defect_phases",
-      "confidence_score": 1.0
+      "target": "commands_defect_phases"
     },
     {
       "relation": "contains",
@@ -108652,9 +109205,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L52",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_defect_spec",
-      "target": "commands_defect_reproduction",
-      "confidence_score": 1.0
+      "target": "commands_defect_reproduction"
     },
     {
       "relation": "contains",
@@ -108662,9 +109215,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L55",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_defect_spec",
-      "target": "commands_defect_root_cause",
-      "confidence_score": 1.0
+      "target": "commands_defect_root_cause"
     },
     {
       "relation": "references",
@@ -108682,9 +109235,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_defect_spec",
-      "target": "commands_defect_step_1_reproduce_triage",
-      "confidence_score": 1.0
+      "target": "commands_defect_step_1_reproduce_triage"
     },
     {
       "relation": "contains",
@@ -108692,9 +109245,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L21",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_defect_spec",
-      "target": "commands_defect_step_2_root_cause_investigation",
-      "confidence_score": 1.0
+      "target": "commands_defect_step_2_root_cause_investigation"
     },
     {
       "relation": "contains",
@@ -108702,9 +109255,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L30",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_defect_spec",
-      "target": "commands_defect_step_3_clarify_with_user",
-      "confidence_score": 1.0
+      "target": "commands_defect_step_3_clarify_with_user"
     },
     {
       "relation": "contains",
@@ -108712,9 +109265,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L38",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_defect_spec",
-      "target": "commands_defect_step_4_draft_and_post_the_issue",
-      "confidence_score": 1.0
+      "target": "commands_defect_step_4_draft_and_post_the_issue"
     },
     {
       "relation": "contains",
@@ -108722,9 +109275,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L5",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_defect_spec",
-      "target": "commands_defect_when_to_use_this",
-      "confidence_score": 1.0
+      "target": "commands_defect_when_to_use_this"
     },
     {
       "relation": "semantically_similar_to",
@@ -108742,9 +109295,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L80",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_phases",
-      "target": "commands_defect_phase_1_name",
-      "confidence_score": 1.0
+      "target": "commands_defect_phase_1_name"
     },
     {
       "relation": "contains",
@@ -108752,9 +109305,9 @@
       "source_file": ".claude/commands/defect.md",
       "source_location": "L86",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_defect_phases",
-      "target": "commands_defect_phase_2_name",
-      "confidence_score": 1.0
+      "target": "commands_defect_phase_2_name"
     },
     {
       "relation": "contains",
@@ -108762,9 +109315,9 @@
       "source_file": ".claude/commands/refactor-spec.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_refactor_spec",
-      "target": "commands_refactor_spec_refactor_spec",
-      "confidence_score": 1.0
+      "target": "commands_refactor_spec_refactor_spec"
     },
     {
       "relation": "contains",
@@ -108772,9 +109325,9 @@
       "source_file": ".claude/commands/refactor-spec.md",
       "source_location": "L47",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_refactor_spec_refactor_spec",
-      "target": "commands_refactor_spec_architecture_notes",
-      "confidence_score": 1.0
+      "target": "commands_refactor_spec_architecture_notes"
     },
     {
       "relation": "references",
@@ -108792,9 +109345,9 @@
       "source_file": ".claude/commands/refactor-spec.md",
       "source_location": "L30",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_refactor_spec_refactor_spec",
-      "target": "commands_refactor_spec_current_state_motivation",
-      "confidence_score": 1.0
+      "target": "commands_refactor_spec_current_state_motivation"
     },
     {
       "relation": "contains",
@@ -108802,9 +109355,9 @@
       "source_file": ".claude/commands/refactor-spec.md",
       "source_location": "L80",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_refactor_spec_refactor_spec",
-      "target": "commands_refactor_spec_definition_of_done",
-      "confidence_score": 1.0
+      "target": "commands_refactor_spec_definition_of_done"
     },
     {
       "relation": "contains",
@@ -108812,9 +109365,9 @@
       "source_file": ".claude/commands/refactor-spec.md",
       "source_location": "L52",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_refactor_spec_refactor_spec",
-      "target": "commands_refactor_spec_open_questions_decisions",
-      "confidence_score": 1.0
+      "target": "commands_refactor_spec_open_questions_decisions"
     },
     {
       "relation": "contains",
@@ -108822,9 +109375,9 @@
       "source_file": ".claude/commands/refactor-spec.md",
       "source_location": "L59",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_refactor_spec_refactor_spec",
-      "target": "commands_refactor_spec_phases",
-      "confidence_score": 1.0
+      "target": "commands_refactor_spec_phases"
     },
     {
       "relation": "contains",
@@ -108832,9 +109385,9 @@
       "source_file": ".claude/commands/refactor-spec.md",
       "source_location": "L5",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_refactor_spec_refactor_spec",
-      "target": "commands_refactor_spec_step_0_behavior_preserving",
-      "confidence_score": 1.0
+      "target": "commands_refactor_spec_step_0_behavior_preserving"
     },
     {
       "relation": "contains",
@@ -108842,9 +109395,9 @@
       "source_file": ".claude/commands/refactor-spec.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_refactor_spec_refactor_spec",
-      "target": "commands_refactor_spec_step_1_architecture_read",
-      "confidence_score": 1.0
+      "target": "commands_refactor_spec_step_1_architecture_read"
     },
     {
       "relation": "contains",
@@ -108852,9 +109405,9 @@
       "source_file": ".claude/commands/refactor-spec.md",
       "source_location": "L15",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_refactor_spec_refactor_spec",
-      "target": "commands_refactor_spec_step_2_clarify_with_user",
-      "confidence_score": 1.0
+      "target": "commands_refactor_spec_step_2_clarify_with_user"
     },
     {
       "relation": "contains",
@@ -108862,9 +109415,9 @@
       "source_file": ".claude/commands/refactor-spec.md",
       "source_location": "L20",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_refactor_spec_refactor_spec",
-      "target": "commands_refactor_spec_step_3_draft_and_post_the_issue",
-      "confidence_score": 1.0
+      "target": "commands_refactor_spec_step_3_draft_and_post_the_issue"
     },
     {
       "relation": "contains",
@@ -108872,9 +109425,9 @@
       "source_file": ".claude/commands/refactor-spec.md",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_refactor_spec_refactor_spec",
-      "target": "commands_refactor_spec_verification_strategy",
-      "confidence_score": 1.0
+      "target": "commands_refactor_spec_verification_strategy"
     },
     {
       "relation": "references",
@@ -108902,9 +109455,9 @@
       "source_file": ".claude/commands/refactor-spec.md",
       "source_location": "L64",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_refactor_spec_phases",
-      "target": "commands_refactor_spec_phase_1_name",
-      "confidence_score": 1.0
+      "target": "commands_refactor_spec_phase_1_name"
     },
     {
       "relation": "contains",
@@ -108912,9 +109465,9 @@
       "source_file": ".claude/commands/refactor-spec.md",
       "source_location": "L71",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_refactor_spec_phases",
-      "target": "commands_refactor_spec_phase_2_name",
-      "confidence_score": 1.0
+      "target": "commands_refactor_spec_phase_2_name"
     },
     {
       "relation": "contains",
@@ -108922,9 +109475,9 @@
       "source_file": ".claude/commands/run.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_run",
-      "target": "commands_run_run_issue",
-      "confidence_score": 1.0
+      "target": "commands_run_run_issue"
     },
     {
       "relation": "references",
@@ -108952,9 +109505,9 @@
       "source_file": ".claude/commands/run.md",
       "source_location": "L169",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_run_run_issue",
-      "target": "commands_run_pause_conditions_stop_and_wait_for_user",
-      "confidence_score": 1.0
+      "target": "commands_run_pause_conditions_stop_and_wait_for_user"
     },
     {
       "relation": "contains",
@@ -108962,9 +109515,9 @@
       "source_file": ".claude/commands/run.md",
       "source_location": "L38",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_run_run_issue",
-      "target": "commands_run_per_phase_loop_n_1_to_final",
-      "confidence_score": 1.0
+      "target": "commands_run_per_phase_loop_n_1_to_final"
     },
     {
       "relation": "contains",
@@ -108972,9 +109525,9 @@
       "source_file": ".claude/commands/run.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_run_run_issue",
-      "target": "commands_run_setup_once",
-      "confidence_score": 1.0
+      "target": "commands_run_setup_once"
     },
     {
       "relation": "conceptually_related_to",
@@ -109002,9 +109555,9 @@
       "source_file": ".claude/commands/run.md",
       "source_location": "L20",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_run_setup_once",
-      "target": "commands_run_create_the_working_branch_once_before_phase_1",
-      "confidence_score": 1.0
+      "target": "commands_run_create_the_working_branch_once_before_phase_1"
     },
     {
       "relation": "contains",
@@ -109012,9 +109565,9 @@
       "source_file": ".claude/commands/run.md",
       "source_location": "L40",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_run_per_phase_loop_n_1_to_final",
-      "target": "commands_run_1_architecture_context_explore_subagent",
-      "confidence_score": 1.0
+      "target": "commands_run_1_architecture_context_explore_subagent"
     },
     {
       "relation": "contains",
@@ -109022,9 +109575,9 @@
       "source_file": ".claude/commands/run.md",
       "source_location": "L47",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_run_per_phase_loop_n_1_to_final",
-      "target": "commands_run_2_implementation_claude_subagent_isolation_worktree",
-      "confidence_score": 1.0
+      "target": "commands_run_2_implementation_claude_subagent_isolation_worktree"
     },
     {
       "relation": "contains",
@@ -109032,9 +109585,9 @@
       "source_file": ".claude/commands/run.md",
       "source_location": "L66",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_run_per_phase_loop_n_1_to_final",
-      "target": "commands_run_3_validation",
-      "confidence_score": 1.0
+      "target": "commands_run_3_validation"
     },
     {
       "relation": "contains",
@@ -109042,9 +109595,9 @@
       "source_file": ".claude/commands/run.md",
       "source_location": "L77",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_run_per_phase_loop_n_1_to_final",
-      "target": "commands_run_4_post_handoff_contract",
-      "confidence_score": 1.0
+      "target": "commands_run_4_post_handoff_contract"
     },
     {
       "relation": "contains",
@@ -109052,9 +109605,9 @@
       "source_file": ".claude/commands/run.md",
       "source_location": "L102",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_run_per_phase_loop_n_1_to_final",
-      "target": "commands_run_5_ux_deviation_comment_only_if_ux_delta_is_non_empty",
-      "confidence_score": 1.0
+      "target": "commands_run_5_ux_deviation_comment_only_if_ux_delta_is_non_empty"
     },
     {
       "relation": "contains",
@@ -109062,9 +109615,9 @@
       "source_file": ".claude/commands/run.md",
       "source_location": "L118",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_run_per_phase_loop_n_1_to_final",
-      "target": "commands_run_6_merge_and_commit",
-      "confidence_score": 1.0
+      "target": "commands_run_6_merge_and_commit"
     },
     {
       "relation": "contains",
@@ -109072,9 +109625,9 @@
       "source_file": ".claude/commands/run.md",
       "source_location": "L139",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_run_per_phase_loop_n_1_to_final",
-      "target": "commands_run_7_continue_or_conclude",
-      "confidence_score": 1.0
+      "target": "commands_run_7_continue_or_conclude"
     },
     {
       "relation": "contains",
@@ -109082,9 +109635,9 @@
       "source_file": ".claude/commands/spec.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_spec",
-      "target": "commands_spec_feature_spec",
-      "confidence_score": 1.0
+      "target": "commands_spec_feature_spec"
     },
     {
       "relation": "contains",
@@ -109092,9 +109645,9 @@
       "source_file": ".claude/commands/spec.md",
       "source_location": "L25",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_spec_feature_spec",
-      "target": "commands_spec_architecture_notes",
-      "confidence_score": 1.0
+      "target": "commands_spec_architecture_notes"
     },
     {
       "relation": "contains",
@@ -109102,9 +109655,9 @@
       "source_file": ".claude/commands/spec.md",
       "source_location": "L56",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_spec_feature_spec",
-      "target": "commands_spec_definition_of_done",
-      "confidence_score": 1.0
+      "target": "commands_spec_definition_of_done"
     },
     {
       "relation": "references",
@@ -109122,9 +109675,9 @@
       "source_file": ".claude/commands/spec.md",
       "source_location": "L29",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_spec_feature_spec",
-      "target": "commands_spec_open_questions_decisions",
-      "confidence_score": 1.0
+      "target": "commands_spec_open_questions_decisions"
     },
     {
       "relation": "references",
@@ -109142,9 +109695,9 @@
       "source_file": ".claude/commands/spec.md",
       "source_location": "L37",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_spec_feature_spec",
-      "target": "commands_spec_phases",
-      "confidence_score": 1.0
+      "target": "commands_spec_phases"
     },
     {
       "relation": "contains",
@@ -109152,9 +109705,9 @@
       "source_file": ".claude/commands/spec.md",
       "source_location": "L5",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_spec_feature_spec",
-      "target": "commands_spec_step_1_architecture_read",
-      "confidence_score": 1.0
+      "target": "commands_spec_step_1_architecture_read"
     },
     {
       "relation": "contains",
@@ -109162,9 +109715,9 @@
       "source_file": ".claude/commands/spec.md",
       "source_location": "L8",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_spec_feature_spec",
-      "target": "commands_spec_step_2_clarify_with_user",
-      "confidence_score": 1.0
+      "target": "commands_spec_step_2_clarify_with_user"
     },
     {
       "relation": "contains",
@@ -109172,9 +109725,9 @@
       "source_file": ".claude/commands/spec.md",
       "source_location": "L11",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_spec_feature_spec",
-      "target": "commands_spec_step_3_draft_and_post_the_issue",
-      "confidence_score": 1.0
+      "target": "commands_spec_step_3_draft_and_post_the_issue"
     },
     {
       "relation": "references",
@@ -109192,9 +109745,9 @@
       "source_file": ".claude/commands/spec.md",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_spec_phases",
-      "target": "commands_spec_phase_1_name",
-      "confidence_score": 1.0
+      "target": "commands_spec_phase_1_name"
     },
     {
       "relation": "contains",
@@ -109202,9 +109755,9 @@
       "source_file": ".claude/commands/spec.md",
       "source_location": "L48",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "commands_spec_phases",
-      "target": "commands_spec_phase_2_name",
-      "confidence_score": 1.0
+      "target": "commands_spec_phase_2_name"
     },
     {
       "relation": "contains",
@@ -109212,9 +109765,9 @@
       "source_file": ".github/copilot-instructions.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "github_copilot_instructions",
-      "target": "github_copilot_instructions_vexp_context_tools_vexp_v2_0_23",
-      "confidence_score": 1.0
+      "target": "github_copilot_instructions_vexp_context_tools_vexp_v2_0_23"
     },
     {
       "relation": "contains",
@@ -109222,9 +109775,9 @@
       "source_file": ".github/copilot-instructions.md",
       "source_location": "L18",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "github_copilot_instructions_vexp_context_tools_vexp_v2_0_23",
-      "target": "github_copilot_instructions_agentic_search",
-      "confidence_score": 1.0
+      "target": "github_copilot_instructions_agentic_search"
     },
     {
       "relation": "contains",
@@ -109232,9 +109785,9 @@
       "source_file": ".github/copilot-instructions.md",
       "source_location": "L11",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "github_copilot_instructions_vexp_context_tools_vexp_v2_0_23",
-      "target": "github_copilot_instructions_available_mcp_tools",
-      "confidence_score": 1.0
+      "target": "github_copilot_instructions_available_mcp_tools"
     },
     {
       "relation": "contains",
@@ -109242,9 +109795,9 @@
       "source_file": ".github/copilot-instructions.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "github_copilot_instructions_vexp_context_tools_vexp_v2_0_23",
-      "target": "github_copilot_instructions_multi_repo",
-      "confidence_score": 1.0
+      "target": "github_copilot_instructions_multi_repo"
     },
     {
       "relation": "contains",
@@ -109252,9 +109805,9 @@
       "source_file": ".github/copilot-instructions.md",
       "source_location": "L23",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "github_copilot_instructions_vexp_context_tools_vexp_v2_0_23",
-      "target": "github_copilot_instructions_smart_features",
-      "confidence_score": 1.0
+      "target": "github_copilot_instructions_smart_features"
     },
     {
       "relation": "contains",
@@ -109262,9 +109815,9 @@
       "source_file": ".github/copilot-instructions.md",
       "source_location": "L6",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "github_copilot_instructions_vexp_context_tools_vexp_v2_0_23",
-      "target": "github_copilot_instructions_workflow",
-      "confidence_score": 1.0
+      "target": "github_copilot_instructions_workflow"
     },
     {
       "relation": "contains",
@@ -109272,9 +109825,9 @@
       "source_file": "CLAUDE.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "claude",
-      "target": "claude_salt_2_0_architecture_contract_for_ai_agents",
-      "confidence_score": 1.0
+      "target": "claude_salt_2_0_architecture_contract_for_ai_agents"
     },
     {
       "relation": "references",
@@ -109282,9 +109835,9 @@
       "source_file": "CLAUDE.md",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "claude",
-      "target": "docs_salt_architecture",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture"
     },
     {
       "relation": "references",
@@ -109292,9 +109845,9 @@
       "source_file": "README.md",
       "source_location": "L5",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "readme",
-      "target": "claude",
-      "confidence_score": 1.0
+      "target": "claude"
     },
     {
       "relation": "contains",
@@ -109302,9 +109855,9 @@
       "source_file": "CLAUDE.md",
       "source_location": "L40",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
-      "target": "claude_ai_genkit_conventions",
-      "confidence_score": 1.0
+      "target": "claude_ai_genkit_conventions"
     },
     {
       "relation": "contains",
@@ -109312,9 +109865,49 @@
       "source_file": "CLAUDE.md",
       "source_location": "L34",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
-      "target": "claude_data_model_conventions",
-      "confidence_score": 1.0
+      "target": "claude_data_model_conventions"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L63",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
+      "target": "claude_enforcement"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L84",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
+      "target": "claude_graphify"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L21",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
+      "target": "claude_hard_rules"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
+      "target": "claude_layer_map"
     },
     {
       "relation": "contains",
@@ -109323,37 +109916,7 @@
       "source_location": "L63",
       "weight": 1.0,
       "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
-      "target": "claude_enforcement",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
-      "source_location": "L84",
-      "weight": 1.0,
-      "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
-      "target": "claude_graphify",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
-      "source_location": "L21",
-      "weight": 1.0,
-      "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
-      "target": "claude_hard_rules",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
-      "source_location": "L5",
-      "weight": 1.0,
-      "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
-      "target": "claude_layer_map",
+      "target": "claude_observability_error_reporting_conventions",
       "confidence_score": 1.0
     },
     {
@@ -109362,9 +109925,9 @@
       "source_file": "CLAUDE.md",
       "source_location": "L71",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
-      "target": "claude_package_names",
-      "confidence_score": 1.0
+      "target": "claude_package_names"
     },
     {
       "relation": "contains",
@@ -109372,9 +109935,9 @@
       "source_file": "CLAUDE.md",
       "source_location": "L46",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
-      "target": "claude_workflow",
-      "confidence_score": 1.0
+      "target": "claude_workflow"
     },
     {
       "relation": "contains",
@@ -109382,9 +109945,9 @@
       "source_file": "CLAUDE.md",
       "source_location": "L51",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "claude_salt_2_0_architecture_contract_for_ai_agents",
-      "target": "claude_zod_schema_conventions",
-      "confidence_score": 1.0
+      "target": "claude_zod_schema_conventions"
     },
     {
       "relation": "semantically_similar_to",
@@ -109432,9 +109995,9 @@
       "source_file": "README.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "readme",
-      "target": "docs_e2e",
-      "confidence_score": 1.0
+      "target": "docs_e2e"
     },
     {
       "relation": "references",
@@ -109442,9 +110005,9 @@
       "source_file": "README.md",
       "source_location": "L6",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "readme",
-      "target": "docs_salt_architecture",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture"
     },
     {
       "relation": "contains",
@@ -109452,9 +110015,9 @@
       "source_file": "README.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "readme",
-      "target": "readme_salt_2_0",
-      "confidence_score": 1.0
+      "target": "readme_salt_2_0"
     },
     {
       "relation": "contains",
@@ -109462,9 +110025,9 @@
       "source_file": "README.md",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "readme_salt_2_0",
-      "target": "readme_getting_started",
-      "confidence_score": 1.0
+      "target": "readme_getting_started"
     },
     {
       "relation": "contains",
@@ -109472,9 +110035,9 @@
       "source_file": "docs/ai-kitchen-assistant.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_ai_kitchen_assistant",
-      "target": "docs_ai_kitchen_assistant_ai_kitchen_assistant",
-      "confidence_score": 1.0
+      "target": "docs_ai_kitchen_assistant_ai_kitchen_assistant"
     },
     {
       "relation": "references",
@@ -109537,6 +110100,66 @@
       "target": "ai_kitchen_assistant_librarian_flow"
     },
     {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/ai-kitchen-assistant.md",
+      "source_location": "L56",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_ai_kitchen_assistant_ai_kitchen_assistant",
+      "target": "docs_ai_kitchen_assistant_components"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/ai-kitchen-assistant.md",
+      "source_location": "L122",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_ai_kitchen_assistant_ai_kitchen_assistant",
+      "target": "docs_ai_kitchen_assistant_constraints_inherited_from_the_architecture"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/ai-kitchen-assistant.md",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_ai_kitchen_assistant_ai_kitchen_assistant",
+      "target": "docs_ai_kitchen_assistant_design_principles_load_bearing_do_not_violate"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/ai-kitchen-assistant.md",
+      "source_location": "L37",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_ai_kitchen_assistant_ai_kitchen_assistant",
+      "target": "docs_ai_kitchen_assistant_per_user_data_a_deliberate_first"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/ai-kitchen-assistant.md",
+      "source_location": "L29",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_ai_kitchen_assistant_ai_kitchen_assistant",
+      "target": "docs_ai_kitchen_assistant_scope_boundaries"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/ai-kitchen-assistant.md",
+      "source_location": "L115",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_ai_kitchen_assistant_ai_kitchen_assistant",
+      "target": "docs_ai_kitchen_assistant_surfaces_web_pwa"
+    },
+    {
       "relation": "references",
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
@@ -109550,71 +110173,11 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/ai-kitchen-assistant.md",
-      "source_location": "L56",
-      "weight": 1.0,
-      "source": "docs_ai_kitchen_assistant_ai_kitchen_assistant",
-      "target": "docs_ai_kitchen_assistant_components",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/ai-kitchen-assistant.md",
-      "source_location": "L122",
-      "weight": 1.0,
-      "source": "docs_ai_kitchen_assistant_ai_kitchen_assistant",
-      "target": "docs_ai_kitchen_assistant_constraints_inherited_from_the_architecture",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/ai-kitchen-assistant.md",
-      "source_location": "L8",
-      "weight": 1.0,
-      "source": "docs_ai_kitchen_assistant_ai_kitchen_assistant",
-      "target": "docs_ai_kitchen_assistant_design_principles_load_bearing_do_not_violate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/ai-kitchen-assistant.md",
-      "source_location": "L37",
-      "weight": 1.0,
-      "source": "docs_ai_kitchen_assistant_ai_kitchen_assistant",
-      "target": "docs_ai_kitchen_assistant_per_user_data_a_deliberate_first",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/ai-kitchen-assistant.md",
-      "source_location": "L29",
-      "weight": 1.0,
-      "source": "docs_ai_kitchen_assistant_ai_kitchen_assistant",
-      "target": "docs_ai_kitchen_assistant_scope_boundaries",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/ai-kitchen-assistant.md",
-      "source_location": "L115",
-      "weight": 1.0,
-      "source": "docs_ai_kitchen_assistant_ai_kitchen_assistant",
-      "target": "docs_ai_kitchen_assistant_surfaces_web_pwa",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/ai-kitchen-assistant.md",
       "source_location": "L65",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_ai_kitchen_assistant_components",
-      "target": "docs_ai_kitchen_assistant_1_chat_session_data_persistence",
-      "confidence_score": 1.0
+      "target": "docs_ai_kitchen_assistant_1_chat_session_data_persistence"
     },
     {
       "relation": "contains",
@@ -109622,9 +110185,9 @@
       "source_file": "docs/ai-kitchen-assistant.md",
       "source_location": "L84",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_ai_kitchen_assistant_components",
-      "target": "docs_ai_kitchen_assistant_2_chef_flow_the_conversation",
-      "confidence_score": 1.0
+      "target": "docs_ai_kitchen_assistant_2_chef_flow_the_conversation"
     },
     {
       "relation": "contains",
@@ -109632,9 +110195,9 @@
       "source_file": "docs/ai-kitchen-assistant.md",
       "source_location": "L101",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_ai_kitchen_assistant_components",
-      "target": "docs_ai_kitchen_assistant_3_librarian_flow_conversation_recipe",
-      "confidence_score": 1.0
+      "target": "docs_ai_kitchen_assistant_3_librarian_flow_conversation_recipe"
     },
     {
       "relation": "contains",
@@ -109642,9 +110205,9 @@
       "source_file": "docs/architecture/canon-matching/logging.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "canon_matching_logging",
-      "target": "canon_matching_logging_canon_matching_logging_observability",
-      "confidence_score": 1.0
+      "target": "canon_matching_logging_canon_matching_logging_observability"
     },
     {
       "relation": "contains",
@@ -109652,9 +110215,9 @@
       "source_file": "docs/architecture/canon-matching/logging.md",
       "source_location": "L80",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "canon_matching_logging_canon_matching_logging_observability",
-      "target": "canon_matching_logging_adapter_behaviour",
-      "confidence_score": 1.0
+      "target": "canon_matching_logging_adapter_behaviour"
     },
     {
       "relation": "contains",
@@ -109662,9 +110225,9 @@
       "source_file": "docs/architecture/canon-matching/logging.md",
       "source_location": "L63",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "canon_matching_logging_canon_matching_logging_observability",
-      "target": "canon_matching_logging_builder",
-      "confidence_score": 1.0
+      "target": "canon_matching_logging_builder"
     },
     {
       "relation": "contains",
@@ -109672,9 +110235,9 @@
       "source_file": "docs/architecture/canon-matching/logging.md",
       "source_location": "L104",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "canon_matching_logging_canon_matching_logging_observability",
-      "target": "canon_matching_logging_how_to_inspect_logs_manually",
-      "confidence_score": 1.0
+      "target": "canon_matching_logging_how_to_inspect_logs_manually"
     },
     {
       "relation": "contains",
@@ -109682,9 +110245,9 @@
       "source_file": "docs/architecture/canon-matching/logging.md",
       "source_location": "L50",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "canon_matching_logging_canon_matching_logging_observability",
-      "target": "canon_matching_logging_port_contract",
-      "confidence_score": 1.0
+      "target": "canon_matching_logging_port_contract"
     },
     {
       "relation": "contains",
@@ -109692,9 +110255,9 @@
       "source_file": "docs/architecture/canon-matching/logging.md",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "canon_matching_logging_canon_matching_logging_observability",
-      "target": "canon_matching_logging_purpose",
-      "confidence_score": 1.0
+      "target": "canon_matching_logging_purpose"
     },
     {
       "relation": "contains",
@@ -109702,9 +110265,9 @@
       "source_file": "docs/architecture/canon-matching/logging.md",
       "source_location": "L15",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "canon_matching_logging_canon_matching_logging_observability",
-      "target": "canon_matching_logging_schema",
-      "confidence_score": 1.0
+      "target": "canon_matching_logging_schema"
     },
     {
       "relation": "contains",
@@ -109712,9 +110275,9 @@
       "source_file": "docs/canon-icons.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_canon_icons",
-      "target": "docs_canon_icons_canon_item_icons_tier_1_pictograms",
-      "confidence_score": 1.0
+      "target": "docs_canon_icons_canon_item_icons_tier_1_pictograms"
     },
     {
       "relation": "references",
@@ -109752,9 +110315,9 @@
       "source_file": "docs/canon-icons.md",
       "source_location": "L148",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_canon_icons_canon_item_icons_tier_1_pictograms",
-      "target": "docs_canon_icons_architecture_contract_notes",
-      "confidence_score": 1.0
+      "target": "docs_canon_icons_architecture_contract_notes"
     },
     {
       "relation": "contains",
@@ -109762,9 +110325,9 @@
       "source_file": "docs/canon-icons.md",
       "source_location": "L35",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_canon_icons_canon_item_icons_tier_1_pictograms",
-      "target": "docs_canon_icons_data_model",
-      "confidence_score": 1.0
+      "target": "docs_canon_icons_data_model"
     },
     {
       "relation": "contains",
@@ -109772,9 +110335,9 @@
       "source_file": "docs/canon-icons.md",
       "source_location": "L50",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_canon_icons_canon_item_icons_tier_1_pictograms",
-      "target": "docs_canon_icons_generation_pipeline",
-      "confidence_score": 1.0
+      "target": "docs_canon_icons_generation_pipeline"
     },
     {
       "relation": "contains",
@@ -109782,9 +110345,9 @@
       "source_file": "docs/canon-icons.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_canon_icons_canon_item_icons_tier_1_pictograms",
-      "target": "docs_canon_icons_house_style_proven_in_prototype",
-      "confidence_score": 1.0
+      "target": "docs_canon_icons_house_style_proven_in_prototype"
     },
     {
       "relation": "contains",
@@ -109792,9 +110355,9 @@
       "source_file": "docs/canon-icons.md",
       "source_location": "L159",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_canon_icons_canon_item_icons_tier_1_pictograms",
-      "target": "docs_canon_icons_out_of_scope",
-      "confidence_score": 1.0
+      "target": "docs_canon_icons_out_of_scope"
     },
     {
       "relation": "contains",
@@ -109802,9 +110365,9 @@
       "source_file": "docs/canon-icons.md",
       "source_location": "L164",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_canon_icons_canon_item_icons_tier_1_pictograms",
-      "target": "docs_canon_icons_proven_prompt_verbatim_reproduce_exactly",
-      "confidence_score": 1.0
+      "target": "docs_canon_icons_proven_prompt_verbatim_reproduce_exactly"
     },
     {
       "relation": "contains",
@@ -109812,9 +110375,9 @@
       "source_file": "docs/canon-icons.md",
       "source_location": "L116",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_canon_icons_canon_item_icons_tier_1_pictograms",
-      "target": "docs_canon_icons_rendering",
-      "confidence_score": 1.0
+      "target": "docs_canon_icons_rendering"
     },
     {
       "relation": "contains",
@@ -109822,9 +110385,9 @@
       "source_file": "docs/canon-icons.md",
       "source_location": "L85",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_canon_icons_canon_item_icons_tier_1_pictograms",
-      "target": "docs_canon_icons_storage",
-      "confidence_score": 1.0
+      "target": "docs_canon_icons_storage"
     },
     {
       "relation": "contains",
@@ -109832,9 +110395,9 @@
       "source_file": "docs/canon-icons.md",
       "source_location": "L15",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_canon_icons_canon_item_icons_tier_1_pictograms",
-      "target": "docs_canon_icons_two_tier_image_system_important_context",
-      "confidence_score": 1.0
+      "target": "docs_canon_icons_two_tier_image_system_important_context"
     },
     {
       "relation": "contains",
@@ -109842,9 +110405,9 @@
       "source_file": "docs/canon-icons.md",
       "source_location": "L5",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_canon_icons_canon_item_icons_tier_1_pictograms",
-      "target": "docs_canon_icons_what_this_is",
-      "confidence_score": 1.0
+      "target": "docs_canon_icons_what_this_is"
     },
     {
       "relation": "cites",
@@ -109862,9 +110425,9 @@
       "source_file": "docs/canon-icons.md",
       "source_location": "L94",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_canon_icons_storage",
-      "target": "docs_canon_icons_provisioning_one_time_per_environment",
-      "confidence_score": 1.0
+      "target": "docs_canon_icons_provisioning_one_time_per_environment"
     },
     {
       "relation": "contains",
@@ -109872,79 +110435,9 @@
       "source_file": "docs/canon-icons.md",
       "source_location": "L125",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_canon_icons_rendering",
-      "target": "docs_canon_icons_canonicon_props",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L1",
-      "weight": 1.0,
-      "source": "docs_data_refresh",
-      "target": "docs_data_refresh_refreshing_staging_with_prod_data",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L73",
-      "weight": 1.0,
-      "source": "docs_data_refresh_refreshing_staging_with_prod_data",
-      "target": "docs_data_refresh_after_a_restore_re_apply_staging_only_config",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L24",
-      "weight": 1.0,
-      "source": "docs_data_refresh_refreshing_staging_with_prod_data",
-      "target": "docs_data_refresh_one_time_setup",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L66",
-      "weight": 1.0,
-      "source": "docs_data_refresh_refreshing_staging_with_prod_data",
-      "target": "docs_data_refresh_safety",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L88",
-      "weight": 1.0,
-      "source": "docs_data_refresh_refreshing_staging_with_prod_data",
-      "target": "docs_data_refresh_scope",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L59",
-      "weight": 1.0,
-      "source": "docs_data_refresh_refreshing_staging_with_prod_data",
-      "target": "docs_data_refresh_usage",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/data-refresh.md",
-      "source_location": "L13",
-      "weight": 1.0,
-      "source": "docs_data_refresh_refreshing_staging_with_prod_data",
-      "target": "docs_data_refresh_why_managed_export_import_and_not_a_copy_script",
-      "confidence_score": 1.0
+      "target": "docs_canon_icons_canonicon_props"
     },
     {
       "relation": "contains",
@@ -109952,9 +110445,9 @@
       "source_file": "docs/design/design.md",
       "source_location": "L118",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_design",
-      "target": "design_design_brand_style",
-      "confidence_score": 1.0
+      "target": "design_design_brand_style"
     },
     {
       "relation": "contains",
@@ -109962,9 +110455,9 @@
       "source_file": "docs/design/design.md",
       "source_location": "L124",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_design",
-      "target": "design_design_colors",
-      "confidence_score": 1.0
+      "target": "design_design_colors"
     },
     {
       "relation": "contains",
@@ -109972,9 +110465,9 @@
       "source_file": "docs/design/design.md",
       "source_location": "L158",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_design",
-      "target": "design_design_components",
-      "confidence_score": 1.0
+      "target": "design_design_components"
     },
     {
       "relation": "contains",
@@ -109982,49 +110475,9 @@
       "source_file": "docs/design/design.md",
       "source_location": "L146",
       "weight": 1.0,
-      "source": "design_design",
-      "target": "design_design_elevation_depth",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/design/design.md",
-      "source_location": "L136",
-      "weight": 1.0,
-      "source": "design_design",
-      "target": "design_design_layout_spacing",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/design/design.md",
-      "source_location": "L152",
-      "weight": 1.0,
-      "source": "design_design",
-      "target": "design_design_shapes",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/design/design.md",
-      "source_location": "L130",
-      "weight": 1.0,
-      "source": "design_design",
-      "target": "design_design_typography",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "references",
-      "confidence": "EXTRACTED",
       "confidence_score": 1.0,
-      "source_file": "docs/design/design.md",
-      "source_location": null,
-      "weight": 1.0,
       "source": "design_design",
-      "target": "design_dual_font_strategy"
+      "target": "design_design_elevation_depth"
     },
     {
       "relation": "references",
@@ -110035,6 +110488,46 @@
       "weight": 1.0,
       "source": "design_design",
       "target": "design_design_kitchen_specific_components"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/design/design.md",
+      "source_location": "L136",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "design_design",
+      "target": "design_design_layout_spacing"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/design/design.md",
+      "source_location": "L152",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "design_design",
+      "target": "design_design_shapes"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/design/design.md",
+      "source_location": "L130",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "design_design",
+      "target": "design_design_typography"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "docs/design/design.md",
+      "source_location": null,
+      "weight": 1.0,
+      "source": "design_design",
+      "target": "design_dual_font_strategy"
     },
     {
       "relation": "references",
@@ -110072,9 +110565,9 @@
       "source_file": "docs/design/design.md",
       "source_location": "L160",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_design_components",
-      "target": "design_design_buttons",
-      "confidence_score": 1.0
+      "target": "design_design_buttons"
     },
     {
       "relation": "contains",
@@ -110082,9 +110575,9 @@
       "source_file": "docs/design/design.md",
       "source_location": "L164",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_design_components",
-      "target": "design_design_cards",
-      "confidence_score": 1.0
+      "target": "design_design_cards"
     },
     {
       "relation": "contains",
@@ -110092,9 +110585,9 @@
       "source_file": "docs/design/design.md",
       "source_location": "L168",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_design_components",
-      "target": "design_design_input_fields",
-      "confidence_score": 1.0
+      "target": "design_design_input_fields"
     },
     {
       "relation": "contains",
@@ -110102,9 +110595,9 @@
       "source_file": "docs/design/design.md",
       "source_location": "L172",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_design_components",
-      "target": "design_design_kitchen_specific_components",
-      "confidence_score": 1.0
+      "target": "design_design_kitchen_specific_components"
     },
     {
       "relation": "contains",
@@ -110112,9 +110605,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L11",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02",
-      "target": "design_ui_spec_v02_0_roadmap_split",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_0_roadmap_split"
     },
     {
       "relation": "contains",
@@ -110122,9 +110615,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L46",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02",
-      "target": "design_ui_spec_v02_1_foundations",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_1_foundations"
     },
     {
       "relation": "contains",
@@ -110132,9 +110625,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L163",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02",
-      "target": "design_ui_spec_v02_2_design_principles",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_2_design_principles"
     },
     {
       "relation": "contains",
@@ -110142,9 +110635,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L257",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02",
-      "target": "design_ui_spec_v02_3_component_architecture",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_3_component_architecture"
     },
     {
       "relation": "contains",
@@ -110152,9 +110645,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L669",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02",
-      "target": "design_ui_spec_v02_4_styling_system",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_4_styling_system"
     },
     {
       "relation": "contains",
@@ -110162,9 +110655,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L808",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02",
-      "target": "design_ui_spec_v02_5_accessibility_system",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_5_accessibility_system"
     },
     {
       "relation": "contains",
@@ -110172,9 +110665,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L839",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02",
-      "target": "design_ui_spec_v02_6_testing_system",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_6_testing_system"
     },
     {
       "relation": "contains",
@@ -110182,9 +110675,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L950",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02",
-      "target": "design_ui_spec_v02_7_primitive_inventory_v0_2_core",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_7_primitive_inventory_v0_2_core"
     },
     {
       "relation": "contains",
@@ -110192,9 +110685,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L956",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02",
-      "target": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_primitive_definitions_v0_2_core"
     },
     {
       "relation": "contains",
@@ -110202,9 +110695,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1569",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02",
-      "target": "design_ui_spec_v02_9_changelog",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_9_changelog"
     },
     {
       "relation": "contains",
@@ -110212,9 +110705,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02",
-      "target": "design_ui_spec_v02_salt_2_0_ui_primitives_specification_v0_2_3",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_salt_2_0_ui_primitives_specification_v0_2_3"
     },
     {
       "relation": "contains",
@@ -110222,9 +110715,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L13",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_0_roadmap_split",
-      "target": "design_ui_spec_v02_v0_2_core_implemented_now",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_v0_2_core_implemented_now"
     },
     {
       "relation": "contains",
@@ -110232,9 +110725,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L34",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_0_roadmap_split",
-      "target": "design_ui_spec_v02_v0_3_advanced_not_implemented_in_v0_2",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_v0_3_advanced_not_implemented_in_v0_2"
     },
     {
       "relation": "contains",
@@ -110242,9 +110735,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L48",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_1_foundations",
-      "target": "design_ui_spec_v02_1_1_technology_stack",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_1_1_technology_stack"
     },
     {
       "relation": "contains",
@@ -110252,9 +110745,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L64",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_1_foundations",
-      "target": "design_ui_spec_v02_1_2_boundaries",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_1_2_boundaries"
     },
     {
       "relation": "contains",
@@ -110262,9 +110755,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L85",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_1_foundations",
-      "target": "design_ui_spec_v02_1_3_package_surface",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_1_3_package_surface"
     },
     {
       "relation": "contains",
@@ -110272,9 +110765,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L137",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_1_foundations",
-      "target": "design_ui_spec_v02_1_4_event_naming_rule",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_1_4_event_naming_rule"
     },
     {
       "relation": "contains",
@@ -110282,9 +110775,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L147",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_1_foundations",
-      "target": "design_ui_spec_v02_1_5_spec_versioning_amendment_rule",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_1_5_spec_versioning_amendment_rule"
     },
     {
       "relation": "contains",
@@ -110292,9 +110785,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L165",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_2_design_principles",
-      "target": "design_ui_spec_v02_2_1_architecture",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_2_1_architecture"
     },
     {
       "relation": "contains",
@@ -110302,9 +110795,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L187",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_2_design_principles",
-      "target": "design_ui_spec_v02_2_2_accessibility",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_2_2_accessibility"
     },
     {
       "relation": "contains",
@@ -110312,9 +110805,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L200",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_2_design_principles",
-      "target": "design_ui_spec_v02_2_3_styling_rules",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_2_3_styling_rules"
     },
     {
       "relation": "contains",
@@ -110322,9 +110815,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L211",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_2_design_principles",
-      "target": "design_ui_spec_v02_2_4_naming_conventions",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_2_4_naming_conventions"
     },
     {
       "relation": "contains",
@@ -110332,9 +110825,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L232",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_2_design_principles",
-      "target": "design_ui_spec_v02_2_5_composition_rules",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_2_5_composition_rules"
     },
     {
       "relation": "contains",
@@ -110342,9 +110835,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L247",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_2_design_principles",
-      "target": "design_ui_spec_v02_2_6_determinism",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_2_6_determinism"
     },
     {
       "relation": "contains",
@@ -110352,9 +110845,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L169",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_2_1_architecture",
-      "target": "design_ui_spec_v02_headless_layer",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_headless_layer"
     },
     {
       "relation": "contains",
@@ -110362,9 +110855,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L176",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_2_1_architecture",
-      "target": "design_ui_spec_v02_styled_layer",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styled_layer"
     },
     {
       "relation": "contains",
@@ -110372,9 +110865,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L259",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_component_architecture",
-      "target": "design_ui_spec_v02_3_1_folder_structure",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_3_1_folder_structure"
     },
     {
       "relation": "contains",
@@ -110382,9 +110875,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L302",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_component_architecture",
-      "target": "design_ui_spec_v02_3_2_export_rules",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_3_2_export_rules"
     },
     {
       "relation": "contains",
@@ -110392,9 +110885,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L315",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_component_architecture",
-      "target": "design_ui_spec_v02_3_3_tailwind_token_ownership",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_3_3_tailwind_token_ownership"
     },
     {
       "relation": "contains",
@@ -110402,9 +110895,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L374",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_component_architecture",
-      "target": "design_ui_spec_v02_3_4_bits_ui_melt_ui_versions",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_3_4_bits_ui_melt_ui_versions"
     },
     {
       "relation": "contains",
@@ -110412,9 +110905,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L383",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_component_architecture",
-      "target": "design_ui_spec_v02_3_5_helpers",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_3_5_helpers"
     },
     {
       "relation": "contains",
@@ -110422,9 +110915,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L442",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_component_architecture",
-      "target": "design_ui_spec_v02_3_6_canonical_patterns_button_worked_example",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_3_6_canonical_patterns_button_worked_example"
     },
     {
       "relation": "contains",
@@ -110432,9 +110925,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L632",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_component_architecture",
-      "target": "design_ui_spec_v02_3_7_bits_ui_mapping_table",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_3_7_bits_ui_mapping_table"
     },
     {
       "relation": "contains",
@@ -110442,9 +110935,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L656",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_component_architecture",
-      "target": "design_ui_spec_v02_3_8_provenance_header_convention",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_3_8_provenance_header_convention"
     },
     {
       "relation": "contains",
@@ -110452,9 +110945,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L385",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_5_helpers",
-      "target": "design_ui_spec_v02_src_lib_cn_ts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_src_lib_cn_ts"
     },
     {
       "relation": "contains",
@@ -110462,9 +110955,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L409",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_5_helpers",
-      "target": "design_ui_spec_v02_src_lib_context_ts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_src_lib_context_ts"
     },
     {
       "relation": "contains",
@@ -110472,9 +110965,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L396",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_5_helpers",
-      "target": "design_ui_spec_v02_src_lib_useid_ts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_src_lib_useid_ts"
     },
     {
       "relation": "contains",
@@ -110482,9 +110975,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L432",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_5_helpers",
-      "target": "design_ui_spec_v02_src_lib_variants_ts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_src_lib_variants_ts"
     },
     {
       "relation": "contains",
@@ -110492,9 +110985,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L600",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_6_canonical_patterns_button_worked_example",
-      "target": "design_ui_spec_v02_canonical_controlled_uncontrolled_wiring_reference_for_all_bindable_primitives",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_canonical_controlled_uncontrolled_wiring_reference_for_all_bindable_primitives"
     },
     {
       "relation": "contains",
@@ -110502,9 +110995,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L620",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_6_canonical_patterns_button_worked_example",
-      "target": "design_ui_spec_v02_canonical_snippet_render_pattern",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_canonical_snippet_render_pattern"
     },
     {
       "relation": "contains",
@@ -110512,9 +111005,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L446",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_6_canonical_patterns_button_worked_example",
-      "target": "design_ui_spec_v02_src_headless_button_headless_svelte_ts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_src_headless_button_headless_svelte_ts"
     },
     {
       "relation": "contains",
@@ -110522,9 +111015,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L525",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_6_canonical_patterns_button_worked_example",
-      "target": "design_ui_spec_v02_src_primitives_button_button_svelte",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_src_primitives_button_button_svelte"
     },
     {
       "relation": "contains",
@@ -110532,9 +111025,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L503",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_6_canonical_patterns_button_worked_example",
-      "target": "design_ui_spec_v02_src_primitives_button_button_types_ts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_src_primitives_button_button_types_ts"
     },
     {
       "relation": "contains",
@@ -110542,9 +111035,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L474",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_6_canonical_patterns_button_worked_example",
-      "target": "design_ui_spec_v02_src_primitives_button_button_variants_ts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_src_primitives_button_button_variants_ts"
     },
     {
       "relation": "contains",
@@ -110552,9 +111045,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L592",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_3_6_canonical_patterns_button_worked_example",
-      "target": "design_ui_spec_v02_src_primitives_button_index_ts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_src_primitives_button_index_ts"
     },
     {
       "relation": "contains",
@@ -110562,9 +111055,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L671",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_styling_system",
-      "target": "design_ui_spec_v02_4_1_tokens",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_4_1_tokens"
     },
     {
       "relation": "contains",
@@ -110572,9 +111065,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L721",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_styling_system",
-      "target": "design_ui_spec_v02_4_2_focus_ring",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_4_2_focus_ring"
     },
     {
       "relation": "contains",
@@ -110582,9 +111075,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L735",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_styling_system",
-      "target": "design_ui_spec_v02_4_3_disabled_loading",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_4_3_disabled_loading"
     },
     {
       "relation": "contains",
@@ -110592,9 +111085,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L755",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_styling_system",
-      "target": "design_ui_spec_v02_4_4_shared_size_scale",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_4_4_shared_size_scale"
     },
     {
       "relation": "contains",
@@ -110602,9 +111095,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L799",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_styling_system",
-      "target": "design_ui_spec_v02_4_5_dark_mode",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_4_5_dark_mode"
     },
     {
       "relation": "contains",
@@ -110612,9 +111105,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L707",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_1_tokens",
-      "target": "design_ui_spec_v02_elevation",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_elevation"
     },
     {
       "relation": "contains",
@@ -110622,9 +111115,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L698",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_1_tokens",
-      "target": "design_ui_spec_v02_motion",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_motion"
     },
     {
       "relation": "contains",
@@ -110632,9 +111125,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L689",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_1_tokens",
-      "target": "design_ui_spec_v02_radius",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_radius"
     },
     {
       "relation": "contains",
@@ -110642,9 +111135,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L675",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_1_tokens",
-      "target": "design_ui_spec_v02_semantic_colors",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_semantic_colors"
     },
     {
       "relation": "contains",
@@ -110652,9 +111145,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L713",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_1_tokens",
-      "target": "design_ui_spec_v02_z_index",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_z_index"
     },
     {
       "relation": "contains",
@@ -110662,9 +111155,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L737",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_3_disabled_loading",
-      "target": "design_ui_spec_v02_disabled_terminal_state_no_interaction",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_disabled_terminal_state_no_interaction"
     },
     {
       "relation": "contains",
@@ -110672,9 +111165,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L744",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_3_disabled_loading",
-      "target": "design_ui_spec_v02_loading_transient_state_disables_interaction_without_terminal_semantics",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_loading_transient_state_disables_interaction_without_terminal_semantics"
     },
     {
       "relation": "contains",
@@ -110682,9 +111175,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L767",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_4_shared_size_scale",
-      "target": "design_ui_spec_v02_control_size_scale_checkbox_switch",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_control_size_scale_checkbox_switch"
     },
     {
       "relation": "contains",
@@ -110692,9 +111185,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L775",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_4_shared_size_scale",
-      "target": "design_ui_spec_v02_dialog_size_scale",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_dialog_size_scale"
     },
     {
       "relation": "contains",
@@ -110702,9 +111195,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L759",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_4_shared_size_scale",
-      "target": "design_ui_spec_v02_field_size_scale_textfield_textarea_frame_button",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_field_size_scale_textfield_textarea_frame_button"
     },
     {
       "relation": "contains",
@@ -110712,9 +111205,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L793",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_4_shared_size_scale",
-      "target": "design_ui_spec_v02_icon_spinner_sizes",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_icon_spinner_sizes"
     },
     {
       "relation": "contains",
@@ -110722,9 +111215,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L785",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_4_4_shared_size_scale",
-      "target": "design_ui_spec_v02_text_size_scale_text_primitive",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_text_size_scale_text_primitive"
     },
     {
       "relation": "contains",
@@ -110732,9 +111225,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L810",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_5_accessibility_system",
-      "target": "design_ui_spec_v02_5_1_universal_requirements",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_5_1_universal_requirements"
     },
     {
       "relation": "contains",
@@ -110742,9 +111235,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L821",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_5_accessibility_system",
-      "target": "design_ui_spec_v02_5_2_keyboard_map",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_5_2_keyboard_map"
     },
     {
       "relation": "contains",
@@ -110752,9 +111245,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L831",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_5_accessibility_system",
-      "target": "design_ui_spec_v02_5_3_focus_management",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_5_3_focus_management"
     },
     {
       "relation": "contains",
@@ -110762,9 +111255,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L841",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_6_testing_system",
-      "target": "design_ui_spec_v02_6_1_required_test_suites",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_6_1_required_test_suites"
     },
     {
       "relation": "contains",
@@ -110772,9 +111265,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L857",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_6_testing_system",
-      "target": "design_ui_spec_v02_6_2_test_file_template",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_6_2_test_file_template"
     },
     {
       "relation": "contains",
@@ -110782,9 +111275,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1393",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_10_heading",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_10_heading"
     },
     {
       "relation": "contains",
@@ -110792,9 +111285,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1413",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_11_text",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_11_text"
     },
     {
       "relation": "contains",
@@ -110802,9 +111295,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1436",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_12_icon",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_12_icon"
     },
     {
       "relation": "contains",
@@ -110812,9 +111305,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1462",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_13_layout_primitives_stack_inline_grid_divider",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_13_layout_primitives_stack_inline_grid_divider"
     },
     {
       "relation": "contains",
@@ -110822,9 +111315,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1505",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_14_spinner",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_14_spinner"
     },
     {
       "relation": "contains",
@@ -110832,9 +111325,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1526",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_15_progress",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_15_progress"
     },
     {
       "relation": "contains",
@@ -110842,9 +111335,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L962",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_1_button",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_1_button"
     },
     {
       "relation": "contains",
@@ -110852,9 +111345,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1027",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_2_textfield",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_2_textfield"
     },
     {
       "relation": "contains",
@@ -110862,9 +111355,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1100",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_3_textarea",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_3_textarea"
     },
     {
       "relation": "contains",
@@ -110872,9 +111365,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1127",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_4_checkbox",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_4_checkbox"
     },
     {
       "relation": "contains",
@@ -110882,9 +111375,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1177",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_5_switch",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_5_switch"
     },
     {
       "relation": "contains",
@@ -110892,9 +111385,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1216",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_6_dialog",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_6_dialog"
     },
     {
       "relation": "contains",
@@ -110902,9 +111395,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1277",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_7_popover",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_7_popover"
     },
     {
       "relation": "contains",
@@ -110912,9 +111405,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1316",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_8_tooltip",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_8_tooltip"
     },
     {
       "relation": "contains",
@@ -110922,9 +111415,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1361",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_primitive_definitions_v0_2_core",
-      "target": "design_ui_spec_v02_8_9_card",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_8_9_card"
     },
     {
       "relation": "contains",
@@ -110932,9 +111425,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L991",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_1_button",
-      "target": "design_ui_spec_v02_accessibility",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_accessibility"
     },
     {
       "relation": "contains",
@@ -110942,9 +111435,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L998",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_1_button",
-      "target": "design_ui_spec_v02_behavior",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_behavior"
     },
     {
       "relation": "contains",
@@ -110952,9 +111445,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L987",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_1_button",
-      "target": "design_ui_spec_v02_events",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_events"
     },
     {
       "relation": "contains",
@@ -110962,9 +111455,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1020",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_1_button",
-      "target": "design_ui_spec_v02_forbidden",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_forbidden"
     },
     {
       "relation": "contains",
@@ -110972,9 +111465,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L968",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_1_button",
-      "target": "design_ui_spec_v02_props",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props"
     },
     {
       "relation": "contains",
@@ -110982,9 +111475,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L964",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_1_button",
-      "target": "design_ui_spec_v02_purpose",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_purpose"
     },
     {
       "relation": "contains",
@@ -110992,9 +111485,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L981",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_1_button",
-      "target": "design_ui_spec_v02_snippets",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_snippets"
     },
     {
       "relation": "contains",
@@ -111002,9 +111495,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1004",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_1_button",
-      "target": "design_ui_spec_v02_styling",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styling"
     },
     {
       "relation": "contains",
@@ -111012,9 +111505,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1063",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_2_textfield",
-      "target": "design_ui_spec_v02_accessibility_1063",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_accessibility_1063"
     },
     {
       "relation": "contains",
@@ -111022,9 +111515,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1089",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_2_textfield",
-      "target": "design_ui_spec_v02_error_message_rendering",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_error_message_rendering"
     },
     {
       "relation": "contains",
@@ -111032,9 +111525,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1058",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_2_textfield",
-      "target": "design_ui_spec_v02_events_1058",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_events_1058"
     },
     {
       "relation": "contains",
@@ -111042,9 +111535,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1093",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_2_textfield",
-      "target": "design_ui_spec_v02_forbidden_1093",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_forbidden_1093"
     },
     {
       "relation": "contains",
@@ -111052,9 +111545,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1033",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_2_textfield",
-      "target": "design_ui_spec_v02_props_1033",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props_1033"
     },
     {
       "relation": "contains",
@@ -111062,9 +111555,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1029",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_2_textfield",
-      "target": "design_ui_spec_v02_purpose_1029",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_purpose_1029"
     },
     {
       "relation": "contains",
@@ -111072,9 +111565,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1053",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_2_textfield",
-      "target": "design_ui_spec_v02_snippets_1053",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_snippets_1053"
     },
     {
       "relation": "contains",
@@ -111082,9 +111575,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1072",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_2_textfield",
-      "target": "design_ui_spec_v02_styling_cva",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styling_cva"
     },
     {
       "relation": "contains",
@@ -111092,9 +111585,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1119",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_3_textarea",
-      "target": "design_ui_spec_v02_autoresize",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_autoresize"
     },
     {
       "relation": "contains",
@@ -111102,9 +111595,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1111",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_3_textarea",
-      "target": "design_ui_spec_v02_size_styling",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_size_styling"
     },
     {
       "relation": "contains",
@@ -111112,9 +111605,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1155",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_4_checkbox",
-      "target": "design_ui_spec_v02_accessibility_1155",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_accessibility_1155"
     },
     {
       "relation": "contains",
@@ -111122,9 +111615,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1151",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_4_checkbox",
-      "target": "design_ui_spec_v02_events_1151",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_events_1151"
     },
     {
       "relation": "contains",
@@ -111132,9 +111625,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1171",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_4_checkbox",
-      "target": "design_ui_spec_v02_forbidden_1171",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_forbidden_1171"
     },
     {
       "relation": "contains",
@@ -111142,9 +111635,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1129",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_4_checkbox",
-      "target": "design_ui_spec_v02_props_1129",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props_1129"
     },
     {
       "relation": "contains",
@@ -111152,9 +111645,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1146",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_4_checkbox",
-      "target": "design_ui_spec_v02_snippets_1146",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_snippets_1146"
     },
     {
       "relation": "contains",
@@ -111162,9 +111655,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1162",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_4_checkbox",
-      "target": "design_ui_spec_v02_styling_1162",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styling_1162"
     },
     {
       "relation": "contains",
@@ -111172,9 +111665,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1199",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_5_switch",
-      "target": "design_ui_spec_v02_accessibility_1199",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_accessibility_1199"
     },
     {
       "relation": "contains",
@@ -111182,9 +111675,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1195",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_5_switch",
-      "target": "design_ui_spec_v02_events_1195",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_events_1195"
     },
     {
       "relation": "contains",
@@ -111192,9 +111685,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1179",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_5_switch",
-      "target": "design_ui_spec_v02_props_1179",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props_1179"
     },
     {
       "relation": "contains",
@@ -111202,9 +111695,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1205",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_5_switch",
-      "target": "design_ui_spec_v02_styling_1205",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styling_1205"
     },
     {
       "relation": "contains",
@@ -111212,9 +111705,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1249",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_6_dialog",
-      "target": "design_ui_spec_v02_accessibility_1249",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_accessibility_1249"
     },
     {
       "relation": "contains",
@@ -111222,9 +111715,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1238",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_6_dialog",
-      "target": "design_ui_spec_v02_content_props",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_content_props"
     },
     {
       "relation": "contains",
@@ -111232,9 +111725,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1245",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_6_dialog",
-      "target": "design_ui_spec_v02_events_root",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_events_root"
     },
     {
       "relation": "contains",
@@ -111242,9 +111735,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1270",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_6_dialog",
-      "target": "design_ui_spec_v02_forbidden_1270",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_forbidden_1270"
     },
     {
       "relation": "contains",
@@ -111252,9 +111745,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1218",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_6_dialog",
-      "target": "design_ui_spec_v02_parts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_parts"
     },
     {
       "relation": "contains",
@@ -111262,9 +111755,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1229",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_6_dialog",
-      "target": "design_ui_spec_v02_root_props",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_root_props"
     },
     {
       "relation": "contains",
@@ -111272,9 +111765,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1257",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_6_dialog",
-      "target": "design_ui_spec_v02_styling_1257",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styling_1257"
     },
     {
       "relation": "contains",
@@ -111282,9 +111775,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1304",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_7_popover",
-      "target": "design_ui_spec_v02_events_root_1304",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_events_root_1304"
     },
     {
       "relation": "contains",
@@ -111292,9 +111785,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1279",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_7_popover",
-      "target": "design_ui_spec_v02_parts_1279",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_parts_1279"
     },
     {
       "relation": "contains",
@@ -111302,9 +111795,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1295",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_7_popover",
-      "target": "design_ui_spec_v02_props_content",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props_content"
     },
     {
       "relation": "contains",
@@ -111312,9 +111805,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1285",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_7_popover",
-      "target": "design_ui_spec_v02_props_root",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props_root"
     },
     {
       "relation": "contains",
@@ -111322,9 +111815,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1308",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_7_popover",
-      "target": "design_ui_spec_v02_styling_1308",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styling_1308"
     },
     {
       "relation": "contains",
@@ -111332,9 +111825,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1342",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_8_tooltip",
-      "target": "design_ui_spec_v02_behavior_1342",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_behavior_1342"
     },
     {
       "relation": "contains",
@@ -111342,9 +111835,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1354",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_8_tooltip",
-      "target": "design_ui_spec_v02_forbidden_1354",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_forbidden_1354"
     },
     {
       "relation": "contains",
@@ -111352,9 +111845,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1318",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_8_tooltip",
-      "target": "design_ui_spec_v02_parts_1318",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_parts_1318"
     },
     {
       "relation": "contains",
@@ -111362,9 +111855,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1334",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_8_tooltip",
-      "target": "design_ui_spec_v02_props_content_1334",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props_content_1334"
     },
     {
       "relation": "contains",
@@ -111372,9 +111865,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1325",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_8_tooltip",
-      "target": "design_ui_spec_v02_props_root_1325",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props_root_1325"
     },
     {
       "relation": "contains",
@@ -111382,9 +111875,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1348",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_8_tooltip",
-      "target": "design_ui_spec_v02_styling_1348",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styling_1348"
     },
     {
       "relation": "contains",
@@ -111392,9 +111885,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1363",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_9_card",
-      "target": "design_ui_spec_v02_parts_1363",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_parts_1363"
     },
     {
       "relation": "contains",
@@ -111402,9 +111895,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1372",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_9_card",
-      "target": "design_ui_spec_v02_props_all_parts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props_all_parts"
     },
     {
       "relation": "contains",
@@ -111412,9 +111905,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1378",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_9_card",
-      "target": "design_ui_spec_v02_styling_1378",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styling_1378"
     },
     {
       "relation": "contains",
@@ -111422,9 +111915,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1395",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_10_heading",
-      "target": "design_ui_spec_v02_props_1395",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props_1395"
     },
     {
       "relation": "contains",
@@ -111432,9 +111925,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1404",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_10_heading",
-      "target": "design_ui_spec_v02_styling_1404",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styling_1404"
     },
     {
       "relation": "contains",
@@ -111442,9 +111935,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1415",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_11_text",
-      "target": "design_ui_spec_v02_props_1415",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props_1415"
     },
     {
       "relation": "contains",
@@ -111452,9 +111945,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1424",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_11_text",
-      "target": "design_ui_spec_v02_styling_1424",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styling_1424"
     },
     {
       "relation": "contains",
@@ -111462,9 +111955,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1447",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_12_icon",
-      "target": "design_ui_spec_v02_accessibility_1447",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_accessibility_1447"
     },
     {
       "relation": "contains",
@@ -111472,9 +111965,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1438",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_12_icon",
-      "target": "design_ui_spec_v02_props_1438",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props_1438"
     },
     {
       "relation": "contains",
@@ -111482,9 +111975,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1452",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_12_icon",
-      "target": "design_ui_spec_v02_styling_1452",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styling_1452"
     },
     {
       "relation": "contains",
@@ -111492,9 +111985,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1489",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_13_layout_primitives_stack_inline_grid_divider",
-      "target": "design_ui_spec_v02_divider",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_divider"
     },
     {
       "relation": "contains",
@@ -111502,9 +111995,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1479",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_13_layout_primitives_stack_inline_grid_divider",
-      "target": "design_ui_spec_v02_grid",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_grid"
     },
     {
       "relation": "contains",
@@ -111512,9 +112005,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1475",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_13_layout_primitives_stack_inline_grid_divider",
-      "target": "design_ui_spec_v02_inline",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_inline"
     },
     {
       "relation": "contains",
@@ -111522,9 +112015,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1464",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_13_layout_primitives_stack_inline_grid_divider",
-      "target": "design_ui_spec_v02_stack",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_stack"
     },
     {
       "relation": "contains",
@@ -111532,9 +112025,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1515",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_14_spinner",
-      "target": "design_ui_spec_v02_accessibility_1515",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_accessibility_1515"
     },
     {
       "relation": "contains",
@@ -111542,9 +112035,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1507",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_14_spinner",
-      "target": "design_ui_spec_v02_props_1507",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props_1507"
     },
     {
       "relation": "contains",
@@ -111552,9 +112045,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1520",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_14_spinner",
-      "target": "design_ui_spec_v02_styling_1520",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styling_1520"
     },
     {
       "relation": "contains",
@@ -111562,9 +112055,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1545",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_15_progress",
-      "target": "design_ui_spec_v02_accessibility_1545",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_accessibility_1545"
     },
     {
       "relation": "contains",
@@ -111572,9 +112065,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1539",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_15_progress",
-      "target": "design_ui_spec_v02_behavior_1539",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_behavior_1539"
     },
     {
       "relation": "contains",
@@ -111582,9 +112075,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1563",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_15_progress",
-      "target": "design_ui_spec_v02_forbidden_1563",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_forbidden_1563"
     },
     {
       "relation": "contains",
@@ -111592,9 +112085,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1528",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_15_progress",
-      "target": "design_ui_spec_v02_props_1528",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_props_1528"
     },
     {
       "relation": "contains",
@@ -111602,9 +112095,9 @@
       "source_file": "docs/design/ui-spec-v02.md",
       "source_location": "L1553",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v02_8_15_progress",
-      "target": "design_ui_spec_v02_styling_1553",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v02_styling_1553"
     },
     {
       "relation": "contains",
@@ -111612,9 +112105,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03",
-      "target": "design_ui_spec_v03_salt_2_0_ui_primitives_specification_v0_3_draft_for_planning",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_salt_2_0_ui_primitives_specification_v0_3_draft_for_planning"
     },
     {
       "relation": "references",
@@ -111662,9 +112155,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_salt_2_0_ui_primitives_specification_v0_3_draft_for_planning",
-      "target": "design_ui_spec_v03_0_v0_3_scope",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_0_v0_3_scope"
     },
     {
       "relation": "contains",
@@ -111672,9 +112165,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L29",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_salt_2_0_ui_primitives_specification_v0_3_draft_for_planning",
-      "target": "design_ui_spec_v03_1_shared_v0_3_rules",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_1_shared_v0_3_rules"
     },
     {
       "relation": "contains",
@@ -111682,9 +112175,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L56",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_salt_2_0_ui_primitives_specification_v0_3_draft_for_planning",
-      "target": "design_ui_spec_v03_2_radiogroup",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_2_radiogroup"
     },
     {
       "relation": "contains",
@@ -111692,9 +112185,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L121",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_salt_2_0_ui_primitives_specification_v0_3_draft_for_planning",
-      "target": "design_ui_spec_v03_3_select",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_3_select"
     },
     {
       "relation": "contains",
@@ -111702,9 +112195,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L205",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_salt_2_0_ui_primitives_specification_v0_3_draft_for_planning",
-      "target": "design_ui_spec_v03_4_slider",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_4_slider"
     },
     {
       "relation": "contains",
@@ -111712,9 +112205,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L268",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_salt_2_0_ui_primitives_specification_v0_3_draft_for_planning",
-      "target": "design_ui_spec_v03_5_sheet",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_5_sheet"
     },
     {
       "relation": "contains",
@@ -111722,9 +112215,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L322",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_salt_2_0_ui_primitives_specification_v0_3_draft_for_planning",
-      "target": "design_ui_spec_v03_6_toast",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_6_toast"
     },
     {
       "relation": "contains",
@@ -111732,9 +112225,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L388",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_salt_2_0_ui_primitives_specification_v0_3_draft_for_planning",
-      "target": "design_ui_spec_v03_7_testing_requirements_v0_3",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_7_testing_requirements_v0_3"
     },
     {
       "relation": "contains",
@@ -111742,9 +112235,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L412",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_salt_2_0_ui_primitives_specification_v0_3_draft_for_planning",
-      "target": "design_ui_spec_v03_8_generator_instructions_claude",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_8_generator_instructions_claude"
     },
     {
       "relation": "contains",
@@ -111752,9 +112245,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L31",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_1_shared_v0_3_rules",
-      "target": "design_ui_spec_v03_1_1_headless_styled",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_1_1_headless_styled"
     },
     {
       "relation": "contains",
@@ -111762,9 +112255,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_1_shared_v0_3_rules",
-      "target": "design_ui_spec_v03_1_2_apg_compliance",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_1_2_apg_compliance"
     },
     {
       "relation": "contains",
@@ -111772,9 +112265,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L58",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_2_radiogroup",
-      "target": "design_ui_spec_v03_2_1_purpose",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_2_1_purpose"
     },
     {
       "relation": "contains",
@@ -111782,9 +112275,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L63",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_2_radiogroup",
-      "target": "design_ui_spec_v03_2_2_parts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_2_2_parts"
     },
     {
       "relation": "contains",
@@ -111792,9 +112285,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L68",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_2_radiogroup",
-      "target": "design_ui_spec_v03_2_3_root_props",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_2_3_root_props"
     },
     {
       "relation": "contains",
@@ -111802,9 +112295,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L81",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_2_radiogroup",
-      "target": "design_ui_spec_v03_2_4_item_props",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_2_4_item_props"
     },
     {
       "relation": "contains",
@@ -111812,9 +112305,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L88",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_2_radiogroup",
-      "target": "design_ui_spec_v03_2_5_events",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_2_5_events"
     },
     {
       "relation": "contains",
@@ -111822,9 +112315,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L92",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_2_radiogroup",
-      "target": "design_ui_spec_v03_2_6_apg_requirements_radio_group",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_2_6_apg_requirements_radio_group"
     },
     {
       "relation": "contains",
@@ -111832,9 +112325,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L110",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_2_radiogroup",
-      "target": "design_ui_spec_v03_2_7_behavior",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_2_7_behavior"
     },
     {
       "relation": "contains",
@@ -111842,9 +112335,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L123",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_3_select",
-      "target": "design_ui_spec_v03_3_1_purpose",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_3_1_purpose"
     },
     {
       "relation": "contains",
@@ -111852,9 +112345,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L128",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_3_select",
-      "target": "design_ui_spec_v03_3_2_parts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_3_2_parts"
     },
     {
       "relation": "contains",
@@ -111862,9 +112355,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L138",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_3_select",
-      "target": "design_ui_spec_v03_3_3_root_props",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_3_3_root_props"
     },
     {
       "relation": "contains",
@@ -111872,9 +112365,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L151",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_3_select",
-      "target": "design_ui_spec_v03_3_4_selecttrigger_props",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_3_4_selecttrigger_props"
     },
     {
       "relation": "contains",
@@ -111882,9 +112375,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L159",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_3_select",
-      "target": "design_ui_spec_v03_3_5_events",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_3_5_events"
     },
     {
       "relation": "contains",
@@ -111892,9 +112385,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L164",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_3_select",
-      "target": "design_ui_spec_v03_3_6_apg_requirements_listbox",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_3_6_apg_requirements_listbox"
     },
     {
       "relation": "contains",
@@ -111902,9 +112395,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L187",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_3_select",
-      "target": "design_ui_spec_v03_3_7_behavior",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_3_7_behavior"
     },
     {
       "relation": "contains",
@@ -111912,9 +112405,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L207",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_4_slider",
-      "target": "design_ui_spec_v03_4_1_purpose",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_4_1_purpose"
     },
     {
       "relation": "contains",
@@ -111922,9 +112415,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L212",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_4_slider",
-      "target": "design_ui_spec_v03_4_2_parts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_4_2_parts"
     },
     {
       "relation": "contains",
@@ -111932,9 +112425,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L219",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_4_slider",
-      "target": "design_ui_spec_v03_4_3_props",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_4_3_props"
     },
     {
       "relation": "contains",
@@ -111942,9 +112435,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L230",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_4_slider",
-      "target": "design_ui_spec_v03_4_4_events",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_4_4_events"
     },
     {
       "relation": "contains",
@@ -111952,9 +112445,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L234",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_4_slider",
-      "target": "design_ui_spec_v03_4_5_apg_requirements_slider",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_4_5_apg_requirements_slider"
     },
     {
       "relation": "contains",
@@ -111962,9 +112455,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L251",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_4_slider",
-      "target": "design_ui_spec_v03_4_6_behavior",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_4_6_behavior"
     },
     {
       "relation": "contains",
@@ -111972,9 +112465,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L270",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_5_sheet",
-      "target": "design_ui_spec_v03_5_1_purpose",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_5_1_purpose"
     },
     {
       "relation": "contains",
@@ -111982,9 +112475,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L275",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_5_sheet",
-      "target": "design_ui_spec_v03_5_2_parts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_5_2_parts"
     },
     {
       "relation": "contains",
@@ -111992,9 +112485,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L286",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_5_sheet",
-      "target": "design_ui_spec_v03_5_3_root_props",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_5_3_root_props"
     },
     {
       "relation": "contains",
@@ -112002,9 +112495,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L294",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_5_sheet",
-      "target": "design_ui_spec_v03_5_4_events",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_5_4_events"
     },
     {
       "relation": "contains",
@@ -112012,9 +112505,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L298",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_5_sheet",
-      "target": "design_ui_spec_v03_5_5_apg_requirements_dialog",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_5_5_apg_requirements_dialog"
     },
     {
       "relation": "contains",
@@ -112022,9 +112515,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L312",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_5_sheet",
-      "target": "design_ui_spec_v03_5_6_behavior",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_5_6_behavior"
     },
     {
       "relation": "contains",
@@ -112032,9 +112525,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L324",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_6_toast",
-      "target": "design_ui_spec_v03_6_1_purpose",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_6_1_purpose"
     },
     {
       "relation": "contains",
@@ -112042,9 +112535,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L329",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_6_toast",
-      "target": "design_ui_spec_v03_6_2_parts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_6_2_parts"
     },
     {
       "relation": "contains",
@@ -112052,9 +112545,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L339",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_6_toast",
-      "target": "design_ui_spec_v03_6_3_root_props",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_6_3_root_props"
     },
     {
       "relation": "contains",
@@ -112062,9 +112555,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L347",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_6_toast",
-      "target": "design_ui_spec_v03_6_4_provider_behavior",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_6_4_provider_behavior"
     },
     {
       "relation": "contains",
@@ -112072,9 +112565,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L357",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_6_toast",
-      "target": "design_ui_spec_v03_6_5_apg_requirements_alert_live_region",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_6_5_apg_requirements_alert_live_region"
     },
     {
       "relation": "contains",
@@ -112082,9 +112575,9 @@
       "source_file": "docs/design/ui-spec-v03.md",
       "source_location": "L370",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v03_6_toast",
-      "target": "design_ui_spec_v03_6_6_undo_able_toast_app_level_action_ondismiss",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v03_6_6_undo_able_toast_app_level_action_ondismiss"
     },
     {
       "relation": "contains",
@@ -112092,9 +112585,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L621",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04",
-      "target": "design_ui_spec_v04_10_list_selection_createlistselection_selectablelist_selectallcheckbox_rowselectcheckbox",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_10_list_selection_createlistselection_selectablelist_selectallcheckbox_rowselectcheckbox"
     },
     {
       "relation": "contains",
@@ -112102,9 +112595,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L700",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04",
-      "target": "design_ui_spec_v04_11_editablerow_primitive",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_11_editablerow_primitive"
     },
     {
       "relation": "contains",
@@ -112112,9 +112605,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L732",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04",
-      "target": "design_ui_spec_v04_12_markdown_primitive",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_12_markdown_primitive"
     },
     {
       "relation": "contains",
@@ -112122,9 +112615,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L797",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04",
-      "target": "design_ui_spec_v04_13_pinned_interaction_constraints",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_13_pinned_interaction_constraints"
     },
     {
       "relation": "contains",
@@ -112132,9 +112625,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L412",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04",
-      "target": "design_ui_spec_v04_9_listpage_selection_mode",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_9_listpage_selection_mode"
     },
     {
       "relation": "references",
@@ -112192,9 +112685,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04",
-      "target": "design_ui_spec_v04_salt_2_0_ui_primitives_specification_v0_4",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_salt_2_0_ui_primitives_specification_v0_4"
     },
     {
       "relation": "contains",
@@ -112202,9 +112695,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L15",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_salt_2_0_ui_primitives_specification_v0_4",
-      "target": "design_ui_spec_v04_0_v0_4_scope",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_0_v0_4_scope"
     },
     {
       "relation": "contains",
@@ -112212,9 +112705,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L28",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_salt_2_0_ui_primitives_specification_v0_4",
-      "target": "design_ui_spec_v04_1_combobox_overview",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_1_combobox_overview"
     },
     {
       "relation": "contains",
@@ -112222,9 +112715,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L52",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_salt_2_0_ui_primitives_specification_v0_4",
-      "target": "design_ui_spec_v04_2_parts",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_2_parts"
     },
     {
       "relation": "contains",
@@ -112232,9 +112725,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L68",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_salt_2_0_ui_primitives_specification_v0_4",
-      "target": "design_ui_spec_v04_3_props_and_events",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_3_props_and_events"
     },
     {
       "relation": "contains",
@@ -112242,9 +112735,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L141",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_salt_2_0_ui_primitives_specification_v0_4",
-      "target": "design_ui_spec_v04_4_behaviour",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_4_behaviour"
     },
     {
       "relation": "contains",
@@ -112252,9 +112745,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L213",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_salt_2_0_ui_primitives_specification_v0_4",
-      "target": "design_ui_spec_v04_5_accessibility_apg_requirements",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_5_accessibility_apg_requirements"
     },
     {
       "relation": "contains",
@@ -112262,9 +112755,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L246",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_salt_2_0_ui_primitives_specification_v0_4",
-      "target": "design_ui_spec_v04_6_headless_api_shape_only",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_6_headless_api_shape_only"
     },
     {
       "relation": "contains",
@@ -112272,9 +112765,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L30",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_1_combobox_overview",
-      "target": "design_ui_spec_v04_1_1_purpose",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_1_1_purpose"
     },
     {
       "relation": "contains",
@@ -112282,9 +112775,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_1_combobox_overview",
-      "target": "design_ui_spec_v04_1_2_apg_mapping",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_1_2_apg_mapping"
     },
     {
       "relation": "contains",
@@ -112292,9 +112785,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L70",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_3_props_and_events",
-      "target": "design_ui_spec_v04_3_1_root_props_combobox",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_3_1_root_props_combobox"
     },
     {
       "relation": "contains",
@@ -112302,9 +112795,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L91",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_3_props_and_events",
-      "target": "design_ui_spec_v04_3_2_events",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_3_2_events"
     },
     {
       "relation": "contains",
@@ -112312,9 +112805,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L97",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_3_props_and_events",
-      "target": "design_ui_spec_v04_3_3_comboboxinput_props_html_attribute_forwarding",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_3_3_comboboxinput_props_html_attribute_forwarding"
     },
     {
       "relation": "contains",
@@ -112322,9 +112815,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L118",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_3_props_and_events",
-      "target": "design_ui_spec_v04_3_4_comboboxfield_optional_input_frame",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_3_4_comboboxfield_optional_input_frame"
     },
     {
       "relation": "contains",
@@ -112332,9 +112825,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L143",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_4_behaviour",
-      "target": "design_ui_spec_v04_4_1_filtering",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_4_1_filtering"
     },
     {
       "relation": "contains",
@@ -112342,9 +112835,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L154",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_4_behaviour",
-      "target": "design_ui_spec_v04_4_2_keyboard_interaction",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_4_2_keyboard_interaction"
     },
     {
       "relation": "contains",
@@ -112352,9 +112845,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L178",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_4_behaviour",
-      "target": "design_ui_spec_v04_4_3_pointer_interaction",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_4_3_pointer_interaction"
     },
     {
       "relation": "contains",
@@ -112362,9 +112855,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L185",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_4_behaviour",
-      "target": "design_ui_spec_v04_4_4_scrolling",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_4_4_scrolling"
     },
     {
       "relation": "contains",
@@ -112372,9 +112865,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L190",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_4_behaviour",
-      "target": "design_ui_spec_v04_4_5_restrict_vs_allowcustom",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_4_5_restrict_vs_allowcustom"
     },
     {
       "relation": "contains",
@@ -112382,9 +112875,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L204",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_4_behaviour",
-      "target": "design_ui_spec_v04_4_6_controlled_uncontrolled",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_4_6_controlled_uncontrolled"
     },
     {
       "relation": "contains",
@@ -112392,9 +112885,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L215",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_5_accessibility_apg_requirements",
-      "target": "design_ui_spec_v04_5_1_input_comboboxinput",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_5_1_input_comboboxinput"
     },
     {
       "relation": "contains",
@@ -112402,9 +112895,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L224",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_5_accessibility_apg_requirements",
-      "target": "design_ui_spec_v04_5_2_content_comboboxcontent",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_5_2_content_comboboxcontent"
     },
     {
       "relation": "contains",
@@ -112412,9 +112905,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L230",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_5_accessibility_apg_requirements",
-      "target": "design_ui_spec_v04_5_3_items_comboboxitem",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_5_3_items_comboboxitem"
     },
     {
       "relation": "contains",
@@ -112422,9 +112915,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L236",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_5_accessibility_apg_requirements",
-      "target": "design_ui_spec_v04_5_4_empty_create",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_5_4_empty_create"
     },
     {
       "relation": "contains",
@@ -112432,9 +112925,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L414",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_listpage_selection_mode",
-      "target": "design_ui_spec_v04_9_1_overview",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_9_1_overview"
     },
     {
       "relation": "contains",
@@ -112442,9 +112935,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L422",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_listpage_selection_mode",
-      "target": "design_ui_spec_v04_9_2_behaviour",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_9_2_behaviour"
     },
     {
       "relation": "contains",
@@ -112452,9 +112945,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L442",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_listpage_selection_mode",
-      "target": "design_ui_spec_v04_9_3_listpage_props_changes",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_9_3_listpage_props_changes"
     },
     {
       "relation": "contains",
@@ -112462,9 +112955,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L550",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_listpage_selection_mode",
-      "target": "design_ui_spec_v04_9_4_consuming_page_contract_bindable_prop",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_9_4_consuming_page_contract_bindable_prop"
     },
     {
       "relation": "contains",
@@ -112472,9 +112965,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L574",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_listpage_selection_mode",
-      "target": "design_ui_spec_v04_9_5_clearing_selection_on_exit",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_9_5_clearing_selection_on_exit"
     },
     {
       "relation": "contains",
@@ -112482,9 +112975,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L584",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_listpage_selection_mode",
-      "target": "design_ui_spec_v04_9_6_programmatic_exit",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_9_6_programmatic_exit"
     },
     {
       "relation": "contains",
@@ -112492,9 +112985,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L592",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_listpage_selection_mode",
-      "target": "design_ui_spec_v04_9_7_context_for_nested_components_only",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_9_7_context_for_nested_components_only"
     },
     {
       "relation": "contains",
@@ -112502,9 +112995,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L612",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_listpage_selection_mode",
-      "target": "design_ui_spec_v04_9_8_forbidden",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_9_8_forbidden"
     },
     {
       "relation": "contains",
@@ -112512,9 +113005,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L424",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_2_behaviour",
-      "target": "design_ui_spec_v04_default_state_selection_mode_off",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_default_state_selection_mode_off"
     },
     {
       "relation": "contains",
@@ -112522,9 +113015,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L437",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_2_behaviour",
-      "target": "design_ui_spec_v04_exiting_selection_mode",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_exiting_selection_mode"
     },
     {
       "relation": "contains",
@@ -112532,9 +113025,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L429",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_2_behaviour",
-      "target": "design_ui_spec_v04_selection_mode_on",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_selection_mode_on"
     },
     {
       "relation": "contains",
@@ -112542,9 +113035,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L452",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_3_listpage_props_changes",
-      "target": "design_ui_spec_v04_9_3_1_bulkaction_declarative_contextual_bar",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_9_3_1_bulkaction_declarative_contextual_bar"
     },
     {
       "relation": "contains",
@@ -112552,9 +113045,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L504",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_3_listpage_props_changes",
-      "target": "design_ui_spec_v04_9_3_2_move_target_picker",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_9_3_2_move_target_picker"
     },
     {
       "relation": "contains",
@@ -112562,9 +113055,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L508",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_3_listpage_props_changes",
-      "target": "design_ui_spec_v04_9_3_3_deferred_bulk_delete_undo_snackbar",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_9_3_3_deferred_bulk_delete_undo_snackbar"
     },
     {
       "relation": "contains",
@@ -112572,9 +113065,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L531",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_9_3_listpage_props_changes",
-      "target": "design_ui_spec_v04_titleslot_custom_header_title",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_titleslot_custom_header_title"
     },
     {
       "relation": "contains",
@@ -112582,9 +113075,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L623",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_10_list_selection_createlistselection_selectablelist_selectallcheckbox_rowselectcheckbox",
-      "target": "design_ui_spec_v04_10_1_overview",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_10_1_overview"
     },
     {
       "relation": "contains",
@@ -112592,9 +113085,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L638",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_10_list_selection_createlistselection_selectablelist_selectallcheckbox_rowselectcheckbox",
-      "target": "design_ui_spec_v04_10_2_createlistselection_options",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_10_2_createlistselection_options"
     },
     {
       "relation": "contains",
@@ -112602,9 +113095,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L664",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_10_list_selection_createlistselection_selectablelist_selectallcheckbox_rowselectcheckbox",
-      "target": "design_ui_spec_v04_10_3_component_props",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_10_3_component_props"
     },
     {
       "relation": "contains",
@@ -112612,9 +113105,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L679",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_10_list_selection_createlistselection_selectablelist_selectallcheckbox_rowselectcheckbox",
-      "target": "design_ui_spec_v04_10_4_behaviour",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_10_4_behaviour"
     },
     {
       "relation": "contains",
@@ -112622,9 +113115,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L686",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_10_list_selection_createlistselection_selectablelist_selectallcheckbox_rowselectcheckbox",
-      "target": "design_ui_spec_v04_10_5_accessibility",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_10_5_accessibility"
     },
     {
       "relation": "contains",
@@ -112632,9 +113125,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L691",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_10_list_selection_createlistselection_selectablelist_selectallcheckbox_rowselectcheckbox",
-      "target": "design_ui_spec_v04_10_6_testing_requirements",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_10_6_testing_requirements"
     },
     {
       "relation": "contains",
@@ -112642,9 +113135,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L702",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_11_editablerow_primitive",
-      "target": "design_ui_spec_v04_11_1_overview",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_11_1_overview"
     },
     {
       "relation": "contains",
@@ -112652,9 +113145,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L706",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_11_editablerow_primitive",
-      "target": "design_ui_spec_v04_11_2_props",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_11_2_props"
     },
     {
       "relation": "contains",
@@ -112662,9 +113155,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L716",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_11_editablerow_primitive",
-      "target": "design_ui_spec_v04_11_3_behaviour",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_11_3_behaviour"
     },
     {
       "relation": "contains",
@@ -112672,9 +113165,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L723",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_11_editablerow_primitive",
-      "target": "design_ui_spec_v04_11_4_testing_requirements",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_11_4_testing_requirements"
     },
     {
       "relation": "contains",
@@ -112682,9 +113175,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L734",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_12_markdown_primitive",
-      "target": "design_ui_spec_v04_12_1_overview",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_12_1_overview"
     },
     {
       "relation": "contains",
@@ -112692,9 +113185,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L740",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_12_markdown_primitive",
-      "target": "design_ui_spec_v04_12_2_props",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_12_2_props"
     },
     {
       "relation": "contains",
@@ -112702,9 +113195,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L747",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_12_markdown_primitive",
-      "target": "design_ui_spec_v04_12_3_implementation",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_12_3_implementation"
     },
     {
       "relation": "contains",
@@ -112712,9 +113205,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L754",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_12_markdown_primitive",
-      "target": "design_ui_spec_v04_12_4_salt_md_css_scope",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_12_4_salt_md_css_scope"
     },
     {
       "relation": "contains",
@@ -112722,9 +113215,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L778",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_12_markdown_primitive",
-      "target": "design_ui_spec_v04_12_5_usage_example",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_12_5_usage_example"
     },
     {
       "relation": "contains",
@@ -112732,9 +113225,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L788",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_12_markdown_primitive",
-      "target": "design_ui_spec_v04_12_6_testing_requirements",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_12_6_testing_requirements"
     },
     {
       "relation": "contains",
@@ -112742,9 +113235,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L801",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_13_pinned_interaction_constraints",
-      "target": "design_ui_spec_v04_13_1_toastviewport_pointer_events_none_container",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_13_1_toastviewport_pointer_events_none_container"
     },
     {
       "relation": "contains",
@@ -112752,9 +113245,9 @@
       "source_file": "docs/design/ui-spec-v04.md",
       "source_location": "L812",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "design_ui_spec_v04_13_pinned_interaction_constraints",
-      "target": "design_ui_spec_v04_13_2_bottomnav_full_height_tap_targets_items_stretch",
-      "confidence_score": 1.0
+      "target": "design_ui_spec_v04_13_2_bottomnav_full_height_tap_targets_items_stretch"
     },
     {
       "relation": "contains",
@@ -112762,9 +113255,9 @@
       "source_file": "docs/domain-implementation.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_domain_implementation",
-      "target": "docs_domain_implementation_domain_modules_coordinators_pattern_guide_v1_3",
-      "confidence_score": 1.0
+      "target": "docs_domain_implementation_domain_modules_coordinators_pattern_guide_v1_3"
     },
     {
       "relation": "references",
@@ -112772,9 +113265,9 @@
       "source_file": "docs/e2e.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e",
-      "target": "docs_e2e_test_spec",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec"
     },
     {
       "relation": "contains",
@@ -112782,9 +113275,9 @@
       "source_file": "docs/e2e-test-spec.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_test_spec",
-      "target": "docs_e2e_test_spec_playwright_e2e_non_functional_specification",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec_playwright_e2e_non_functional_specification"
     },
     {
       "relation": "contains",
@@ -112792,9 +113285,9 @@
       "source_file": "docs/e2e-test-spec.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_test_spec_playwright_e2e_non_functional_specification",
-      "target": "docs_e2e_test_spec_a_async_settling_determinism",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec_a_async_settling_determinism"
     },
     {
       "relation": "contains",
@@ -112802,9 +113295,9 @@
       "source_file": "docs/e2e-test-spec.md",
       "source_location": "L354",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_test_spec_playwright_e2e_non_functional_specification",
-      "target": "docs_e2e_test_spec_appendix_evaluation_of_the_generic_best_practice_list_against_salt",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec_appendix_evaluation_of_the_generic_best_practice_list_against_salt"
     },
     {
       "relation": "contains",
@@ -112812,9 +113305,9 @@
       "source_file": "docs/e2e-test-spec.md",
       "source_location": "L66",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_test_spec_playwright_e2e_non_functional_specification",
-      "target": "docs_e2e_test_spec_b_locators",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec_b_locators"
     },
     {
       "relation": "contains",
@@ -112822,9 +113315,9 @@
       "source_file": "docs/e2e-test-spec.md",
       "source_location": "L86",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_test_spec_playwright_e2e_non_functional_specification",
-      "target": "docs_e2e_test_spec_c_isolation_state",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec_c_isolation_state"
     },
     {
       "relation": "contains",
@@ -112832,9 +113325,9 @@
       "source_file": "docs/e2e-test-spec.md",
       "source_location": "L125",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_test_spec_playwright_e2e_non_functional_specification",
-      "target": "docs_e2e_test_spec_d_realtime_cross_tab_convergence_salt_specific",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec_d_realtime_cross_tab_convergence_salt_specific"
     },
     {
       "relation": "contains",
@@ -112842,9 +113335,9 @@
       "source_file": "docs/e2e-test-spec.md",
       "source_location": "L151",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_test_spec_playwright_e2e_non_functional_specification",
-      "target": "docs_e2e_test_spec_e_ai_cloud_function_trigger_determinism_salt_specific",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec_e_ai_cloud_function_trigger_determinism_salt_specific"
     },
     {
       "relation": "contains",
@@ -112852,9 +113345,9 @@
       "source_file": "docs/e2e-test-spec.md",
       "source_location": "L181",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_test_spec_playwright_e2e_non_functional_specification",
-      "target": "docs_e2e_test_spec_f_timeouts",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec_f_timeouts"
     },
     {
       "relation": "contains",
@@ -112862,9 +113355,9 @@
       "source_file": "docs/e2e-test-spec.md",
       "source_location": "L203",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_test_spec_playwright_e2e_non_functional_specification",
-      "target": "docs_e2e_test_spec_g_config_harness_invariants",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec_g_config_harness_invariants"
     },
     {
       "relation": "contains",
@@ -112872,9 +113365,9 @@
       "source_file": "docs/e2e-test-spec.md",
       "source_location": "L264",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_test_spec_playwright_e2e_non_functional_specification",
-      "target": "docs_e2e_test_spec_h_environment_vs_code_triage",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec_h_environment_vs_code_triage"
     },
     {
       "relation": "contains",
@@ -112882,9 +113375,9 @@
       "source_file": "docs/e2e-test-spec.md",
       "source_location": "L281",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_test_spec_playwright_e2e_non_functional_specification",
-      "target": "docs_e2e_test_spec_i_observability_diagnosability",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec_i_observability_diagnosability"
     },
     {
       "relation": "contains",
@@ -112892,9 +113385,9 @@
       "source_file": "docs/e2e-test-spec.md",
       "source_location": "L300",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_test_spec_playwright_e2e_non_functional_specification",
-      "target": "docs_e2e_test_spec_reviewer_checklist",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec_reviewer_checklist"
     },
     {
       "relation": "contains",
@@ -112902,9 +113395,9 @@
       "source_file": "docs/e2e-test-spec.md",
       "source_location": "L237",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_test_spec_g_config_harness_invariants",
-      "target": "docs_e2e_test_spec_harness_option_webserver_deferred",
-      "confidence_score": 1.0
+      "target": "docs_e2e_test_spec_harness_option_webserver_deferred"
     },
     {
       "relation": "contains",
@@ -112912,9 +113405,9 @@
       "source_file": "docs/e2e.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e",
-      "target": "docs_e2e_e2e_emulator_integration_tests",
-      "confidence_score": 1.0
+      "target": "docs_e2e_e2e_emulator_integration_tests"
     },
     {
       "relation": "contains",
@@ -112922,9 +113415,9 @@
       "source_file": "docs/e2e.md",
       "source_location": "L227",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_e2e_emulator_integration_tests",
-      "target": "docs_e2e_authoring_conventions",
-      "confidence_score": 1.0
+      "target": "docs_e2e_authoring_conventions"
     },
     {
       "relation": "contains",
@@ -112932,9 +113425,9 @@
       "source_file": "docs/e2e.md",
       "source_location": "L169",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_e2e_emulator_integration_tests",
-      "target": "docs_e2e_ci",
-      "confidence_score": 1.0
+      "target": "docs_e2e_ci"
     },
     {
       "relation": "contains",
@@ -112942,9 +113435,9 @@
       "source_file": "docs/e2e.md",
       "source_location": "L85",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_e2e_emulator_integration_tests",
-      "target": "docs_e2e_lifecycle_reuse_teardown",
-      "confidence_score": 1.0
+      "target": "docs_e2e_lifecycle_reuse_teardown"
     },
     {
       "relation": "contains",
@@ -112952,9 +113445,9 @@
       "source_file": "docs/e2e.md",
       "source_location": "L104",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_e2e_emulator_integration_tests",
-      "target": "docs_e2e_running_locally",
-      "confidence_score": 1.0
+      "target": "docs_e2e_running_locally"
     },
     {
       "relation": "contains",
@@ -112962,9 +113455,9 @@
       "source_file": "docs/e2e.md",
       "source_location": "L189",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_e2e_emulator_integration_tests",
-      "target": "docs_e2e_spotting_clearing_a_poisoned_environment",
-      "confidence_score": 1.0
+      "target": "docs_e2e_spotting_clearing_a_poisoned_environment"
     },
     {
       "relation": "contains",
@@ -112972,9 +113465,9 @@
       "source_file": "docs/e2e.md",
       "source_location": "L21",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_e2e_emulator_integration_tests",
-      "target": "docs_e2e_the_containerized_test_emulator_stacks",
-      "confidence_score": 1.0
+      "target": "docs_e2e_the_containerized_test_emulator_stacks"
     },
     {
       "relation": "contains",
@@ -112982,9 +113475,9 @@
       "source_file": "docs/e2e.md",
       "source_location": "L59",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_e2e_emulator_integration_tests",
-      "target": "docs_e2e_the_dedicated_e2e_app_server",
-      "confidence_score": 1.0
+      "target": "docs_e2e_the_dedicated_e2e_app_server"
     },
     {
       "relation": "contains",
@@ -112992,9 +113485,9 @@
       "source_file": "docs/e2e.md",
       "source_location": "L143",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_e2e_emulator_integration_tests",
-      "target": "docs_e2e_vitest_emulator_integration_suites",
-      "confidence_score": 1.0
+      "target": "docs_e2e_vitest_emulator_integration_suites"
     },
     {
       "relation": "contains",
@@ -113002,9 +113495,9 @@
       "source_file": "docs/e2e.md",
       "source_location": "L39",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_e2e_the_containerized_test_emulator_stacks",
-      "target": "docs_e2e_port_sets",
-      "confidence_score": 1.0
+      "target": "docs_e2e_port_sets"
     },
     {
       "relation": "contains",
@@ -113012,9 +113505,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline",
-      "target": "docs_matching_pipeline_canon_item_matching_pipeline",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_canon_item_matching_pipeline"
     },
     {
       "relation": "conceptually_related_to",
@@ -113024,106 +113517,6 @@
       "source_location": null,
       "weight": 1.0,
       "source": "canon_matching_logging_canon_match_event",
-      "target": "docs_matching_pipeline_canon_item_matching_pipeline"
-    },
-    {
-      "relation": "references",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/matching-pipeline.md",
-      "source_location": null,
-      "weight": 1.0,
-      "confidence_score": 1.0,
-      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
-      "target": "docs_matching_pipeline_ai_arbitration"
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/matching-pipeline.md",
-      "source_location": "L9",
-      "weight": 1.0,
-      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
-      "target": "docs_matching_pipeline_authority_and_runtime",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/matching-pipeline.md",
-      "source_location": "L255",
-      "weight": 1.0,
-      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
-      "target": "docs_matching_pipeline_batch_entry_point_recipe_ingredient_canonicalisation",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/matching-pipeline.md",
-      "source_location": "L23",
-      "weight": 1.0,
-      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
-      "target": "docs_matching_pipeline_flow_diagram",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/matching-pipeline.md",
-      "source_location": "L162",
-      "weight": 1.0,
-      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
-      "target": "docs_matching_pipeline_logging_schema",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/matching-pipeline.md",
-      "source_location": "L298",
-      "weight": 1.0,
-      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
-      "target": "docs_matching_pipeline_reference_integrity_edits_and_canon_deletion",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/matching-pipeline.md",
-      "source_location": "L154",
-      "weight": 1.0,
-      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
-      "target": "docs_matching_pipeline_review_via_needs_approval",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/matching-pipeline.md",
-      "source_location": "L79",
-      "weight": 1.0,
-      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
-      "target": "docs_matching_pipeline_stage_by_stage_narrative",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "docs/matching-pipeline.md",
-      "source_location": "L326",
-      "weight": 1.0,
-      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
-      "target": "docs_matching_pipeline_thresholds_at_a_glance",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "conceptually_related_to",
-      "confidence": "INFERRED",
-      "confidence_score": 0.95,
-      "source_file": "docs/domain-implementation.md",
-      "source_location": null,
-      "weight": 1.0,
-      "source": "domain_implementation_canon_module",
       "target": "docs_matching_pipeline_canon_item_matching_pipeline"
     },
     {
@@ -113145,6 +113538,96 @@
       "weight": 1.0,
       "source": "docs_matching_pipeline_canon_item_matching_pipeline",
       "target": "canon_matching_logging_to_canon_match_event"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/matching-pipeline.md",
+      "source_location": null,
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
+      "target": "docs_matching_pipeline_ai_arbitration"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/matching-pipeline.md",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
+      "target": "docs_matching_pipeline_authority_and_runtime"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/matching-pipeline.md",
+      "source_location": "L255",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
+      "target": "docs_matching_pipeline_batch_entry_point_recipe_ingredient_canonicalisation"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/matching-pipeline.md",
+      "source_location": "L23",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
+      "target": "docs_matching_pipeline_flow_diagram"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/matching-pipeline.md",
+      "source_location": "L162",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
+      "target": "docs_matching_pipeline_logging_schema"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/matching-pipeline.md",
+      "source_location": "L298",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
+      "target": "docs_matching_pipeline_reference_integrity_edits_and_canon_deletion"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/matching-pipeline.md",
+      "source_location": "L154",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
+      "target": "docs_matching_pipeline_review_via_needs_approval"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/matching-pipeline.md",
+      "source_location": "L79",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
+      "target": "docs_matching_pipeline_stage_by_stage_narrative"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/matching-pipeline.md",
+      "source_location": "L326",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_matching_pipeline_canon_item_matching_pipeline",
+      "target": "docs_matching_pipeline_thresholds_at_a_glance"
     },
     {
       "relation": "references",
@@ -113207,14 +113690,24 @@
       "target": "matching_pipeline_trace_unification"
     },
     {
+      "relation": "conceptually_related_to",
+      "confidence": "INFERRED",
+      "confidence_score": 0.95,
+      "source_file": "docs/domain-implementation.md",
+      "source_location": null,
+      "weight": 1.0,
+      "source": "domain_implementation_canon_module",
+      "target": "docs_matching_pipeline_canon_item_matching_pipeline"
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L83",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_stage_by_stage_narrative",
-      "target": "docs_matching_pipeline_stage_1_exact_name_match",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_stage_1_exact_name_match"
     },
     {
       "relation": "contains",
@@ -113222,9 +113715,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L87",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_stage_by_stage_narrative",
-      "target": "docs_matching_pipeline_stage_2_token_overlap",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_stage_2_token_overlap"
     },
     {
       "relation": "contains",
@@ -113232,9 +113725,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L91",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_stage_by_stage_narrative",
-      "target": "docs_matching_pipeline_stage_3_synonym_exact_match",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_stage_3_synonym_exact_match"
     },
     {
       "relation": "contains",
@@ -113242,9 +113735,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L95",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_stage_by_stage_narrative",
-      "target": "docs_matching_pipeline_stage_4_string_similarity_levenshtein",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_stage_4_string_similarity_levenshtein"
     },
     {
       "relation": "contains",
@@ -113252,9 +113745,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L99",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_stage_by_stage_narrative",
-      "target": "docs_matching_pipeline_stage_5_embedding_cosine",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_stage_5_embedding_cosine"
     },
     {
       "relation": "contains",
@@ -113262,9 +113755,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L103",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_stage_by_stage_narrative",
-      "target": "docs_matching_pipeline_stage_6_merged_shortlist_ai_arbitration",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_stage_6_merged_shortlist_ai_arbitration"
     },
     {
       "relation": "contains",
@@ -113272,9 +113765,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L122",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_ai_arbitration",
-      "target": "docs_matching_pipeline_ai_fallback_rule_behavioural_contract",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_ai_fallback_rule_behavioural_contract"
     },
     {
       "relation": "contains",
@@ -113282,9 +113775,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L148",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_ai_arbitration",
-      "target": "docs_matching_pipeline_why_fall_back_rather_than_create_new",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_why_fall_back_rather_than_create_new"
     },
     {
       "relation": "references",
@@ -113302,9 +113795,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L132",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_ai_fallback_rule_behavioural_contract",
-      "target": "docs_matching_pipeline_stage_4_edit_distance_is_ai_confirm_only",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_stage_4_edit_distance_is_ai_confirm_only"
     },
     {
       "relation": "contains",
@@ -113312,9 +113805,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L236",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_logging_schema",
-      "target": "docs_matching_pipeline_adapter_serialisation",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_adapter_serialisation"
     },
     {
       "relation": "contains",
@@ -113322,9 +113815,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L183",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_logging_schema",
-      "target": "docs_matching_pipeline_per_stage_fields_stages_1_4_fast_path_cf_parity",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_per_stage_fields_stages_1_4_fast_path_cf_parity"
     },
     {
       "relation": "contains",
@@ -113332,9 +113825,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L209",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_logging_schema",
-      "target": "docs_matching_pipeline_per_stage_fields_stages_5_6_cf_only",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_per_stage_fields_stages_5_6_cf_only"
     },
     {
       "relation": "contains",
@@ -113342,9 +113835,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L170",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_logging_schema",
-      "target": "docs_matching_pipeline_top_level_fields",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_top_level_fields"
     },
     {
       "relation": "contains",
@@ -113352,9 +113845,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L245",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_logging_schema",
-      "target": "docs_matching_pipeline_trace_context_unification_server_side_env_gated",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_trace_context_unification_server_side_env_gated"
     },
     {
       "relation": "contains",
@@ -113362,9 +113855,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L200",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_per_stage_fields_stages_1_4_fast_path_cf_parity",
-      "target": "docs_matching_pipeline_per_stage_outcomes",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_per_stage_outcomes"
     },
     {
       "relation": "contains",
@@ -113372,9 +113865,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L281",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_batch_entry_point_recipe_ingredient_canonicalisation",
-      "target": "docs_matching_pipeline_batched_embedding_without_forking_stage_5",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_batched_embedding_without_forking_stage_5"
     },
     {
       "relation": "contains",
@@ -113382,9 +113875,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L277",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_batch_entry_point_recipe_ingredient_canonicalisation",
-      "target": "docs_matching_pipeline_growing_snapshot",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_growing_snapshot"
     },
     {
       "relation": "contains",
@@ -113392,9 +113885,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L261",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_batch_entry_point_recipe_ingredient_canonicalisation",
-      "target": "docs_matching_pipeline_one_path_batch_with_single_as_n_1",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_one_path_batch_with_single_as_n_1"
     },
     {
       "relation": "contains",
@@ -113402,9 +113895,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L287",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_batch_entry_point_recipe_ingredient_canonicalisation",
-      "target": "docs_matching_pipeline_parity_guarantee",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_parity_guarantee"
     },
     {
       "relation": "contains",
@@ -113412,9 +113905,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L309",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_reference_integrity_edits_and_canon_deletion",
-      "target": "docs_matching_pipeline_canon_deletion_is_resolved_at_display_time_never_written_back",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_canon_deletion_is_resolved_at_display_time_never_written_back"
     },
     {
       "relation": "contains",
@@ -113422,9 +113915,9 @@
       "source_file": "docs/matching-pipeline.md",
       "source_location": "L302",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_matching_pipeline_reference_integrity_edits_and_canon_deletion",
-      "target": "docs_matching_pipeline_edits_clear_the_match_eagerly",
-      "confidence_score": 1.0
+      "target": "docs_matching_pipeline_edits_clear_the_match_eagerly"
     },
     {
       "relation": "contains",
@@ -113432,9 +113925,9 @@
       "source_file": "docs/meal-planning.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_meal_planning",
-      "target": "docs_meal_planning_meal_planning_module",
-      "confidence_score": 1.0
+      "target": "docs_meal_planning_meal_planning_module"
     },
     {
       "relation": "contains",
@@ -113442,9 +113935,9 @@
       "source_file": "docs/meal-planning.md",
       "source_location": "L81",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_meal_planning_meal_planning_module",
-      "target": "docs_meal_planning_access_admin",
-      "confidence_score": 1.0
+      "target": "docs_meal_planning_access_admin"
     },
     {
       "relation": "contains",
@@ -113452,9 +113945,9 @@
       "source_file": "docs/meal-planning.md",
       "source_location": "L90",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_meal_planning_meal_planning_module",
-      "target": "docs_meal_planning_architecture_placement",
-      "confidence_score": 1.0
+      "target": "docs_meal_planning_architecture_placement"
     },
     {
       "relation": "contains",
@@ -113462,9 +113955,9 @@
       "source_file": "docs/meal-planning.md",
       "source_location": "L66",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_meal_planning_meal_planning_module",
-      "target": "docs_meal_planning_conflict_model",
-      "confidence_score": 1.0
+      "target": "docs_meal_planning_conflict_model"
     },
     {
       "relation": "contains",
@@ -113472,9 +113965,9 @@
       "source_file": "docs/meal-planning.md",
       "source_location": "L22",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_meal_planning_meal_planning_module",
-      "target": "docs_meal_planning_day_shape_shared_by_template_and_week",
-      "confidence_score": 1.0
+      "target": "docs_meal_planning_day_shape_shared_by_template_and_week"
     },
     {
       "relation": "contains",
@@ -113482,9 +113975,9 @@
       "source_file": "docs/meal-planning.md",
       "source_location": "L11",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_meal_planning_meal_planning_module",
-      "target": "docs_meal_planning_documents",
-      "confidence_score": 1.0
+      "target": "docs_meal_planning_documents"
     },
     {
       "relation": "contains",
@@ -113492,9 +113985,9 @@
       "source_file": "docs/meal-planning.md",
       "source_location": "L47",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_meal_planning_meal_planning_module",
-      "target": "docs_meal_planning_first_day_of_week_week_identity",
-      "confidence_score": 1.0
+      "target": "docs_meal_planning_first_day_of_week_week_identity"
     },
     {
       "relation": "contains",
@@ -113502,9 +113995,9 @@
       "source_file": "docs/meal-planning.md",
       "source_location": "L100",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_meal_planning_meal_planning_module",
-      "target": "docs_meal_planning_future_seam_recipes_17",
-      "confidence_score": 1.0
+      "target": "docs_meal_planning_future_seam_recipes_17"
     },
     {
       "relation": "contains",
@@ -113512,9 +114005,9 @@
       "source_file": "docs/meal-planning.md",
       "source_location": "L74",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_meal_planning_meal_planning_module",
-      "target": "docs_meal_planning_member_references",
-      "confidence_score": 1.0
+      "target": "docs_meal_planning_member_references"
     },
     {
       "relation": "contains",
@@ -113522,9 +114015,9 @@
       "source_file": "docs/meal-planning.md",
       "source_location": "L58",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_meal_planning_meal_planning_module",
-      "target": "docs_meal_planning_the_core_mechanic_load_template",
-      "confidence_score": 1.0
+      "target": "docs_meal_planning_the_core_mechanic_load_template"
     },
     {
       "relation": "references",
@@ -113562,9 +114055,9 @@
       "source_file": "docs/recipe-module.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_recipe_module",
-      "target": "docs_recipe_module_recipe_module",
-      "confidence_score": 1.0
+      "target": "docs_recipe_module_recipe_module"
     },
     {
       "relation": "references",
@@ -113572,9 +114065,9 @@
       "source_file": "docs/recipe-module.md",
       "source_location": "L29",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_recipe_module",
-      "target": "docs_salt_architecture",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture"
     },
     {
       "relation": "contains",
@@ -113582,9 +114075,9 @@
       "source_file": "docs/recipe-module.md",
       "source_location": "L177",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_recipe_module_recipe_module",
-      "target": "docs_recipe_module_access_admin",
-      "confidence_score": 1.0
+      "target": "docs_recipe_module_access_admin"
     },
     {
       "relation": "contains",
@@ -113592,9 +114085,9 @@
       "source_file": "docs/recipe-module.md",
       "source_location": "L166",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_recipe_module_recipe_module",
-      "target": "docs_recipe_module_architecture_placement",
-      "confidence_score": 1.0
+      "target": "docs_recipe_module_architecture_placement"
     },
     {
       "relation": "contains",
@@ -113602,9 +114095,9 @@
       "source_file": "docs/recipe-module.md",
       "source_location": "L107",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_recipe_module_recipe_module",
-      "target": "docs_recipe_module_canon_interaction_batch_cf_one_read_per_recipe",
-      "confidence_score": 1.0
+      "target": "docs_recipe_module_canon_interaction_batch_cf_one_read_per_recipe"
     },
     {
       "relation": "contains",
@@ -113612,9 +114105,9 @@
       "source_file": "docs/recipe-module.md",
       "source_location": "L158",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_recipe_module_recipe_module",
-      "target": "docs_recipe_module_cross_module_seams_already_shipped_awaiting_this_module",
-      "confidence_score": 1.0
+      "target": "docs_recipe_module_cross_module_seams_already_shipped_awaiting_this_module"
     },
     {
       "relation": "contains",
@@ -113622,9 +114115,9 @@
       "source_file": "docs/recipe-module.md",
       "source_location": "L182",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_recipe_module_recipe_module",
-      "target": "docs_recipe_module_deferred_the_ai_generation_epic_own_issue_design_session",
-      "confidence_score": 1.0
+      "target": "docs_recipe_module_deferred_the_ai_generation_epic_own_issue_design_session"
     },
     {
       "relation": "contains",
@@ -113632,9 +114125,9 @@
       "source_file": "docs/recipe-module.md",
       "source_location": "L23",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_recipe_module_recipe_module",
-      "target": "docs_recipe_module_document",
-      "confidence_score": 1.0
+      "target": "docs_recipe_module_document"
     },
     {
       "relation": "contains",
@@ -113642,9 +114135,9 @@
       "source_file": "docs/recipe-module.md",
       "source_location": "L32",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_recipe_module_recipe_module",
-      "target": "docs_recipe_module_schema_simplified_from_28",
-      "confidence_score": 1.0
+      "target": "docs_recipe_module_schema_simplified_from_28"
     },
     {
       "relation": "contains",
@@ -113652,9 +114145,9 @@
       "source_file": "docs/recipe-module.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_recipe_module_recipe_module",
-      "target": "docs_recipe_module_scope_split_decided_in_28_design_session",
-      "confidence_score": 1.0
+      "target": "docs_recipe_module_scope_split_decided_in_28_design_session"
     },
     {
       "relation": "contains",
@@ -113662,19 +114155,9 @@
       "source_file": "docs/recipe-module.md",
       "source_location": "L131",
       "weight": 1.0,
-      "source": "docs_recipe_module_recipe_module",
-      "target": "docs_recipe_module_shopping_list_extraction_recipe_list",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "references",
-      "confidence": "EXTRACTED",
       "confidence_score": 1.0,
-      "source_file": "docs/meal-planning.md",
-      "source_location": null,
-      "weight": 1.0,
-      "source": "meal_planning_day_shape",
-      "target": "docs_recipe_module_recipe_module"
+      "source": "docs_recipe_module_recipe_module",
+      "target": "docs_recipe_module_shopping_list_extraction_recipe_list"
     },
     {
       "relation": "cites",
@@ -113717,14 +114200,24 @@
       "target": "recipe_module_recipe_schema"
     },
     {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "docs/meal-planning.md",
+      "source_location": null,
+      "weight": 1.0,
+      "source": "meal_planning_day_shape",
+      "target": "docs_recipe_module_recipe_module"
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/recipe-module.md",
       "source_location": "L87",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_recipe_module_schema_simplified_from_28",
-      "target": "docs_recipe_module_schema_extensions_issue_180",
-      "confidence_score": 1.0
+      "target": "docs_recipe_module_schema_extensions_issue_180"
     },
     {
       "relation": "contains",
@@ -113732,9 +114225,9 @@
       "source_file": "docs/releases.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_releases",
-      "target": "docs_releases_releases_environments",
-      "confidence_score": 1.0
+      "target": "docs_releases_releases_environments"
     },
     {
       "relation": "contains",
@@ -113742,9 +114235,9 @@
       "source_file": "docs/releases.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_releases_releases_environments",
-      "target": "docs_releases_config_secrets_what_lives_where",
-      "confidence_score": 1.0
+      "target": "docs_releases_config_secrets_what_lives_where"
     },
     {
       "relation": "contains",
@@ -113752,9 +114245,9 @@
       "source_file": "docs/releases.md",
       "source_location": "L115",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_releases_releases_environments",
-      "target": "docs_releases_deploying",
-      "confidence_score": 1.0
+      "target": "docs_releases_deploying"
     },
     {
       "relation": "contains",
@@ -113762,9 +114255,9 @@
       "source_file": "docs/releases.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_releases_releases_environments",
-      "target": "docs_releases_firebase_projects_firebaserc_aliases",
-      "confidence_score": 1.0
+      "target": "docs_releases_firebase_projects_firebaserc_aliases"
     },
     {
       "relation": "contains",
@@ -113772,9 +114265,9 @@
       "source_file": "docs/releases.md",
       "source_location": "L162",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_releases_releases_environments",
-      "target": "docs_releases_first_deploy_to_a_fresh_project_one_time_bootstrap",
-      "confidence_score": 1.0
+      "target": "docs_releases_first_deploy_to_a_fresh_project_one_time_bootstrap"
     },
     {
       "relation": "contains",
@@ -113782,9 +114275,9 @@
       "source_file": "docs/releases.md",
       "source_location": "L185",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_releases_releases_environments",
-      "target": "docs_releases_setup_status",
-      "confidence_score": 1.0
+      "target": "docs_releases_setup_status"
     },
     {
       "relation": "references",
@@ -113862,9 +114355,9 @@
       "source_file": "docs/releases.md",
       "source_location": "L29",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_releases_config_secrets_what_lives_where",
-      "target": "docs_releases_1_client_config_build_time_committed_not_secret",
-      "confidence_score": 1.0
+      "target": "docs_releases_1_client_config_build_time_committed_not_secret"
     },
     {
       "relation": "contains",
@@ -113872,9 +114365,9 @@
       "source_file": "docs/releases.md",
       "source_location": "L60",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_releases_config_secrets_what_lives_where",
-      "target": "docs_releases_2_cloud_functions_runtime_secrets_secret_manager_per_project_never_committed",
-      "confidence_score": 1.0
+      "target": "docs_releases_2_cloud_functions_runtime_secrets_secret_manager_per_project_never_committed"
     },
     {
       "relation": "contains",
@@ -113882,9 +114375,9 @@
       "source_file": "docs/releases.md",
       "source_location": "L86",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_releases_config_secrets_what_lives_where",
-      "target": "docs_releases_3_ci_github_environments",
-      "confidence_score": 1.0
+      "target": "docs_releases_3_ci_github_environments"
     },
     {
       "relation": "contains",
@@ -113892,9 +114385,9 @@
       "source_file": "docs/releases.md",
       "source_location": "L101",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_releases_3_ci_github_environments",
-      "target": "docs_releases_wif_identifiers_provisioned_phase_2",
-      "confidence_score": 1.0
+      "target": "docs_releases_wif_identifiers_provisioned_phase_2"
     },
     {
       "relation": "contains",
@@ -113902,9 +114395,9 @@
       "source_file": "docs/releases.md",
       "source_location": "L128",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_releases_deploying",
-      "target": "docs_releases_cutting_a_release_promote_staging_production",
-      "confidence_score": 1.0
+      "target": "docs_releases_cutting_a_release_promote_staging_production"
     },
     {
       "relation": "contains",
@@ -113912,9 +114405,9 @@
       "source_file": "docs/releases.md",
       "source_location": "L147",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_releases_deploying",
-      "target": "docs_releases_rollback_re_deploy",
-      "confidence_score": 1.0
+      "target": "docs_releases_rollback_re_deploy"
     },
     {
       "relation": "contains",
@@ -113922,9 +114415,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture",
-      "target": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0"
     },
     {
       "relation": "contains",
@@ -113932,9 +114425,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L305",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_10_shared_types_requirements",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_10_shared_types_requirements"
     },
     {
       "relation": "contains",
@@ -113942,9 +114435,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L320",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_11_enforcement_rules",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_11_enforcement_rules"
     },
     {
       "relation": "contains",
@@ -113952,9 +114445,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L358",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_12_testing_strategy",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_12_testing_strategy"
     },
     {
       "relation": "contains",
@@ -113962,9 +114455,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L388",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_13_deployment_units",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_13_deployment_units"
     },
     {
       "relation": "contains",
@@ -113972,9 +114465,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L400",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_14_non_negotiables",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_14_non_negotiables"
     },
     {
       "relation": "contains",
@@ -113982,9 +114475,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_1_purpose",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_1_purpose"
     },
     {
       "relation": "contains",
@@ -113992,9 +114485,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L28",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_2_mono_repo_structure_logical_modules",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_2_mono_repo_structure_logical_modules"
     },
     {
       "relation": "contains",
@@ -114002,9 +114495,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L51",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_3_dependency_graph_allowed_imports",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_3_dependency_graph_allowed_imports"
     },
     {
       "relation": "contains",
@@ -114012,9 +114505,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L88",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_4_domain_layer_requirements",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_4_domain_layer_requirements"
     },
     {
       "relation": "contains",
@@ -114022,9 +114515,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L121",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_5_workspace_and_access_model",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_5_workspace_and_access_model"
     },
     {
       "relation": "contains",
@@ -114032,9 +114525,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L136",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_6_adapter_requirements",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_6_adapter_requirements"
     },
     {
       "relation": "contains",
@@ -114042,9 +114535,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L201",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_7_adapter_error_contract",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_7_adapter_error_contract"
     },
     {
       "relation": "contains",
@@ -114052,9 +114545,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L254",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_8_cloud_functions_requirements",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_8_cloud_functions_requirements"
     },
     {
       "relation": "contains",
@@ -114062,9 +114555,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L285",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_salt_2_0_architecture_contract_v1_0",
-      "target": "docs_salt_architecture_9_pwa_ui_requirements",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_9_pwa_ui_requirements"
     },
     {
       "relation": "contains",
@@ -114072,9 +114565,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L20",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_1_purpose",
-      "target": "docs_salt_architecture_1_1_schema_evolution_and_production_data",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_1_1_schema_evolution_and_production_data"
     },
     {
       "relation": "contains",
@@ -114082,9 +114575,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L53",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_3_dependency_graph_allowed_imports",
-      "target": "docs_salt_architecture_allowed",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_allowed"
     },
     {
       "relation": "contains",
@@ -114092,9 +114585,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L62",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_3_dependency_graph_allowed_imports",
-      "target": "docs_salt_architecture_forbidden",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_forbidden"
     },
     {
       "relation": "contains",
@@ -114102,9 +114595,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L78",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_forbidden",
-      "target": "docs_salt_architecture_narrow_exception_pre_authentication_ephemeral_state_in_web_pwa",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_narrow_exception_pre_authentication_ephemeral_state_in_web_pwa"
     },
     {
       "relation": "contains",
@@ -114112,9 +114605,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L138",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_6_adapter_requirements",
-      "target": "docs_salt_architecture_6_1_firebase_sync_adapter",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_6_1_firebase_sync_adapter"
     },
     {
       "relation": "contains",
@@ -114122,9 +114615,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L166",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_6_adapter_requirements",
-      "target": "docs_salt_architecture_6_2_observability_adapter",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_6_2_observability_adapter"
     },
     {
       "relation": "contains",
@@ -114132,9 +114625,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L190",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_6_adapter_requirements",
-      "target": "docs_salt_architecture_6_3_common_rules",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_6_3_common_rules"
     },
     {
       "relation": "contains",
@@ -114142,9 +114635,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L206",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_7_adapter_error_contract",
-      "target": "docs_salt_architecture_7_1_error_shape",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_7_1_error_shape"
     },
     {
       "relation": "contains",
@@ -114152,9 +114645,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L216",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_7_adapter_error_contract",
-      "target": "docs_salt_architecture_7_2_domainerror_categories",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_7_2_domainerror_categories"
     },
     {
       "relation": "contains",
@@ -114162,9 +114655,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L230",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_7_adapter_error_contract",
-      "target": "docs_salt_architecture_7_3_loading_states",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_7_3_loading_states"
     },
     {
       "relation": "contains",
@@ -114172,9 +114665,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L234",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_7_adapter_error_contract",
-      "target": "docs_salt_architecture_7_4_offline_behaviour",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_7_4_offline_behaviour"
     },
     {
       "relation": "contains",
@@ -114182,9 +114675,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L240",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_7_adapter_error_contract",
-      "target": "docs_salt_architecture_7_5_error_propagation_rules",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_7_5_error_propagation_rules"
     },
     {
       "relation": "contains",
@@ -114192,9 +114685,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L246",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_7_adapter_error_contract",
-      "target": "docs_salt_architecture_7_6_logging_and_error_reporting",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_7_6_logging_and_error_reporting"
     },
     {
       "relation": "contains",
@@ -114202,9 +114695,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L341",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_11_enforcement_rules",
-      "target": "docs_salt_architecture_commit_gateway",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_commit_gateway"
     },
     {
       "relation": "contains",
@@ -114212,9 +114705,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L322",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_11_enforcement_rules",
-      "target": "docs_salt_architecture_eslint",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_eslint"
     },
     {
       "relation": "contains",
@@ -114222,9 +114715,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L335",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_11_enforcement_rules",
-      "target": "docs_salt_architecture_tsconfig",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_tsconfig"
     },
     {
       "relation": "contains",
@@ -114232,9 +114725,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L375",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_12_testing_strategy",
-      "target": "docs_salt_architecture_cloud_functions",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_cloud_functions"
     },
     {
       "relation": "contains",
@@ -114242,9 +114735,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L360",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_12_testing_strategy",
-      "target": "docs_salt_architecture_domain",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_domain"
     },
     {
       "relation": "contains",
@@ -114252,9 +114745,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L365",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_12_testing_strategy",
-      "target": "docs_salt_architecture_firebase_sync",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_firebase_sync"
     },
     {
       "relation": "contains",
@@ -114262,9 +114755,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L370",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_12_testing_strategy",
-      "target": "docs_salt_architecture_observability",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_observability"
     },
     {
       "relation": "contains",
@@ -114272,9 +114765,9 @@
       "source_file": "docs/salt-architecture.md",
       "source_location": "L380",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_salt_architecture_12_testing_strategy",
-      "target": "docs_salt_architecture_ui",
-      "confidence_score": 1.0
+      "target": "docs_salt_architecture_ui"
     },
     {
       "relation": "references",
@@ -116093,5 +116586,5 @@
       "source_file": ".claude/commands/spec.md"
     }
   ],
-  "built_at_commit": "64a386d0e9e8236dbd74edd896b232be3aef3048"
+  "built_at_commit": "fd895d5989d2ae19cfc48cdc1f421de5b2e96542"
 }

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -651,7 +651,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "apps_cloud_functions_src_boundary_tests_no_stage_internals_ts_boundary_tests_no_stage_internals",
-      "community": 64,
+      "community": 7,
       "norm_label": "no-stage-internals.ts"
     },
     {
@@ -851,7 +851,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_serverarbitration",
-      "community": 161,
+      "community": 64,
       "norm_label": "serverarbitration.ts"
     },
     {
@@ -891,7 +891,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_serverentryparse",
-      "community": 96,
+      "community": 75,
       "norm_label": "serverentryparse.ts"
     },
     {
@@ -901,7 +901,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "adapters_serverentryparse_createserverentryparseadapter",
-      "community": 96,
+      "community": 75,
       "norm_label": "createserverentryparseadapter()"
     },
     {
@@ -1131,7 +1131,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_fakemodel",
-      "community": 28,
+      "community": 161,
       "norm_label": "fakemodel.ts"
     },
     {
@@ -1141,7 +1141,7 @@
       "source_location": "L72",
       "_origin": "ast",
       "id": "ai_fakemodel_aifakeenabled",
-      "community": 29,
+      "community": 161,
       "norm_label": "aifakeenabled()"
     },
     {
@@ -1151,7 +1151,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "ai_fakemodel_fakemodels",
-      "community": 28,
+      "community": 161,
       "norm_label": "fakemodels"
     },
     {
@@ -1161,7 +1161,7 @@
       "source_location": "L85",
       "_origin": "ast",
       "id": "ai_fakemodel_definefakemodel",
-      "community": 28,
+      "community": 161,
       "norm_label": "definefakemodel()"
     },
     {
@@ -1171,7 +1171,7 @@
       "source_location": "L157",
       "_origin": "ast",
       "id": "ai_fakemodel_flowmodel",
-      "community": 28,
+      "community": 161,
       "norm_label": "flowmodel()"
     },
     {
@@ -1181,7 +1181,7 @@
       "source_location": "L175",
       "_origin": "ast",
       "id": "ai_fakemodel_aimodellabel",
-      "community": 28,
+      "community": 161,
       "norm_label": "aimodellabel()"
     },
     {
@@ -1191,7 +1191,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_listaimodels",
-      "community": 96,
+      "community": 61,
       "norm_label": "listaimodels.ts"
     },
     {
@@ -1201,7 +1201,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "ai_listaimodels_catalogmodelschema",
-      "community": 96,
+      "community": 61,
       "norm_label": "catalogmodelschema"
     },
     {
@@ -1211,7 +1211,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "ai_listaimodels_catalogresponseschema",
-      "community": 96,
+      "community": 61,
       "norm_label": "catalogresponseschema"
     },
     {
@@ -1221,7 +1221,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "ai_listaimodels_listaimodelsinputschema",
-      "community": 96,
+      "community": 61,
       "norm_label": "listaimodelsinputschema"
     },
     {
@@ -1231,7 +1231,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "ai_listaimodels_aicatalogmodel",
-      "community": 96,
+      "community": 61,
       "norm_label": "aicatalogmodel"
     },
     {
@@ -1241,7 +1241,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "ai_listaimodels_listaimodelsresult",
-      "community": 96,
+      "community": 61,
       "norm_label": "listaimodelsresult"
     },
     {
@@ -1251,7 +1251,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "ai_listaimodels_cacheentry",
-      "community": 96,
+      "community": 61,
       "norm_label": "cacheentry"
     },
     {
@@ -1261,7 +1261,7 @@
       "source_location": "L59",
       "_origin": "ast",
       "id": "ai_listaimodels_bareid",
-      "community": 96,
+      "community": 61,
       "norm_label": "bareid()"
     },
     {
@@ -1271,7 +1271,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "ai_listaimodels_fetchcatalog",
-      "community": 96,
+      "community": 61,
       "norm_label": "fetchcatalog()"
     },
     {
@@ -1281,7 +1281,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "ai_listaimodels_loadcatalog",
-      "community": 96,
+      "community": 61,
       "norm_label": "loadcatalog()"
     },
     {
@@ -1291,7 +1291,7 @@
       "source_location": "L114",
       "_origin": "ast",
       "id": "ai_listaimodels_handlelistaimodels",
-      "community": 96,
+      "community": 61,
       "norm_label": "handlelistaimodels()"
     },
     {
@@ -1301,7 +1301,7 @@
       "source_location": "L124",
       "_origin": "ast",
       "id": "ai_listaimodels_resetlistaimodelscachefortest",
-      "community": 96,
+      "community": 61,
       "norm_label": "__resetlistaimodelscachefortest()"
     },
     {
@@ -1401,7 +1401,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "ai_modelcapabilities_modelsupportsrole",
-      "community": 96,
+      "community": 61,
       "norm_label": "modelsupportsrole()"
     },
     {
@@ -1481,7 +1481,7 @@
       "source_location": "L71",
       "_origin": "ast",
       "id": "ai_resolvemodel_resolvemodel",
-      "community": 28,
+      "community": 161,
       "norm_label": "resolvemodel()"
     },
     {
@@ -1575,10 +1575,20 @@
       "norm_label": "regeneratecanonicon.ts"
     },
     {
+      "label": "posthogApiKey",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/src/callables/regenerateCanonIcon.ts",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "callables_regeneratecanonicon_posthogapikey",
+      "community": 34,
+      "norm_label": "posthogapikey"
+    },
+    {
       "label": "regenerateCanonIcon",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/callables/regenerateCanonIcon.ts",
-      "source_location": "L21",
+      "source_location": "L27",
       "_origin": "ast",
       "id": "callables_regeneratecanonicon_regeneratecanonicon",
       "community": 34,
@@ -1591,7 +1601,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_dev",
-      "community": 29,
+      "community": 161,
       "norm_label": "dev.ts"
     },
     {
@@ -1691,7 +1701,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "flows_authorrecipe_assembledraft",
-      "community": 68,
+      "community": 28,
       "norm_label": "assembledraft()"
     },
     {
@@ -1701,7 +1711,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_canonicaliserecipeingredients",
-      "community": 75,
+      "community": 28,
       "norm_label": "canonicaliserecipeingredients.ts"
     },
     {
@@ -1711,7 +1721,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "flows_canonicaliserecipeingredients_itemresultschema",
-      "community": 75,
+      "community": 28,
       "norm_label": "itemresultschema"
     },
     {
@@ -1721,7 +1731,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "flows_canonicaliserecipeingredients_outputschema",
-      "community": 75,
+      "community": 28,
       "norm_label": "outputschema"
     },
     {
@@ -1731,7 +1741,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "flows_canonicaliserecipeingredients_canonicaliserecipeingredientsflow",
-      "community": 68,
+      "community": 28,
       "norm_label": "canonicaliserecipeingredientsflow"
     },
     {
@@ -1741,47 +1751,47 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_chefchat",
-      "community": 28,
+      "community": 96,
       "norm_label": "chefchat.ts"
     },
     {
       "label": "readEquipmentContext()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/chefChat.ts",
-      "source_location": "L16",
+      "source_location": "L17",
       "_origin": "ast",
       "id": "flows_chefchat_readequipmentcontext",
-      "community": 28,
+      "community": 96,
       "norm_label": "readequipmentcontext()"
     },
     {
       "label": "readRecipeContext()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/chefChat.ts",
-      "source_location": "L48",
+      "source_location": "L49",
       "_origin": "ast",
       "id": "flows_chefchat_readrecipecontext",
-      "community": 28,
+      "community": 96,
       "norm_label": "readrecipecontext()"
     },
     {
       "label": "buildSystemPrompt()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/chefChat.ts",
-      "source_location": "L80",
+      "source_location": "L81",
       "_origin": "ast",
       "id": "flows_chefchat_buildsystemprompt",
-      "community": 28,
+      "community": 96,
       "norm_label": "buildsystemprompt()"
     },
     {
       "label": "chefChatFlow",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/chefChat.ts",
-      "source_location": "L98",
+      "source_location": "L99",
       "_origin": "ast",
       "id": "flows_chefchat_chefchatflow",
-      "community": 34,
+      "community": 96,
       "norm_label": "chefchatflow"
     },
     {
@@ -1791,7 +1801,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_embedtext",
-      "community": 29,
+      "community": 161,
       "norm_label": "embedtext.ts"
     },
     {
@@ -1801,7 +1811,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "flows_embedtext_fake_embedding",
-      "community": 29,
+      "community": 161,
       "norm_label": "fake_embedding"
     },
     {
@@ -1821,7 +1831,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl",
-      "community": 68,
+      "community": 28,
       "norm_label": "extractrecipefromurl.ts"
     },
     {
@@ -1831,7 +1841,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_urlimporterror",
-      "community": 68,
+      "community": 34,
       "norm_label": "urlimporterror"
     },
     {
@@ -1841,7 +1851,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_urlimporterror_constructor",
-      "community": 68,
+      "community": 34,
       "norm_label": ".constructor()"
     },
     {
@@ -1851,7 +1861,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_outputschema",
-      "community": 68,
+      "community": 28,
       "norm_label": "outputschema"
     },
     {
@@ -1861,7 +1871,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_extractrecipefromurlflow",
-      "community": 68,
+      "community": 34,
       "norm_label": "extractrecipefromurlflow"
     },
     {
@@ -1871,7 +1881,7 @@
       "source_location": "L159",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_hasusablerecipe",
-      "community": 68,
+      "community": 28,
       "norm_label": "hasusablerecipe()"
     },
     {
@@ -1881,7 +1891,7 @@
       "source_location": "L184",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_buildjsonldprompt",
-      "community": 68,
+      "community": 28,
       "norm_label": "buildjsonldprompt()"
     },
     {
@@ -1891,7 +1901,7 @@
       "source_location": "L220",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_striphtmlnoise",
-      "community": 68,
+      "community": 28,
       "norm_label": "striphtmlnoise()"
     },
     {
@@ -1901,7 +1911,7 @@
       "source_location": "L237",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_buildhtmlprompt",
-      "community": 68,
+      "community": 28,
       "norm_label": "buildhtmlprompt()"
     },
     {
@@ -1911,7 +1921,7 @@
       "source_location": "L249",
       "_origin": "ast",
       "id": "flows_extractrecipefromurl_assembledraft",
-      "community": 68,
+      "community": 28,
       "norm_label": "assembledraft()"
     },
     {
@@ -1981,24 +1991,24 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_generatechattitle",
-      "community": 28,
+      "community": 161,
       "norm_label": "generatechattitle.ts"
     },
     {
       "label": "InputSchema",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/generateChatTitle.ts",
-      "source_location": "L7",
+      "source_location": "L8",
       "_origin": "ast",
       "id": "flows_generatechattitle_inputschema",
-      "community": 28,
+      "community": 161,
       "norm_label": "inputschema"
     },
     {
       "label": "generateChatTitleFlow",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/generateChatTitle.ts",
-      "source_location": "L18",
+      "source_location": "L19",
       "_origin": "ast",
       "id": "flows_generatechattitle_generatechattitleflow",
       "community": 34,
@@ -2011,14 +2021,14 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_identifyequipment",
-      "community": 28,
+      "community": 34,
       "norm_label": "identifyequipment.ts"
     },
     {
       "label": "identifyEquipmentFlow",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/identifyEquipment.ts",
-      "source_location": "L10",
+      "source_location": "L11",
       "_origin": "ast",
       "id": "flows_identifyequipment_identifyequipmentflow",
       "community": 34,
@@ -2028,10 +2038,10 @@
       "label": "SYSTEM_INSTRUCTIONS",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/identifyEquipment.ts",
-      "source_location": "L35",
+      "source_location": "L45",
       "_origin": "ast",
       "id": "flows_identifyequipment_system_instructions",
-      "community": 28,
+      "community": 34,
       "norm_label": "system_instructions"
     },
     {
@@ -2121,7 +2131,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "flows_parseentry_parseentryflow",
-      "community": 96,
+      "community": 75,
       "norm_label": "parseentryflow"
     },
     {
@@ -2151,7 +2161,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "flows_parserecipeingredients_parserecipeingredientsflow",
-      "community": 68,
+      "community": 28,
       "norm_label": "parserecipeingredientsflow"
     },
     {
@@ -2171,14 +2181,14 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_populateequipmententry",
-      "community": 28,
+      "community": 34,
       "norm_label": "populateequipmententry.ts"
     },
     {
       "label": "populateEquipmentEntryFlow",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/populateEquipmentEntry.ts",
-      "source_location": "L10",
+      "source_location": "L11",
       "_origin": "ast",
       "id": "flows_populateequipmententry_populateequipmententryflow",
       "community": 34,
@@ -2188,10 +2198,10 @@
       "label": "SYSTEM_INSTRUCTIONS",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/populateEquipmentEntry.ts",
-      "source_location": "L40",
+      "source_location": "L49",
       "_origin": "ast",
       "id": "flows_populateequipmententry_system_instructions",
-      "community": 28,
+      "community": 34,
       "norm_label": "system_instructions"
     },
     {
@@ -2288,7 +2298,7 @@
       "label": "geminiApiKey",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L66",
+      "source_location": "L67",
       "_origin": "ast",
       "id": "src_index_geminiapikey",
       "community": 34,
@@ -2298,7 +2308,7 @@
       "label": "posthogApiKey",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L70",
+      "source_location": "L71",
       "_origin": "ast",
       "id": "src_index_posthogapikey",
       "community": 34,
@@ -2308,7 +2318,7 @@
       "label": "APP_CHECK_ENFORCEMENT",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L76",
+      "source_location": "L77",
       "_origin": "ast",
       "id": "src_index_app_check_enforcement",
       "community": 34,
@@ -2318,7 +2328,7 @@
       "label": "embedText",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L78",
+      "source_location": "L79",
       "_origin": "ast",
       "id": "src_index_embedtext",
       "community": 34,
@@ -2328,7 +2338,7 @@
       "label": "arbitrateCanon",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L87",
+      "source_location": "L88",
       "_origin": "ast",
       "id": "src_index_arbitratecanon",
       "community": 34,
@@ -2338,7 +2348,7 @@
       "label": "matchOrCreateCanon",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L112",
+      "source_location": "L113",
       "_origin": "ast",
       "id": "src_index_matchorcreatecanon",
       "community": 34,
@@ -2348,7 +2358,7 @@
       "label": "canonicaliseRecipeIngredients",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L143",
+      "source_location": "L155",
       "_origin": "ast",
       "id": "src_index_canonicaliserecipeingredients",
       "community": 34,
@@ -2358,7 +2368,7 @@
       "label": "identifyEquipment",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L167",
+      "source_location": "L186",
       "_origin": "ast",
       "id": "src_index_identifyequipment",
       "community": 34,
@@ -2368,7 +2378,7 @@
       "label": "populateEquipmentEntry",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L176",
+      "source_location": "L197",
       "_origin": "ast",
       "id": "src_index_populateequipmententry",
       "community": 34,
@@ -2378,7 +2388,7 @@
       "label": "parseRecipeIngredients",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L187",
+      "source_location": "L208",
       "_origin": "ast",
       "id": "src_index_parserecipeingredients",
       "community": 34,
@@ -2388,7 +2398,7 @@
       "label": "authorRecipe",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L200",
+      "source_location": "L221",
       "_origin": "ast",
       "id": "src_index_authorrecipe",
       "community": 34,
@@ -2398,7 +2408,7 @@
       "label": "mapUrlImportFailure()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L226",
+      "source_location": "L254",
       "_origin": "ast",
       "id": "src_index_mapurlimportfailure",
       "community": 34,
@@ -2408,7 +2418,7 @@
       "label": "extractRecipeFromUrl",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L248",
+      "source_location": "L276",
       "_origin": "ast",
       "id": "src_index_extractrecipefromurl",
       "community": 34,
@@ -2418,7 +2428,7 @@
       "label": "chefChat",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L276",
+      "source_location": "L314",
       "_origin": "ast",
       "id": "src_index_chefchat",
       "community": 34,
@@ -2428,17 +2438,27 @@
       "label": "generateChatTitle",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L286",
+      "source_location": "L324",
       "_origin": "ast",
       "id": "src_index_generatechattitle",
       "community": 34,
       "norm_label": "generatechattitle"
     },
     {
+      "label": "reportUnexpected()",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/src/index.ts",
+      "source_location": "L345",
+      "_origin": "ast",
+      "id": "src_index_reportunexpected",
+      "community": 34,
+      "norm_label": "reportunexpected()"
+    },
+    {
       "label": "listAiModels",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L299",
+      "source_location": "L354",
       "_origin": "ast",
       "id": "src_index_listaimodels",
       "community": 34,
@@ -2448,11 +2468,51 @@
       "label": "testModel",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L307",
+      "source_location": "L362",
       "_origin": "ast",
       "id": "src_index_testmodel",
       "community": 34,
       "norm_label": "testmodel"
+    },
+    {
+      "label": "reportServerError.ts",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "observability_reportservererror",
+      "community": 34,
+      "norm_label": "reportservererror.ts"
+    },
+    {
+      "label": "reporter",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
+      "source_location": "L17",
+      "_origin": "ast",
+      "id": "observability_reportservererror_reporter",
+      "community": 34,
+      "norm_label": "reporter"
+    },
+    {
+      "label": "reportServerError()",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "observability_reportservererror_reportservererror",
+      "community": 29,
+      "norm_label": "reportservererror()"
+    },
+    {
+      "label": "reportFlowError()",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
+      "source_location": "L40",
+      "_origin": "ast",
+      "id": "observability_reportservererror_reportflowerror",
+      "community": 34,
+      "norm_label": "reportflowerror()"
     },
     {
       "label": "onCanonItemWritten.ts",
@@ -2468,17 +2528,27 @@
       "label": "geminiApiKey",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
-      "source_location": "L18",
+      "source_location": "L20",
       "_origin": "ast",
       "id": "triggers_oncanonitemwritten_geminiapikey",
       "community": 29,
       "norm_label": "geminiapikey"
     },
     {
+      "label": "posthogApiKey",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "triggers_oncanonitemwritten_posthogapikey",
+      "community": 29,
+      "norm_label": "posthogapikey"
+    },
+    {
       "label": "maybeGenerateEmbedding()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
-      "source_location": "L26",
+      "source_location": "L33",
       "_origin": "ast",
       "id": "triggers_oncanonitemwritten_maybegenerateembedding",
       "community": 29,
@@ -2488,7 +2558,7 @@
       "label": "iconNeedsGeneration()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
-      "source_location": "L60",
+      "source_location": "L71",
       "_origin": "ast",
       "id": "triggers_oncanonitemwritten_iconneedsgeneration",
       "community": 29,
@@ -2498,7 +2568,7 @@
       "label": "maybeGenerateIcon()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
-      "source_location": "L80",
+      "source_location": "L91",
       "_origin": "ast",
       "id": "triggers_oncanonitemwritten_maybegenerateicon",
       "community": 29,
@@ -2508,7 +2578,7 @@
       "label": "isCanonIconGenerationEnabled()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
-      "source_location": "L132",
+      "source_location": "L147",
       "_origin": "ast",
       "id": "triggers_oncanonitemwritten_iscanonicongenerationenabled",
       "community": 29,
@@ -2518,7 +2588,7 @@
       "label": "uploadCanonIcon()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
-      "source_location": "L159",
+      "source_location": "L182",
       "_origin": "ast",
       "id": "triggers_oncanonitemwritten_uploadcanonicon",
       "community": 29,
@@ -2528,7 +2598,7 @@
       "label": "buildIconDownloadUrl()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
-      "source_location": "L170",
+      "source_location": "L193",
       "_origin": "ast",
       "id": "triggers_oncanonitemwritten_buildicondownloadurl",
       "community": 29,
@@ -2538,7 +2608,7 @@
       "label": "onCanonItemWritten",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
-      "source_location": "L182",
+      "source_location": "L205",
       "_origin": "ast",
       "id": "triggers_oncanonitemwritten_oncanonitemwritten",
       "community": 29,
@@ -2558,7 +2628,7 @@
       "label": "geminiApiKey",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts",
-      "source_location": "L22",
+      "source_location": "L23",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_geminiapikey",
       "community": 75,
@@ -2568,7 +2638,7 @@
       "label": "posthogApiKey",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts",
-      "source_location": "L23",
+      "source_location": "L24",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_posthogapikey",
       "community": 75,
@@ -2578,7 +2648,7 @@
       "label": "looksCompound()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts",
-      "source_location": "L25",
+      "source_location": "L26",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_lookscompound",
       "community": 75,
@@ -2588,7 +2658,7 @@
       "label": "onShoppingListItemWrite",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts",
-      "source_location": "L29",
+      "source_location": "L30",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_onshoppinglistitemwrite",
       "community": 75,
@@ -2761,7 +2831,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_resolvemodel_test",
-      "community": 77,
+      "community": 141,
       "norm_label": "resolvemodel.test.ts"
     },
     {
@@ -2771,7 +2841,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "ai_resolvemodel_test_mockget",
-      "community": 77,
+      "community": 141,
       "norm_label": "mockget"
     },
     {
@@ -3105,6 +3175,106 @@
       "norm_label": "mockembed"
     },
     {
+      "label": "extractRecipeFromUrl.reporting.test.ts",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "flows_extractrecipefromurl_reporting_test",
+      "community": 68,
+      "norm_label": "extractrecipefromurl.reporting.test.ts"
+    },
+    {
+      "label": "mockReport",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L13",
+      "_origin": "ast",
+      "id": "flows_extractrecipefromurl_reporting_test_mockreport",
+      "community": 68,
+      "norm_label": "mockreport"
+    },
+    {
+      "label": "mockFlush",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L14",
+      "_origin": "ast",
+      "id": "flows_extractrecipefromurl_reporting_test_mockflush",
+      "community": 68,
+      "norm_label": "mockflush"
+    },
+    {
+      "label": "FakeHttpsError",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "flows_extractrecipefromurl_reporting_test_fakehttpserror",
+      "community": 68,
+      "norm_label": "fakehttpserror"
+    },
+    {
+      "label": ".constructor()",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L27",
+      "_origin": "ast",
+      "id": "flows_extractrecipefromurl_reporting_test_fakehttpserror_constructor",
+      "community": 68,
+      "norm_label": ".constructor()"
+    },
+    {
+      "label": "extractRecipeFromUrlFlow",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L45",
+      "_origin": "ast",
+      "id": "flows_extractrecipefromurl_reporting_test_extractrecipefromurlflow",
+      "community": 68,
+      "norm_label": "extractrecipefromurlflow"
+    },
+    {
+      "label": "UrlImportError",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L47",
+      "_origin": "ast",
+      "id": "flows_extractrecipefromurl_reporting_test_urlimporterror",
+      "community": 68,
+      "norm_label": "urlimporterror"
+    },
+    {
+      "label": ".constructor()",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L48",
+      "_origin": "ast",
+      "id": "flows_extractrecipefromurl_reporting_test_urlimporterror_constructor",
+      "community": 68,
+      "norm_label": ".constructor()"
+    },
+    {
+      "label": "invoke()",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L83",
+      "_origin": "ast",
+      "id": "flows_extractrecipefromurl_reporting_test_invoke",
+      "community": 68,
+      "norm_label": "invoke()"
+    },
+    {
+      "label": "VALID",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L86",
+      "_origin": "ast",
+      "id": "flows_extractrecipefromurl_reporting_test_valid",
+      "community": 68,
+      "norm_label": "valid"
+    },
+    {
       "label": "generateCanonIcon.test.ts",
       "file_type": "code",
       "source_file": "apps/cloud-functions/tests/flows/generateCanonIcon.test.ts",
@@ -3123,6 +3293,56 @@
       "id": "flows_generatecanonicon_test_mockgenerate",
       "community": 185,
       "norm_label": "mockgenerate"
+    },
+    {
+      "label": "generateChatTitle.reporting.test.ts",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "flows_generatechattitle_reporting_test",
+      "community": 285,
+      "norm_label": "generatechattitle.reporting.test.ts"
+    },
+    {
+      "label": "mockReport",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts",
+      "source_location": "L11",
+      "_origin": "ast",
+      "id": "flows_generatechattitle_reporting_test_mockreport",
+      "community": 285,
+      "norm_label": "mockreport"
+    },
+    {
+      "label": "mockFlush",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts",
+      "source_location": "L12",
+      "_origin": "ast",
+      "id": "flows_generatechattitle_reporting_test_mockflush",
+      "community": 285,
+      "norm_label": "mockflush"
+    },
+    {
+      "label": "mockGenerate",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts",
+      "source_location": "L20",
+      "_origin": "ast",
+      "id": "flows_generatechattitle_reporting_test_mockgenerate",
+      "community": 285,
+      "norm_label": "mockgenerate"
+    },
+    {
+      "label": "INPUT",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts",
+      "source_location": "L41",
+      "_origin": "ast",
+      "id": "flows_generatechattitle_reporting_test_input",
+      "community": 285,
+      "norm_label": "input"
     },
     {
       "label": "identifyEquipment.test.ts",
@@ -3318,7 +3538,7 @@
       "label": "FakeHttpsError",
       "file_type": "code",
       "source_file": "apps/cloud-functions/tests/flows/matchOrCreateCanon.tracePropagation.test.ts",
-      "source_location": "L45",
+      "source_location": "L49",
       "_origin": "ast",
       "id": "flows_matchorcreatecanon_tracepropagation_test_fakehttpserror",
       "community": 127,
@@ -3328,7 +3548,7 @@
       "label": ".constructor()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/tests/flows/matchOrCreateCanon.tracePropagation.test.ts",
-      "source_location": "L47",
+      "source_location": "L51",
       "_origin": "ast",
       "id": "flows_matchorcreatecanon_tracepropagation_test_fakehttpserror_constructor",
       "community": 127,
@@ -3338,7 +3558,7 @@
       "label": "makeRequest()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/tests/flows/matchOrCreateCanon.tracePropagation.test.ts",
-      "source_location": "L112",
+      "source_location": "L116",
       "_origin": "ast",
       "id": "flows_matchorcreatecanon_tracepropagation_test_makerequest",
       "community": 127,
@@ -3348,7 +3568,7 @@
       "label": "invoke()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/tests/flows/matchOrCreateCanon.tracePropagation.test.ts",
-      "source_location": "L123",
+      "source_location": "L127",
       "_origin": "ast",
       "id": "flows_matchorcreatecanon_tracepropagation_test_invoke",
       "community": 127,
@@ -3705,10 +3925,30 @@
       "norm_label": "mockspan"
     },
     {
+      "label": "mockReport",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts",
+      "source_location": "L45",
+      "_origin": "ast",
+      "id": "triggers_onshoppinglistitemwrite_test_mockreport",
+      "community": 104,
+      "norm_label": "mockreport"
+    },
+    {
+      "label": "mockFlush",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts",
+      "source_location": "L46",
+      "_origin": "ast",
+      "id": "triggers_onshoppinglistitemwrite_test_mockflush",
+      "community": 104,
+      "norm_label": "mockflush"
+    },
+    {
       "label": "mockMatchOrCreate",
       "file_type": "code",
       "source_file": "apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts",
-      "source_location": "L57",
+      "source_location": "L63",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_test_mockmatchorcreate",
       "community": 104,
@@ -3718,7 +3958,7 @@
       "label": "mockEntryParseAdapterParse",
       "file_type": "code",
       "source_file": "apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts",
-      "source_location": "L72",
+      "source_location": "L78",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_test_mockentryparseadapterparse",
       "community": 104,
@@ -3728,7 +3968,7 @@
       "label": "ItemData",
       "file_type": "code",
       "source_file": "apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts",
-      "source_location": "L83",
+      "source_location": "L89",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_test_itemdata",
       "community": 104,
@@ -3738,7 +3978,7 @@
       "label": "makeEvent()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts",
-      "source_location": "L91",
+      "source_location": "L97",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_test_makeevent",
       "community": 104,
@@ -3748,7 +3988,7 @@
       "label": "makeCanonItem()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts",
-      "source_location": "L113",
+      "source_location": "L119",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_test_makecanonitem",
       "community": 104,
@@ -3758,7 +3998,7 @@
       "label": "PENDING_ITEM",
       "file_type": "code",
       "source_file": "apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts",
-      "source_location": "L128",
+      "source_location": "L134",
       "_origin": "ast",
       "id": "triggers_onshoppinglistitemwrite_test_pending_item",
       "community": 104,
@@ -6000,7 +6240,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "svelte_spa_router",
-      "community": 20,
+      "community": 50,
       "norm_label": "svelte-spa-router"
     },
     {
@@ -6011,7 +6251,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "components_authgate",
-      "community": 10,
+      "community": 20,
       "norm_label": "authgate.svelte"
     },
     {
@@ -6022,7 +6262,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_auth_svelte",
-      "community": 10,
+      "community": 20,
       "norm_label": "../../lib/auth.svelte.js"
     },
     {
@@ -6044,7 +6284,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "routes_index",
-      "community": 20,
+      "community": 50,
       "norm_label": "index.ts"
     },
     {
@@ -6143,7 +6383,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_devsettingsservice",
-      "community": 107,
+      "community": 141,
       "norm_label": "../../lib/devsettingsservice.js"
     },
     {
@@ -6205,7 +6445,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "apps_web_pwa_src_boundary_tests_no_stage_internals_ts_boundary_tests_no_stage_internals",
-      "community": 64,
+      "community": 7,
       "norm_label": "no-stage-internals.ts"
     },
     {
@@ -6226,7 +6466,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "components_loginpage",
-      "community": 10,
+      "community": 20,
       "norm_label": "loginpage.svelte"
     },
     {
@@ -6237,7 +6477,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_firebase",
-      "community": 10,
+      "community": 20,
       "norm_label": "firebase.ts"
     },
     {
@@ -6659,7 +6899,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "lib_auth_svelte_readpendingemail",
-      "community": 10,
+      "community": 20,
       "norm_label": "readpendingemail()"
     },
     {
@@ -6669,7 +6909,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "lib_auth_svelte_writependingemail",
-      "community": 10,
+      "community": 20,
       "norm_label": "writependingemail()"
     },
     {
@@ -6679,7 +6919,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "lib_auth_svelte_clearpendingemail",
-      "community": 10,
+      "community": 20,
       "norm_label": "clearpendingemail()"
     },
     {
@@ -6689,7 +6929,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore",
-      "community": 10,
+      "community": 20,
       "norm_label": "authstore"
     },
     {
@@ -6699,7 +6939,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore_constructor",
-      "community": 10,
+      "community": 20,
       "norm_label": ".constructor()"
     },
     {
@@ -6709,7 +6949,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore_maybecompletefromurl",
-      "community": 10,
+      "community": 20,
       "norm_label": ".maybecompletefromurl()"
     },
     {
@@ -6719,7 +6959,7 @@
       "source_location": "L88",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore_finishsignin",
-      "community": 10,
+      "community": 20,
       "norm_label": ".finishsignin()"
     },
     {
@@ -6729,7 +6969,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore_completewithemail",
-      "community": 10,
+      "community": 20,
       "norm_label": ".completewithemail()"
     },
     {
@@ -6739,7 +6979,7 @@
       "source_location": "L110",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore_sendlink",
-      "community": 10,
+      "community": 20,
       "norm_label": ".sendlink()"
     },
     {
@@ -6749,7 +6989,7 @@
       "source_location": "L126",
       "_origin": "ast",
       "id": "lib_auth_svelte_authstore_signout",
-      "community": 10,
+      "community": 20,
       "norm_label": ".signout()"
     },
     {
@@ -6759,7 +6999,7 @@
       "source_location": "L135",
       "_origin": "ast",
       "id": "lib_auth_svelte_formaterror",
-      "community": 10,
+      "community": 20,
       "norm_label": "formaterror()"
     },
     {
@@ -6779,7 +7019,7 @@
       "source_location": "L145",
       "_origin": "ast",
       "id": "lib_auth_svelte_devsignin",
-      "community": 10,
+      "community": 20,
       "norm_label": "devsignin()"
     },
     {
@@ -6849,7 +7089,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "lib_canonservice_recomputeaisleusage",
-      "community": 8,
+      "community": 3,
       "norm_label": "recomputeaisleusage()"
     },
     {
@@ -6909,7 +7149,7 @@
       "source_location": "L179",
       "_origin": "ast",
       "id": "lib_canonservice_addcanonitem",
-      "community": 3,
+      "community": 17,
       "norm_label": "addcanonitem()"
     },
     {
@@ -6989,7 +7229,7 @@
       "source_location": "L293",
       "_origin": "ast",
       "id": "lib_canonservice_approvecanonitems",
-      "community": 7,
+      "community": 33,
       "norm_label": "approvecanonitems()"
     },
     {
@@ -7230,7 +7470,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "lib_devsettingsservice_defaults",
-      "community": 107,
+      "community": 141,
       "norm_label": "defaults"
     },
     {
@@ -7240,7 +7480,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "lib_devsettingsservice_settings",
-      "community": 107,
+      "community": 141,
       "norm_label": "_settings"
     },
     {
@@ -7250,7 +7490,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "lib_devsettingsservice_isloading",
-      "community": 107,
+      "community": 141,
       "norm_label": "_isloading"
     },
     {
@@ -7260,7 +7500,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "lib_devsettingsservice_canonicongenerationenabled",
-      "community": 107,
+      "community": 141,
       "norm_label": "canonicongenerationenabled"
     },
     {
@@ -7270,7 +7510,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "lib_devsettingsservice_initdevsettingssync",
-      "community": 107,
+      "community": 141,
       "norm_label": "initdevsettingssync()"
     },
     {
@@ -7280,7 +7520,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "lib_devsettingsservice_setcanonicongenerationenabled",
-      "community": 107,
+      "community": 141,
       "norm_label": "setcanonicongenerationenabled()"
     },
     {
@@ -7290,7 +7530,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "lib_devsettingsservice_resetdevsettingsservicefortest",
-      "community": 107,
+      "community": 141,
       "norm_label": "__resetdevsettingsservicefortest()"
     },
     {
@@ -7310,7 +7550,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "lib_e2ehooks_installe2ehooks",
-      "community": 49,
+      "community": 2,
       "norm_label": "installe2ehooks()"
     },
     {
@@ -7550,7 +7790,7 @@
       "source_location": "L304",
       "_origin": "ast",
       "id": "lib_equipmentservice_getequipmentsnapshot",
-      "community": 8,
+      "community": 9,
       "norm_label": "getequipmentsnapshot()"
     },
     {
@@ -7570,7 +7810,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_errorreporting",
-      "community": 117,
+      "community": 8,
       "norm_label": "errorreporting.ts"
     },
     {
@@ -7580,7 +7820,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "lib_errorreporting_reportsubscriptionerror",
-      "community": 117,
+      "community": 8,
       "norm_label": "reportsubscriptionerror()"
     },
     {
@@ -7610,7 +7850,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_firebase_authprovider",
-      "community": 10,
+      "community": 20,
       "norm_label": "authprovider"
     },
     {
@@ -8220,7 +8460,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_observability",
-      "community": 49,
+      "community": 25,
       "norm_label": "observability.ts"
     },
     {
@@ -8230,7 +8470,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "lib_observability_phkey",
-      "community": 49,
+      "community": 25,
       "norm_label": "_phkey"
     },
     {
@@ -8240,7 +8480,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "lib_observability_identifyuser",
-      "community": 49,
+      "community": 25,
       "norm_label": "identifyuser()"
     },
     {
@@ -8250,7 +8490,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "lib_observability_identifyanonymous",
-      "community": 49,
+      "community": 25,
       "norm_label": "identifyanonymous()"
     },
     {
@@ -8270,7 +8510,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "lib_observability_getsessionurl",
-      "community": 49,
+      "community": 25,
       "norm_label": "getsessionurl()"
     },
     {
@@ -8280,7 +8520,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_observability_startsession",
-      "community": 49,
+      "community": 25,
       "norm_label": "startsession()"
     },
     {
@@ -8290,7 +8530,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "lib_observability_stopsession",
-      "community": 49,
+      "community": 25,
       "norm_label": "stopsession()"
     },
     {
@@ -8300,7 +8540,7 @@
       "source_location": "L56",
       "_origin": "ast",
       "id": "lib_observability_issessionactive",
-      "community": 49,
+      "community": 25,
       "norm_label": "issessionactive()"
     },
     {
@@ -8310,7 +8550,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_pwa",
-      "community": 49,
+      "community": 2,
       "norm_label": "pwa.ts"
     },
     {
@@ -8320,7 +8560,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "lib_pwa_registerserviceworker",
-      "community": 49,
+      "community": 2,
       "norm_label": "registerserviceworker()"
     },
     {
@@ -8330,7 +8570,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_pwa_setupupdateflow",
-      "community": 49,
+      "community": 2,
       "norm_label": "setupupdateflow()"
     },
     {
@@ -8697,7 +8937,7 @@
       "label": "removeList()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L184",
+      "source_location": "L187",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_removelist",
       "community": 8,
@@ -8707,7 +8947,7 @@
       "label": "changeDefaultList()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L192",
+      "source_location": "L195",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_changedefaultlist",
       "community": 8,
@@ -8717,7 +8957,7 @@
       "label": "addItemToList()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L202",
+      "source_location": "L205",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_additemtolist",
       "community": 8,
@@ -8727,7 +8967,7 @@
       "label": "updateItemRawText()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L219",
+      "source_location": "L222",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_updateitemrawtext",
       "community": 8,
@@ -8737,7 +8977,7 @@
       "label": "updateItemAmountUnit()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L232",
+      "source_location": "L235",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_updateitemamountunit",
       "community": 8,
@@ -8747,7 +8987,7 @@
       "label": "updateItemNotes()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L246",
+      "source_location": "L249",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_updateitemnotes",
       "community": 8,
@@ -8757,7 +8997,7 @@
       "label": "toggleItemChecked()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L259",
+      "source_location": "L262",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_toggleitemchecked",
       "community": 8,
@@ -8767,7 +9007,7 @@
       "label": "confirmItemNeeded()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L275",
+      "source_location": "L278",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_confirmitemneeded",
       "community": 8,
@@ -8777,7 +9017,7 @@
       "label": "confirmItemsNeeded()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L289",
+      "source_location": "L292",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_confirmitemsneeded",
       "community": 8,
@@ -8787,7 +9027,7 @@
       "label": "checkItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L305",
+      "source_location": "L308",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_checkitems",
       "community": 8,
@@ -8797,7 +9037,7 @@
       "label": "uncheckItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L318",
+      "source_location": "L321",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_uncheckitems",
       "community": 8,
@@ -8807,7 +9047,7 @@
       "label": "removeItem()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L331",
+      "source_location": "L334",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_removeitem",
       "community": 8,
@@ -8817,7 +9057,7 @@
       "label": "removeItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L341",
+      "source_location": "L344",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_removeitems",
       "community": 8,
@@ -8827,7 +9067,7 @@
       "label": "clearChecked()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L348",
+      "source_location": "L351",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_clearchecked",
       "community": 8,
@@ -8837,7 +9077,7 @@
       "label": "moveSelectedItems()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L355",
+      "source_location": "L358",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_moveselecteditems",
       "community": 8,
@@ -8847,7 +9087,7 @@
       "label": "getShoppingListsSnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L372",
+      "source_location": "L375",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_getshoppinglistssnapshot",
       "community": 8,
@@ -8857,7 +9097,7 @@
       "label": "getDefaultListIdSnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L376",
+      "source_location": "L379",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_getdefaultlistidsnapshot",
       "community": 8,
@@ -8867,7 +9107,7 @@
       "label": "getItemsSnapshot()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L380",
+      "source_location": "L383",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_getitemssnapshot",
       "community": 8,
@@ -8877,7 +9117,7 @@
       "label": "__resetShoppingListServiceForTest()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
-      "source_location": "L386",
+      "source_location": "L389",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_resetshoppinglistservicefortest",
       "community": 10,
@@ -9011,7 +9251,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "apps_web_pwa_src_main_ts_src_main",
-      "community": 49,
+      "community": 2,
       "norm_label": "main.ts"
     },
     {
@@ -9021,7 +9261,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "routes_notfound",
-      "community": 20,
+      "community": 50,
       "norm_label": "notfound.svelte"
     },
     {
@@ -9032,7 +9272,7 @@
       "_origin": "ast",
       "confidence": "EXTRACTED",
       "id": "admin_adminguard",
-      "community": 20,
+      "community": 50,
       "norm_label": "../admin/adminguard.svelte"
     },
     {
@@ -9042,7 +9282,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "admin_adminguard_isadmin",
-      "community": 20,
+      "community": 50,
       "norm_label": "isadmin"
     },
     {
@@ -9052,7 +9292,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "admin_adminguard_settled",
-      "community": 20,
+      "community": 50,
       "norm_label": "settled"
     },
     {
@@ -9062,7 +9302,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "admin_adminhomepage",
-      "community": 20,
+      "community": 50,
       "norm_label": "adminhomepage.svelte"
     },
     {
@@ -9072,7 +9312,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "admin_adminhomepage_tools",
-      "community": 20,
+      "community": 50,
       "norm_label": "tools"
     },
     {
@@ -9113,7 +9353,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "admin_adminmemberspage",
-      "community": 20,
+      "community": 50,
       "norm_label": "adminmemberspage.svelte"
     },
     {
@@ -9123,7 +9363,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "admin_appsettingspage",
-      "community": 20,
+      "community": 50,
       "norm_label": "appsettingspage.svelte"
     },
     {
@@ -9133,7 +9373,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "schemas",
-      "community": 77,
+      "community": 141,
       "norm_label": "@salt/domain/schemas"
     },
     {
@@ -9144,7 +9384,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "admin_modelcombofield",
-      "community": 20,
+      "community": 50,
       "norm_label": "modelcombofield.svelte"
     },
     {
@@ -9154,7 +9394,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "admin_devsettingspage",
-      "community": 20,
+      "community": 50,
       "norm_label": "devsettingspage.svelte"
     },
     {
@@ -9164,7 +9404,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "firebase_sync",
-      "community": 20,
+      "community": 50,
       "norm_label": "@salt/firebase-sync"
     },
     {
@@ -9214,7 +9454,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canonlistpage",
-      "community": 7,
+      "community": 33,
       "norm_label": "canonlistpage.svelte"
     },
     {
@@ -9224,7 +9464,7 @@
       "source_location": "L88",
       "_origin": "ast",
       "id": "canon_canonlistpage_topapprovalitems",
-      "community": 7,
+      "community": 33,
       "norm_label": "topapprovalitems"
     },
     {
@@ -9234,7 +9474,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "canon_canonlistpage_allvisibleids",
-      "community": 7,
+      "community": 33,
       "norm_label": "allvisibleids"
     },
     {
@@ -9244,7 +9484,7 @@
       "source_location": "L98",
       "_origin": "ast",
       "id": "canon_canonlistpage_selection",
-      "community": 7,
+      "community": 33,
       "norm_label": "selection"
     },
     {
@@ -9254,7 +9494,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "canon_canonlistpage_selectedapprovalids",
-      "community": 7,
+      "community": 33,
       "norm_label": "selectedapprovalids"
     },
     {
@@ -9264,7 +9504,7 @@
       "source_location": "L107",
       "_origin": "ast",
       "id": "canon_canonlistpage_selectpending",
-      "community": 7,
+      "community": 33,
       "norm_label": "selectpending()"
     },
     {
@@ -9274,7 +9514,7 @@
       "source_location": "L111",
       "_origin": "ast",
       "id": "canon_canonlistpage_handlebulkapprove",
-      "community": 7,
+      "community": 33,
       "norm_label": "handlebulkapprove()"
     },
     {
@@ -9294,7 +9534,7 @@
       "source_location": "L128",
       "_origin": "ast",
       "id": "canon_canonlistpage_handlebulkdelete",
-      "community": 7,
+      "community": 33,
       "norm_label": "handlebulkdelete()"
     },
     {
@@ -9445,7 +9685,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "equipment_equipmentcapturepage",
-      "community": 20,
+      "community": 50,
       "norm_label": "equipmentcapturepage.svelte"
     },
     {
@@ -9655,7 +9895,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "routes_index_routes",
-      "community": 20,
+      "community": 50,
       "norm_label": "routes"
     },
     {
@@ -9816,7 +10056,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "recipes_recipelistpage",
-      "community": 20,
+      "community": 33,
       "norm_label": "recipelistpage.svelte"
     },
     {
@@ -10086,7 +10326,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shopping_shoppinglistcreatepage",
-      "community": 20,
+      "community": 50,
       "norm_label": "shoppinglistcreatepage.svelte"
     },
     {
@@ -10116,7 +10356,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shopping_shoppinglistredirectpage",
-      "community": 20,
+      "community": 50,
       "norm_label": "shoppinglistredirectpage.svelte"
     },
     {
@@ -10126,7 +10366,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shopping_shoppinglistsmanagepage",
-      "community": 33,
+      "community": 50,
       "norm_label": "shoppinglistsmanagepage.svelte"
     },
     {
@@ -10356,7 +10596,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test",
-      "community": 33,
+      "community": 9,
       "norm_label": "equipmentcapturepage.test.ts"
     },
     {
@@ -10366,7 +10606,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_mockisloadingequipment",
-      "community": 33,
+      "community": 9,
       "norm_label": "{ mockisloadingequipment }"
     },
     {
@@ -10376,7 +10616,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_makemanifest",
-      "community": 33,
+      "community": 9,
       "norm_label": "makemanifest()"
     },
     {
@@ -10386,7 +10626,7 @@
       "source_location": "L60",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_walkthroughcapture",
-      "community": 141,
+      "community": 9,
       "norm_label": "walkthroughcapture()"
     },
     {
@@ -10733,7 +10973,7 @@
       "label": "fs",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
-      "source_location": "L50",
+      "source_location": "L52",
       "_origin": "ast",
       "id": "tests_canonservice_errorreporting_test_fs",
       "community": 3,
@@ -10743,7 +10983,7 @@
       "label": "STORAGE_ERR",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
-      "source_location": "L52",
+      "source_location": "L54",
       "_origin": "ast",
       "id": "tests_canonservice_errorreporting_test_storage_err",
       "community": 3,
@@ -10753,7 +10993,7 @@
       "label": "SYNC_ERR",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
-      "source_location": "L53",
+      "source_location": "L55",
       "_origin": "ast",
       "id": "tests_canonservice_errorreporting_test_sync_err",
       "community": 3,
@@ -10763,7 +11003,7 @@
       "label": "NETWORK_ERR",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
-      "source_location": "L54",
+      "source_location": "L56",
       "_origin": "ast",
       "id": "tests_canonservice_errorreporting_test_network_err",
       "community": 3,
@@ -10773,7 +11013,7 @@
       "label": "NOTFOUND_ERR",
       "file_type": "code",
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
-      "source_location": "L55",
+      "source_location": "L57",
       "_origin": "ast",
       "id": "tests_canonservice_errorreporting_test_notfound_err",
       "community": 3,
@@ -11026,7 +11266,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_errorreporting_test",
-      "community": 117,
+      "community": 8,
       "norm_label": "errorreporting.test.ts"
     },
     {
@@ -11036,7 +11276,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "tests_errorreporting_test_isauthtransitioning",
-      "community": 117,
+      "community": 8,
       "norm_label": "isauthtransitioning"
     },
     {
@@ -12882,7 +13122,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "src_appsettingssync_subscribeappsettings",
-      "community": 47,
+      "community": 141,
       "norm_label": "subscribeappsettings()"
     },
     {
@@ -12962,7 +13202,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "src_auth_createfirebaseauth",
-      "community": 117,
+      "community": 20,
       "norm_label": "createfirebaseauth()"
     },
     {
@@ -13032,7 +13272,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_canonmatching",
-      "community": 1,
+      "community": 107,
       "norm_label": "canonmatching.ts"
     },
     {
@@ -13042,7 +13282,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "src_canonmatching_wireresult",
-      "community": 1,
+      "community": 107,
       "norm_label": "wireresult"
     },
     {
@@ -13052,7 +13292,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "src_canonmatching_callmatchorcreate",
-      "community": 3,
+      "community": 17,
       "norm_label": "callmatchorcreate()"
     },
     {
@@ -13062,7 +13302,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_canonmatching_wirebatchresult",
-      "community": 1,
+      "community": 107,
       "norm_label": "wirebatchresult"
     },
     {
@@ -13192,7 +13432,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_subscribechatsessions",
-      "community": 141,
+      "community": 42,
       "norm_label": "subscribechatsessions()"
     },
     {
@@ -13242,7 +13482,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "src_devsettingssync_subscribedevsettings",
-      "community": 107,
+      "community": 141,
       "norm_label": "subscribedevsettings()"
     },
     {
@@ -13332,7 +13572,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "src_equipmentcallables_callidentifyequipment",
-      "community": 141,
+      "community": 9,
       "norm_label": "callidentifyequipment()"
     },
     {
@@ -13342,7 +13582,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "src_equipmentcallables_callpopulateequipmententry",
-      "community": 141,
+      "community": 9,
       "norm_label": "callpopulateequipmententry()"
     },
     {
@@ -13442,7 +13682,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "src_init_appcheckconfig",
-      "community": 117,
+      "community": 20,
       "norm_label": "appcheckconfig"
     },
     {
@@ -13472,7 +13712,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_mealplansync",
-      "community": 141,
+      "community": 0,
       "norm_label": "mealplansync.ts"
     },
     {
@@ -13512,7 +13752,7 @@
       "source_location": "L93",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplanconfig",
-      "community": 141,
+      "community": 0,
       "norm_label": "savemealplanconfig()"
     },
     {
@@ -13522,7 +13762,7 @@
       "source_location": "L105",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplantemplate",
-      "community": 141,
+      "community": 0,
       "norm_label": "savemealplantemplate()"
     },
     {
@@ -13532,7 +13772,7 @@
       "source_location": "L118",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplanweek",
-      "community": 141,
+      "community": 0,
       "norm_label": "savemealplanweek()"
     },
     {
@@ -13672,7 +13912,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription",
-      "community": 8,
+      "community": 141,
       "norm_label": "shoppinglistitemsubscription.ts"
     },
     {
@@ -13682,7 +13922,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_subscribeshoppinglistitems",
-      "community": 8,
+      "community": 141,
       "norm_label": "subscribeshoppinglistitems()"
     },
     {
@@ -13692,7 +13932,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_listshoppinglistitems",
-      "community": 8,
+      "community": 141,
       "norm_label": "listshoppinglistitems()"
     },
     {
@@ -13712,7 +13952,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_deleteshoppinglistitem",
-      "community": 8,
+      "community": 141,
       "norm_label": "deleteshoppinglistitem()"
     },
     {
@@ -13732,7 +13972,7 @@
       "source_location": "L114",
       "_origin": "ast",
       "id": "src_shoppinglistitemsubscription_moveshoppinglistitems",
-      "community": 8,
+      "community": 141,
       "norm_label": "moveshoppinglistitems()"
     },
     {
@@ -13832,7 +14072,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription_saveshoppinglistsconfig",
-      "community": 141,
+      "community": 8,
       "norm_label": "saveshoppinglistsconfig()"
     },
     {
@@ -13842,7 +14082,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_appsettingssync_test",
-      "community": 47,
+      "community": 141,
       "norm_label": "appsettingssync.test.ts"
     },
     {
@@ -13852,7 +14092,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdoc_mockgetfirestore",
-      "community": 47,
+      "community": 141,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -13862,7 +14102,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_snapcallback",
-      "community": 47,
+      "community": 141,
       "norm_label": "snapcallback"
     },
     {
@@ -13872,7 +14112,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_errorcallback",
-      "community": 47,
+      "community": 141,
       "norm_label": "errorcallback"
     },
     {
@@ -14292,7 +14532,7 @@
       "source_location": "L490",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_delay",
-      "community": 141,
+      "community": 9,
       "norm_label": "delay()"
     },
     {
@@ -14302,7 +14542,7 @@
       "source_location": "L494",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_waitfor",
-      "community": 141,
+      "community": 9,
       "norm_label": "waitfor()"
     },
     {
@@ -14372,7 +14612,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test",
-      "community": 8,
+      "community": 141,
       "norm_label": "shoppinglistitemsubscription.test.ts"
     },
     {
@@ -14382,7 +14622,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdeletedoc_mockgetdocs_mockdoc_mockcollection_mockgetfirestore_mockwritebatch_mockbatchdelete_mockbatchset_mockbatchcommit",
-      "community": 8,
+      "community": 141,
       "norm_label": "{\n  mockunsubscribe,\n  mockonsnapshot,\n  mocksetdoc,\n  mockdeletedoc,\n  mockgetdocs,\n  mockdoc,\n  mockcollection,\n  mockgetfirestore,\n  mockwritebatch,\n  mockbatchdelete,\n  mockbatchset,\n  mockbatchcommit,\n}"
     },
     {
@@ -14392,7 +14632,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_snapcallback",
-      "community": 8,
+      "community": 141,
       "norm_label": "snapcallback"
     },
     {
@@ -14402,7 +14642,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_errorcallback",
-      "community": 8,
+      "community": 141,
       "norm_label": "errorcallback"
     },
     {
@@ -14412,7 +14652,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_item_1",
-      "community": 8,
+      "community": 141,
       "norm_label": "item_1"
     },
     {
@@ -14422,7 +14662,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "tests_shoppinglistitemsubscription_test_item_2",
-      "community": 8,
+      "community": 141,
       "norm_label": "item_2"
     },
     {
@@ -15042,7 +15282,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_posthogerrorreportingadapter",
-      "community": 72,
+      "community": 25,
       "norm_label": "posthogerrorreportingadapter.ts"
     },
     {
@@ -15052,7 +15292,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "src_posthogerrorreportingadapter_createposthogerrorreportingadapter",
-      "community": 72,
+      "community": 25,
       "norm_label": "createposthogerrorreportingadapter()"
     },
     {
@@ -15072,7 +15312,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_posthogmatchloggingadapter_createposthogmatchloggingadapter",
-      "community": 93,
+      "community": 25,
       "norm_label": "createposthogmatchloggingadapter()"
     },
     {
@@ -15279,7 +15519,7 @@
       "label": "createPosthogServerErrorReportingAdapter()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/posthogServerErrorReportingAdapter.ts",
-      "source_location": "L8",
+      "source_location": "L16",
       "_origin": "ast",
       "id": "server_posthogservererrorreportingadapter_createposthogservererrorreportingadapter",
       "community": 46,
@@ -15452,7 +15692,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shared_reportablecategory",
-      "community": 72,
+      "community": 25,
       "norm_label": "reportablecategory.ts"
     },
     {
@@ -15462,17 +15702,17 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "shared_reportablecategory_suppressed_categories",
-      "community": 72,
+      "community": 25,
       "norm_label": "suppressed_categories"
     },
     {
       "label": "isReportableCategory()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/shared/reportableCategory.ts",
-      "source_location": "L29",
+      "source_location": "L38",
       "_origin": "ast",
       "id": "shared_reportablecategory_isreportablecategory",
-      "community": 72,
+      "community": 25,
       "norm_label": "isreportablecategory()"
     },
     {
@@ -15502,7 +15742,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_posthogerrorreportingadapter_test",
-      "community": 72,
+      "community": 25,
       "norm_label": "posthogerrorreportingadapter.test.ts"
     },
     {
@@ -15512,8 +15752,28 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_posthogerrorreportingadapter_test_captureexception_init",
-      "community": 72,
+      "community": 25,
       "norm_label": "{ captureexception, init }"
+    },
+    {
+      "label": "posthogServerErrorReportingAdapter.test.ts",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "tests_posthogservererrorreportingadapter_test",
+      "community": 46,
+      "norm_label": "posthogservererrorreportingadapter.test.ts"
+    },
+    {
+      "label": "{ captureException, FakePostHog }",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
+      "source_location": "L8",
+      "_origin": "ast",
+      "id": "tests_posthogservererrorreportingadapter_test_captureexception_fakeposthog",
+      "community": 46,
+      "norm_label": "{ captureexception, fakeposthog }"
     },
     {
       "label": "reportableCategory.test.ts",
@@ -15522,7 +15782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_reportablecategory_test",
-      "community": 72,
+      "community": 25,
       "norm_label": "reportablecategory.test.ts"
     },
     {
@@ -15919,7 +16179,7 @@
       "label": "ErrorReportingPort",
       "file_type": "code",
       "source_file": "packages/domain/src/ErrorReportingPort.ts",
-      "source_location": "L9",
+      "source_location": "L16",
       "_origin": "ast",
       "id": "src_errorreportingport_errorreportingport",
       "community": 117,
@@ -16162,7 +16422,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_createaisle",
-      "community": 1,
+      "community": 64,
       "norm_label": "createaisle.ts"
     },
     {
@@ -16182,7 +16442,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createaisle_createaisle",
-      "community": 2,
+      "community": 64,
       "norm_label": "createaisle()"
     },
     {
@@ -16192,7 +16452,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_createaislesbulk",
-      "community": 1,
+      "community": 64,
       "norm_label": "createaislesbulk.ts"
     },
     {
@@ -16212,7 +16472,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createaislesbulk_createaislesbulk",
-      "community": 2,
+      "community": 64,
       "norm_label": "createaislesbulk()"
     },
     {
@@ -16252,7 +16512,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_deleteaisles",
-      "community": 1,
+      "community": 64,
       "norm_label": "deleteaisles.ts"
     },
     {
@@ -16272,7 +16532,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_deleteaisles_deleteaisles",
-      "community": 281,
+      "community": 64,
       "norm_label": "deleteaisles()"
     },
     {
@@ -16282,7 +16542,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_matchorcreate",
-      "community": 17,
+      "community": 7,
       "norm_label": "matchorcreate.ts"
     },
     {
@@ -16292,7 +16552,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateinput",
-      "community": 95,
+      "community": 107,
       "norm_label": "matchorcreateinput"
     },
     {
@@ -16302,7 +16562,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateresult",
-      "community": 3,
+      "community": 107,
       "norm_label": "matchorcreateresult"
     },
     {
@@ -16322,7 +16582,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreate",
-      "community": 17,
+      "community": 275,
       "norm_label": "matchorcreate()"
     },
     {
@@ -16332,7 +16592,7 @@
       "source_location": "L88",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreatebatch",
-      "community": 17,
+      "community": 95,
       "norm_label": "matchorcreatebatch()"
     },
     {
@@ -16342,7 +16602,7 @@
       "source_location": "L147",
       "_origin": "ast",
       "id": "commands_matchorcreate_buildembeddingcache",
-      "community": 17,
+      "community": 95,
       "norm_label": "buildembeddingcache()"
     },
     {
@@ -16352,7 +16612,7 @@
       "source_location": "L177",
       "_origin": "ast",
       "id": "commands_matchorcreate_commitlog",
-      "community": 17,
+      "community": 7,
       "norm_label": "commitlog"
     },
     {
@@ -16362,7 +16622,7 @@
       "source_location": "L183",
       "_origin": "ast",
       "id": "commands_matchorcreate_arboutcome",
-      "community": 17,
+      "community": 7,
       "norm_label": "arboutcome"
     },
     {
@@ -16372,7 +16632,7 @@
       "source_location": "L185",
       "_origin": "ast",
       "id": "commands_matchorcreate_classification",
-      "community": 17,
+      "community": 7,
       "norm_label": "classification"
     },
     {
@@ -16392,7 +16652,7 @@
       "source_location": "L361",
       "_origin": "ast",
       "id": "commands_matchorcreate_applyclassification",
-      "community": 17,
+      "community": 7,
       "norm_label": "applyclassification()"
     },
     {
@@ -16412,7 +16672,7 @@
       "source_location": "L478",
       "_origin": "ast",
       "id": "commands_matchorcreate_arbitrationnew",
-      "community": 17,
+      "community": 7,
       "norm_label": "arbitrationnew"
     },
     {
@@ -16422,7 +16682,7 @@
       "source_location": "L483",
       "_origin": "ast",
       "id": "commands_matchorcreate_extrasfromnew",
-      "community": 17,
+      "community": 7,
       "norm_label": "extrasfromnew()"
     },
     {
@@ -16432,7 +16692,7 @@
       "source_location": "L494",
       "_origin": "ast",
       "id": "commands_matchorcreate_arbitrationfailurereasoning",
-      "community": 17,
+      "community": 7,
       "norm_label": "arbitrationfailurereasoning()"
     },
     {
@@ -16442,7 +16702,7 @@
       "source_location": "L500",
       "_origin": "ast",
       "id": "commands_matchorcreate_loadaisles",
-      "community": 17,
+      "community": 95,
       "norm_label": "loadaisles()"
     },
     {
@@ -16452,7 +16712,7 @@
       "source_location": "L505",
       "_origin": "ast",
       "id": "commands_matchorcreate_logarbitration",
-      "community": 17,
+      "community": 7,
       "norm_label": "logarbitration()"
     },
     {
@@ -16462,7 +16722,7 @@
       "source_location": "L530",
       "_origin": "ast",
       "id": "commands_matchorcreate_findsnapshotmatch",
-      "community": 17,
+      "community": 7,
       "norm_label": "findsnapshotmatch()"
     },
     {
@@ -16482,7 +16742,7 @@
       "source_location": "L565",
       "_origin": "ast",
       "id": "commands_matchorcreate_resolvematch",
-      "community": 17,
+      "community": 7,
       "norm_label": "resolvematch()"
     },
     {
@@ -16492,7 +16752,7 @@
       "source_location": "L584",
       "_origin": "ast",
       "id": "commands_matchorcreate_persistnew",
-      "community": 17,
+      "community": 7,
       "norm_label": "persistnew()"
     },
     {
@@ -16542,7 +16802,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "commands_mergeaisles_mergeaisles",
-      "community": 266,
+      "community": 64,
       "norm_label": "mergeaisles()"
     },
     {
@@ -16582,7 +16842,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_renameaisle",
-      "community": 1,
+      "community": 64,
       "norm_label": "renameaisle.ts"
     },
     {
@@ -16602,7 +16862,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_renameaisle_renameaisle",
-      "community": 2,
+      "community": 64,
       "norm_label": "renameaisle()"
     },
     {
@@ -16622,7 +16882,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_renamecanonitem_renamecanonitem",
-      "community": 11,
+      "community": 3,
       "norm_label": "renamecanonitem()"
     },
     {
@@ -16632,7 +16892,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_reorderaisles",
-      "community": 1,
+      "community": 64,
       "norm_label": "reorderaisles.ts"
     },
     {
@@ -16652,7 +16912,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_reorderaisles_reorderaisles",
-      "community": 2,
+      "community": 64,
       "norm_label": "reorderaisles()"
     },
     {
@@ -16702,7 +16962,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setcanonitemaisle_setcanonitemaisle",
-      "community": 11,
+      "community": 3,
       "norm_label": "setcanonitemaisle()"
     },
     {
@@ -16722,7 +16982,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setcanonitemshoppingfields_setcanonitemshoppingbehavior",
-      "community": 11,
+      "community": 3,
       "norm_label": "setcanonitemshoppingbehavior()"
     },
     {
@@ -16732,7 +16992,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "commands_setcanonitemshoppingfields_setcanonitemthreshold",
-      "community": 11,
+      "community": 3,
       "norm_label": "setcanonitemthreshold()"
     },
     {
@@ -16752,7 +17012,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setcanonitemsynonyms_setcanonitemsynonyms",
-      "community": 11,
+      "community": 3,
       "norm_label": "setcanonitemsynonyms()"
     },
     {
@@ -16782,7 +17042,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_aisle",
-      "community": 1,
+      "community": 64,
       "norm_label": "aisle.ts"
     },
     {
@@ -16792,7 +17052,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_aisle_aisle",
-      "community": 1,
+      "community": 64,
       "norm_label": "aisle"
     },
     {
@@ -16802,7 +17062,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_aislesdocument",
-      "community": 1,
+      "community": 64,
       "norm_label": "aislesdocument.ts"
     },
     {
@@ -16812,7 +17072,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_aislesdocument_aislesdocument",
-      "community": 1,
+      "community": 64,
       "norm_label": "aislesdocument"
     },
     {
@@ -16842,7 +17102,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_matchcandidate",
-      "community": 64,
+      "community": 11,
       "norm_label": "matchcandidate.ts"
     },
     {
@@ -16852,7 +17112,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "entities_matchcandidate_matchstage",
-      "community": 64,
+      "community": 11,
       "norm_label": "matchstage"
     },
     {
@@ -16862,7 +17122,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_matchcandidate_matchcandidate",
-      "community": 64,
+      "community": 11,
       "norm_label": "matchcandidate"
     },
     {
@@ -16952,7 +17212,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_aislelocalstoreport",
-      "community": 1,
+      "community": 64,
       "norm_label": "aislelocalstoreport.ts"
     },
     {
@@ -16962,7 +17222,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_aislelocalstoreport_aislelocalstoreport",
-      "community": 1,
+      "community": 64,
       "norm_label": "aislelocalstoreport"
     },
     {
@@ -17032,7 +17292,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_canonlookupport",
-      "community": 64,
+      "community": 11,
       "norm_label": "canonlookupport.ts"
     },
     {
@@ -17052,7 +17312,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_embeddingport",
-      "community": 64,
+      "community": 7,
       "norm_label": "embeddingport.ts"
     },
     {
@@ -17062,7 +17322,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "ports_embeddingport_embeddingport",
-      "community": 64,
+      "community": 7,
       "norm_label": "embeddingport"
     },
     {
@@ -17092,7 +17352,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_matchloggingport",
-      "community": 64,
+      "community": 7,
       "norm_label": "matchloggingport.ts"
     },
     {
@@ -17102,7 +17362,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "ports_matchloggingport_matchloggingport",
-      "community": 64,
+      "community": 7,
       "norm_label": "matchloggingport"
     },
     {
@@ -17152,7 +17412,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_embedmatch",
-      "community": 64,
+      "community": 7,
       "norm_label": "embedmatch.ts"
     },
     {
@@ -17162,7 +17422,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "queries_embedmatch_embedmatch",
-      "community": 64,
+      "community": 7,
       "norm_label": "embedmatch()"
     },
     {
@@ -17172,7 +17432,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_findclosestmatch",
-      "community": 32,
+      "community": 17,
       "norm_label": "findclosestmatch.ts"
     },
     {
@@ -17202,7 +17462,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_getaisleusage",
-      "community": 1,
+      "community": 64,
       "norm_label": "getaisleusage.ts"
     },
     {
@@ -17212,7 +17472,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "queries_getaisleusage_getaisleusage",
-      "community": 11,
+      "community": 64,
       "norm_label": "getaisleusage()"
     },
     {
@@ -17242,7 +17502,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_listaisles",
-      "community": 1,
+      "community": 64,
       "norm_label": "listaisles.ts"
     },
     {
@@ -17252,7 +17512,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "queries_listaisles_listaisles",
-      "community": 1,
+      "community": 64,
       "norm_label": "listaisles()"
     },
     {
@@ -17262,7 +17522,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_matchthresholds",
-      "community": 64,
+      "community": 7,
       "norm_label": "matchthresholds.ts"
     },
     {
@@ -17272,7 +17532,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "queries_matchthresholds_match_thresholds",
-      "community": 64,
+      "community": 7,
       "norm_label": "match_thresholds"
     },
     {
@@ -17352,7 +17612,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_summarizematchlog",
-      "community": 32,
+      "community": 49,
       "norm_label": "summarizematchlog.ts"
     },
     {
@@ -17362,7 +17622,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "queries_summarizematchlog_matchlogsummary",
-      "community": 32,
+      "community": 49,
       "norm_label": "matchlogsummary"
     },
     {
@@ -17372,7 +17632,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "queries_summarizematchlog_nearmisscount",
-      "community": 32,
+      "community": 49,
       "norm_label": "nearmisscount()"
     },
     {
@@ -17382,7 +17642,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "queries_summarizematchlog_formatstage",
-      "community": 32,
+      "community": 49,
       "norm_label": "formatstage()"
     },
     {
@@ -17392,7 +17652,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "queries_summarizematchlog_formatarbitration",
-      "community": 32,
+      "community": 49,
       "norm_label": "formatarbitration()"
     },
     {
@@ -17402,7 +17662,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "queries_summarizematchlog_summarizematchlog",
-      "community": 32,
+      "community": 49,
       "norm_label": "summarizematchlog()"
     },
     {
@@ -20482,7 +20742,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_additem",
-      "community": 4,
+      "community": 1,
       "norm_label": "additem.ts"
     },
     {
@@ -20492,7 +20752,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "commands_additem_additeminput",
-      "community": 4,
+      "community": 1,
       "norm_label": "additeminput"
     },
     {
@@ -20512,7 +20772,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_checkitem",
-      "community": 4,
+      "community": 1,
       "norm_label": "checkitem.ts"
     },
     {
@@ -20542,7 +20802,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_clearcheckeditems",
-      "community": 4,
+      "community": 1,
       "norm_label": "clearcheckeditems.ts"
     },
     {
@@ -20552,7 +20812,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_clearcheckeditems_clearcheckeditems",
-      "community": 4,
+      "community": 8,
       "norm_label": "clearcheckeditems()"
     },
     {
@@ -20562,7 +20822,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_confirmitemneeded",
-      "community": 4,
+      "community": 1,
       "norm_label": "confirmitemneeded.ts"
     },
     {
@@ -20582,7 +20842,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "commands_confirmitemneeded_confirmitemneeded",
-      "community": 4,
+      "community": 8,
       "norm_label": "confirmitemneeded()"
     },
     {
@@ -20592,7 +20852,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_createlist",
-      "community": 66,
+      "community": 4,
       "norm_label": "createlist.ts"
     },
     {
@@ -20602,7 +20862,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_createlist_createlistinput",
-      "community": 66,
+      "community": 4,
       "norm_label": "createlistinput"
     },
     {
@@ -20612,7 +20872,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createlist_createlist",
-      "community": 8,
+      "community": 4,
       "norm_label": "createlist()"
     },
     {
@@ -20622,7 +20882,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_deleteitem",
-      "community": 4,
+      "community": 1,
       "norm_label": "deleteitem.ts"
     },
     {
@@ -20642,7 +20902,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "commands_deleteitem_deleteitem",
-      "community": 4,
+      "community": 8,
       "norm_label": "deleteitem()"
     },
     {
@@ -20652,7 +20912,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_deletelist",
-      "community": 66,
+      "community": 4,
       "norm_label": "deletelist.ts"
     },
     {
@@ -20662,7 +20922,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_deletelist_deletelistinput",
-      "community": 66,
+      "community": 4,
       "norm_label": "deletelistinput"
     },
     {
@@ -20672,7 +20932,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_deletelist_deletelist",
-      "community": 8,
+      "community": 4,
       "norm_label": "deletelist()"
     },
     {
@@ -20682,7 +20942,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_edititemamountunit",
-      "community": 4,
+      "community": 1,
       "norm_label": "edititemamountunit.ts"
     },
     {
@@ -20712,7 +20972,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_edititemnotes",
-      "community": 4,
+      "community": 1,
       "norm_label": "edititemnotes.ts"
     },
     {
@@ -20732,7 +20992,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_edititemnotes_edititemnotes",
-      "community": 4,
+      "community": 8,
       "norm_label": "edititemnotes()"
     },
     {
@@ -20742,7 +21002,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_edititemrawtext",
-      "community": 4,
+      "community": 1,
       "norm_label": "edititemrawtext.ts"
     },
     {
@@ -20762,7 +21022,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_edititemrawtext_edititemrawtext",
-      "community": 4,
+      "community": 8,
       "norm_label": "edititemrawtext()"
     },
     {
@@ -20772,7 +21032,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_moveitems",
-      "community": 4,
+      "community": 1,
       "norm_label": "moveitems.ts"
     },
     {
@@ -20792,7 +21052,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_moveitems_moveitemsresult",
-      "community": 4,
+      "community": 1,
       "norm_label": "moveitemsresult"
     },
     {
@@ -20802,7 +21062,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "commands_moveitems_moveitems",
-      "community": 4,
+      "community": 8,
       "norm_label": "moveitems()"
     },
     {
@@ -20812,7 +21072,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_renamelist",
-      "community": 66,
+      "community": 4,
       "norm_label": "renamelist.ts"
     },
     {
@@ -20822,7 +21082,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_renamelist_renamelistinput",
-      "community": 66,
+      "community": 4,
       "norm_label": "renamelistinput"
     },
     {
@@ -20832,7 +21092,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_renamelist_renamelist",
-      "community": 8,
+      "community": 4,
       "norm_label": "renamelist()"
     },
     {
@@ -20842,7 +21102,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_setdefaultlist",
-      "community": 66,
+      "community": 4,
       "norm_label": "setdefaultlist.ts"
     },
     {
@@ -20852,7 +21112,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_setdefaultlist_setdefaultlistinput",
-      "community": 66,
+      "community": 4,
       "norm_label": "setdefaultlistinput"
     },
     {
@@ -20862,7 +21122,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_setdefaultlist_setdefaultlist",
-      "community": 8,
+      "community": 4,
       "norm_label": "setdefaultlist()"
     },
     {
@@ -20872,7 +21132,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_uncheckitem",
-      "community": 4,
+      "community": 1,
       "norm_label": "uncheckitem.ts"
     },
     {
@@ -20902,7 +21162,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglist",
-      "community": 66,
+      "community": 4,
       "norm_label": "shoppinglist.ts"
     },
     {
@@ -20912,7 +21172,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglist_shoppinglist",
-      "community": 66,
+      "community": 4,
       "norm_label": "shoppinglist"
     },
     {
@@ -20922,7 +21182,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglistitem",
-      "community": 4,
+      "community": 1,
       "norm_label": "shoppinglistitem.ts"
     },
     {
@@ -20932,7 +21192,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "entities_shoppinglistitem_matchstate",
-      "community": 4,
+      "community": 1,
       "norm_label": "matchstate"
     },
     {
@@ -20942,7 +21202,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_shoppinglistitem_shoppinglistitem",
-      "community": 4,
+      "community": 1,
       "norm_label": "shoppinglistitem"
     },
     {
@@ -20952,7 +21212,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglistsconfig",
-      "community": 66,
+      "community": 4,
       "norm_label": "shoppinglistsconfig.ts"
     },
     {
@@ -20962,7 +21222,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglistsconfig_shoppinglistsconfig",
-      "community": 66,
+      "community": 4,
       "norm_label": "shoppinglistsconfig"
     },
     {
@@ -20972,7 +21232,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_sourceref",
-      "community": 4,
+      "community": 1,
       "norm_label": "sourceref.ts"
     },
     {
@@ -20982,7 +21242,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_sourceref_sourceref",
-      "community": 4,
+      "community": 1,
       "norm_label": "sourceref"
     },
     {
@@ -21042,7 +21302,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_shoppinglistitemport",
-      "community": 4,
+      "community": 1,
       "norm_label": "shoppinglistitemport.ts"
     },
     {
@@ -21062,7 +21322,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_shoppinglistport",
-      "community": 66,
+      "community": 4,
       "norm_label": "shoppinglistport.ts"
     },
     {
@@ -21072,7 +21332,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "ports_shoppinglistport_shoppinglistport",
-      "community": 66,
+      "community": 4,
       "norm_label": "shoppinglistport"
     },
     {
@@ -21082,7 +21342,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_shoppinglistsconfigport",
-      "community": 66,
+      "community": 4,
       "norm_label": "shoppinglistsconfigport.ts"
     },
     {
@@ -21092,7 +21352,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "ports_shoppinglistsconfigport_shoppinglistsconfigport",
-      "community": 66,
+      "community": 4,
       "norm_label": "shoppinglistsconfigport"
     },
     {
@@ -21442,7 +21702,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_resolveitemdisplayname",
-      "community": 4,
+      "community": 83,
       "norm_label": "resolveitemdisplayname.ts"
     },
     {
@@ -21452,7 +21712,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "queries_resolveitemdisplayname_resolveitemdisplayname",
-      "community": 4,
+      "community": 83,
       "norm_label": "resolveitemdisplayname()"
     },
     {
@@ -21462,7 +21722,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_appsettings_schema_test",
-      "community": 77,
+      "community": 141,
       "norm_label": "appsettings.schema.test.ts"
     },
     {
@@ -21492,7 +21752,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_aislesdocument_schema_test",
-      "community": 1,
+      "community": 64,
       "norm_label": "aislesdocument.schema.test.ts"
     },
     {
@@ -21642,7 +21902,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_createaisle_test",
-      "community": 1,
+      "community": 64,
       "norm_label": "createaisle.test.ts"
     },
     {
@@ -21652,7 +21912,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "canon_createaisle_test_makeids",
-      "community": 1,
+      "community": 64,
       "norm_label": "makeids()"
     },
     {
@@ -21662,7 +21922,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "canon_createaisle_test_makeaislestore",
-      "community": 1,
+      "community": 64,
       "norm_label": "makeaislestore()"
     },
     {
@@ -21672,7 +21932,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_createaislesbulk_test",
-      "community": 1,
+      "community": 64,
       "norm_label": "createaislesbulk.test.ts"
     },
     {
@@ -21682,7 +21942,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "canon_createaislesbulk_test_makeids",
-      "community": 1,
+      "community": 64,
       "norm_label": "makeids()"
     },
     {
@@ -21692,7 +21952,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "canon_createaislesbulk_test_makeaislestore",
-      "community": 1,
+      "community": 64,
       "norm_label": "makeaislestore()"
     },
     {
@@ -21752,7 +22012,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_deleteaisles_test",
-      "community": 281,
+      "community": 64,
       "norm_label": "deleteaisles.test.ts"
     },
     {
@@ -21762,7 +22022,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_deleteaisles_test_makeaislestore",
-      "community": 281,
+      "community": 64,
       "norm_label": "makeaislestore()"
     },
     {
@@ -21772,7 +22032,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "canon_deleteaisles_test_makecanonstore",
-      "community": 281,
+      "community": 64,
       "norm_label": "makecanonstore()"
     },
     {
@@ -21782,7 +22042,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "canon_deleteaisles_test_canonitem",
-      "community": 281,
+      "community": 64,
       "norm_label": "canonitem()"
     },
     {
@@ -21792,7 +22052,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_embedmatch_test",
-      "community": 64,
+      "community": 7,
       "norm_label": "embedmatch.test.ts"
     },
     {
@@ -21802,7 +22062,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_embedmatch_test_item",
-      "community": 64,
+      "community": 7,
       "norm_label": "item()"
     },
     {
@@ -21812,7 +22072,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "canon_embedmatch_test_cosine",
-      "community": 64,
+      "community": 7,
       "norm_label": "cosine()"
     },
     {
@@ -21822,7 +22082,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "canon_embedmatch_test_okport",
-      "community": 64,
+      "community": 7,
       "norm_label": "okport()"
     },
     {
@@ -21832,7 +22092,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "canon_embedmatch_test_failport",
-      "community": 64,
+      "community": 7,
       "norm_label": "failport()"
     },
     {
@@ -21842,7 +22102,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "canon_embedmatch_test_ex",
-      "community": 64,
+      "community": 7,
       "norm_label": "ex"
     },
     {
@@ -21852,7 +22112,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "canon_embedmatch_test_ey",
-      "community": 64,
+      "community": 7,
       "norm_label": "ey"
     },
     {
@@ -21862,7 +22122,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "canon_embedmatch_test_esim",
-      "community": 64,
+      "community": 7,
       "norm_label": "esim"
     },
     {
@@ -21872,7 +22132,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_findclosestmatch_test",
-      "community": 11,
+      "community": 17,
       "norm_label": "findclosestmatch.test.ts"
     },
     {
@@ -21882,7 +22142,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_findclosestmatch_test_item",
-      "community": 11,
+      "community": 17,
       "norm_label": "item()"
     },
     {
@@ -21892,7 +22152,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "canon_findclosestmatch_test_catalog",
-      "community": 11,
+      "community": 17,
       "norm_label": "catalog"
     },
     {
@@ -21902,7 +22162,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_getaisleusage_test",
-      "community": 11,
+      "community": 64,
       "norm_label": "getaisleusage.test.ts"
     },
     {
@@ -21912,7 +22172,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_getaisleusage_test_makeaislestore",
-      "community": 11,
+      "community": 64,
       "norm_label": "makeaislestore()"
     },
     {
@@ -21922,7 +22182,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "canon_getaisleusage_test_makecanonstore",
-      "community": 11,
+      "community": 64,
       "norm_label": "makecanonstore()"
     },
     {
@@ -21932,7 +22192,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "canon_getaisleusage_test_canonitem",
-      "community": 11,
+      "community": 64,
       "norm_label": "canonitem()"
     },
     {
@@ -21952,7 +22212,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_listaisles_test",
-      "community": 1,
+      "community": 64,
       "norm_label": "listaisles.test.ts"
     },
     {
@@ -21962,7 +22222,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_listaisles_test_makeaislestore",
-      "community": 1,
+      "community": 64,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22272,7 +22532,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_mergeaisles_test",
-      "community": 266,
+      "community": 64,
       "norm_label": "mergeaisles.test.ts"
     },
     {
@@ -22282,7 +22542,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_makeaislestore",
-      "community": 266,
+      "community": 64,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22292,7 +22552,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_makecanonstore",
-      "community": 266,
+      "community": 64,
       "norm_label": "makecanonstore()"
     },
     {
@@ -22302,7 +22562,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_canonitem",
-      "community": 266,
+      "community": 64,
       "norm_label": "canonitem()"
     },
     {
@@ -22312,7 +22572,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_aisles",
-      "community": 266,
+      "community": 64,
       "norm_label": "aisles"
     },
     {
@@ -22352,7 +22612,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_ports_contract_test",
-      "community": 1,
+      "community": 64,
       "norm_label": "ports.contract.test.ts"
     },
     {
@@ -22362,7 +22622,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_renameaisle_test",
-      "community": 1,
+      "community": 64,
       "norm_label": "renameaisle.test.ts"
     },
     {
@@ -22372,7 +22632,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_renameaisle_test_makeaislestore",
-      "community": 1,
+      "community": 64,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22382,7 +22642,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "canon_renameaisle_test_base",
-      "community": 1,
+      "community": 64,
       "norm_label": "base"
     },
     {
@@ -22412,7 +22672,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_reorderaisles_test",
-      "community": 1,
+      "community": 64,
       "norm_label": "reorderaisles.test.ts"
     },
     {
@@ -22422,7 +22682,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_reorderaisles_test_makeaislestore",
-      "community": 1,
+      "community": 64,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22432,7 +22692,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "canon_reorderaisles_test_base",
-      "community": 1,
+      "community": 64,
       "norm_label": "base"
     },
     {
@@ -22572,7 +22832,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test",
-      "community": 32,
+      "community": 49,
       "norm_label": "summarizematchlog.test.ts"
     },
     {
@@ -22582,7 +22842,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makestage",
-      "community": 32,
+      "community": 49,
       "norm_label": "makestage()"
     },
     {
@@ -22592,7 +22852,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makeentry",
-      "community": 32,
+      "community": 49,
       "norm_label": "makeentry()"
     },
     {
@@ -22602,7 +22862,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "canon_summarizematchlog_test_makearbitration",
-      "community": 32,
+      "community": 49,
       "norm_label": "makearbitration()"
     },
     {
@@ -22642,7 +22902,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_devsettings_schema_test",
-      "community": 77,
+      "community": 141,
       "norm_label": "devsettings.schema.test.ts"
     },
     {
@@ -22812,7 +23072,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_commands_test",
-      "community": 4,
+      "community": 8,
       "norm_label": "commands.test.ts"
     },
     {
@@ -22822,7 +23082,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeids",
-      "community": 4,
+      "community": 8,
       "norm_label": "makeids()"
     },
     {
@@ -22832,7 +23092,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makelist",
-      "community": 4,
+      "community": 8,
       "norm_label": "makelist()"
     },
     {
@@ -22842,7 +23102,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeconfig",
-      "community": 4,
+      "community": 8,
       "norm_label": "makeconfig()"
     },
     {
@@ -22852,7 +23112,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeitem",
-      "community": 4,
+      "community": 8,
       "norm_label": "makeitem()"
     },
     {
@@ -22952,7 +23212,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_resolveitemdisplayname_test",
-      "community": 4,
+      "community": 83,
       "norm_label": "resolveitemdisplayname.test.ts"
     },
     {
@@ -22962,7 +23222,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "shoppinglist_resolveitemdisplayname_test_makeitem",
-      "community": 4,
+      "community": 83,
       "norm_label": "makeitem()"
     },
     {
@@ -25062,7 +25322,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_ui_components_src_index_ts_src_index",
-      "community": 21,
+      "community": 14,
       "norm_label": "index.ts"
     },
     {
@@ -25082,7 +25342,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_lib_cn",
-      "community": 40,
+      "community": 41,
       "norm_label": "../../lib/cn"
     },
     {
@@ -25315,7 +25575,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_cn",
-      "community": 21,
+      "community": 298,
       "norm_label": "cn.ts"
     },
     {
@@ -25325,7 +25585,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "lib_cn_twmerge",
-      "community": 21,
+      "community": 298,
       "norm_label": "twmerge"
     },
     {
@@ -25335,7 +25595,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "lib_cn_cn",
-      "community": 21,
+      "community": 298,
       "norm_label": "cn()"
     },
     {
@@ -25507,7 +25767,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canonicon_canonicon",
-      "community": 40,
+      "community": 41,
       "norm_label": "canonicon.svelte"
     },
     {
@@ -25517,7 +25777,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_canonicon_canonicon_types",
-      "community": 40,
+      "community": 41,
       "norm_label": "./canonicon.types"
     },
     {
@@ -25527,7 +25787,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canonicon_canonicon_types",
-      "community": 21,
+      "community": 14,
       "norm_label": "canonicon.types.ts"
     },
     {
@@ -25537,7 +25797,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "canonicon_canonicon_types_canoniconprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "canoniconprops"
     },
     {
@@ -25929,7 +26189,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "combobox_combobox_types",
-      "community": 21,
+      "community": 14,
       "norm_label": "combobox.types.ts"
     },
     {
@@ -25939,7 +26199,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxitem",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxitem"
     },
     {
@@ -25949,7 +26209,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxprops"
     },
     {
@@ -25959,7 +26219,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxinputprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxinputprops"
     },
     {
@@ -25969,7 +26229,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxfieldprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxfieldprops"
     },
     {
@@ -25979,7 +26239,7 @@
       "source_location": "L56",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxtriggerprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxtriggerprops"
     },
     {
@@ -25989,7 +26249,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxcontentprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxcontentprops"
     },
     {
@@ -25999,7 +26259,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxitemprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxitemprops"
     },
     {
@@ -26009,7 +26269,7 @@
       "source_location": "L73",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxgroupprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxgroupprops"
     },
     {
@@ -26019,7 +26279,7 @@
       "source_location": "L78",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxlabelprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxlabelprops"
     },
     {
@@ -26029,7 +26289,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxseparatorprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxseparatorprops"
     },
     {
@@ -26039,7 +26299,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxemptyprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxemptyprops"
     },
     {
@@ -26049,7 +26309,7 @@
       "source_location": "L92",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxcreateprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxcreateprops"
     },
     {
@@ -26150,7 +26410,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "dom",
-      "community": 14,
+      "community": 18,
       "norm_label": "@floating-ui/dom"
     },
     {
@@ -26419,7 +26679,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "combobox_index",
-      "community": 21,
+      "community": 14,
       "norm_label": "index.ts"
     },
     {
@@ -27122,7 +27382,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "markdown_markdown",
-      "community": 40,
+      "community": 13,
       "norm_label": "markdown.svelte"
     },
     {
@@ -27142,7 +27402,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "gfm",
-      "community": 40,
+      "community": 13,
       "norm_label": "svelte-exmarkdown/gfm"
     },
     {
@@ -28339,7 +28599,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "sortablelist_sortablelist_types",
-      "community": 21,
+      "community": 14,
       "norm_label": "sortablelist.types.ts"
     },
     {
@@ -28349,7 +28609,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "sortablelist_sortablelist_types_sortablelistprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "sortablelistprops"
     },
     {
@@ -29407,7 +29667,7 @@
       "_origin": "ast",
       "confidence": "EXTRACTED",
       "id": "listpage_listpage_context",
-      "community": 21,
+      "community": 38,
       "norm_label": "./listpage.context.js"
     },
     {
@@ -29417,7 +29677,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "listpage_listpage_context_listpagecontext",
-      "community": 21,
+      "community": 38,
       "norm_label": "listpagecontext"
     },
     {
@@ -29427,7 +29687,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "listpage_listpage_context_list_page_context",
-      "community": 21,
+      "community": 38,
       "norm_label": "list_page_context"
     },
     {
@@ -29487,7 +29747,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "listpage_listpage_types",
-      "community": 21,
+      "community": 38,
       "norm_label": "listpage.types.ts"
     },
     {
@@ -29497,7 +29757,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "listpage_listpage_types_bulkactionicon",
-      "community": 21,
+      "community": 38,
       "norm_label": "bulkactionicon"
     },
     {
@@ -29507,7 +29767,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "listpage_listpage_types_bulkaction",
-      "community": 21,
+      "community": 38,
       "norm_label": "bulkaction"
     },
     {
@@ -29517,7 +29777,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "listpage_listpage_types_listpageprops",
-      "community": 21,
+      "community": 38,
       "norm_label": "listpageprops"
     },
     {
@@ -29527,7 +29787,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "listpage_index",
-      "community": 21,
+      "community": 38,
       "norm_label": "index.ts"
     },
     {
@@ -29769,7 +30029,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_canonicon_test",
-      "community": 40,
+      "community": 41,
       "norm_label": "canonicon.test.ts"
     },
     {
@@ -29809,7 +30069,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_combobox_test",
-      "community": 14,
+      "community": 286,
       "norm_label": "combobox.test.ts"
     },
     {
@@ -29819,7 +30079,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "tests_combobox_test_setup",
-      "community": 14,
+      "community": 286,
       "norm_label": "setup()"
     },
     {
@@ -29829,7 +30089,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "tests_combobox_test_getinput",
-      "community": 14,
+      "community": 286,
       "norm_label": "getinput()"
     },
     {
@@ -29839,7 +30099,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "tests_combobox_test_getlistbox",
-      "community": 14,
+      "community": 286,
       "norm_label": "getlistbox()"
     },
     {
@@ -29849,7 +30109,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "tests_combobox_test_opencombobox",
-      "community": 14,
+      "community": 286,
       "norm_label": "opencombobox()"
     },
     {
@@ -30229,7 +30489,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_lib_cn_test",
-      "community": 21,
+      "community": 298,
       "norm_label": "lib.cn.test.ts"
     },
     {
@@ -31875,7 +32135,7 @@
       "source_location": "L75",
       "_origin": "ast",
       "id": "commands_defect_phases",
-      "community": 329,
+      "community": 270,
       "norm_label": "phases"
     },
     {
@@ -31885,7 +32145,7 @@
       "source_location": "L80",
       "_origin": "ast",
       "id": "commands_defect_phase_1_name",
-      "community": 329,
+      "community": 270,
       "norm_label": "phase 1: [name]"
     },
     {
@@ -31895,7 +32155,7 @@
       "source_location": "L86",
       "_origin": "ast",
       "id": "commands_defect_phase_2_name",
-      "community": 329,
+      "community": 270,
       "norm_label": "phase 2: [name]"
     },
     {
@@ -32065,7 +32325,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_run",
-      "community": 98,
+      "community": 278,
       "norm_label": "run.md"
     },
     {
@@ -32075,7 +32335,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_run_run_issue",
-      "community": 98,
+      "community": 278,
       "norm_label": "run issue"
     },
     {
@@ -32085,7 +32345,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_run_setup_once",
-      "community": 98,
+      "community": 278,
       "norm_label": "setup (once)"
     },
     {
@@ -32095,7 +32355,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "commands_run_create_the_working_branch_once_before_phase_1",
-      "community": 98,
+      "community": 278,
       "norm_label": "create the working branch (once, before phase 1)"
     },
     {
@@ -32185,7 +32445,7 @@
       "source_location": "L169",
       "_origin": "ast",
       "id": "commands_run_pause_conditions_stop_and_wait_for_user",
-      "community": 98,
+      "community": 278,
       "norm_label": "pause conditions (stop and wait for user)"
     },
     {
@@ -32245,7 +32505,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "commands_spec_intended_experience",
-      "community": 98,
+      "community": 278,
       "norm_label": "intended experience"
     },
     {
@@ -33035,7 +33295,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_foundations",
-      "community": 273,
+      "community": 72,
       "norm_label": "1. foundations"
     },
     {
@@ -33045,7 +33305,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_1_technology_stack",
-      "community": 273,
+      "community": 72,
       "norm_label": "1.1 technology stack"
     },
     {
@@ -33055,7 +33315,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_2_boundaries",
-      "community": 273,
+      "community": 72,
       "norm_label": "1.2 boundaries"
     },
     {
@@ -33065,7 +33325,7 @@
       "source_location": "L85",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_3_package_surface",
-      "community": 273,
+      "community": 72,
       "norm_label": "1.3 package surface"
     },
     {
@@ -33075,7 +33335,7 @@
       "source_location": "L137",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_4_event_naming_rule",
-      "community": 273,
+      "community": 72,
       "norm_label": "1.4 event naming rule"
     },
     {
@@ -33085,7 +33345,7 @@
       "source_location": "L147",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_5_spec_versioning_amendment_rule",
-      "community": 273,
+      "community": 72,
       "norm_label": "1.5 spec versioning & amendment rule"
     },
     {
@@ -33235,7 +33495,7 @@
       "source_location": "L383",
       "_origin": "ast",
       "id": "design_ui_spec_v02_3_5_helpers",
-      "community": 299,
+      "community": 266,
       "norm_label": "3.5 helpers"
     },
     {
@@ -33245,7 +33505,7 @@
       "source_location": "L385",
       "_origin": "ast",
       "id": "design_ui_spec_v02_src_lib_cn_ts",
-      "community": 299,
+      "community": 266,
       "norm_label": "`src/lib/cn.ts`"
     },
     {
@@ -33255,7 +33515,7 @@
       "source_location": "L396",
       "_origin": "ast",
       "id": "design_ui_spec_v02_src_lib_useid_ts",
-      "community": 299,
+      "community": 266,
       "norm_label": "`src/lib/useid.ts`"
     },
     {
@@ -33265,7 +33525,7 @@
       "source_location": "L409",
       "_origin": "ast",
       "id": "design_ui_spec_v02_src_lib_context_ts",
-      "community": 299,
+      "community": 266,
       "norm_label": "`src/lib/context.ts`"
     },
     {
@@ -33275,7 +33535,7 @@
       "source_location": "L432",
       "_origin": "ast",
       "id": "design_ui_spec_v02_src_lib_variants_ts",
-      "community": 299,
+      "community": 266,
       "norm_label": "`src/lib/variants.ts`"
     },
     {
@@ -33385,7 +33645,7 @@
       "source_location": "L669",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_styling_system",
-      "community": 311,
+      "community": 82,
       "norm_label": "4. styling system"
     },
     {
@@ -33455,7 +33715,7 @@
       "source_location": "L721",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_2_focus_ring",
-      "community": 311,
+      "community": 82,
       "norm_label": "4.2 focus ring"
     },
     {
@@ -33465,7 +33725,7 @@
       "source_location": "L735",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_3_disabled_loading",
-      "community": 311,
+      "community": 82,
       "norm_label": "4.3 disabled + loading"
     },
     {
@@ -33475,7 +33735,7 @@
       "source_location": "L737",
       "_origin": "ast",
       "id": "design_ui_spec_v02_disabled_terminal_state_no_interaction",
-      "community": 311,
+      "community": 82,
       "norm_label": "disabled (terminal state \u2014 no interaction)"
     },
     {
@@ -33485,7 +33745,7 @@
       "source_location": "L744",
       "_origin": "ast",
       "id": "design_ui_spec_v02_loading_transient_state_disables_interaction_without_terminal_semantics",
-      "community": 311,
+      "community": 82,
       "norm_label": "loading (transient state \u2014 disables interaction without terminal semantics)"
     },
     {
@@ -33495,7 +33755,7 @@
       "source_location": "L755",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_4_shared_size_scale",
-      "community": 311,
+      "community": 98,
       "norm_label": "4.4 shared size scale"
     },
     {
@@ -33505,7 +33765,7 @@
       "source_location": "L759",
       "_origin": "ast",
       "id": "design_ui_spec_v02_field_size_scale_textfield_textarea_frame_button",
-      "community": 311,
+      "community": 98,
       "norm_label": "field size scale (textfield, textarea frame, button)"
     },
     {
@@ -33515,7 +33775,7 @@
       "source_location": "L767",
       "_origin": "ast",
       "id": "design_ui_spec_v02_control_size_scale_checkbox_switch",
-      "community": 311,
+      "community": 98,
       "norm_label": "control size scale (checkbox, switch)"
     },
     {
@@ -33525,7 +33785,7 @@
       "source_location": "L775",
       "_origin": "ast",
       "id": "design_ui_spec_v02_dialog_size_scale",
-      "community": 311,
+      "community": 98,
       "norm_label": "dialog size scale"
     },
     {
@@ -33535,7 +33795,7 @@
       "source_location": "L785",
       "_origin": "ast",
       "id": "design_ui_spec_v02_text_size_scale_text_primitive",
-      "community": 311,
+      "community": 98,
       "norm_label": "text size scale (text primitive)"
     },
     {
@@ -33545,7 +33805,7 @@
       "source_location": "L793",
       "_origin": "ast",
       "id": "design_ui_spec_v02_icon_spinner_sizes",
-      "community": 311,
+      "community": 98,
       "norm_label": "icon / spinner sizes"
     },
     {
@@ -33555,7 +33815,7 @@
       "source_location": "L799",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_5_dark_mode",
-      "community": 311,
+      "community": 82,
       "norm_label": "4.5 dark mode"
     },
     {
@@ -33935,7 +34195,7 @@
       "source_location": "L1177",
       "_origin": "ast",
       "id": "design_ui_spec_v02_8_5_switch",
-      "community": 283,
+      "community": 282,
       "norm_label": "8.5 switch"
     },
     {
@@ -33945,7 +34205,7 @@
       "source_location": "L1179",
       "_origin": "ast",
       "id": "design_ui_spec_v02_props_1179",
-      "community": 283,
+      "community": 282,
       "norm_label": "props"
     },
     {
@@ -33955,7 +34215,7 @@
       "source_location": "L1195",
       "_origin": "ast",
       "id": "design_ui_spec_v02_events_1195",
-      "community": 283,
+      "community": 282,
       "norm_label": "events"
     },
     {
@@ -33965,7 +34225,7 @@
       "source_location": "L1199",
       "_origin": "ast",
       "id": "design_ui_spec_v02_accessibility_1199",
-      "community": 283,
+      "community": 282,
       "norm_label": "accessibility"
     },
     {
@@ -33975,7 +34235,7 @@
       "source_location": "L1205",
       "_origin": "ast",
       "id": "design_ui_spec_v02_styling_1205",
-      "community": 283,
+      "community": 282,
       "norm_label": "styling"
     },
     {
@@ -34335,7 +34595,7 @@
       "source_location": "L1462",
       "_origin": "ast",
       "id": "design_ui_spec_v02_8_13_layout_primitives_stack_inline_grid_divider",
-      "community": 283,
+      "community": 281,
       "norm_label": "8.13 layout primitives \u2014 stack / inline / grid / divider"
     },
     {
@@ -34345,7 +34605,7 @@
       "source_location": "L1464",
       "_origin": "ast",
       "id": "design_ui_spec_v02_stack",
-      "community": 283,
+      "community": 281,
       "norm_label": "stack"
     },
     {
@@ -34355,7 +34615,7 @@
       "source_location": "L1475",
       "_origin": "ast",
       "id": "design_ui_spec_v02_inline",
-      "community": 283,
+      "community": 281,
       "norm_label": "inline"
     },
     {
@@ -34365,7 +34625,7 @@
       "source_location": "L1479",
       "_origin": "ast",
       "id": "design_ui_spec_v02_grid",
-      "community": 283,
+      "community": 281,
       "norm_label": "grid"
     },
     {
@@ -34375,7 +34635,7 @@
       "source_location": "L1489",
       "_origin": "ast",
       "id": "design_ui_spec_v02_divider",
-      "community": 283,
+      "community": 281,
       "norm_label": "divider"
     },
     {
@@ -35885,7 +36145,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_by_stage_narrative",
-      "community": 82,
+      "community": 71,
       "norm_label": "stage-by-stage narrative"
     },
     {
@@ -35895,7 +36155,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_1_exact_name_match",
-      "community": 82,
+      "community": 71,
       "norm_label": "stage 1 \u2014 exact name match"
     },
     {
@@ -35905,7 +36165,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_2_token_overlap",
-      "community": 82,
+      "community": 71,
       "norm_label": "stage 2 \u2014 token overlap"
     },
     {
@@ -35915,7 +36175,7 @@
       "source_location": "L91",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_3_synonym_exact_match",
-      "community": 82,
+      "community": 71,
       "norm_label": "stage 3 \u2014 synonym exact match"
     },
     {
@@ -35925,7 +36185,7 @@
       "source_location": "L95",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_4_string_similarity_levenshtein",
-      "community": 82,
+      "community": 71,
       "norm_label": "stage 4 \u2014 string similarity (levenshtein)"
     },
     {
@@ -35935,7 +36195,7 @@
       "source_location": "L99",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_5_embedding_cosine",
-      "community": 82,
+      "community": 71,
       "norm_label": "stage 5 \u2014 embedding cosine"
     },
     {
@@ -35945,7 +36205,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_6_merged_shortlist_ai_arbitration",
-      "community": 82,
+      "community": 71,
       "norm_label": "stage 6 \u2014 merged shortlist + ai arbitration"
     },
     {
@@ -36395,7 +36655,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_releases",
-      "community": 89,
+      "community": 53,
       "norm_label": "releases.md"
     },
     {
@@ -36405,7 +36665,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_releases_releases_environments",
-      "community": 89,
+      "community": 53,
       "norm_label": "releases & environments"
     },
     {
@@ -36415,7 +36675,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "docs_releases_firebase_projects_firebaserc_aliases",
-      "community": 89,
+      "community": 53,
       "norm_label": "firebase projects (`.firebaserc` aliases)"
     },
     {
@@ -36475,7 +36735,7 @@
       "source_location": "L115",
       "_origin": "ast",
       "id": "docs_releases_deploying",
-      "community": 89,
+      "community": 53,
       "norm_label": "deploying"
     },
     {
@@ -36485,7 +36745,7 @@
       "source_location": "L128",
       "_origin": "ast",
       "id": "docs_releases_cutting_a_release_promote_staging_production",
-      "community": 89,
+      "community": 53,
       "norm_label": "cutting a release (promote staging \u2192 production)"
     },
     {
@@ -36495,7 +36755,7 @@
       "source_location": "L147",
       "_origin": "ast",
       "id": "docs_releases_rollback_re_deploy",
-      "community": 89,
+      "community": 53,
       "norm_label": "rollback / re-deploy"
     },
     {
@@ -36505,7 +36765,7 @@
       "source_location": "L162",
       "_origin": "ast",
       "id": "docs_releases_first_deploy_to_a_fresh_project_one_time_bootstrap",
-      "community": 89,
+      "community": 53,
       "norm_label": "first deploy to a fresh project (one-time bootstrap)"
     },
     {
@@ -36515,7 +36775,7 @@
       "source_location": "L185",
       "_origin": "ast",
       "id": "docs_releases_setup_status",
-      "community": 89,
+      "community": 53,
       "norm_label": "setup status"
     },
     {
@@ -38091,7 +38351,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 98,
+      "community": 278,
       "norm_label": "per-phase handoff contract",
       "id": "commands_run_handoff_contract"
     },
@@ -38104,7 +38364,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 98,
+      "community": 278,
       "norm_label": "orchestrator/subagent pattern",
       "id": "commands_run_orchestrator_subagent_pattern"
     },
@@ -38195,7 +38455,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 48,
+      "community": 97,
       "norm_label": "last-write-wins per document",
       "id": "claude_lww_per_document"
     },
@@ -39040,7 +39300,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 89,
+      "community": 53,
       "norm_label": "trunk-based release model",
       "id": "releases_trunk_based_model"
     },
@@ -39079,7 +39339,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 89,
+      "community": 53,
       "norm_label": "workload identity federation auth",
       "id": "releases_wif_auth"
     },
@@ -39092,7 +39352,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 89,
+      "community": 53,
       "norm_label": "production promotion approval gate",
       "id": "releases_production_approval_gate"
     },
@@ -39118,7 +39378,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 89,
+      "community": 53,
       "norm_label": "dev/staging share one google ai studio project",
       "id": "releases_gemini_shared_ai_studio"
     },
@@ -39157,7 +39417,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 48,
+      "community": 97,
       "norm_label": "schema evolution / end-of-greenfield",
       "id": "salt_architecture_schema_evolution_greenfield"
     },
@@ -39274,7 +39534,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 89,
+      "community": 53,
       "norm_label": "admin-managed model selection (resolvemodel/ai_flow_roles)",
       "id": "salt_architecture_resolve_model_roles"
     },
@@ -42961,11 +43221,43 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "apps/cloud-functions/src/callables/regenerateCanonIcon.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "callables_regeneratecanonicon",
+      "target": "callables_regeneratecanonicon_posthogapikey",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/callables/regenerateCanonIcon.ts",
       "source_location": "L21",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "callables_regeneratecanonicon",
       "target": "callables_regeneratecanonicon_regeneratecanonicon"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/callables/regenerateCanonIcon.ts",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "callables_regeneratecanonicon",
+      "target": "observability_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/callables/regenerateCanonIcon.ts",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "callables_regeneratecanonicon",
+      "target": "observability_reportservererror_reportflowerror",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -43497,6 +43789,28 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "apps/cloud-functions/src/flows/chefChat.ts",
+      "source_location": "L15",
+      "weight": 1.0,
+      "source": "flows_chefchat",
+      "target": "observability_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/flows/chefChat.ts",
+      "source_location": "L15",
+      "weight": 1.0,
+      "source": "flows_chefchat",
+      "target": "observability_reportservererror_reportflowerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/flows/chefChat.ts",
       "source_location": "L5",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -44007,6 +44321,28 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "apps/cloud-functions/src/flows/generateChatTitle.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "flows_generatechattitle",
+      "target": "observability_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/flows/generateChatTitle.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "flows_generatechattitle",
+      "target": "observability_reportservererror_reportflowerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/flows/generateChatTitle.ts",
       "source_location": "L3",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -44065,6 +44401,28 @@
       "confidence_score": 1.0,
       "source": "flows_identifyequipment",
       "target": "flows_identifyequipment_system_instructions"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/flows/identifyEquipment.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "flows_identifyequipment",
+      "target": "observability_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/flows/identifyEquipment.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "flows_identifyequipment",
+      "target": "observability_reportservererror_reportflowerror",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -44488,6 +44846,28 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "apps/cloud-functions/src/flows/populateEquipmentEntry.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "flows_populateequipmententry",
+      "target": "observability_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/flows/populateEquipmentEntry.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "flows_populateequipmententry",
+      "target": "observability_reportservererror_reportflowerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/flows/populateEquipmentEntry.ts",
       "source_location": "L1",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -44670,6 +45050,28 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "apps/cloud-functions/src/index.ts",
+      "source_location": "L18",
+      "weight": 1.0,
+      "source": "apps_cloud_functions_src_index_ts_src_index",
+      "target": "observability_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/index.ts",
+      "source_location": "L18",
+      "weight": 1.0,
+      "source": "apps_cloud_functions_src_index_ts_src_index",
+      "target": "observability_reportservererror_reportflowerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/index.ts",
       "source_location": "L5",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -44840,6 +45242,16 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "apps/cloud-functions/src/index.ts",
+      "source_location": "L345",
+      "weight": 1.0,
+      "source": "apps_cloud_functions_src_index_ts_src_index",
+      "target": "src_index_reportunexpected",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/index.ts",
       "source_location": "L307",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -44889,6 +45301,157 @@
       "confidence_score": 1.0,
       "source": "apps_cloud_functions_src_index_ts_src_index",
       "target": "triggers_onshoppinglistitemwrite_onshoppinglistitemwrite"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/index.ts",
+      "source_location": "L349",
+      "weight": 1.0,
+      "source": "src_index_reportunexpected",
+      "target": "observability_reportservererror_reportflowerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
+      "source_location": "L17",
+      "weight": 1.0,
+      "source": "observability_reportservererror",
+      "target": "observability_reportservererror_reporter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
+      "source_location": "L40",
+      "weight": 1.0,
+      "source": "observability_reportservererror",
+      "target": "observability_reportservererror_reportflowerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "observability_reportservererror",
+      "target": "observability_reportservererror_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "observability_reportservererror",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "triggers_oncanonitemwritten",
+      "target": "observability_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "triggers_onshoppinglistitemwrite",
+      "target": "observability_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "observability_reportservererror_reportflowerror",
+      "target": "observability_reportservererror_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "triggers_oncanonitemwritten",
+      "target": "observability_reportservererror_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
+      "source_location": "L166",
+      "weight": 1.0,
+      "source": "triggers_oncanonitemwritten_iscanonicongenerationenabled",
+      "target": "observability_reportservererror_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
+      "source_location": "L47",
+      "weight": 1.0,
+      "source": "triggers_oncanonitemwritten_maybegenerateembedding",
+      "target": "observability_reportservererror_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
+      "source_location": "L136",
+      "weight": 1.0,
+      "source": "triggers_oncanonitemwritten_maybegenerateicon",
+      "target": "observability_reportservererror_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "triggers_onshoppinglistitemwrite",
+      "target": "observability_reportservererror_reportservererror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "apps/cloud-functions/src/observability/reportServerError.ts",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "observability_reportservererror_reportflowerror",
+      "target": "server_init_flushserverobservability"
     },
     {
       "relation": "imports",
@@ -44981,6 +45544,16 @@
       "confidence_score": 1.0,
       "source": "triggers_oncanonitemwritten",
       "target": "triggers_oncanonitemwritten_oncanonitemwritten"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/triggers/onCanonItemWritten.ts",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "triggers_oncanonitemwritten",
+      "target": "triggers_oncanonitemwritten_posthogapikey",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -45533,12 +46106,142 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "flows_extractrecipefromurl_reporting_test",
+      "target": "flows_extractrecipefromurl_reporting_test_extractrecipefromurlflow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "flows_extractrecipefromurl_reporting_test",
+      "target": "flows_extractrecipefromurl_reporting_test_fakehttpserror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L83",
+      "weight": 1.0,
+      "source": "flows_extractrecipefromurl_reporting_test",
+      "target": "flows_extractrecipefromurl_reporting_test_invoke",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "flows_extractrecipefromurl_reporting_test",
+      "target": "flows_extractrecipefromurl_reporting_test_mockflush",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "flows_extractrecipefromurl_reporting_test",
+      "target": "flows_extractrecipefromurl_reporting_test_mockreport",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L47",
+      "weight": 1.0,
+      "source": "flows_extractrecipefromurl_reporting_test",
+      "target": "flows_extractrecipefromurl_reporting_test_urlimporterror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L86",
+      "weight": 1.0,
+      "source": "flows_extractrecipefromurl_reporting_test",
+      "target": "flows_extractrecipefromurl_reporting_test_valid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L27",
+      "weight": 1.0,
+      "source": "flows_extractrecipefromurl_reporting_test_fakehttpserror",
+      "target": "flows_extractrecipefromurl_reporting_test_fakehttpserror_constructor",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/flows/extractRecipeFromUrl.reporting.test.ts",
+      "source_location": "L48",
+      "weight": 1.0,
+      "source": "flows_extractrecipefromurl_reporting_test_urlimporterror",
+      "target": "flows_extractrecipefromurl_reporting_test_urlimporterror_constructor",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "apps/cloud-functions/tests/flows/generateCanonIcon.test.ts",
       "source_location": "L3",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "flows_generatecanonicon_test",
       "target": "flows_generatecanonicon_test_mockgenerate"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "flows_generatechattitle_reporting_test",
+      "target": "flows_generatechattitle_reporting_test_input",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts",
+      "source_location": "L12",
+      "weight": 1.0,
+      "source": "flows_generatechattitle_reporting_test",
+      "target": "flows_generatechattitle_reporting_test_mockflush",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts",
+      "source_location": "L20",
+      "weight": 1.0,
+      "source": "flows_generatechattitle_reporting_test",
+      "target": "flows_generatechattitle_reporting_test_mockgenerate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/flows/generateChatTitle.reporting.test.ts",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "flows_generatechattitle_reporting_test",
+      "target": "flows_generatechattitle_reporting_test_mockreport",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -46674,6 +47377,16 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "triggers_onshoppinglistitemwrite_test",
+      "target": "triggers_onshoppinglistitemwrite_test_mockflush",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts",
       "source_location": "L13",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -46699,6 +47412,16 @@
       "confidence_score": 1.0,
       "source": "triggers_onshoppinglistitemwrite_test",
       "target": "triggers_onshoppinglistitemwrite_test_mockmatchorcreate"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/tests/triggers/onShoppingListItemWrite.test.ts",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "triggers_onshoppinglistitemwrite_test",
+      "target": "triggers_onshoppinglistitemwrite_test_mockreport",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -51301,9 +52024,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L44",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "lib_auth_svelte",
-      "confidence_score": 1.0
+      "target": "lib_auth_svelte"
     },
     {
       "relation": "imports_from",
@@ -52397,9 +53120,9 @@
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_canonservice",
-      "target": "lib_errorreporting_reportiffailed",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting_reportiffailed"
     },
     {
       "relation": "imports",
@@ -52419,9 +53142,9 @@
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_canonservice",
-      "target": "lib_errorreporting_reportwriteerror",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting_reportwriteerror"
     },
     {
       "relation": "imports",
@@ -52704,9 +53427,9 @@
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_canonservice_errorreporting_test",
-      "target": "lib_canonservice",
-      "confidence_score": 1.0
+      "target": "lib_canonservice"
     },
     {
       "relation": "imports_from",
@@ -53506,9 +54229,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L38",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte",
-      "target": "lib_errorreporting_reportiffailed",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting_reportiffailed"
     },
     {
       "relation": "imports",
@@ -53528,9 +54251,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L38",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte",
-      "target": "lib_errorreporting_reportwriteerror",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting_reportwriteerror"
     },
     {
       "relation": "imports_from",
@@ -53800,9 +54523,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L77",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte",
-      "target": "lib_shoppinglistservice_svelte_reportfirstwritefailure",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_reportfirstwritefailure"
     },
     {
       "relation": "contains",
@@ -54075,9 +54798,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L46",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "lib_shoppinglistservice_svelte",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte"
     },
     {
       "relation": "imports_from",
@@ -54423,9 +55146,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L45",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "lib_membersservice",
-      "confidence_score": 1.0
+      "target": "lib_membersservice"
     },
     {
       "relation": "imports_from",
@@ -55327,9 +56050,9 @@
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
       "source_location": "L11",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_recipeservice",
-      "target": "lib_errorreporting_reportiffailed",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting_reportiffailed"
     },
     {
       "relation": "imports",
@@ -55809,9 +56532,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "lib_recipeservice",
-      "confidence_score": 1.0
+      "target": "lib_recipeservice"
     },
     {
       "relation": "imports_from",
@@ -55988,9 +56711,9 @@
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_chatservice",
-      "target": "lib_errorreporting_reportiffailed",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting_reportiffailed"
     },
     {
       "relation": "imports",
@@ -56010,9 +56733,9 @@
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_chatservice",
-      "target": "lib_errorreporting_reportwriteerror",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting_reportwriteerror"
     },
     {
       "relation": "imports_from",
@@ -56139,9 +56862,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L32",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "lib_chatservice",
-      "confidence_score": 1.0
+      "target": "lib_chatservice"
     },
     {
       "relation": "imports_from",
@@ -58046,9 +58769,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L44",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "lib_auth_svelte_auth",
-      "confidence_score": 1.0
+      "target": "lib_auth_svelte_auth"
     },
     {
       "relation": "imports",
@@ -58167,9 +58890,9 @@
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
       "source_location": "L226",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_canonservice_addcanonitem",
-      "target": "lib_canonservice_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_canonservice_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -58178,9 +58901,9 @@
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
       "source_location": "L325",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_canonservice_deletecanonitem",
-      "target": "lib_canonservice_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_canonservice_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -58200,9 +58923,9 @@
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
       "source_location": "L339",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_canonservice_regeneratecanonicon",
-      "target": "lib_canonservice_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_canonservice_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -58211,9 +58934,9 @@
       "source_file": "apps/web-pwa/src/lib/canonService.ts",
       "source_location": "L353",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_canonservice_unhidecanonicon",
-      "target": "lib_canonservice_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_canonservice_geterrorreporter"
     },
     {
       "relation": "imports",
@@ -58398,9 +59121,9 @@
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_canonservice_errorreporting_test",
-      "target": "lib_canonservice_addcanonitem",
-      "confidence_score": 1.0
+      "target": "lib_canonservice_addcanonitem"
     },
     {
       "relation": "calls",
@@ -58684,9 +59407,9 @@
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_canonservice_errorreporting_test",
-      "target": "lib_canonservice_deletecanonitem",
-      "confidence_score": 1.0
+      "target": "lib_canonservice_deletecanonitem"
     },
     {
       "relation": "imports",
@@ -58739,9 +59462,9 @@
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_canonservice_errorreporting_test",
-      "target": "lib_canonservice_regeneratecanonicon",
-      "confidence_score": 1.0
+      "target": "lib_canonservice_regeneratecanonicon"
     },
     {
       "relation": "imports",
@@ -58827,9 +59550,9 @@
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_canonservice_errorreporting_test",
-      "target": "lib_canonservice_unhidecanonicon",
-      "confidence_score": 1.0
+      "target": "lib_canonservice_unhidecanonicon"
     },
     {
       "relation": "imports",
@@ -58849,9 +59572,9 @@
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_canonservice_errorreporting_test",
-      "target": "lib_canonservice_resetcanonservicefortest",
-      "confidence_score": 1.0
+      "target": "lib_canonservice_resetcanonservicefortest"
     },
     {
       "relation": "imports",
@@ -58893,9 +59616,9 @@
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
       "source_location": "L110",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_chatservice_createchatsession",
-      "target": "lib_chatservice_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_chatservice_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -58915,9 +59638,9 @@
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
       "source_location": "L123",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_chatservice_persistsession",
-      "target": "lib_chatservice_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_chatservice_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -58926,9 +59649,9 @@
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
       "source_location": "L129",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_chatservice_removesession",
-      "target": "lib_chatservice_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_chatservice_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -58937,9 +59660,9 @@
       "source_file": "apps/web-pwa/src/lib/chatService.ts",
       "source_location": "L172",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_chatservice_sendmessage",
-      "target": "lib_chatservice_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_chatservice_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -59047,9 +59770,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L32",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "lib_chatservice_createchatsession",
-      "confidence_score": 1.0
+      "target": "lib_chatservice_createchatsession"
     },
     {
       "relation": "calls",
@@ -59091,9 +59814,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L32",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "lib_chatservice_persistsession",
-      "confidence_score": 1.0
+      "target": "lib_chatservice_persistsession"
     },
     {
       "relation": "calls",
@@ -59124,9 +59847,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L32",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "lib_chatservice_removesession",
-      "confidence_score": 1.0
+      "target": "lib_chatservice_removesession"
     },
     {
       "relation": "calls",
@@ -59168,9 +59891,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L32",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "lib_chatservice_sendmessage",
-      "confidence_score": 1.0
+      "target": "lib_chatservice_sendmessage"
     },
     {
       "relation": "imports_from",
@@ -60189,9 +60912,9 @@
       "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
       "source_location": "L56",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_errorreporting",
-      "target": "lib_errorreporting_reportiffailed",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting_reportiffailed"
     },
     {
       "relation": "contains",
@@ -60209,9 +60932,9 @@
       "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
       "source_location": "L43",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_errorreporting",
-      "target": "lib_errorreporting_reportwriteerror",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting_reportwriteerror"
     },
     {
       "relation": "imports",
@@ -60253,9 +60976,9 @@
       "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_errorreporting",
-      "target": "src_index_readresult",
-      "confidence_score": 1.0
+      "target": "src_index_readresult"
     },
     {
       "relation": "imports",
@@ -60264,9 +60987,9 @@
       "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_errorreporting",
-      "target": "src_index_result",
-      "confidence_score": 1.0
+      "target": "src_index_result"
     },
     {
       "relation": "imports_from",
@@ -60308,9 +61031,9 @@
       "source_file": "apps/web-pwa/src/lib/errorReporting.ts",
       "source_location": "L61",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_errorreporting_reportiffailed",
-      "target": "lib_errorreporting_reportwriteerror",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting_reportwriteerror"
     },
     {
       "relation": "calls",
@@ -60330,9 +61053,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L80",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_reportfirstwritefailure",
-      "target": "lib_errorreporting_reportwriteerror",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting_reportwriteerror"
     },
     {
       "relation": "imports",
@@ -60341,9 +61064,9 @@
       "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
       "source_location": "L11",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_errorreporting_test",
-      "target": "lib_errorreporting_reportwriteerror",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting_reportwriteerror"
     },
     {
       "relation": "calls",
@@ -60550,9 +61273,9 @@
       "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
       "source_location": "L11",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_errorreporting_test",
-      "target": "lib_errorreporting_reportiffailed",
-      "confidence_score": 1.0
+      "target": "lib_errorreporting_reportiffailed"
     },
     {
       "relation": "calls",
@@ -61859,9 +62582,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L45",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "lib_membersservice_resetmembersservicefortest",
-      "confidence_score": 1.0
+      "target": "lib_membersservice_resetmembersservicefortest"
     },
     {
       "relation": "imports",
@@ -62135,9 +62858,9 @@
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
       "source_location": "L201",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_recipeservice_canonicaliseingredients",
-      "target": "lib_recipeservice_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_recipeservice_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62146,9 +62869,9 @@
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
       "source_location": "L395",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_recipeservice_commitrecipeaddplan",
-      "target": "lib_recipeservice_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_recipeservice_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62168,9 +62891,9 @@
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
       "source_location": "L238",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_recipeservice_matchingredient",
-      "target": "lib_recipeservice_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_recipeservice_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62179,9 +62902,9 @@
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
       "source_location": "L114",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_recipeservice_persistrecipe",
-      "target": "lib_recipeservice_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_recipeservice_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62190,9 +62913,9 @@
       "source_file": "apps/web-pwa/src/lib/recipeService.ts",
       "source_location": "L267",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_recipeservice_removerecipe",
-      "target": "lib_recipeservice_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_recipeservice_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62245,9 +62968,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "lib_recipeservice_persistrecipe",
-      "confidence_score": 1.0
+      "target": "lib_recipeservice_persistrecipe"
     },
     {
       "relation": "calls",
@@ -62311,9 +63034,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "lib_recipeservice_canonicaliseingredients",
-      "confidence_score": 1.0
+      "target": "lib_recipeservice_canonicaliseingredients"
     },
     {
       "relation": "calls",
@@ -62355,9 +63078,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "lib_recipeservice_matchingredient",
-      "confidence_score": 1.0
+      "target": "lib_recipeservice_matchingredient"
     },
     {
       "relation": "imports",
@@ -62377,9 +63100,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "lib_recipeservice_removerecipe",
-      "confidence_score": 1.0
+      "target": "lib_recipeservice_removerecipe"
     },
     {
       "relation": "calls",
@@ -62399,9 +63122,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "lib_recipeservice_recipeaddrow",
-      "confidence_score": 1.0
+      "target": "lib_recipeservice_recipeaddrow"
     },
     {
       "relation": "calls",
@@ -62476,9 +63199,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "lib_recipeservice_commitrecipeaddplan",
-      "confidence_score": 1.0
+      "target": "lib_recipeservice_commitrecipeaddplan"
     },
     {
       "relation": "calls",
@@ -62487,9 +63210,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L216",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_additemtolist",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62498,9 +63221,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L162",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_addlist",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62509,9 +63232,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L197",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_changedefaultlist",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62520,9 +63243,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L352",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_clearchecked",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62531,9 +63254,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L284",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_confirmitemneeded",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62553,9 +63276,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L365",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_moveselecteditems",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62564,9 +63287,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L338",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_removeitem",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62575,9 +63298,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L345",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_removeitems",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62586,9 +63309,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L189",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_removelist",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62597,9 +63320,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L181",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_renamelistbyid",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62608,9 +63331,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L80",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_reportfirstwritefailure",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62630,9 +63353,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L270",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_toggleitemchecked",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62641,9 +63364,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L243",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_updateitemamountunit",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62652,9 +63375,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L256",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_updateitemnotes",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62663,9 +63386,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L229",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_updateitemrawtext",
-      "target": "lib_shoppinglistservice_svelte_geterrorreporter",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_geterrorreporter"
     },
     {
       "relation": "calls",
@@ -62674,9 +63397,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L315",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_checkitems",
-      "target": "lib_shoppinglistservice_svelte_reportfirstwritefailure",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_reportfirstwritefailure"
     },
     {
       "relation": "calls",
@@ -62685,9 +63408,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L302",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_confirmitemsneeded",
-      "target": "lib_shoppinglistservice_svelte_reportfirstwritefailure",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_reportfirstwritefailure"
     },
     {
       "relation": "calls",
@@ -62696,9 +63419,9 @@
       "source_file": "apps/web-pwa/src/lib/shoppingListService.svelte.ts",
       "source_location": "L328",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "lib_shoppinglistservice_svelte_uncheckitems",
-      "target": "lib_shoppinglistservice_svelte_reportfirstwritefailure",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_reportfirstwritefailure"
     },
     {
       "relation": "calls",
@@ -62773,9 +63496,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L46",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "lib_shoppinglistservice_svelte_addlist",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_addlist"
     },
     {
       "relation": "calls",
@@ -62883,9 +63606,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L46",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "lib_shoppinglistservice_svelte_additemtolist",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_additemtolist"
     },
     {
       "relation": "imports",
@@ -63070,9 +63793,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L46",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "lib_shoppinglistservice_svelte_removeitems",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_removeitems"
     },
     {
       "relation": "calls",
@@ -63114,9 +63837,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L46",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "lib_shoppinglistservice_svelte_resetshoppinglistservicefortest",
-      "confidence_score": 1.0
+      "target": "lib_shoppinglistservice_svelte_resetshoppinglistservicefortest"
     },
     {
       "relation": "imports_from",
@@ -63798,9 +64521,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "schemas",
-      "confidence_score": 1.0
+      "target": "schemas"
     },
     {
       "relation": "imports_from",
@@ -65533,9 +66256,9 @@
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_canonservice_errorreporting_test",
-      "target": "src_index_domainerror",
-      "confidence_score": 1.0
+      "target": "src_index_domainerror"
     },
     {
       "relation": "contains",
@@ -65543,9 +66266,9 @@
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
       "source_location": "L50",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_canonservice_errorreporting_test",
-      "target": "tests_canonservice_errorreporting_test_fs",
-      "confidence_score": 1.0
+      "target": "tests_canonservice_errorreporting_test_fs"
     },
     {
       "relation": "contains",
@@ -65553,9 +66276,9 @@
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
       "source_location": "L54",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_canonservice_errorreporting_test",
-      "target": "tests_canonservice_errorreporting_test_network_err",
-      "confidence_score": 1.0
+      "target": "tests_canonservice_errorreporting_test_network_err"
     },
     {
       "relation": "contains",
@@ -65563,9 +66286,9 @@
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
       "source_location": "L55",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_canonservice_errorreporting_test",
-      "target": "tests_canonservice_errorreporting_test_notfound_err",
-      "confidence_score": 1.0
+      "target": "tests_canonservice_errorreporting_test_notfound_err"
     },
     {
       "relation": "contains",
@@ -65573,9 +66296,9 @@
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_canonservice_errorreporting_test",
-      "target": "tests_canonservice_errorreporting_test_reportspy_gatedreport",
-      "confidence_score": 1.0
+      "target": "tests_canonservice_errorreporting_test_reportspy_gatedreport"
     },
     {
       "relation": "contains",
@@ -65583,9 +66306,9 @@
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
       "source_location": "L52",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_canonservice_errorreporting_test",
-      "target": "tests_canonservice_errorreporting_test_storage_err",
-      "confidence_score": 1.0
+      "target": "tests_canonservice_errorreporting_test_storage_err"
     },
     {
       "relation": "contains",
@@ -65593,9 +66316,9 @@
       "source_file": "apps/web-pwa/tests/canonService.errorReporting.test.ts",
       "source_location": "L53",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_canonservice_errorreporting_test",
-      "target": "tests_canonservice_errorreporting_test_sync_err",
-      "confidence_score": 1.0
+      "target": "tests_canonservice_errorreporting_test_sync_err"
     },
     {
       "relation": "imports",
@@ -65717,9 +66440,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "src_index_domainerror",
-      "confidence_score": 1.0
+      "target": "src_index_domainerror"
     },
     {
       "relation": "contains",
@@ -65727,9 +66450,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L44",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "tests_chatservice_errorreporting_test_auth_err",
-      "confidence_score": 1.0
+      "target": "tests_chatservice_errorreporting_test_auth_err"
     },
     {
       "relation": "contains",
@@ -65737,9 +66460,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L39",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "tests_chatservice_errorreporting_test_fs",
-      "confidence_score": 1.0
+      "target": "tests_chatservice_errorreporting_test_fs"
     },
     {
       "relation": "contains",
@@ -65747,9 +66470,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L46",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "tests_chatservice_errorreporting_test_makesession",
-      "confidence_score": 1.0
+      "target": "tests_chatservice_errorreporting_test_makesession"
     },
     {
       "relation": "contains",
@@ -65757,9 +66480,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L43",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "tests_chatservice_errorreporting_test_network_err",
-      "confidence_score": 1.0
+      "target": "tests_chatservice_errorreporting_test_network_err"
     },
     {
       "relation": "contains",
@@ -65767,9 +66490,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "tests_chatservice_errorreporting_test_reportspy",
-      "confidence_score": 1.0
+      "target": "tests_chatservice_errorreporting_test_reportspy"
     },
     {
       "relation": "contains",
@@ -65777,9 +66500,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "tests_chatservice_errorreporting_test_storage_err",
-      "confidence_score": 1.0
+      "target": "tests_chatservice_errorreporting_test_storage_err"
     },
     {
       "relation": "contains",
@@ -65787,9 +66510,9 @@
       "source_file": "apps/web-pwa/tests/chatService.errorReporting.test.ts",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_chatservice_errorreporting_test",
-      "target": "tests_chatservice_errorreporting_test_sync_err",
-      "confidence_score": 1.0
+      "target": "tests_chatservice_errorreporting_test_sync_err"
     },
     {
       "relation": "imports",
@@ -65903,9 +66626,9 @@
       "source_file": "apps/web-pwa/tests/errorReporting.test.ts",
       "source_location": "L16",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_errorreporting_test",
-      "target": "src_index_readresult",
-      "confidence_score": 1.0
+      "target": "src_index_readresult"
     },
     {
       "relation": "contains",
@@ -66361,9 +67084,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "entities_ingredient_ingredient",
-      "confidence_score": 1.0
+      "target": "entities_ingredient_ingredient"
     },
     {
       "relation": "imports",
@@ -66372,9 +67095,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "entities_ingredient_ingredientgroup",
-      "confidence_score": 1.0
+      "target": "entities_ingredient_ingredientgroup"
     },
     {
       "relation": "imports",
@@ -66383,9 +67106,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "entities_recipe_recipe",
-      "confidence_score": 1.0
+      "target": "entities_recipe_recipe"
     },
     {
       "relation": "imports",
@@ -66394,9 +67117,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "src_index_domainerror",
-      "confidence_score": 1.0
+      "target": "src_index_domainerror"
     },
     {
       "relation": "contains",
@@ -66404,9 +67127,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L55",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "tests_recipeservice_errorreporting_test_conflict_err",
-      "confidence_score": 1.0
+      "target": "tests_recipeservice_errorreporting_test_conflict_err"
     },
     {
       "relation": "contains",
@@ -66414,9 +67137,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L50",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "tests_recipeservice_errorreporting_test_fs",
-      "confidence_score": 1.0
+      "target": "tests_recipeservice_errorreporting_test_fs"
     },
     {
       "relation": "contains",
@@ -66424,9 +67147,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L79",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "tests_recipeservice_errorreporting_test_makeingredient",
-      "confidence_score": 1.0
+      "target": "tests_recipeservice_errorreporting_test_makeingredient"
     },
     {
       "relation": "contains",
@@ -66434,9 +67157,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L57",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "tests_recipeservice_errorreporting_test_makerecipe",
-      "confidence_score": 1.0
+      "target": "tests_recipeservice_errorreporting_test_makerecipe"
     },
     {
       "relation": "contains",
@@ -66444,9 +67167,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L33",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "tests_recipeservice_errorreporting_test_mockgetcanonitemssnapshot",
-      "confidence_score": 1.0
+      "target": "tests_recipeservice_errorreporting_test_mockgetcanonitemssnapshot"
     },
     {
       "relation": "contains",
@@ -66454,9 +67177,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L54",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "tests_recipeservice_errorreporting_test_network_err",
-      "confidence_score": 1.0
+      "target": "tests_recipeservice_errorreporting_test_network_err"
     },
     {
       "relation": "contains",
@@ -66464,9 +67187,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "tests_recipeservice_errorreporting_test_reportspy",
-      "confidence_score": 1.0
+      "target": "tests_recipeservice_errorreporting_test_reportspy"
     },
     {
       "relation": "contains",
@@ -66474,9 +67197,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L52",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "tests_recipeservice_errorreporting_test_storage_err",
-      "confidence_score": 1.0
+      "target": "tests_recipeservice_errorreporting_test_storage_err"
     },
     {
       "relation": "contains",
@@ -66484,9 +67207,9 @@
       "source_file": "apps/web-pwa/tests/recipeService.errorReporting.test.ts",
       "source_location": "L53",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_recipeservice_errorreporting_test",
-      "target": "tests_recipeservice_errorreporting_test_sync_err",
-      "confidence_score": 1.0
+      "target": "tests_recipeservice_errorreporting_test_sync_err"
     },
     {
       "relation": "imports",
@@ -66567,9 +67290,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "src_index_domainerror",
-      "confidence_score": 1.0
+      "target": "src_index_domainerror"
     },
     {
       "relation": "contains",
@@ -66577,9 +67300,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L53",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "tests_shoppinglistservice_errorreporting_test_fs",
-      "confidence_score": 1.0
+      "target": "tests_shoppinglistservice_errorreporting_test_fs"
     },
     {
       "relation": "contains",
@@ -66587,9 +67310,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L57",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "tests_shoppinglistservice_errorreporting_test_network_err",
-      "confidence_score": 1.0
+      "target": "tests_shoppinglistservice_errorreporting_test_network_err"
     },
     {
       "relation": "contains",
@@ -66597,9 +67320,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L6",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "tests_shoppinglistservice_errorreporting_test_reportspy",
-      "confidence_score": 1.0
+      "target": "tests_shoppinglistservice_errorreporting_test_reportspy"
     },
     {
       "relation": "contains",
@@ -66607,9 +67330,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L55",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "tests_shoppinglistservice_errorreporting_test_storage_err",
-      "confidence_score": 1.0
+      "target": "tests_shoppinglistservice_errorreporting_test_storage_err"
     },
     {
       "relation": "contains",
@@ -66617,9 +67340,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L56",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "tests_shoppinglistservice_errorreporting_test_sync_err",
-      "confidence_score": 1.0
+      "target": "tests_shoppinglistservice_errorreporting_test_sync_err"
     },
     {
       "relation": "contains",
@@ -66627,9 +67350,9 @@
       "source_file": "apps/web-pwa/tests/shoppingListService.errorReporting.test.ts",
       "source_location": "L58",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_shoppinglistservice_errorreporting_test",
-      "target": "tests_shoppinglistservice_errorreporting_test_validation_err",
-      "confidence_score": 1.0
+      "target": "tests_shoppinglistservice_errorreporting_test_validation_err"
     },
     {
       "relation": "imports",
@@ -74314,12 +75037,34 @@
       "relation": "imports_from",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "tests_posthogservererrorreportingadapter_test",
+      "target": "server_init",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "packages/adapters/observability/tests/runWithExtractedTraceContext.test.ts",
       "source_location": "L12",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "tests_runwithextractedtracecontext_test",
       "target": "server_init"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "tests_posthogservererrorreportingadapter_test",
+      "target": "server_init_initserverobservability",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -74420,6 +75165,28 @@
       "target": "server_posthogservererrorreportingadapter_createposthogservererrorreportingadapter"
     },
     {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/server/posthogServerErrorReportingAdapter.ts",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "server_posthogservererrorreportingadapter",
+      "target": "shared_reportablecategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/server/posthogServerErrorReportingAdapter.ts",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "server_posthogservererrorreportingadapter",
+      "target": "shared_reportablecategory_isreportablecategory",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -74429,6 +75196,39 @@
       "confidence_score": 1.0,
       "source": "server_posthogservererrorreportingadapter",
       "target": "src_errorreportingport_errorreportingport"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/server/posthogServerErrorReportingAdapter.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "server_posthogservererrorreportingadapter",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
+      "source_location": "L31",
+      "weight": 1.0,
+      "source": "tests_posthogservererrorreportingadapter_test",
+      "target": "server_posthogservererrorreportingadapter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
+      "source_location": "L31",
+      "weight": 1.0,
+      "source": "tests_posthogservererrorreportingadapter_test",
+      "target": "server_posthogservererrorreportingadapter_createposthogservererrorreportingadapter",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports",
@@ -74776,6 +75576,27 @@
       "confidence_score": 1.0,
       "source": "tests_posthogerrorreportingadapter_test",
       "target": "tests_posthogerrorreportingadapter_test_captureexception_init"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "tests_posthogservererrorreportingadapter_test",
+      "target": "src_index_domainerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts",
+      "source_location": "L8",
+      "weight": 1.0,
+      "source": "tests_posthogservererrorreportingadapter_test",
+      "target": "tests_posthogservererrorreportingadapter_test_captureexception_fakeposthog",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports",
@@ -118423,5 +119244,5 @@
       "source_file": ".claude/commands/spec.md"
     }
   ],
-  "built_at_commit": "77a9c480e5c1c67a15b137ead51ffe3f9fa136af"
+  "built_at_commit": "511937f721cf38cefe42910e25dd40dceaf193a7"
 }

--- a/packages/adapters/firebase-sync/src/aisleSubscription.ts
+++ b/packages/adapters/firebase-sync/src/aisleSubscription.ts
@@ -10,7 +10,9 @@ const AISLES_DOC_ID = 'aisles';
 
 export function subscribeAisles(
   onAisles: (aisles: Aisle[]) => void,
-  onError: (err: DomainError) => void,
+  // rawError forwards the original Firestore error for the real stack; the
+  // synthetic schema-corruption DomainError below has none, so it omits it.
+  onError: (err: DomainError, rawError?: unknown) => void,
 ): () => void {
   const db = getFirestore(getApp());
   return onSnapshot(
@@ -27,7 +29,7 @@ export function subscribeAisles(
       }
       onAisles(result.data.aisles);
     },
-    (err) => onError(classifyFirestoreError(err)),
+    (err) => onError(classifyFirestoreError(err), err),
   );
 }
 

--- a/packages/adapters/firebase-sync/src/auth.ts
+++ b/packages/adapters/firebase-sync/src/auth.ts
@@ -12,6 +12,7 @@ import {
 import { getApp } from 'firebase/app';
 import { failure, success, type DomainError, type ReadResult } from '@salt/shared-types';
 import type { AuthProvider, User, ErrorReportingPort } from '@salt/domain';
+import { setAuthTransitioning, isAuthTransitioning } from './authTransition.js';
 
 // Keyed to the Auth instance (not a module-global boolean) so a re-created
 // default app — as the emulator integration suite does per test, #319 — gets
@@ -45,6 +46,21 @@ function toAuthError(err: unknown): DomainError {
   return { kind: 'AuthError', reason: 'unauthenticated' };
 }
 
+// Categorise-first reporting for auth catch sites: the gate runs on the
+// DomainError category, not the raw error. The RAW error is what's reported (so
+// PostHog gets the real stack), keyed by the categorised kind. While a sign-out /
+// token-refresh transition is in flight we additionally suppress AuthError — the
+// teardown `permission-denied` race — distinguishing it from a genuine
+// rules-misconfig AuthError (no transition in flight), which still reports.
+function reportAuthFailure(
+  errors: ErrorReportingPort | null,
+  rawError: unknown,
+  domainError: DomainError,
+): void {
+  if (domainError.kind === 'AuthError' && isAuthTransitioning()) return;
+  errors?.report(rawError, domainError.kind);
+}
+
 export function createFirebaseAuth(errors: ErrorReportingPort | null = null): AuthProvider {
   const auth = getAuth(getApp());
 
@@ -60,8 +76,9 @@ export function createFirebaseAuth(errors: ErrorReportingPort | null = null): Au
         });
         return success(undefined);
       } catch (err) {
-        errors?.report(err);
-        return failure(toAuthError(err));
+        const domainError = toAuthError(err);
+        reportAuthFailure(errors, err, domainError);
+        return failure(domainError);
       }
     },
 
@@ -74,23 +91,37 @@ export function createFirebaseAuth(errors: ErrorReportingPort | null = null): Au
         const cred = await signInWithEmailLink(auth, email, url);
         return success(toUser(cred.user));
       } catch (err) {
-        errors?.report(err);
-        return failure(toAuthError(err));
+        const domainError = toAuthError(err);
+        reportAuthFailure(errors, err, domainError);
+        return failure(domainError);
       }
     },
 
     async signOut(): Promise<ReadResult<void, DomainError>> {
+      // Open the transition window BEFORE tearing down the session: in-flight
+      // Firestore listeners fire `permission-denied` (→ AuthError) as the rules
+      // stop matching the now-signed-out user. The flag suppresses that expected
+      // race at every AuthError report site until auth state settles to null.
+      setAuthTransitioning(true);
       try {
         await fbSignOut(auth);
         return success(undefined);
       } catch (err) {
-        errors?.report(err);
-        return failure(toAuthError(err));
+        // Sign-out itself failed: the session is NOT actually tearing down, so
+        // close the window immediately — this AuthError is genuine, not the race.
+        setAuthTransitioning(false);
+        const domainError = toAuthError(err);
+        reportAuthFailure(errors, err, domainError);
+        return failure(domainError);
       }
     },
 
     observe(callback: (user: User | null) => void): () => void {
       return onAuthStateChanged(auth, (fb) => {
+        // Auth state has settled. Once the user is null, the sign-out teardown is
+        // complete and the listener race window is closed — clear the flag so a
+        // subsequent genuine AuthError reports normally.
+        if (!fb) setAuthTransitioning(false);
         callback(fb ? toUser(fb) : null);
       });
     },

--- a/packages/adapters/firebase-sync/src/authTransition.ts
+++ b/packages/adapters/firebase-sync/src/authTransition.ts
@@ -1,0 +1,27 @@
+// Auth-transition flag for the sign-out / token-refresh teardown race.
+//
+// When the user signs out (or a token refresh tears down in-flight listeners),
+// Firestore listeners that were still attached fire a `permission-denied` error
+// as the security rules stop matching the now-signed-out user. That maps to
+// `AuthError` (firestoreErrors.ts / toAuthError) — which is reportable BY
+// CATEGORY ("report the unexpected") — but it is an EXPECTED teardown artefact,
+// not a real failure, so it must be suppressed.
+//
+// A genuine rules-misconfig `permission-denied` (with NO transition in flight)
+// must still be reported. So the suppression cannot live in isReportableCategory
+// (that would silence every AuthError); it is this in-flight flag instead. Both
+// the auth catch sites AND the listener/service onError sites consult it before
+// reporting an AuthError.
+//
+// Module-level boolean (single Auth per app); deliberately not keyed to an Auth
+// instance — the race window is short and a stale-true is harmless (it only ever
+// suppresses an AuthError that is, by construction, the teardown race).
+let authTransitioning = false;
+
+export function setAuthTransitioning(value: boolean): void {
+  authTransitioning = value;
+}
+
+export function isAuthTransitioning(): boolean {
+  return authTransitioning;
+}

--- a/packages/adapters/firebase-sync/src/canonSubscription.ts
+++ b/packages/adapters/firebase-sync/src/canonSubscription.ts
@@ -10,7 +10,11 @@ const COLLECTION = 'canonItems';
 
 export function subscribeCanonItems(
   onItems: (items: CanonItem[]) => void,
-  onError: (err: DomainError) => void,
+  // rawError forwards the original Firestore error alongside the categorised
+  // DomainError so the service report site can send the REAL stack to PostHog
+  // (the synthetic DomainError carries none). Optional + last-positional, so
+  // existing two-arg callers stay source-compatible.
+  onError: (err: DomainError, rawError?: unknown) => void,
 ): () => void {
   const db = getFirestore(getApp());
   return onSnapshot(
@@ -27,7 +31,7 @@ export function subscribeCanonItems(
       }
       onItems(valid);
     },
-    (err) => onError(classifyFirestoreError(err)),
+    (err) => onError(classifyFirestoreError(err), err),
   );
 }
 

--- a/packages/adapters/firebase-sync/src/chatSessionSubscription.ts
+++ b/packages/adapters/firebase-sync/src/chatSessionSubscription.ts
@@ -32,7 +32,9 @@ function expiresAt(): string {
 export function subscribeChatSessions(
   ownerUid: string,
   onSessions: (sessions: ChatSessionDoc[]) => void,
-  onError: (err: DomainError) => void,
+  // rawError forwards the original Firestore error for the real stack alongside
+  // the categorised DomainError. Optional + last-positional: backward-compatible.
+  onError: (err: DomainError, rawError?: unknown) => void,
 ): () => void {
   const db = getFirestore(getApp());
   const q = query(collection(db, COLLECTION), where('ownerUid', '==', ownerUid));
@@ -50,7 +52,7 @@ export function subscribeChatSessions(
       }
       onSessions(valid);
     },
-    (err) => onError(classifyFirestoreError(err)),
+    (err) => onError(classifyFirestoreError(err), err),
   );
 }
 

--- a/packages/adapters/firebase-sync/src/index.ts
+++ b/packages/adapters/firebase-sync/src/index.ts
@@ -2,6 +2,11 @@ export type { FirebaseOptions } from 'firebase/app';
 export { initFirebase, setFirestoreNetwork } from './init.js';
 export type { AppCheckConfig } from './init.js';
 export { createFirebaseAuth } from './auth.js';
+// Sign-out / token-refresh teardown-race reader. Service onError sites consult
+// this before reporting an AuthError so the in-flight-listener permission-denied
+// race is suppressed (a genuine rules-misconfig AuthError, with no transition in
+// flight, still reports).
+export { isAuthTransitioning } from './authTransition.js';
 export { subscribeCanonItems, upsertCanonItem, deleteCanonItem } from './canonSubscription.js';
 export { subscribeAisles, saveAisles } from './aisleSubscription.js';
 export {

--- a/packages/adapters/firebase-sync/src/recipeSubscription.ts
+++ b/packages/adapters/firebase-sync/src/recipeSubscription.ts
@@ -23,7 +23,9 @@ const RECIPES_COLLECTION = 'recipes';
 
 export function subscribeRecipes(
   onRecipes: (recipes: Recipe[]) => void,
-  onError: (err: DomainError) => void,
+  // rawError forwards the original Firestore error for the real stack alongside
+  // the categorised DomainError. Optional + last-positional: backward-compatible.
+  onError: (err: DomainError, rawError?: unknown) => void,
 ): () => void {
   const db = getFirestore(getApp());
   return onSnapshot(
@@ -40,7 +42,7 @@ export function subscribeRecipes(
       }
       onRecipes(valid);
     },
-    (err) => onError(classifyFirestoreError(err)),
+    (err) => onError(classifyFirestoreError(err), err),
   );
 }
 

--- a/packages/adapters/firebase-sync/src/shoppingListItemSubscription.ts
+++ b/packages/adapters/firebase-sync/src/shoppingListItemSubscription.ts
@@ -21,7 +21,9 @@ const ITEMS_SUB = 'items';
 export function subscribeShoppingListItems(
   listId: string,
   onItems: (items: ShoppingListItem[]) => void,
-  onError: (err: DomainError) => void,
+  // rawError forwards the original Firestore error for the real stack alongside
+  // the categorised DomainError. Optional + last-positional: backward-compatible.
+  onError: (err: DomainError, rawError?: unknown) => void,
 ): () => void {
   const db = getFirestore(getApp());
   return onSnapshot(
@@ -41,7 +43,7 @@ export function subscribeShoppingListItems(
       }
       onItems(valid);
     },
-    (err) => onError(classifyFirestoreError(err)),
+    (err) => onError(classifyFirestoreError(err), err),
   );
 }
 

--- a/packages/adapters/firebase-sync/src/shoppingListSubscription.ts
+++ b/packages/adapters/firebase-sync/src/shoppingListSubscription.ts
@@ -19,7 +19,9 @@ const COLLECTION = 'shoppingLists';
 
 export function subscribeShoppingLists(
   onLists: (lists: ShoppingList[]) => void,
-  onError: (err: DomainError) => void,
+  // rawError forwards the original Firestore error for the real stack alongside
+  // the categorised DomainError. Optional + last-positional: backward-compatible.
+  onError: (err: DomainError, rawError?: unknown) => void,
 ): () => void {
   const db = getFirestore(getApp());
   return onSnapshot(
@@ -36,7 +38,7 @@ export function subscribeShoppingLists(
       }
       onLists(valid);
     },
-    (err) => onError(classifyFirestoreError(err)),
+    (err) => onError(classifyFirestoreError(err), err),
   );
 }
 

--- a/packages/adapters/firebase-sync/src/shoppingListsConfigSubscription.ts
+++ b/packages/adapters/firebase-sync/src/shoppingListsConfigSubscription.ts
@@ -11,7 +11,9 @@ const CONFIG_DOC_ID = 'singleton';
 
 export function subscribeShoppingListsConfig(
   onConfig: (config: ShoppingListsConfig | null) => void,
-  onError: (err: DomainError) => void,
+  // rawError forwards the original Firestore error for the real stack; the
+  // synthetic schema-corruption DomainError below has none, so it omits it.
+  onError: (err: DomainError, rawError?: unknown) => void,
 ): () => void {
   const db = getFirestore(getApp());
   return onSnapshot(
@@ -28,7 +30,7 @@ export function subscribeShoppingListsConfig(
       }
       onConfig(result.data);
     },
-    (err) => onError(classifyFirestoreError(err)),
+    (err) => onError(classifyFirestoreError(err), err),
   );
 }
 

--- a/packages/adapters/firebase-sync/tests/authTransition.test.ts
+++ b/packages/adapters/firebase-sync/tests/authTransition.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ErrorReportingPort } from '@salt/domain';
+
+// ─── Mock the Firebase SDKs createFirebaseAuth leans on ─────────────────────────
+// getAuth/getApp just need to return a stable handle; the auth methods are spies
+// whose resolve/reject we drive per test. onAuthStateChanged lets us simulate the
+// post-sign-out null transition that clears the auth-transition flag.
+const sendSignInLinkToEmail = vi.fn();
+const signInWithEmailLink = vi.fn();
+const fbSignOut = vi.fn();
+let authStateListener: ((user: unknown) => void) | null = null;
+
+vi.mock('firebase/app', () => ({ getApp: vi.fn(() => ({})) }));
+vi.mock('firebase/auth', () => ({
+  getAuth: vi.fn(() => ({ currentUser: null })),
+  connectAuthEmulator: vi.fn(),
+  sendSignInLinkToEmail: (...a: unknown[]) => sendSignInLinkToEmail(...a),
+  isSignInWithEmailLink: vi.fn(),
+  signInWithEmailLink: (...a: unknown[]) => signInWithEmailLink(...a),
+  signOut: (...a: unknown[]) => fbSignOut(...a),
+  onAuthStateChanged: (_auth: unknown, cb: (user: unknown) => void) => {
+    authStateListener = cb;
+    return vi.fn();
+  },
+}));
+
+import { createFirebaseAuth } from '../src/auth.js';
+import { isAuthTransitioning, setAuthTransitioning } from '../src/authTransition.js';
+
+function fbAuthError(code: string): Error & { code: string } {
+  const e = new Error(`Firebase: ${code}`) as Error & { code: string };
+  e.code = code;
+  return e;
+}
+
+describe('auth-transition flag', () => {
+  beforeEach(() => {
+    setAuthTransitioning(false);
+    sendSignInLinkToEmail.mockReset();
+    signInWithEmailLink.mockReset();
+    fbSignOut.mockReset();
+    authStateListener = null;
+    vi.stubGlobal('navigator', { onLine: true });
+  });
+
+  it('set/read round-trips', () => {
+    expect(isAuthTransitioning()).toBe(false);
+    setAuthTransitioning(true);
+    expect(isAuthTransitioning()).toBe(true);
+    setAuthTransitioning(false);
+    expect(isAuthTransitioning()).toBe(false);
+  });
+
+  it('signOut opens the transition window; the null auth-state settle closes it', async () => {
+    fbSignOut.mockResolvedValue(undefined);
+    const provider = createFirebaseAuth(null);
+    provider.observe(() => {}); // attach the listener that clears the flag
+
+    const p = provider.signOut();
+    expect(isAuthTransitioning()).toBe(true); // window open before teardown completes
+    await p;
+    expect(isAuthTransitioning()).toBe(true); // still open until auth settles
+
+    // Firebase reports the user signed out → flag clears.
+    authStateListener?.(null);
+    expect(isAuthTransitioning()).toBe(false);
+  });
+
+  it('suppresses the AuthError teardown race while a transition is in flight', async () => {
+    const report = vi.fn();
+    const errors: ErrorReportingPort = { report };
+    const provider = createFirebaseAuth(errors);
+
+    setAuthTransitioning(true);
+    // permission-denied / unauthenticated during teardown → AuthError, suppressed.
+    signInWithEmailLink.mockRejectedValue(fbAuthError('auth/internal-error'));
+    await provider.completeMagicLink('url', 'a@b.com');
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  it('reports a genuine AuthError when no transition is in flight', async () => {
+    const report = vi.fn();
+    const errors: ErrorReportingPort = { report };
+    const provider = createFirebaseAuth(errors);
+
+    const raw = fbAuthError('auth/internal-error'); // → AuthError:unauthenticated
+    signInWithEmailLink.mockRejectedValue(raw);
+    await provider.completeMagicLink('url', 'a@b.com');
+
+    expect(report).toHaveBeenCalledTimes(1);
+    // Categorise-first: the RAW error is reported, keyed by the categorised kind.
+    expect(report).toHaveBeenCalledWith(raw, 'AuthError');
+  });
+
+  it('reports a non-Auth category (NetworkError) even during a transition', async () => {
+    const report = vi.fn();
+    const errors: ErrorReportingPort = { report };
+    const provider = createFirebaseAuth(errors);
+
+    setAuthTransitioning(true); // the flag only ever suppresses AuthError
+    const raw = fbAuthError('auth/network-request-failed'); // → NetworkError
+    sendSignInLinkToEmail.mockRejectedValue(raw);
+    await provider.sendMagicLink('a@b.com', 'https://x');
+
+    expect(report).toHaveBeenCalledWith(raw, 'NetworkError');
+  });
+
+  it('signOut failure closes the window and reports (genuine, not the race)', async () => {
+    const report = vi.fn();
+    const errors: ErrorReportingPort = { report };
+    const provider = createFirebaseAuth(errors);
+
+    const raw = fbAuthError('auth/internal-error');
+    fbSignOut.mockRejectedValue(raw);
+    await provider.signOut();
+
+    // The sign-out itself failed, so the session is NOT tearing down: window
+    // closes and the AuthError reports.
+    expect(isAuthTransitioning()).toBe(false);
+    expect(report).toHaveBeenCalledWith(raw, 'AuthError');
+  });
+});

--- a/packages/adapters/firebase-sync/tests/recipeSubscription.test.ts
+++ b/packages/adapters/firebase-sync/tests/recipeSubscription.test.ts
@@ -114,10 +114,10 @@ describe('subscribeRecipes', () => {
   it('classifies stream-level errors', () => {
     const onError = vi.fn();
     subscribeRecipes(() => {}, onError);
-    (mockOnSnapshot.mock.calls[0][2] as ErrorCallback)(
-      Object.assign(new Error('e'), { code: 'permission-denied' }),
-    );
-    expect(onError).toHaveBeenCalledWith({ kind: 'AuthError', reason: 'forbidden' });
+    const raw = Object.assign(new Error('e'), { code: 'permission-denied' });
+    (mockOnSnapshot.mock.calls[0][2] as ErrorCallback)(raw);
+    // onError forwards the raw error (real stack) alongside the classified kind.
+    expect(onError).toHaveBeenCalledWith({ kind: 'AuthError', reason: 'forbidden' }, raw);
   });
 });
 

--- a/packages/adapters/firebase-sync/tests/shoppingListItemSubscription.test.ts
+++ b/packages/adapters/firebase-sync/tests/shoppingListItemSubscription.test.ts
@@ -256,9 +256,11 @@ describe('subscribeShoppingListItems', () => {
     subscribeShoppingListItems('list-1', () => {}, onError);
 
     const errCb = mockOnSnapshot.mock.calls[0][2] as ErrorCallback;
-    errCb(Object.assign(new Error('err'), { code: 'permission-denied' }));
+    const raw = Object.assign(new Error('err'), { code: 'permission-denied' });
+    errCb(raw);
 
-    expect(onError).toHaveBeenCalledWith({ kind: 'AuthError', reason: 'forbidden' });
+    // onError forwards the raw error (real stack) alongside the classified kind.
+    expect(onError).toHaveBeenCalledWith({ kind: 'AuthError', reason: 'forbidden' }, raw);
   });
 });
 

--- a/packages/adapters/firebase-sync/tests/shoppingListSubscription.test.ts
+++ b/packages/adapters/firebase-sync/tests/shoppingListSubscription.test.ts
@@ -138,9 +138,11 @@ describe('subscribeShoppingLists', () => {
     subscribeShoppingLists(() => {}, onError);
 
     const errCb = mockOnSnapshot.mock.calls[0][2] as ErrorCallback;
-    errCb(Object.assign(new Error('err'), { code: 'permission-denied' }));
+    const raw = Object.assign(new Error('err'), { code: 'permission-denied' });
+    errCb(raw);
 
-    expect(onError).toHaveBeenCalledWith({ kind: 'AuthError', reason: 'forbidden' });
+    // onError forwards the raw error (real stack) alongside the classified kind.
+    expect(onError).toHaveBeenCalledWith({ kind: 'AuthError', reason: 'forbidden' }, raw);
   });
 });
 

--- a/packages/adapters/firebase-sync/tests/shoppingListsConfigSubscription.test.ts
+++ b/packages/adapters/firebase-sync/tests/shoppingListsConfigSubscription.test.ts
@@ -101,9 +101,12 @@ describe('subscribeShoppingListsConfig', () => {
     subscribeShoppingListsConfig(() => {}, onError);
 
     const errCb = mockOnSnapshot.mock.calls[0][2] as ErrorCallback;
-    errCb(Object.assign(new Error('err'), { code: 'permission-denied' }));
+    const raw = Object.assign(new Error('err'), { code: 'permission-denied' });
+    errCb(raw);
 
-    expect(onError).toHaveBeenCalledWith({ kind: 'AuthError', reason: 'forbidden' });
+    // onError now forwards the raw error (real stack) alongside the classified
+    // DomainError so the service report site can send the stack to PostHog.
+    expect(onError).toHaveBeenCalledWith({ kind: 'AuthError', reason: 'forbidden' }, raw);
   });
 
   it('calls onError with classified DomainError on unauthenticated', () => {
@@ -111,9 +114,10 @@ describe('subscribeShoppingListsConfig', () => {
     subscribeShoppingListsConfig(() => {}, onError);
 
     const errCb = mockOnSnapshot.mock.calls[0][2] as ErrorCallback;
-    errCb(Object.assign(new Error('err'), { code: 'unauthenticated' }));
+    const raw = Object.assign(new Error('err'), { code: 'unauthenticated' });
+    errCb(raw);
 
-    expect(onError).toHaveBeenCalledWith({ kind: 'AuthError', reason: 'unauthenticated' });
+    expect(onError).toHaveBeenCalledWith({ kind: 'AuthError', reason: 'unauthenticated' }, raw);
   });
 });
 

--- a/packages/adapters/observability/src/index.ts
+++ b/packages/adapters/observability/src/index.ts
@@ -31,3 +31,6 @@ export {
 } from './sessionControl.js';
 export { CANON_MATCH_EVENT } from './shared/matchOutcomeEvent.js';
 export type { CanonMatchEventProps, CanonMatchPath } from './shared/matchOutcomeEvent.js';
+// Category-gated error reporting predicate — single source of truth, shared with
+// the /server subpath (Phase 3) so the report/suppress gate cannot drift.
+export { isReportableCategory } from './shared/reportableCategory.js';

--- a/packages/adapters/observability/src/posthogErrorReportingAdapter.ts
+++ b/packages/adapters/observability/src/posthogErrorReportingAdapter.ts
@@ -1,15 +1,31 @@
 import type { ErrorReportingPort } from '@salt/domain';
 import { safePosthog } from './init.js';
+import { isReportableCategory } from './shared/reportableCategory.js';
 
+// Browser error reporter. Explicit reporting only — posthog-js exception
+// autocapture (`capture_exceptions`) stays OFF (see init.ts); failures reach
+// PostHog solely through this gated port.
 export function createPosthogErrorReportingAdapter(): ErrorReportingPort {
   return {
-    report(error: unknown): void {
+    report(error: unknown, category): void {
+      // Category gate: report the unexpected, suppress the expected. No-op for
+      // suppressed kinds (NetworkError/offline, ValidationError, NotFound,
+      // ConflictError). The sign-out auth race is gated separately at the call
+      // site via the auth-transition flag, so AuthError still passes here.
+      if (!isReportableCategory(category)) return;
+
       // safePosthog stays inert before init and swallows any SDK failure, so a
       // dropped report can never throw across the port boundary (CLAUDE.md
       // Rule 10).
       safePosthog((ph) => {
+        // The raw error carries the real stack to PostHog. Firebase errors carry
+        // a code, not free-form user content, so the message is safe to keep.
         const err = error instanceof Error ? error : new Error(String(error));
-        ph.captureException(err);
+        // Attach ONLY the category as scrubbed context — deliberately do not
+        // spread any caller-supplied bag, so free-form user content (e.g. canon
+        // match text) can never ride along with a report. Data is family-shared,
+        // but user-typed strings still must not be sent (CLAUDE.md §Observability).
+        ph.captureException(err, { 'error.category': category });
       });
     },
   };

--- a/packages/adapters/observability/src/posthogErrorReportingAdapter.ts
+++ b/packages/adapters/observability/src/posthogErrorReportingAdapter.ts
@@ -2,9 +2,12 @@ import type { ErrorReportingPort } from '@salt/domain';
 import { safePosthog } from './init.js';
 import { isReportableCategory } from './shared/reportableCategory.js';
 
-// Browser error reporter. Explicit reporting only — posthog-js exception
-// autocapture (`capture_exceptions`) stays OFF (see init.ts); failures reach
-// PostHog solely through this gated port.
+// Browser error reporter for CAUGHT errors — these reach PostHog solely through
+// this gated port (report the unexpected, suppress the expected). UNCAUGHT errors
+// (unhandled exceptions / promise rejections) are surfaced separately by PostHog's
+// exception autocapture, governed by the project-level setting — init.ts does not
+// set `capture_exceptions`, so there is no code-side gate or duplicate. An uncaught
+// error is unexpected by definition, so it is intentionally not category-gated here.
 export function createPosthogErrorReportingAdapter(): ErrorReportingPort {
   return {
     report(error: unknown, category): void {

--- a/packages/adapters/observability/src/server/index.ts
+++ b/packages/adapters/observability/src/server/index.ts
@@ -44,3 +44,7 @@ export {
 // barrel and so cf-side tests can assert against the single source of truth.
 export { CANON_MATCH_EVENT, toCanonMatchEvent } from '../shared/matchOutcomeEvent.js';
 export type { CanonMatchEventProps, CanonMatchPath } from '../shared/matchOutcomeEvent.js';
+
+// Same category-gated reporting predicate the browser barrel exports — shared so
+// the server adapter (Phase 3) reuses the single source of truth, not a copy.
+export { isReportableCategory } from '../shared/reportableCategory.js';

--- a/packages/adapters/observability/src/server/posthogServerErrorReportingAdapter.ts
+++ b/packages/adapters/observability/src/server/posthogServerErrorReportingAdapter.ts
@@ -1,13 +1,24 @@
 import type { ErrorReportingPort } from '@salt/domain';
+import type { DomainError } from '@salt/shared-types';
 import { captureServerException } from './init.js';
+import { isReportableCategory } from '../shared/reportableCategory.js';
 
 // Server-side error reporter, backed by posthog-node exception capture. There
 // was no server error reporter before this phase; firebase-functions/logger
 // stays additively at the CF call sites — this reports the same failures to
 // PostHog error tracking so they surface alongside browser-side exceptions.
+//
+// Honours the SAME `isReportableCategory` predicate as the browser adapter — the
+// single source of truth in src/shared/ — so the report/suppress boundary cannot
+// drift between client and CF. Server failures are usually RAW uncategorised
+// exceptions (there is no server classifyFirestoreError), so `category` is
+// optional and an absent category gates as reportable ("report the unexpected").
 export function createPosthogServerErrorReportingAdapter(): ErrorReportingPort {
   return {
-    report(error: unknown): void {
+    report(error: unknown, category?: DomainError['kind']): void {
+      // Gate first: a suppressed category (e.g. a NetworkError surfaced from a
+      // classified server path) never reaches PostHog, matching the client.
+      if (!isReportableCategory(category)) return;
       // captureServerException stays inert before init and swallows any SDK
       // failure, so a dropped report can never throw across the port boundary
       // (CLAUDE.md Rule 10).

--- a/packages/adapters/observability/src/shared/reportableCategory.ts
+++ b/packages/adapters/observability/src/shared/reportableCategory.ts
@@ -26,6 +26,16 @@ const SUPPRESSED_CATEGORIES: ReadonlySet<DomainError['kind']> = new Set<DomainEr
   'ConflictError',
 ]);
 
-export function isReportableCategory(kind: DomainError['kind']): boolean {
+// `kind` is widened to `| undefined` so the SAME predicate gates both subpaths:
+//   • client (Phase 1/2) always passes a concrete DomainError['kind'] — behaviour
+//     for every known kind is unchanged.
+//   • server (Phase 3) usually catches RAW, uncategorised exceptions (there is no
+//     server classifyFirestoreError), so it passes `undefined`. An absent or
+//     unrecognised category is "the unexpected" → reportable, matching the policy
+//     north star ("report the unexpected, suppress the expected"). This is an
+//     evolution of the one source of truth, not a fork: suppression is still keyed
+//     ONLY off the explicit SUPPRESSED_CATEGORIES set.
+export function isReportableCategory(kind: DomainError['kind'] | undefined): boolean {
+  if (kind === undefined) return true; // uncategorised → report the unexpected
   return !SUPPRESSED_CATEGORIES.has(kind);
 }

--- a/packages/adapters/observability/src/shared/reportableCategory.ts
+++ b/packages/adapters/observability/src/shared/reportableCategory.ts
@@ -1,0 +1,31 @@
+import type { DomainError } from '@salt/shared-types';
+
+// Single source of truth for the caught-error reporting gate
+// ("report the unexpected, suppress the expected" — CLAUDE.md §Observability).
+//
+// Lives in the runtime-neutral src/shared/ area so BOTH the browser default
+// subpath and the /server subpath import the same predicate — the report/suppress
+// boundary cannot drift between client and CF.
+//
+// Categorisation drives the gate, not call-site shape:
+//   SUPPRESS (expected): NetworkError/offline, ValidationError, NotFound,
+//     ConflictError.
+//   REPORT (unexpected): everything else — StorageError, SyncError, AuthError,
+//     and any future/unknown kind (default-reportable so a new failure mode is
+//     surfaced rather than silently swallowed).
+//
+// NOTE: the sign-out / token-refresh `permission-denied` teardown race is NOT
+// handled here. AuthError stays reportable BY CATEGORY; the race is suppressed
+// separately via the auth-transition flag in @salt/firebase-sync, which the
+// catch/onError call sites consult before reporting an AuthError. A genuine
+// rules-misconfig `permission-denied` (no transition in flight) still reports.
+const SUPPRESSED_CATEGORIES: ReadonlySet<DomainError['kind']> = new Set<DomainError['kind']>([
+  'NetworkError',
+  'ValidationError',
+  'NotFound',
+  'ConflictError',
+]);
+
+export function isReportableCategory(kind: DomainError['kind']): boolean {
+  return !SUPPRESSED_CATEGORIES.has(kind);
+}

--- a/packages/adapters/observability/tests/payloadScrubbing.test.ts
+++ b/packages/adapters/observability/tests/payloadScrubbing.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Payload scrubbing (Phase 4): no raw user content leaks into the reported
+// event payload from EITHER adapter.
+//
+// Data is family-shared (no per-user PII by design), but free-form user content
+// (canon match text, recipe ingredient strings, …) must never be attached as a
+// SEPARATE context/properties bag on a reported error (CLAUDE.md §Observability,
+// docs/salt-architecture.md §7.6).
+//
+// IMPORTANT invariant being asserted: the error's own message/stack is the
+// SIGNAL and is intentionally KEPT — we do NOT scrub the message. The invariant
+// is narrower: no additional free-form context bag carrying user input is
+// attached alongside the error. So we embed user text in the MESSAGE and assert
+// the adapters add no user-content property — NOT that the message is sanitised.
+// ---------------------------------------------------------------------------
+
+const { clientCapture, clientInit, serverCapture, FakePostHog } = vi.hoisted(() => {
+  const serverCapture = vi.fn();
+  class FakePostHog {
+    constructor(
+      public key: string,
+      public opts: unknown,
+    ) {}
+    captureException(...args: unknown[]): void {
+      serverCapture(...args);
+    }
+    capture(): void {}
+    async flush(): Promise<void> {}
+    async shutdown(): Promise<void> {}
+  }
+  return {
+    clientCapture: vi.fn(),
+    clientInit: vi.fn(),
+    serverCapture,
+    FakePostHog,
+  };
+});
+
+vi.mock('posthog-js', () => ({
+  default: {
+    init: clientInit,
+    captureException: clientCapture,
+    capture: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+  },
+}));
+
+vi.mock('posthog-node', () => ({
+  PostHog: FakePostHog,
+}));
+
+import { initObservability } from '../src/init.js';
+import { initServerObservability } from '../src/server/init.js';
+import { createPosthogErrorReportingAdapter } from '../src/posthogErrorReportingAdapter.js';
+import { createPosthogServerErrorReportingAdapter } from '../src/server/posthogServerErrorReportingAdapter.js';
+
+// Free-form user content embedded in the error message — the kind of string that
+// must NOT be re-attached as a separate property bag.
+const USER_TEXT = 'two pounds of organic heirloom tomatoes, finely diced';
+
+describe('error-reporting payload scrubbing (both adapters)', () => {
+  beforeEach(() => {
+    clientCapture.mockClear();
+    serverCapture.mockClear();
+    initObservability('test-key');
+    initServerObservability('test-key');
+  });
+
+  it('client: attaches ONLY error.category, no user-content property bag', () => {
+    const error = new Error(`canon match failed: "${USER_TEXT}"`);
+    createPosthogErrorReportingAdapter().report(error, 'SyncError');
+
+    expect(clientCapture).toHaveBeenCalledTimes(1);
+    const [capturedError, props] = clientCapture.mock.calls[0]!;
+
+    // The raw error (message/stack = the signal) is forwarded verbatim.
+    expect(capturedError).toBe(error);
+
+    // The properties bag is EXACTLY the category — no spread, no user-text key.
+    expect(Object.keys(props as Record<string, unknown>)).toEqual(['error.category']);
+    expect((props as Record<string, unknown>)['error.category']).toBe('SyncError');
+
+    // Defence-in-depth: no property VALUE carries the user text either.
+    for (const value of Object.values(props as Record<string, unknown>)) {
+      expect(String(value)).not.toContain(USER_TEXT);
+    }
+  });
+
+  it('server: passes only the distinctId string, no properties bag at all', () => {
+    const error = new Error(`recipe ingredient parse failed: "${USER_TEXT}"`);
+    createPosthogServerErrorReportingAdapter().report(error, 'StorageError');
+
+    expect(serverCapture).toHaveBeenCalledTimes(1);
+    const args = serverCapture.mock.calls[0]!;
+
+    // captureServerException(err, SERVER_DISTINCT_ID): exactly two args, the raw
+    // error then a plain distinctId string. No third properties argument.
+    expect(args).toHaveLength(2);
+    expect(args[0]).toBe(error);
+    expect(typeof args[1]).toBe('string');
+
+    // The distinctId is a synthetic server person, NOT user content.
+    expect(String(args[1])).not.toContain(USER_TEXT);
+  });
+
+  it('server: distinctId is the synthetic server person, never derived from the error', () => {
+    // Two different errors with different user text must produce the SAME
+    // distinctId — proving the second arg is a fixed synthetic id, not anything
+    // computed from the (user-bearing) error.
+    createPosthogServerErrorReportingAdapter().report(
+      new Error(`first: ${USER_TEXT}`),
+      'StorageError',
+    );
+    createPosthogServerErrorReportingAdapter().report(
+      new Error('second: completely different content'),
+      'SyncError',
+    );
+
+    expect(serverCapture).toHaveBeenCalledTimes(2);
+    const [, firstId] = serverCapture.mock.calls[0]!;
+    const [, secondId] = serverCapture.mock.calls[1]!;
+    expect(firstId).toBe(secondId);
+  });
+});

--- a/packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts
+++ b/packages/adapters/observability/tests/posthogErrorReportingAdapter.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DomainError } from '@salt/shared-types';
+
+// Mock posthog-js so initObservability flips `ready` true and we can spy on
+// captureException without a real SDK / network. vi.hoisted keeps the spies
+// available to the hoisted vi.mock factory.
+const { captureException, init } = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  init: vi.fn(),
+}));
+vi.mock('posthog-js', () => ({
+  default: {
+    init,
+    captureException,
+    capture: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+  },
+}));
+
+import { initObservability } from '../src/init.js';
+import { createPosthogErrorReportingAdapter } from '../src/posthogErrorReportingAdapter.js';
+
+describe('createPosthogErrorReportingAdapter', () => {
+  beforeEach(() => {
+    captureException.mockClear();
+    init.mockClear();
+    // initObservability is idempotent across modules within a run; calling with a
+    // key flips the shared `ready` flag so safePosthog actually invokes the SDK.
+    initObservability('test-key');
+  });
+
+  const reporter = () => createPosthogErrorReportingAdapter();
+
+  const reportable: ReadonlyArray<DomainError['kind']> = ['StorageError', 'SyncError', 'AuthError'];
+  const suppressed: ReadonlyArray<DomainError['kind']> = [
+    'NetworkError',
+    'ValidationError',
+    'NotFound',
+    'ConflictError',
+  ];
+
+  it.each(suppressed)('no-ops (does not capture) for suppressed category %s', (kind) => {
+    reporter().report(new Error('boom'), kind);
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it.each(reportable)('captures for reportable category %s', (kind) => {
+    reporter().report(new Error('boom'), kind);
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards the raw Error (real stack) and attaches only the scrubbed category', () => {
+    const raw = new Error('storage exploded');
+    reporter().report(raw, 'StorageError');
+    expect(captureException).toHaveBeenCalledWith(raw, { 'error.category': 'StorageError' });
+  });
+
+  it('does not attach any free-form / user content beyond the category', () => {
+    reporter().report(
+      new Error('canon match: "two pounds of organic heirloom tomatoes"'),
+      'SyncError',
+    );
+    const [, props] = captureException.mock.calls[0]!;
+    // The only property attached is the category. No spread bag, no user text key.
+    expect(Object.keys(props)).toEqual(['error.category']);
+  });
+
+  it('wraps a non-Error value so a thrown string still carries a stack', () => {
+    reporter().report('plain string failure', 'StorageError');
+    const [arg] = captureException.mock.calls[0]!;
+    expect(arg).toBeInstanceOf(Error);
+    expect((arg as Error).message).toBe('plain string failure');
+  });
+});

--- a/packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts
+++ b/packages/adapters/observability/tests/posthogServerErrorReportingAdapter.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DomainError } from '@salt/shared-types';
+
+// Mock posthog-node so initServerObservability builds a fake client and we can
+// spy on captureException without a real SDK / network. vi.hoisted keeps the spy
+// AND the fake class available to the hoisted vi.mock factory (a top-level class
+// would be referenced before initialization inside the hoisted factory).
+const { captureException, FakePostHog } = vi.hoisted(() => {
+  const captureException = vi.fn();
+  // Minimal PostHog stand-in: only the methods the server adapter / init touch.
+  class FakePostHog {
+    constructor(
+      public key: string,
+      public opts: unknown,
+    ) {}
+    captureException(...args: unknown[]): void {
+      captureException(...args);
+    }
+    capture(): void {}
+    async flush(): Promise<void> {}
+    async shutdown(): Promise<void> {}
+  }
+  return { captureException, FakePostHog };
+});
+
+vi.mock('posthog-node', () => ({
+  PostHog: FakePostHog,
+}));
+
+import { initServerObservability } from '../src/server/init.js';
+import { createPosthogServerErrorReportingAdapter } from '../src/server/posthogServerErrorReportingAdapter.js';
+
+describe('createPosthogServerErrorReportingAdapter', () => {
+  beforeEach(() => {
+    captureException.mockClear();
+    // initServerObservability is idempotent (no-ops if a client already exists),
+    // so the first test to run builds the fake client; subsequent calls no-op.
+    // A non-empty key flips the package out of its inert state.
+    initServerObservability('test-key');
+  });
+
+  const reporter = () => createPosthogServerErrorReportingAdapter();
+
+  const reportable: ReadonlyArray<DomainError['kind']> = ['StorageError', 'SyncError', 'AuthError'];
+  const suppressed: ReadonlyArray<DomainError['kind']> = [
+    'NetworkError',
+    'ValidationError',
+    'NotFound',
+    'ConflictError',
+  ];
+
+  it.each(suppressed)('no-ops (does not capture) for suppressed category %s', (kind) => {
+    reporter().report(new Error('boom'), kind);
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it.each(reportable)('captures for reportable category %s', (kind) => {
+    reporter().report(new Error('boom'), kind);
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures when the category is UNDEFINED (raw server exception → reportable)', () => {
+    // The dominant server case: a caught exception with no DomainError
+    // classification. The widened predicate gates `undefined` as reportable, so
+    // the server adapter surfaces it.
+    reporter().report(new Error('uncategorised server failure'));
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards the raw Error (real stack) and attaches no free-form context', () => {
+    const raw = new Error('storage exploded');
+    reporter().report(raw, 'StorageError');
+    // captureServerException calls captureException(err, SERVER_DISTINCT_ID) — the
+    // raw error carries the stack; nothing else (no user content) is attached.
+    expect(captureException).toHaveBeenCalledWith(raw, expect.any(String));
+  });
+
+  it('wraps a non-Error value so a thrown string still carries a stack', () => {
+    reporter().report('plain string failure');
+    const [arg] = captureException.mock.calls[0]!;
+    expect(arg).toBeInstanceOf(Error);
+    expect((arg as Error).message).toBe('plain string failure');
+  });
+
+  it('never throws across the port boundary when the SDK throws (Rule 10)', () => {
+    captureException.mockImplementationOnce(() => {
+      throw new Error('posthog SDK exploded');
+    });
+    // safePosthog swallows the SDK failure — report() must return normally.
+    expect(() => reporter().report(new Error('boom'), 'StorageError')).not.toThrow();
+  });
+});

--- a/packages/adapters/observability/tests/reportabilityParity.test.ts
+++ b/packages/adapters/observability/tests/reportabilityParity.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DomainError } from '@salt/shared-types';
+
+// ---------------------------------------------------------------------------
+// Client/server reportability PARITY (Phase 4 regression guard).
+//
+// The report/suppress decision is meant to be ONE source of truth
+// (`isReportableCategory`, src/shared/), shared verbatim by the browser default
+// subpath and the /server subpath. This file proves that invariant end-to-end
+// by driving BOTH real adapters for every DomainError kind (plus `undefined`)
+// and asserting they make the SAME capture decision — and that the decision
+// matches `isReportableCategory`.
+//
+// If a future change forks the gate (e.g. someone re-implements the server-side
+// suppression list, or drops `undefined → report` on one side), this test fails
+// even if each adapter's own focused test still passes. The explicit expected
+// table below is what keeps this from being a tautology: it pins the intended
+// per-category outcome so a coordinated-but-wrong change to BOTH sides is also
+// caught.
+// ---------------------------------------------------------------------------
+
+// Both SDKs are mocked in the SAME file so we can prime both inits and exercise
+// both adapters side by side. vi.hoisted keeps the spies / fake class available
+// to the hoisted vi.mock factories.
+const { clientCapture, clientInit, serverCapture, FakePostHog } = vi.hoisted(() => {
+  const serverCapture = vi.fn();
+  class FakePostHog {
+    constructor(
+      public key: string,
+      public opts: unknown,
+    ) {}
+    captureException(...args: unknown[]): void {
+      serverCapture(...args);
+    }
+    capture(): void {}
+    async flush(): Promise<void> {}
+    async shutdown(): Promise<void> {}
+  }
+  return {
+    clientCapture: vi.fn(),
+    clientInit: vi.fn(),
+    serverCapture,
+    FakePostHog,
+  };
+});
+
+vi.mock('posthog-js', () => ({
+  default: {
+    init: clientInit,
+    captureException: clientCapture,
+    capture: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+  },
+}));
+
+vi.mock('posthog-node', () => ({
+  PostHog: FakePostHog,
+}));
+
+import { initObservability } from '../src/init.js';
+import { initServerObservability } from '../src/server/init.js';
+import { createPosthogErrorReportingAdapter } from '../src/posthogErrorReportingAdapter.js';
+import { createPosthogServerErrorReportingAdapter } from '../src/server/posthogServerErrorReportingAdapter.js';
+import { isReportableCategory } from '../src/shared/reportableCategory.js';
+
+// Explicit, hand-maintained expected outcome per category. This is the regression
+// guard: it does NOT call isReportableCategory to compute itself, so a change to
+// the predicate that flips a category will diverge from this table and fail.
+// `true` = should report (captureException called); `false` = should suppress.
+const EXPECTED_REPORT: ReadonlyArray<[DomainError['kind'] | undefined, boolean]> = [
+  ['StorageError', true],
+  ['SyncError', true],
+  ['AuthError', true],
+  ['NetworkError', false],
+  ['ValidationError', false],
+  ['NotFound', false],
+  ['ConflictError', false],
+  [undefined, true], // uncategorised / unknown → report the unexpected
+];
+
+describe('client/server error-reporting reportability parity', () => {
+  beforeEach(() => {
+    clientCapture.mockClear();
+    serverCapture.mockClear();
+    initObservability('test-key');
+    initServerObservability('test-key');
+  });
+
+  it('covers exactly the 7 DomainError kinds plus undefined (8 cases)', () => {
+    // Guards against a new DomainError['kind'] being added without extending the
+    // expected table — the parity guarantee must cover EVERY category.
+    const concreteKinds = EXPECTED_REPORT.map(([k]) => k).filter(
+      (k): k is DomainError['kind'] => k !== undefined,
+    );
+    expect(EXPECTED_REPORT).toHaveLength(8);
+    expect(new Set(concreteKinds).size).toBe(7);
+  });
+
+  it.each(EXPECTED_REPORT)(
+    'client and server make the SAME decision for category %s (expected report=%s)',
+    (category, expectedReport) => {
+      // Sanity: the shared predicate agrees with our hand-maintained table. If a
+      // future edit forks the predicate, this line fails first.
+      expect(isReportableCategory(category)).toBe(expectedReport);
+
+      const error = new Error(`failure for ${String(category)}`);
+
+      // Server `report` takes an OPTIONAL category — pass the same value to both
+      // so the comparison is apples-to-apples (incl. the undefined case).
+      createPosthogErrorReportingAdapter().report(error, category as DomainError['kind']);
+      createPosthogServerErrorReportingAdapter().report(error, category);
+
+      const clientReported = clientCapture.mock.calls.length > 0;
+      const serverReported = serverCapture.mock.calls.length > 0;
+
+      // 1) Both adapters must agree with each other (no fork between subpaths).
+      expect(clientReported).toBe(serverReported);
+      // 2) That shared decision must equal the predicate's verdict.
+      expect(clientReported).toBe(expectedReport);
+      // 3) And both must match the explicit expected-outcome table.
+      expect(serverReported).toBe(expectedReport);
+
+      // When reported, exactly one capture per adapter (no double-report).
+      if (expectedReport) {
+        expect(clientCapture).toHaveBeenCalledTimes(1);
+        expect(serverCapture).toHaveBeenCalledTimes(1);
+      } else {
+        expect(clientCapture).not.toHaveBeenCalled();
+        expect(serverCapture).not.toHaveBeenCalled();
+      }
+    },
+  );
+});

--- a/packages/adapters/observability/tests/reportableCategory.test.ts
+++ b/packages/adapters/observability/tests/reportableCategory.test.ts
@@ -37,4 +37,12 @@ describe('isReportableCategory', () => {
     // unexpected category — it must report, never silently drop.
     expect(isReportableCategory('SomethingBrandNew' as DomainError['kind'])).toBe(true);
   });
+
+  it('defaults an UNDEFINED (uncategorised) kind to reportable', () => {
+    // Phase 3 widening: server catch sites usually have a RAW exception with no
+    // DomainError classification (there is no server classifyFirestoreError), so
+    // they pass `undefined`. An absent category is "the unexpected" → report.
+    // This must NOT change behaviour for any known kind (asserted above).
+    expect(isReportableCategory(undefined)).toBe(true);
+  });
 });

--- a/packages/adapters/observability/tests/reportableCategory.test.ts
+++ b/packages/adapters/observability/tests/reportableCategory.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import type { DomainError } from '@salt/shared-types';
+import { isReportableCategory } from '../src/shared/reportableCategory.js';
+
+// "Report the unexpected, suppress the expected." This is the single source of
+// truth for the category gate, shared by the client and /server subpaths.
+describe('isReportableCategory', () => {
+  // Exhaustive over the DomainError kind union (shared-types §7.2). If a new kind
+  // is added, this map should be updated — but note the predicate defaults a NEW
+  // kind to reportable (the `unknown` case below), so a forgotten kind surfaces
+  // rather than silently disappears.
+  const cases: ReadonlyArray<[DomainError['kind'], boolean]> = [
+    ['StorageError', true],
+    ['SyncError', true],
+    ['AuthError', true], // reportable by category; the sign-out race is gated elsewhere
+    ['NetworkError', false],
+    ['ValidationError', false],
+    ['NotFound', false],
+    ['ConflictError', false],
+  ];
+
+  it.each(cases)('%s → reportable=%s', (kind, expected) => {
+    expect(isReportableCategory(kind)).toBe(expected);
+  });
+
+  it('suppresses exactly the expected set, reports everything else', () => {
+    const reportable = cases.filter(([, r]) => r).map(([k]) => k);
+    const suppressed = cases.filter(([, r]) => !r).map(([k]) => k);
+    expect(new Set(suppressed)).toEqual(
+      new Set(['NetworkError', 'ValidationError', 'NotFound', 'ConflictError']),
+    );
+    expect(reportable).toEqual(expect.arrayContaining(['StorageError', 'SyncError', 'AuthError']));
+  });
+
+  it('defaults an unknown/uncategorised kind to reportable', () => {
+    // A kind outside the current union (forced cast) models a future or
+    // unexpected category — it must report, never silently drop.
+    expect(isReportableCategory('SomethingBrandNew' as DomainError['kind'])).toBe(true);
+  });
+});

--- a/packages/domain/src/ErrorReportingPort.ts
+++ b/packages/domain/src/ErrorReportingPort.ts
@@ -6,6 +6,13 @@ import type { DomainError } from '@salt/shared-types';
 // stack to the reporting backend. Domain stays pure: this is only the port shape,
 // the gate + backend live in @salt/observability. Implementations must never
 // throw across this boundary (Rule 10).
+//
+// `category` is OPTIONAL: client call sites always pass a classified
+// DomainError['kind'] (back-compatible — unchanged for them), but server call
+// sites usually catch RAW, uncategorised exceptions (there is no server
+// classifyFirestoreError), so they omit it. An absent category is "the
+// unexpected" → reportable, per the gate's single source of truth
+// (isReportableCategory, widened to accept `undefined`).
 export interface ErrorReportingPort {
-  report(error: unknown, category: DomainError['kind']): void;
+  report(error: unknown, category?: DomainError['kind']): void;
 }

--- a/packages/domain/src/ErrorReportingPort.ts
+++ b/packages/domain/src/ErrorReportingPort.ts
@@ -1,3 +1,11 @@
+import type { DomainError } from '@salt/shared-types';
+
+// Best-effort, category-gated error reporting boundary (CLAUDE.md §Observability).
+// `category` is the DomainError `kind` — it drives the report/suppress gate
+// ("report the unexpected, suppress the expected"). The raw `error` carries the
+// stack to the reporting backend. Domain stays pure: this is only the port shape,
+// the gate + backend live in @salt/observability. Implementations must never
+// throw across this boundary (Rule 10).
 export interface ErrorReportingPort {
-  report(error: unknown): void;
+  report(error: unknown, category: DomainError['kind']): void;
 }


### PR DESCRIPTION
Closes #347

## Summary
Caught errors now reach PostHog Error Tracking only via `ErrorReportingPort`, gated on the `DomainError` **category** ("report the unexpected, suppress the expected") — turning an incidental feed into a high-signal one. End users see no change; friendly failure messages are untouched.

- **Policy** — formalizes the caught-error reporting policy in `docs/salt-architecture.md` §7.6 + the CLAUDE.md conventions block.
- **Phase 1 — category-gated client reporting:** `report(error, category)` on the port; single-source-of-truth `isReportableCategory` predicate; client adapter gates + scrubs; 7 subscription `onError` sites forward the raw error (real stacks); auth catch sites categorise-first; an auth-transition flag suppresses the sign-out/token-refresh `permission-denied` race while keeping genuine auth-misconfig.
- **Phase 2 — browser write/command-failure reporting:** every adapter/callable write failure across canon, recipe, shopping, and chat services reports additively through the gate (no toast/UX change).
- **Phase 3 — server CF + AI reporting:** the server adapter honours the same predicate (widened to treat `undefined`/unknown as reportable); `report()` wired additively into triggers, onCall callables, and onCallGenkit flows, each flushing before the function freezes; `POSTHOG_API_KEY` bound to newly-reporting functions. `firebase-functions/logger` is kept (additive).
- **Phase 4 — parity & calibration:** a client/server parity test (regression guard against predicate forks), a payload-scrubbing test, and a calibration note for the PostHog before/after.

## Phases
- **Phase 1:** Offline/validation/not-found/conflict + the sign-out race stop appearing client-side; storage/sync/unknown/auth-misconfig still appear with stacks.
- **Phase 2:** Browser write failures in reportable categories now surface with a stack instead of vanishing behind a friendly toast.
- **Phase 3:** CF / callable / AI-flow failures appear under the synthetic server person `salt-cloud-functions`, alongside the existing logger entry.
- **Phase 4:** Parity + scrubbing tests green in CI; calibration note documents the before/after read.

## For reviewers
- **Single source of truth:** both subpaths import one `isReportableCategory` (`packages/adapters/observability/src/shared/reportableCategory.ts`); the parity test fails CI if client and server ever diverge.
- **Rule 4/5 respected:** `@salt/observability` never imports `firebase-sync`; `cloud-functions` uses `@salt/observability/server` only (enforced by `boundary:test`). The category is passed into the port by the caller, since the adapter cannot classify.
- **Two intentional, documented asymmetries (not bugs)** — see `docs/error-reporting-calibration.md`:
  1. The server adapter does not attach an `error.category` property even when the category is known (deliberately deferred to avoid a behaviour change in the verification phase; candidate follow-up for dashboard parity).
  2. Server does not re-report embed/arbitrate/parse flow failures that their adapters downgrade to a suppressed `NetworkError` Result (avoids double/over-reporting).
- **Out of scope / deferred:** browser→CF trace unification (unchanged); the `error.category` server payload enhancement above.
- **Invariants:** never reports a suppressed category; never attaches raw user content; best-effort, never throws (Rule 10); server reporting additive to `firebase-functions/logger`.

> Note: the branch also carries the `docs/error-reporting-policy` base commit (the §7.6 policy + CLAUDE.md block), which had not yet landed on `main` — policy and implementation ship together here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)