### PR TITLE
feat(observability): set PostHog `environment` flag on every browser + CF event

### DIFF
--- a/apps/cloud-functions/src/flows/matchOrCreateCanon.ts
+++ b/apps/cloud-functions/src/flows/matchOrCreateCanon.ts
@@ -18,6 +18,7 @@ import { createFirestoreAisleStore } from '../adapters/firestoreAisleStore.js';
 import { createServerEmbeddingAdapter } from '../adapters/serverEmbedding.js';
 import { createServerArbitrationAdapter } from '../adapters/serverArbitration.js';
 import { createServerMatchLoggingAdapter } from '../adapters/serverMatchLog.js';
+import { resolveServerEnvironment } from '../observability/environment.js';
 
 // Trace context is no longer piggy-backed on the payload. Server-side trace
 // unification now happens at the callable entrypoint (index.ts), which extracts
@@ -74,7 +75,7 @@ function ensureObservabilityInitialised(): void {
   // env (e.g. emulator without the secret) — initServerObservability no-ops on
   // an empty key, the firebase-functions/logger adapter still emits, and the
   // PostHog match adapter silently drops.
-  initServerObservability(process.env['POSTHOG_API_KEY'] ?? '');
+  initServerObservability(process.env['POSTHOG_API_KEY'] ?? '', resolveServerEnvironment());
 }
 
 export const matchOrCreateCanonFlow = ai.defineFlow(

--- a/apps/cloud-functions/src/index.ts
+++ b/apps/cloud-functions/src/index.ts
@@ -16,6 +16,7 @@ import {
 } from '@salt/observability/server';
 import { registerGenkitDevTracing } from './genkitTracing.js';
 import { reportFlowError } from './observability/reportServerError.js';
+import { resolveServerEnvironment } from './observability/environment.js';
 import { embedTextFlow } from './flows/embedText.js';
 import { arbitrateCanonFlow } from './flows/arbitrateCanon.js';
 import { matchOrCreateCanonFlow } from './flows/matchOrCreateCanon.js';
@@ -61,7 +62,7 @@ try {
 } catch {
   // enableFirebaseTelemetry is async, but guard the synchronous path too.
 }
-initServerObservability(process.env['POSTHOG_API_KEY'] ?? '');
+initServerObservability(process.env['POSTHOG_API_KEY'] ?? '', resolveServerEnvironment());
 registerGenkitDevTracing();
 
 const geminiApiKey = defineSecret('GEMINI_API_KEY');

--- a/apps/cloud-functions/src/observability/environment.ts
+++ b/apps/cloud-functions/src/observability/environment.ts
@@ -1,0 +1,28 @@
+// Resolves the deployment environment for server-side PostHog telemetry. The
+// value is passed to initServerObservability and attached to every server event
+// as the `environment` property — the server counterpart to the browser side,
+// which derives the same value from Vite's build mode (import.meta.env.MODE).
+//
+// Kept in the SAME vocabulary as the browser ('production' | 'staging' |
+// 'development') so the `environment` dimension is consistent across client and
+// CF events in PostHog. Project ids come from .firebaserc.
+const PROJECT_ENVIRONMENTS: Readonly<Record<string, string>> = {
+  's2-prod-e46bd': 'production',
+  's2-stage-ccb22': 'staging',
+  'demo-salt': 'development',
+};
+
+// The Functions runtime exposes the active GCP project as GCLOUD_PROJECT (with
+// GCP_PROJECT as an older fallback); the emulator additionally sets
+// FUNCTIONS_EMULATOR. Resolution order:
+//   1. Emulator run               → 'development' (regardless of project id).
+//   2. Known project id           → its friendly name.
+//   3. Unknown but present id      → the raw id (debuggable; never mislabelled).
+//   4. No project id at all        → 'development' (local / unconfigured).
+export function resolveServerEnvironment(): string {
+  if (process.env['FUNCTIONS_EMULATOR'] === 'true') return 'development';
+  const projectId = process.env['GCLOUD_PROJECT'] ?? process.env['GCP_PROJECT'] ?? '';
+  // `projectId || 'development'` (not ??) so an empty/unset id — a falsy '' that
+  // ?? would pass through — falls back to 'development'.
+  return PROJECT_ENVIRONMENTS[projectId] ?? (projectId || 'development');
+}

--- a/apps/web-pwa/src/lib/observability.ts
+++ b/apps/web-pwa/src/lib/observability.ts
@@ -15,7 +15,12 @@ import type { User } from '@salt/domain';
 // session replay manually there so e2e/automated runs don't auto-record every page.
 const _phKey = import.meta.env.VITE_PUBLIC_POSTHOG_KEY as string | undefined;
 const _useEmulators = import.meta.env.VITE_USE_EMULATORS === 'true';
-if (_phKey) initObservability(_phKey, { manualStart: _useEmulators });
+// Vite's mode is the build target — 'development' (vite dev), 'staging'
+// (build:staging --mode staging), or 'production' (build). It maps 1:1 to the
+// deployment environment, so it becomes the PostHog `environment` super property
+// in the SAME vocabulary the cloud-functions side derives from its project id.
+if (_phKey)
+  initObservability(_phKey, { manualStart: _useEmulators, environment: import.meta.env.MODE });
 
 // Dev runs against the Firebase Auth emulator, whose uid is ephemeral (new on
 // every restart / sign-in) and whose e2e suite signs in as uniqueEmail() per

--- a/packages/adapters/observability/src/init.ts
+++ b/packages/adapters/observability/src/init.ts
@@ -12,6 +12,11 @@ export interface ObservabilityOptions {
   // automated runs pass this so they don't record every page. Mirrors the LD
   // `manualStart` flag.
   manualStart?: boolean;
+  // Deployment environment ('production' | 'staging' | 'development'). When set,
+  // it is registered as a PostHog super property so it rides on EVERY event the
+  // SDK emits — autocapture, pageviews, manual captures, exceptions, and replay
+  // metadata — without each call site having to attach it.
+  environment?: string;
 }
 
 // True once initObservability has successfully called posthog.init. Adapter
@@ -75,6 +80,16 @@ export function initObservability(key: string, opts?: ObservabilityOptions): voi
     // If init itself throws (misconfig, blocked network), stay inert rather
     // than crash the app at startup.
     ready = false;
+  }
+
+  // Register the environment as a super property so it persists in the SDK and
+  // is attached to every subsequent event. Guarded via safePosthog so a register
+  // failure can never unset readiness or throw at startup, and so it no-ops when
+  // init above failed (ready === false). Captured into a const so the value stays
+  // narrowed to string inside the closure.
+  const environment = opts?.environment;
+  if (environment) {
+    safePosthog((ph) => ph.register({ environment }));
   }
 }
 

