### PR TITLE
feat(observability): capture on-screen text in session replays

### DIFF
--- a/packages/adapters/observability/src/init.ts
+++ b/packages/adapters/observability/src/init.ts
@@ -60,12 +60,14 @@ export function initObservability(key: string, opts?: ObservabilityOptions): voi
       autocapture: true,
       capture_pageview: true,
       capture_pageleave: true,
-      // Session replay only in production; PostHog default masking (mask all
-      // text + all inputs) so no user content leaks into recordings.
+      // Session replay only in production. On-screen text is captured so
+      // recordings are legible — recipe-app content (recipes, shopping list,
+      // canon, aisles) is family-shared and non-PII. Inputs stay masked
+      // (maskAllInputs) so what users actively type — including the login
+      // email field — never lands in a recording.
       disable_session_recording: !replayEnabled,
       session_recording: {
         maskAllInputs: true,
-        maskTextSelector: '*',
       },
     });
     ready = true;


### PR DESCRIPTION
## What

Stop masking **all** on-screen text in PostHog session recordings. Removes `maskTextSelector: '*'` from the browser observability init; keeps `maskAllInputs: true`.

## Why

With everything masked, replays were illegible and not useful for debugging UX. Recipe-app content (recipes, shopping list, canon, aisles) is **family-shared and non-PII**, so capturing on-screen text is acceptable and makes recordings worth having.

## Privacy guard retained

- **`maskAllInputs: true` stays** — anything a user *actively types*, including the **login email field**, is still never captured.
- Session replay remains **production-only** (`import.meta.env.PROD`) and is held back under `manualStart` for e2e/automated runs — so dev and test behaviour is unchanged.

## Note for reviewers

This is a deliberate privacy-posture change (recordings will now show on-screen recipe/shopping/canon content). Flagging explicitly so it's reviewed as such, not waved through as a config tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
