### PR TITLE
fix(cf): chefChat 512MiB + $ai_generation secret bindings

### DIFF
--- a/apps/cloud-functions/src/index.ts
+++ b/apps/cloud-functions/src/index.ts
@@ -88,7 +88,12 @@ export const embedText = onCallGenkit(
 export const arbitrateCanon = onCallGenkit(
   {
     ...APP_CHECK_ENFORCEMENT,
-    secrets: [geminiApiKey],
+    // posthogApiKey bound so the flow's tracedGenerate $ai_generation emit
+    // reaches PostHog when arbitrateCanon runs as its own callable. Without it,
+    // initServerObservability gets an empty key in this function's process and
+    // the emit silently no-ops (it only worked when invoked inside a
+    // posthog-bound parent like matchOrCreateCanon).
+    secrets: [geminiApiKey, posthogApiKey],
     authPolicy: isSignedIn(),
   },
   arbitrateCanonFlow,
@@ -208,7 +213,11 @@ export const populateEquipmentEntry = onCallGenkit(
 export const parseRecipeIngredients = onCallGenkit(
   {
     ...APP_CHECK_ENFORCEMENT,
-    secrets: [geminiApiKey],
+    // posthogApiKey bound so the flow's tracedGenerate $ai_generation emit
+    // reaches PostHog. Without it, POSTHOG_API_KEY is absent in this function's
+    // process, initServerObservability inits with an empty key, and the emit
+    // silently no-ops — so this callable's AI usage never lands in PostHog.
+    secrets: [geminiApiKey, posthogApiKey],
     authPolicy: isSignedIn(),
     timeoutSeconds: 90,
   },
@@ -317,6 +326,13 @@ export const chefChat = onCallGenkit(
     secrets: [geminiApiKey, posthogApiKey],
     authPolicy: isSignedIn(),
     timeoutSeconds: 120,
+    // Pro-tier streaming + equipment/recipe/history context reads exceed the
+    // 256 MiB default (observed "Memory limit of 256 MiB exceeded with 263 MiB
+    // used" in staging). The OOM SIGKILL also kills the instance before
+    // enableFirebaseTelemetry can flush the flow span, so chefChat never
+    // appeared in Genkit Monitoring. 512MiB matches the other heavy flows
+    // (authorRecipe, canonicaliseRecipeIngredients, extractRecipeFromUrl).
+    memory: '512MiB',
   },
   chefChatFlow,
 );


### PR DESCRIPTION
## What

Three small Cloud Functions config fixes for AI-observability coverage, found while investigating why `chefChat` was absent from Genkit Monitoring in staging.

### 1. `chefChat` → `memory: '512MiB'`
Staging logs show `chefChat` OOMing on the 256 MiB default:
> 'Memory limit of 256 MiB exceeded with 263 MiB used.'

Pro-tier streaming + equipment/recipe/history context reads tip it over. The OOM is a SIGKILL, which also kills the instance before `enableFirebaseTelemetry` flushes the flow span — so `chefChat` never appeared in Genkit Monitoring even though requests returned 200. Bumped to 512MiB, matching the other heavy flows (`authorRecipe`, `canonicaliseRecipeIngredients`, `extractRecipeFromUrl`).

### 2 & 3. Bind `posthogApiKey` on `arbitrateCanon` + `parseRecipeIngredients`
Both call `tracedGenerate` (which emits `$ai_generation`) but bound only `geminiApiKey`. In Cloud Functions a secret is only present in a function's process if that function declares it, so `POSTHOG_API_KEY` was absent → `initServerObservability` inited with an empty key → the emit silently no-opped. Their AI usage never reached PostHog. (`arbitrateCanon` still emitted correctly when invoked *inside* a posthog-bound parent like `matchOrCreateCanon`; this fixes the standalone callable path.)

## Verification
- `chefChat`: after deploy, confirm the 256 MiB OOM line is gone and `chefChat` shows up in Genkit Monitoring + PostHog `$ai_generation`.
- `arbitrateCanon` / `parseRecipeIngredients`: confirm `$ai_generation` events appear when each is invoked as its own callable.

## Out of scope (flagged, not fixed here)
- Embeddings (`embedText` / batch) emit no PostHog AI event at all (no `$ai_embedding`) — highest-volume AI calls, invisible in PostHog.
- `chefChat`'s `$ai_generation` reads usage off a streamed response and measures latency post-drain, so tokens/cost/latency are likely empty/misleading even once it emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