--- a/packages/adapters/observability/src/server/init.ts
+++ b/packages/adapters/observability/src/server/init.ts
@@ -22,6 +22,15 @@ const SERVER_DISTINCT_ID = 'salt-cloud-functions';
 
 let client: PostHog | null = null;
 
+// Deployment environment ('production' | 'staging' | 'development'), recorded at
+// init and attached to every server event as the PostHog `environment` property.
+// posthog-node has NO register()/super-property concept like posthog-js, so the
+// value is merged into the properties of each capture from the emit helpers below
+// (withEnvironment) — the single chokepoint every server event funnels through.
+// undefined until init, or when the caller omits it, in which case nothing is
+// attached and the captures behave exactly as before.
+let serverEnvironment: string | undefined;
+
 // True once initServerObservability has built the posthog-node client. Adapter
 // entrypoints gate on this so they stay inert — rather than throwing — when
 // PostHog is uninitialised (e.g. POSTHOG_API_KEY not set in an emulator run).
@@ -43,7 +52,12 @@ export async function whenServerObservabilityReady(): Promise<void> {
 // server observability off), so no client is built and every adapter method
 // silently no-ops. Never throws: a misconfig or constructor failure leaves the
 // package inert rather than crashing the function at module load.
-export function initServerObservability(key: string): void {
+//
+// `environment` (e.g. 'production' | 'staging' | 'development') is recorded and
+// attached to every server event as the `environment` property — the posthog-node
+// equivalent of the browser side's posthog.register({ environment }). Optional:
+// an omitted environment attaches nothing.
+export function initServerObservability(key: string, environment?: string): void {
   if (client) return;
   if (!key) return; // inert when the key is absent
 
@@ -59,6 +73,9 @@ export function initServerObservability(key: string): void {
       flushAt: 1,
       flushInterval: 0,
     });
+    // Record the environment only after the client is live, so an init failure
+    // leaves both client and environment unset (the package stays fully inert).
+    serverEnvironment = environment;
   } catch {
     // Stay inert rather than crash the function at startup.
     client = null;
@@ -78,12 +95,24 @@ export function safePosthog(fn: (ph: PostHog) => void): void {
   }
 }
 
+// Merge the `environment` super-property into an event's properties. posthog-node
+// has no posthog-js-style register(), so every server capture site routes its
+// properties through here to pick up the environment. Returns the input unchanged
+// when no environment was recorded (pre-init callers / omitted on init). The
+// environment is spread FIRST so an explicit event property of the same name wins,
+// mirroring posthog-js semantics where event properties override super properties.
+function withEnvironment(properties: Record<string, unknown>): Record<string, unknown> {
+  return serverEnvironment === undefined
+    ? properties
+    : { environment: serverEnvironment, ...properties };
+}
+
 // Capture a plain server-side event under the synthetic server person. Used by
 // the match-logging adapter; exposed so other CF telemetry can reuse the same
 // inert/never-throw guard rather than touching the client directly.
 export function captureServerEvent(event: string, properties: Record<string, unknown>): void {
   safePosthog((ph) => {
-    ph.capture({ distinctId: SERVER_DISTINCT_ID, event, properties });
+    ph.capture({ distinctId: SERVER_DISTINCT_ID, event, properties: withEnvironment(properties) });
   });
 }
 
@@ -94,7 +123,15 @@ export function captureServerEvent(event: string, properties: Record<string, unk
 export function captureServerException(error: unknown): void {
   safePosthog((ph) => {
     const err = error instanceof Error ? error : new Error(String(error));
-    ph.captureException(err, SERVER_DISTINCT_ID);
+    // Attach the environment only when one was recorded — kept off the call
+    // entirely otherwise so no empty properties bag rides along (and so the
+    // "exactly two args / no user-content bag" payload-scrubbing invariant holds
+    // when telemetry runs un-environmented).
+    if (serverEnvironment === undefined) {
+      ph.captureException(err, SERVER_DISTINCT_ID);
+    } else {
+      ph.captureException(err, SERVER_DISTINCT_ID, { environment: serverEnvironment });
+    }
   });
 }
 
@@ -142,7 +179,11 @@ export function captureAiGeneration(ev: AiGenerationEvent): void {
     if (ev.usage?.outputTokens !== undefined) props.$ai_output_tokens = ev.usage.outputTokens;
     if (ev.latencyMs !== undefined) props.$ai_latency = ev.latencyMs / 1000;
     if (ev.isError !== undefined) props.$ai_is_error = ev.isError;
-    ph.capture({ distinctId: SERVER_DISTINCT_ID, event: '$ai_generation', properties: props });
+    ph.capture({
+      distinctId: SERVER_DISTINCT_ID,
+      event: '$ai_generation',
+      properties: withEnvironment(props),
+    });
   });
 }
 

--- a/packages/adapters/observability/tests/environmentSuperProperty.test.ts
+++ b/packages/adapters/observability/tests/environmentSuperProperty.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// `environment` flag parity across the two runtimes.
+//
+//  - Browser (posthog-js): registered as a SUPER PROPERTY at init, so the SDK
+//    rides it on every event automatically — one register() call, no per-site
+//    plumbing.
+//  - Server (posthog-node): has NO register()/super-property concept, so the
+//    value is merged into the properties of every capture from the three emit
+//    helpers (the single chokepoint server events funnel through).
+//
+// Both sides use the SAME property name (`environment`) and vocabulary so the
+// dimension is consistent across client and CF events in PostHog.
+// ---------------------------------------------------------------------------
+
+const {
+  register,
+  clientCapture,
+  clientCaptureException,
+  serverCapture,
+  serverCaptureException,
+  FakePostHog,
+} = vi.hoisted(() => {
+  const serverCapture = vi.fn();
+  const serverCaptureException = vi.fn();
+  // Minimal posthog-node stand-in: only the methods init / the captures touch.
+  class FakePostHog {
+    constructor(
+      public key: string,
+      public opts: unknown,
+    ) {}
+    capture(...args: unknown[]): void {
+      serverCapture(...args);
+    }
+    captureException(...args: unknown[]): void {
+      serverCaptureException(...args);
+    }
+    async flush(): Promise<void> {}
+    async shutdown(): Promise<void> {}
+  }
+  return {
+    register: vi.fn(),
+    clientCapture: vi.fn(),
+    clientCaptureException: vi.fn(),
+    serverCapture,
+    serverCaptureException,
+    FakePostHog,
+  };
+});
+
+vi.mock('posthog-js', () => ({
+  default: {
+    init: vi.fn(),
+    register,
+    capture: clientCapture,
+    captureException: clientCaptureException,
+    identify: vi.fn(),
+    reset: vi.fn(),
+  },
+}));
+
+vi.mock('posthog-node', () => ({ PostHog: FakePostHog }));
+
+import { initObservability } from '../src/init.js';
+import {
+  initServerObservability,
+  captureServerEvent,
+  captureServerException,
+  captureAiGeneration,
+} from '../src/server/init.js';
+
+const ENV = 'staging';
+
+type CaptureArg = { event?: string; properties: Record<string, unknown> };
+
+describe('environment flag (super property browser-side, per-event server-side)', () => {
+  beforeEach(() => {
+    register.mockClear();
+    serverCapture.mockClear();
+    serverCaptureException.mockClear();
+    // Both inits are idempotent — the first call in this (vitest-isolated) test
+    // module records the environment; later beforeEach calls no-op.
+    initObservability('test-key', { environment: ENV });
+    initServerObservability('test-key', ENV);
+  });
+
+  it('browser: registers the environment as a PostHog super property at init', () => {
+    expect(register).toHaveBeenCalledWith({ environment: ENV });
+  });
+
+  it('server: attaches environment to a plain captured event', () => {
+    captureServerEvent('canon.match', { 'canon.path': 'cf' });
+    const [arg] = serverCapture.mock.calls.at(-1)!;
+    expect((arg as CaptureArg).properties).toMatchObject({ 'canon.path': 'cf', environment: ENV });
+  });
+
+  it('server: attaches environment to the $ai_generation event', () => {
+    captureAiGeneration({ flow: 'parseEntry', model: 'gemini-2.5-flash' });
+    const [arg] = serverCapture.mock.calls.at(-1)!;
+    expect((arg as CaptureArg).properties).toMatchObject({
+      environment: ENV,
+      $ai_model: 'gemini-2.5-flash',
+    });
+  });
+
+  it('server: passes environment as captureException additionalProperties', () => {
+    const err = new Error('boom');
+    captureServerException(err);
+    expect(serverCaptureException).toHaveBeenCalledWith(err, expect.any(String), {
+      environment: ENV,
+    });
+  });
+
+  it('server: an explicit event property of the same name wins over the global', () => {
+    // posthog-js semantics: event properties override super properties. The
+    // server withEnvironment merge mirrors that (environment spread first).
+    captureServerEvent('canon.match', { environment: 'override' });
+    const [arg] = serverCapture.mock.calls.at(-1)!;
+    expect((arg as CaptureArg).properties.environment).toBe('override');
+  });
+});


### PR DESCRIPTION
## What

Tags every PostHog event with the deployment environment (`production` | `staging` | `development`) so the dimension is filterable across both runtimes. Uses the right mechanism for each SDK, since `posthog-js` and `posthog-node` differ.

## Why

There was no consistent way to slice PostHog events (analytics, `canon.match`, `$ai_generation`, error tracking, session replays) by environment, so staging/dev traffic mixed with production in every dashboard and the error-tracking surface.

## How

**Browser (`posthog-js`) — true super property**
- [`ObservabilityOptions.environment`](packages/adapters/observability/src/init.ts) → after a successful `posthog.init`, calls `posthog.register({ environment })`. PostHog persists super properties, so it rides on autocapture, pageviews, manual captures, exceptions, and replay metadata automatically. Guarded via `safePosthog` so a register failure can't unset readiness or throw (Rule 10).
- [`observability.ts`](apps/web-pwa/src/lib/observability.ts) passes `import.meta.env.MODE` — exactly `development` / `staging` / `production` given the `--mode staging` build + `.env.*` files.

**Server (`posthog-node`) — no `register()`, so attach per-event**
posthog-node has no super-property concept, so the env is recorded at init and merged in at the **three capture chokepoints** every server event funnels through, in [`server/init.ts`](packages/adapters/observability/src/server/init.ts):
- `initServerObservability(key, environment?)` records it once the client is live.
- `withEnvironment()` (env spread first, so an explicit event prop wins — mirrors posthog-js semantics) feeds `captureServerEvent` and `captureAiGeneration`.
- `captureServerException` passes `{ environment }` as the 3rd `additionalProperties` arg **only when set**, preserving the existing "exactly two args / no extra bag" payload-scrubbing invariant for un-environmented runs.
- New [`environment.ts`](apps/cloud-functions/src/observability/environment.ts) resolves the env from `FUNCTIONS_EMULATOR` / `GCLOUD_PROJECT` against the `.firebaserc` project ids (`s2-prod-e46bd`→production, `s2-stage-ccb22`→staging, `demo-salt`→development), wired into both init sites (module-load in `index.ts` + the lazy guard in `matchOrCreateCanon.ts`).

Both sides emit the same property name + vocabulary, so client and CF events share one consistent `environment` dimension.

## Design note

Environment **resolution** lives in the apps, not the shared adapter — mapping project ids → env names is app config, and the adapter just receives a string. This matches the existing pattern where apps compute the key / `manualStart` and pass them in.

## Testing

- New [`environmentSuperProperty.test.ts`](packages/adapters/observability/tests/environmentSuperProperty.test.ts): browser `register`, server event / `$ai_generation` / exception attachment, and override precedence.
- `pnpm test` — observability 62 ✓, cloud-functions 189 ✓
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · dependency-cruiser clean (pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)