### PR TITLE
CF 512MiB memory floor + app_version super property & feedback box

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -62,6 +62,12 @@ jobs:
       # Default Vite mode is production -> loads apps/web-pwa/.env.production
       # (prod Firebase config + PostHog browser key). Output -> apps/web-pwa/dist.
       - name: Build web-pwa (production)
+        env:
+          # The published release tag (or the ref chosen for a manual re-deploy),
+          # surfaced as the Settings "Version" and the `app_version` event super
+          # property. Passed explicitly because actions/checkout does not fetch git
+          # tags, so `git describe` can't recover the tag during the CI build.
+          APP_VERSION: ${{ github.event.release.tag_name || inputs.ref }}
         run: pnpm --filter @salt/web-pwa build
 
       - name: Authenticate to Google Cloud (WIF)

--- a/apps/cloud-functions/src/auth/beforeMemberCreated.ts
+++ b/apps/cloud-functions/src/auth/beforeMemberCreated.ts
@@ -13,22 +13,27 @@ import { normaliseMemberEmail } from '@salt/domain';
 //
 // Throwing HttpsError aborts account creation and surfaces the message to the
 // client; returning normally allows it.
-export const beforeMemberCreated = beforeUserCreated({ region: 'europe-west2' }, async (event) => {
-  const rawEmail = event.data?.email;
-  if (!rawEmail) {
-    logger.warn('beforeMemberCreated: rejected account with no email');
-    throw new HttpsError('permission-denied', 'An email address is required to use Salt.');
-  }
+export const beforeMemberCreated = beforeUserCreated(
+  // memory: 512MiB floor, pinned inline (top-imported, runs before
+  // setGlobalOptions — same reason region is inline).
+  { region: 'europe-west2', memory: '512MiB' },
+  async (event) => {
+    const rawEmail = event.data?.email;
+    if (!rawEmail) {
+      logger.warn('beforeMemberCreated: rejected account with no email');
+      throw new HttpsError('permission-denied', 'An email address is required to use Salt.');
+    }
 
-  const email = normaliseMemberEmail(rawEmail);
-  const snap = await getFirestore().collection('members').doc(email).get();
-  if (!snap.exists) {
-    logger.warn('beforeMemberCreated: rejected off-list email', { email });
-    throw new HttpsError(
-      'permission-denied',
-      'This email address is not on the Salt member list. Ask an admin to add you.',
-    );
-  }
+    const email = normaliseMemberEmail(rawEmail);
+    const snap = await getFirestore().collection('members').doc(email).get();
+    if (!snap.exists) {
+      logger.warn('beforeMemberCreated: rejected off-list email', { email });
+      throw new HttpsError(
+        'permission-denied',
+        'This email address is not on the Salt member list. Ask an admin to add you.',
+      );
+    }
 
-  logger.info('beforeMemberCreated: allowed member', { email });
-});
+    logger.info('beforeMemberCreated: allowed member', { email });
+  },
+);

--- a/apps/cloud-functions/src/callables/regenerateCanonIcon.ts
+++ b/apps/cloud-functions/src/callables/regenerateCanonIcon.ts
@@ -25,7 +25,14 @@ const posthogApiKey = defineSecret('POSTHOG_API_KEY');
 // alongside the index.ts callables at the enforcement step (this also fires AI
 // image generation, so it is part of the cost surface App Check protects).
 export const regenerateCanonIcon = onCall(
-  { region: 'europe-west2', enforceAppCheck: false, secrets: [posthogApiKey] },
+  {
+    region: 'europe-west2',
+    enforceAppCheck: false,
+    secrets: [posthogApiKey],
+    // 512MiB floor, pinned inline (top-imported, runs before setGlobalOptions —
+    // same reason region is inline above).
+    memory: '512MiB',
+  },
   async (request) => {
     if (!request.auth) {
       throw new HttpsError('unauthenticated', 'Sign in required.');

--- a/apps/cloud-functions/src/index.ts
+++ b/apps/cloud-functions/src/index.ts
@@ -39,7 +39,19 @@ import { handleTestModel } from './ai/testModel.js';
 
 initializeApp();
 
-setGlobalOptions({ region: 'europe-west2' });
+// 512MiB is the memory floor for every function. The 256MiB default sits just
+// below this codebase's resting footprint — firebase-admin, Genkit/OTel
+// (enableFirebaseTelemetry), and posthog-node all load at module init — so a
+// function OOMs on its first real context read (chefChat died at "263 MiB used",
+// 7 over). Override UPWARD per function where proven (onCanonItemWritten's icon
+// decode needs 1GiB).
+//
+// NB: firebase-functions bakes global options into each function's __endpoint
+// EAGERLY at definition time, and ES imports evaluate before this line runs, so
+// this only reaches the callables defined inline below. The top-imported modules
+// (the triggers, regenerateCanonIcon, beforeMemberCreated) pin memory inline —
+// the same reason they already pin region inline.
+setGlobalOptions({ region: 'europe-west2', memory: '512MiB' });
 
 // Telemetry, owned at module load so it's in place before any flow runs:
 //
@@ -163,11 +175,9 @@ export const canonicaliseRecipeIngredients = onCall(
     ...APP_CHECK_ENFORCEMENT,
     secrets: [geminiApiKey, posthogApiKey],
     timeoutSeconds: 120,
-    // Batch canonicalisation reads the whole canon collection and batches
-    // embeddings for every ingredient in the recipe, so it exceeds the default
-    // 256 MiB and the instance is OOM-killed (surfaces as 500/504 + a CORS
-    // error in the browser because the dead response carries no CORS headers).
-    memory: '512MiB',
+    // Memory-heavy (whole-canon read + batched embeddings); covered by the
+    // 512MiB global floor — at 256 it OOM-killed (500/504 + a browser CORS error,
+    // since the dead response carries no CORS headers).
   },
   async (request) => {
     if (!request.auth) {
@@ -226,14 +236,14 @@ export const parseRecipeIngredients = onCallGenkit(
 );
 
 // Librarian: conversation → recipe draft with canon-matched ingredients.
-// Uses onCall (not onCallGenkit) so we can bump memory for the batch
-// canonicalisation, mirroring canonicaliseRecipeIngredients.
+// Uses onCall (not onCallGenkit) so the handler can wrap the batch-canonicalise
+// flow in reportFlowError, mirroring canonicaliseRecipeIngredients. Memory comes
+// from the 512MiB global floor.
 export const authorRecipe = onCall(
   {
     ...APP_CHECK_ENFORCEMENT,
     secrets: [geminiApiKey, posthogApiKey],
     timeoutSeconds: 120,
-    memory: '512MiB',
   },
   async (request) => {
     if (!request.auth) {
@@ -257,10 +267,9 @@ export const authorRecipe = onCall(
 
 // SSRF-hardened URL import (recipe URL import epic). Uses onCall (not
 // onCallGenkit) so we can map the flow's UrlImportError taxonomy to specific
-// HttpsError codes with user-safe copy (no internal SSRF detail leaked), and
-// bump memory for the batch canonicalisation like authorRecipe. The flow does
-// outbound DNS + a network fetch in addition to the AI call, so the function
-// timeout is generous.
+// HttpsError codes with user-safe copy (no internal SSRF detail leaked). The
+// flow does outbound DNS + a network fetch in addition to the AI call, so the
+// function timeout is generous. Memory comes from the 512MiB global floor.
 function mapUrlImportFailure(code: UrlImportFailureCode): HttpsError {
   switch (code) {
     case 'invalid-url':
@@ -288,7 +297,6 @@ export const extractRecipeFromUrl = onCall(
     ...APP_CHECK_ENFORCEMENT,
     secrets: [geminiApiKey, posthogApiKey],
     timeoutSeconds: 120,
-    memory: '512MiB',
   },
   async (request) => {
     if (!request.auth) {
@@ -327,13 +335,10 @@ export const chefChat = onCallGenkit(
     secrets: [geminiApiKey, posthogApiKey],
     authPolicy: isSignedIn(),
     timeoutSeconds: 120,
-    // Pro-tier streaming + equipment/recipe/history context reads exceed the
-    // 256 MiB default (observed "Memory limit of 256 MiB exceeded with 263 MiB
-    // used" in staging). The OOM SIGKILL also kills the instance before
-    // enableFirebaseTelemetry can flush the flow span, so chefChat never
-    // appeared in Genkit Monitoring. 512MiB matches the other heavy flows
-    // (authorRecipe, canonicaliseRecipeIngredients, extractRecipeFromUrl).
-    memory: '512MiB',
+    // Memory-heavy: pro-tier streaming + equipment/recipe/history context reads.
+    // Covered by the 512MiB global floor — at 256 it OOM'd ("263 MiB used"), and
+    // the SIGKILL killed the instance before enableFirebaseTelemetry flushed the
+    // flow span, so it never appeared in Genkit Monitoring.
   },
   chefChatFlow,
 );

--- a/apps/cloud-functions/src/triggers/onCanonItemWritten.ts
+++ b/apps/cloud-functions/src/triggers/onCanonItemWritten.ts
@@ -216,7 +216,9 @@ export const onCanonItemWritten = onDocumentWritten(
     // in parallel blow past the memory cap and the instance is OOM-killed,
     // losing every in-flight icon. concurrency:1 serialises icon work per
     // instance (Cloud Run scales out instances instead), bounding memory
-    // regardless of batch size; 1GiB gives the single decode comfortable room.
+    // regardless of batch size; 1GiB gives the single decode comfortable room —
+    // an upward override of the 512MiB floor, pinned inline (this trigger module
+    // loads before index.ts's setGlobalOptions, same reason region is inline).
     concurrency: 1,
     memory: '1GiB',
   },

--- a/apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts
+++ b/apps/cloud-functions/src/triggers/onShoppingListItemWrite.ts
@@ -39,9 +39,11 @@ export const onShoppingListItemWrite = onDocumentWritten(
     // write-back runs, stranding the item at 'pending' forever: triggers don't
     // auto-retry and the item gets no further write to re-fire on. 180s leaves
     // headroom over the bounded AI budget so a terminal state is always written.
-    // 512MiB mirrors canonicaliseRecipeIngredients — the same list() over the
-    // whole canon collection + embeddings OOM-kills the default 256MiB instance,
-    // another mid-flight death that leaves the item stuck 'pending'.
+    // memory: the same list() over the whole canon collection + embeddings would
+    // OOM-kill a 256MiB instance — another mid-flight death that strands the item
+    // at 'pending'. Pinned inline at the 512MiB floor rather than inherited from
+    // index.ts's setGlobalOptions: this trigger module is evaluated before that
+    // call runs, so the global never reaches it (same reason region is inline).
     timeoutSeconds: 180,
     memory: '512MiB',
   },

--- a/apps/web-pwa/src/env.d.ts
+++ b/apps/web-pwa/src/env.d.ts
@@ -27,5 +27,5 @@ interface ImportMeta {
 }
 
 // Build stamp injected by Vite `define` (see vite.config.ts). Shown on Settings.
-declare const __APP_COMMIT__: string;
+declare const __APP_VERSION__: string;
 declare const __APP_BUILD_TIME__: string;

--- a/apps/web-pwa/src/lib/observability.ts
+++ b/apps/web-pwa/src/lib/observability.ts
@@ -7,6 +7,7 @@ import {
   startObservabilitySession,
   stopObservabilitySession,
   isObservabilitySessionActive,
+  sendSupportFeedback,
   type ObservabilitySessionMeta,
 } from '@salt/observability';
 import type { User } from '@salt/domain';
@@ -20,7 +21,13 @@ const _useEmulators = import.meta.env.VITE_USE_EMULATORS === 'true';
 // deployment environment, so it becomes the PostHog `environment` super property
 // in the SAME vocabulary the cloud-functions side derives from its project id.
 if (_phKey)
-  initObservability(_phKey, { manualStart: _useEmulators, environment: import.meta.env.MODE });
+  initObservability(_phKey, {
+    manualStart: _useEmulators,
+    environment: import.meta.env.MODE,
+    // Build commit (settings page "Version") → `app_version` super property on
+    // every event, so exceptions/feedback/analytics all carry the running build.
+    version: __APP_VERSION__,
+  });
 
 // Dev runs against the Firebase Auth emulator, whose uid is ephemeral (new on
 // every restart / sign-in) and whose e2e suite signs in as uniqueEmail() per
@@ -60,6 +67,31 @@ export function stopSession(): void {
 
 export function isSessionActive(): boolean {
   return isObservabilitySessionActive();
+}
+
+// Sends a user's settings-page feedback to PostHog Support as a new ticket. The
+// signed-in email is attached as the ticket identity — identifyUser already calls
+// posthog.identify with it, but passing it keeps the inbox ticket labelled
+// regardless. Resolves true on a confirmed send; the settings page renders
+// success/error from the boolean.
+//
+// Non-production feedback is footer-tagged with the deployment environment — the
+// SAME `import.meta.env.MODE` value we register as the PostHog `environment`
+// super property. The super property already rides on the $conversations_message_sent
+// event (so analytics can split by env), but the Support *inbox* can't filter
+// tickets by a super property, so the env has to live on the ticket itself. Prod
+// feedback (real users) is sent verbatim; dev/staging tickets self-label as test.
+export function submitFeedback(text: string, email?: string): Promise<boolean> {
+  const env = import.meta.env.MODE;
+  // Stamp every ticket with the running version (triage context for any bug
+  // report), and additionally flag non-prod submissions as test. The super
+  // properties carry these on the $conversations_message_sent event, but the
+  // Support inbox can't read super properties, so they go on the ticket body too.
+  const footer =
+    env === 'production'
+      ? `— version ${__APP_VERSION__}`
+      : `— version ${__APP_VERSION__} · sent from ${env} (test)`;
+  return sendSupportFeedback(`${text}\n\n${footer}`, email ? { name: email, email } : undefined);
 }
 
 export type { ObservabilitySessionMeta };

--- a/apps/web-pwa/src/routes/settings/SettingsPage.svelte
+++ b/apps/web-pwa/src/routes/settings/SettingsPage.svelte
@@ -1,25 +1,96 @@
 <script lang="ts">
-  import { FormPage, Text } from '@salt/ui-components';
+  import {
+    FormPage,
+    Text,
+    Card,
+    CardHeader,
+    CardTitle,
+    CardDescription,
+    CardContent,
+    CardFooter,
+    TextArea,
+    Button,
+  } from '@salt/ui-components';
   import { auth } from '../../lib/auth.svelte.js';
+  import { submitFeedback } from '../../lib/observability.js';
 
   // Build stamp injected at build time (vite.config.ts). The timestamp makes
   // every build distinct, so it doubles as the "did the PWA auto-update?" signal.
-  const commit = __APP_COMMIT__;
+  const version = __APP_VERSION__;
   const builtAt = new Date(__APP_BUILD_TIME__);
   const builtAtLabel = Number.isNaN(builtAt.getTime())
     ? __APP_BUILD_TIME__
     : builtAt.toLocaleString();
   const environment = import.meta.env.MODE;
+
+  // Feedback box — pipes the message into PostHog Support (the same inbox the
+  // floating chat widget would use), so it arrives with the session replay +
+  // exceptions attached and can be replied to. Best-effort: a false result just
+  // surfaces a retry message.
+  let feedback = $state('');
+  let status = $state<'idle' | 'sending' | 'sent' | 'error'>('idle');
+
+  async function sendFeedback() {
+    const text = feedback.trim();
+    if (!text || status === 'sending') return;
+    status = 'sending';
+    const ok = await submitFeedback(text, auth.user?.email ?? undefined);
+    if (ok) {
+      feedback = '';
+      status = 'sent';
+    } else {
+      status = 'error';
+    }
+  }
 </script>
 
-<div class="p-4 sm:p-6">
+<div class="p-4 sm:p-6 space-y-6">
   <FormPage title="Settings" description="Manage your account." canSubmit={false}>
+    <!-- Empty footer: an informational page has nothing to save, so suppress
+         FormPage's default (disabled) Save button. -->
+    {#snippet footer()}{/snippet}
     <Text muted>Signed in as {auth.user?.email ?? '—'}</Text>
 
-    <div class="mt-6 space-y-1 border-t pt-4">
+    <div class="mt-2 space-y-1 border-t pt-4">
       <Text muted>Environment: {environment}</Text>
-      <Text muted>Version: {commit}</Text>
+      <Text muted>Version: {version}</Text>
       <Text muted>Built: {builtAtLabel}</Text>
     </div>
   </FormPage>
+
+  <Card>
+    <CardHeader>
+      <CardTitle>Send feedback</CardTitle>
+      <CardDescription>
+        Hit a bug or have an idea? Send it straight to me — it lands in our inbox with the page you
+        were on attached.
+      </CardDescription>
+    </CardHeader>
+    <CardContent class="space-y-3">
+      <TextArea
+        label="Your message"
+        placeholder="What went wrong, or what would you like to see?"
+        rows={4}
+        maxLength={2000}
+        bind:value={feedback}
+        disabled={status === 'sending'}
+        error={status === 'error' ? "Couldn't send — please try again." : undefined}
+        onValueChange={() => {
+          if (status === 'sent' || status === 'error') status = 'idle';
+        }}
+      />
+      {#if status === 'sent'}
+        <Text class="text-sm text-emerald-600">Thanks — your feedback's on its way. 💚</Text>
+      {/if}
+    </CardContent>
+    <CardFooter class="justify-end">
+      <Button
+        onclick={sendFeedback}
+        loading={status === 'sending'}
+        disabled={feedback.trim().length === 0}
+      >
+        Submit feedback
+      </Button>
+    </CardFooter>
+  </Card>
 </div>

--- a/apps/web-pwa/vite.config.ts
+++ b/apps/web-pwa/vite.config.ts
@@ -4,21 +4,28 @@ import { VitePWA } from 'vite-plugin-pwa';
 import { resolve } from 'path';
 import { execSync } from 'node:child_process';
 
-// Build stamp shown on the Settings screen. The git SHA identifies the code; the
-// build timestamp guarantees every build is distinct — so a re-dispatched deploy
-// of the same commit still produces a visibly new version, which is what lets us
-// validate the open-client PWA auto-update flow (issue #141 Phase 3) with a plain
-// workflow_dispatch re-deploy, no throwaway commit required.
-function gitShortSha(): string {
+// Version stamp shown on the Settings screen and registered as the `app_version`
+// PostHog super property. Production CI passes the published GitHub Release tag via
+// APP_VERSION (e.g. 202606.15) — reliable because git tags are NOT fetched in CI.
+// Locally and on staging we derive it from git: `git describe --tags --always`
+// yields the nearest release tag, plus commits-ahead + short SHA when the build is
+// not exactly on a tag (e.g. 202606.15-3-gabc1234), falling back to a bare short
+// SHA, then 'unknown'. The build timestamp (below) still guarantees every build is
+// distinct — so a re-dispatched deploy of the SAME tag produces a visibly new
+// build, which validates the open-client PWA auto-update flow (issue #141 Phase 3)
+// via a plain workflow_dispatch re-deploy, no throwaway commit required.
+function resolveAppVersion(): string {
+  const fromEnv = process.env.APP_VERSION?.trim();
+  if (fromEnv) return fromEnv;
   try {
-    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+    return execSync('git describe --tags --always', { stdio: ['ignore', 'pipe', 'ignore'] })
       .toString()
       .trim();
   } catch {
     return 'unknown';
   }
 }
-const appCommit = gitShortSha();
+const appVersion = resolveAppVersion();
 const buildTime = new Date().toISOString();
 
 // PWA identity is env-distinct (issue #141): staging installs as "Salt (Staging)"
@@ -96,7 +103,7 @@ export default defineConfig(({ mode }) => {
       }),
     ],
     define: {
-      __APP_COMMIT__: JSON.stringify(appCommit),
+      __APP_VERSION__: JSON.stringify(appVersion),
       __APP_BUILD_TIME__: JSON.stringify(buildTime),
     },
     resolve: {

--- a/apps/web-pwa/vitest.config.ts
+++ b/apps/web-pwa/vitest.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     ),
     // Build stamp globals (injected by vite.config.ts in real builds) — stubbed
     // here so rendering Settings under vitest doesn't hit an undefined global.
-    __APP_COMMIT__: JSON.stringify('test'),
+    __APP_VERSION__: JSON.stringify('test'),
     __APP_BUILD_TIME__: JSON.stringify('1970-01-01T00:00:00.000Z'),
   },
   test: {

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - salt-vscode  (2026-06-27)
+# Graph Report - salt-vscode  (2026-06-28)
 
 ## Corpus Check
-- 829 files · ~295,146 words
+- 834 files · ~299,605 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3895 nodes · 7675 edges · 326 communities (275 shown, 51 thin omitted)
-- Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 121 edges (avg confidence: 0.81)
+- 3924 nodes · 7718 edges · 333 communities (279 shown, 54 thin omitted)
+- Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 122 edges (avg confidence: 0.81)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `585c82e8`
+- Built from commit: `e6bdb0fd`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -104,7 +104,7 @@
 - [[_COMMUNITY_eslint.config.js|eslint.config.js]]
 - [[_COMMUNITY_Scripts|Scripts]]
 - [[_COMMUNITY_Sections|Sections]]
-- [[_COMMUNITY_Canon|Canon]]
+- [[_COMMUNITY_Community 89|Community 89]]
 - [[_COMMUNITY_Chat|Chat]]
 - [[_COMMUNITY_Domain|Domain]]
 - [[_COMMUNITY_Flows|Flows]]
@@ -281,13 +281,20 @@
 - [[_COMMUNITY_Community 316|Community 316]]
 - [[_COMMUNITY_Community 317|Community 317]]
 - [[_COMMUNITY_Community 318|Community 318]]
+- [[_COMMUNITY_Community 319|Community 319]]
+- [[_COMMUNITY_Community 320|Community 320]]
+- [[_COMMUNITY_Community 321|Community 321]]
 - [[_COMMUNITY_Community 322|Community 322]]
+- [[_COMMUNITY_Community 323|Community 323]]
 - [[_COMMUNITY_Community 324|Community 324]]
 - [[_COMMUNITY_Community 325|Community 325]]
 - [[_COMMUNITY_Community 326|Community 326]]
 - [[_COMMUNITY_Community 327|Community 327]]
 - [[_COMMUNITY_Community 328|Community 328]]
+- [[_COMMUNITY_Community 329|Community 329]]
 - [[_COMMUNITY_Community 330|Community 330]]
+- [[_COMMUNITY_Community 331|Community 331]]
+- [[_COMMUNITY_Community 332|Community 332]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `DomainError` - 100 edges
@@ -324,27 +331,27 @@
 - **Canon Matching Entry Points & Shared Core** — matching_pipeline_fast_path, matching_pipeline_match_or_create_canon_callable, matching_pipeline_on_shopping_list_item_write, matching_pipeline_canonicalise_recipe_ingredients, matching_pipeline_match_or_create_batch [EXTRACTED 1.00]
 - **Issue-Driven Agentic Workflow Commands** — commands_spec_feature_spec, commands_defect_defect_spec, commands_refactor_spec_refactor_spec, commands_run_run_issue [INFERRED 0.85]
 
-## Communities (326 total, 51 thin omitted)
+## Communities (333 total, 54 thin omitted)
 
 ### Community 0 - "Meal Planner & Attendees"
-Cohesion: 0.05
-Nodes (96): addAttendee(), DayContainer, removeAttendee(), setAttendeeHomeTime(), setAttendeeNote(), setDayChefs(), setDayGuests(), setDayNote() (+88 more)
+Cohesion: 0.06
+Nodes (84): addAttendee(), DayContainer, removeAttendee(), setAttendeeHomeTime(), setAttendeeNote(), setDayChefs(), setDayGuests(), setDayNote() (+76 more)
 
 ### Community 1 - "Aisles & Canon Stores"
-Cohesion: 0.13
-Nodes (18): AddAccessoryInput, AddEquipmentInput, addRule(), AddRuleInput, editRule(), EditRuleInput, RemoveAccessoryInput, RemoveEquipmentInput (+10 more)
+Cohesion: 0.12
+Nodes (17): 1. Client config — build-time, committed, **not secret**, 2. Cloud Functions runtime secrets — Secret Manager, per project, **never committed**, 3. CI / GitHub Environments, Config & secrets — what lives where, Cutting a release (promote staging → production), Deploying, Firebase projects (`.firebaserc` aliases), First deploy to a fresh project (one-time bootstrap) (+9 more)
 
 ### Community 2 - "Firebase-Sync Shopping Config"
-Cohesion: 0.22
-Nodes (17): createAisle(), createAislesBulk(), deleteAisles(), ../../lib/aisleService.js, addAisle(), addAislesBulk(), deleteAisles(), idGen (+9 more)
+Cohesion: 0.29
+Nodes (8): CANON_MATCH_EVENT, CanonMatchEventProps, CanonMatchPath, scaleScore(), toCanonMatchEvent(), ObservabilitySpan, createPosthogMatchLoggingAdapter(), fixture
 
 ### Community 3 - "Canon Approval UI"
-Cohesion: 0.07
-Nodes (37): base, handleBulkApprove(), approveCanonItem(), ../../lib/canonService.js, aisles, aisleUsage, approveCanonItems(), approveCanonItemWithOverrides() (+29 more)
+Cohesion: 0.09
+Nodes (31): base, approveCanonItem(), ../../lib/canonService.js, addCanonItem(), approveCanonItemWithOverrides(), commitCanonItemUpdate(), deleteCanonItem(), getErrorReporter() (+23 more)
 
 ### Community 4 - "Shopping List Commands"
-Cohesion: 0.07
-Nodes (45): AddItemInput, CheckItemInput, clearCheckedItems(), confirmItemNeeded(), ConfirmItemNeededInput, CreateListInput, deleteItem(), DeleteItemInput (+37 more)
+Cohesion: 0.12
+Nodes (17): checkItem(), CheckItemInput, confirmItemNeeded(), ConfirmItemNeededInput, CreateListInput, deleteItem(), DeleteItemInput, DeleteListInput (+9 more)
 
 ### Community 5 - "Headless UI Primitives"
 Cohesion: 0.06
@@ -355,24 +362,24 @@ Cohesion: 0.10
 Nodes (30): createViaCombobox(), PASTE_TEXT, STUB_PARSE, AutoFixtures, E2E_RAW_DIR, test, gotoAndSignIn(), seedMemberAllowlist() (+22 more)
 
 ### Community 7 - "Firestore Stores & Classify"
-Cohesion: 0.08
-Nodes (26): eSim, eX, eY, CreateAisleInput, CreateAislesBulkInput, DeleteAislesInput, MatchOrCreatePorts, MatchOrCreateResult (+18 more)
+Cohesion: 0.09
+Nodes (24): fakeStore(), BASE, BASE, createAisle(), createAislesBulk(), renameAisle(), reorderAisles(), Aisle (+16 more)
 
 ### Community 8 - "Shopping List UI"
-Cohesion: 0.13
-Nodes (41): addItem(), checkItem(), uncheckItem(), get(), reportIfFailed(), findMemberByEmail(), commitRecipeAddPlan(), removeRecipe() (+33 more)
+Cohesion: 0.11
+Nodes (44): get(), reportIfFailed(), commitRecipeAddPlan(), removeRecipe(), ../../lib/shoppingListService.svelte.js, activeListId, addItemToList(), addList() (+36 more)
 
 ### Community 9 - "Equipment & Rules"
-Cohesion: 0.12
-Nodes (40): addAccessory(), addEquipment(), removeAccessory(), removeEquipment(), setAccessoryOwned(), ../../lib/equipmentService.js, addEquipmentAccessory(), addEquipmentItem() (+32 more)
+Cohesion: 0.07
+Nodes (57): addAccessory(), AddAccessoryInput, addEquipment(), AddEquipmentInput, addRule(), AddRuleInput, editRule(), EditRuleInput (+49 more)
 
 ### Community 10 - "Members Management"
 Cohesion: 0.07
-Nodes (33): createMember(), CreateMemberInput, normaliseMemberEmail(), updateMember(), UpdateMemberPatch, Member, auth, ../../lib/membersService.js (+25 more)
+Nodes (35): createMember(), CreateMemberInput, normaliseMemberEmail(), updateMember(), UpdateMemberPatch, Member, auth, ../../lib/membersService.js (+27 more)
 
 ### Community 11 - "Canon Matching Core"
-Cohesion: 0.12
-Nodes (14): catalog, ApproveCanonItemOverrides, CreateCanonItemInput, ArbitrationExtras, renameCanonItem(), setCanonItemAisle(), setCanonItemShoppingBehavior(), setCanonItemThreshold() (+6 more)
+Cohesion: 0.09
+Nodes (19): catalog, items, ApproveCanonItemOverrides, CreateCanonItemInput, ArbitrationExtras, renameCanonItem(), setCanonItemAisle(), setCanonItemShoppingBehavior() (+11 more)
 
 ### Community 12 - "web-pwa Dependencies"
 Cohesion: 0.04
@@ -384,7 +391,7 @@ Nodes (40): dependencies, bits-ui, class-variance-authority, clsx, @floating-ui/
 
 ### Community 14 - "Combobox Primitive"
 Cohesion: 0.07
-Nodes (30): ../../src/primitives/Combobox/Combobox.svelte, ctx, filterValue, initialItem, inputId, inputValue, listboxId, ../../src/primitives/Combobox/ComboboxContent.svelte (+22 more)
+Nodes (39): CanonIconProps, ../../src/primitives/Combobox/Combobox.svelte, ctx, filterValue, initialItem, inputId, inputValue, listboxId (+31 more)
 
 ### Community 15 - "Domain Zod Schemas"
 Cohesion: 0.09
@@ -395,8 +402,8 @@ Cohesion: 0.05
 Nodes (37): COLOR_MAP, CONTROLS_CHECKBOX_MAP, CONTROLS_SWITCH_MAP, cssVars, design, DESIGN_MD_PATH, designCheckbox, designColors (+29 more)
 
 ### Community 17 - "Canon Fast-Path Parity"
-Cohesion: 0.09
-Nodes (34): aisleStore, failingArbitration, failingEmbedding, ids, makeStore(), runCfPath(), runFastPath(), items (+26 more)
+Cohesion: 0.08
+Nodes (32): aisleStore, failingArbitration, failingEmbedding, ids, makeStore(), runCfPath(), runFastPath(), appendCanonSynonym() (+24 more)
 
 ### Community 18 - "Select Primitive"
 Cohesion: 0.09
@@ -407,28 +414,28 @@ Cohesion: 0.09
 Nodes (11): cp, DEFAULT_LABELS, FALLBACK_META, getTaskLabel(), metaFor(), net, NUKE_PORTS, SERVICE_META (+3 more)
 
 ### Community 20 - "Admin Routes"
-Cohesion: 0.14
-Nodes (13): ../../lib/auth.svelte.js, AuthStore, clearPendingEmail(), devSignIn(), formatError(), readPendingEmail(), writePendingEmail(), authProvider (+5 more)
+Cohesion: 0.22
+Nodes (8): ../../lib/auth.svelte.js, AuthStore, clearPendingEmail(), devSignIn(), formatError(), readPendingEmail(), writePendingEmail(), identifyAnonymous()
 
 ### Community 21 - "Combobox & ListPage Types"
-Cohesion: 0.12
-Nodes (25): CanonIconProps, ComboboxContentProps, ComboboxCreateProps, ComboboxEmptyProps, ComboboxFieldProps, ComboboxGroupProps, ComboboxInputProps, ComboboxItem (+17 more)
+Cohesion: 0.43
+Nodes (6): ./ListPage.context.js, LIST_PAGE_CONTEXT, ListPageContext, BulkAction, BulkActionIcon, ListPageProps
 
 ### Community 22 - "Task Pilot Manifest"
 Cohesion: 0.06
 Nodes (35): categories, properties, title, contributes, commands, configuration, menus, views (+27 more)
 
 ### Community 23 - "Dialog & Popover Primitives"
-Cohesion: 0.11
-Nodes (12): comboboxContentVariants, comboboxCreateVariants, comboboxInputVariants, comboboxItemVariants, comboboxTriggerVariants, DialogContentProps, DialogPartProps, DialogProps (+4 more)
+Cohesion: 0.33
+Nodes (5): comboboxContentVariants, comboboxCreateVariants, comboboxInputVariants, comboboxItemVariants, comboboxTriggerVariants
 
 ### Community 24 - "Recipe Service"
-Cohesion: 0.13
-Nodes (19): ../../lib/recipeService.js, applySnapshot(), buildRecipeAddPlan(), canonicaliseIngredients(), getErrorReporter(), initRecipeSync(), isLoadingRecipes, _itemIds (+11 more)
+Cohesion: 0.11
+Nodes (23): ../../lib/recipeService.js, applySnapshot(), buildRecipeAddPlan(), canonicaliseIngredients(), getErrorReporter(), getRecipesSnapshot(), importRecipeFromUrl(), initRecipeSync() (+15 more)
 
 ### Community 25 - "Observability (PostHog)"
 Cohesion: 0.14
-Nodes (25): getSessionURL(), identifyAnonymous(), identifyUser(), isSessionActive(), _phKey, startSession(), stopSession(), tagSession() (+17 more)
+Nodes (27): ../../lib/observability.js, getSessionURL(), identifyUser(), isSessionActive(), _phKey, startSession(), stopSession(), submitFeedback() (+19 more)
 
 ### Community 26 - "Selectable List & Checkbox"
 Cohesion: 0.11
@@ -443,8 +450,8 @@ Cohesion: 0.17
 Nodes (11): assembleDraft(), authorRecipeFlow, OutputSchema, canonicaliseRecipeIngredientsFlow, assembleDraft(), buildHtmlPrompt(), extractRecipeFromUrlFlow, OutputSchema (+3 more)
 
 ### Community 29 - "AI Timeout Guard"
-Cohesion: 0.18
-Nodes (14): generateCanonIconFlow, removeFlatBackground(), RemoveFlatBackgroundOptions, sampleBackgroundColour(), reportServerError(), buildIconDownloadUrl(), geminiApiKey, iconNeedsGeneration() (+6 more)
+Cohesion: 0.12
+Nodes (18): loadCanonIconSeed(), embedTextFlow, generateCanonIconFlow, GenerateCanonIconInputSchema, GenerateCanonIconOutputSchema, removeFlatBackground(), RemoveFlatBackgroundOptions, sampleBackgroundColour() (+10 more)
 
 ### Community 30 - "cloud-functions Dependencies"
 Cohesion: 0.07
@@ -455,36 +462,36 @@ Cohesion: 0.17
 Nodes (22): assertUrlAllowed(), fetchOnce(), guardedLookup(), SingleFetch, SsrfFetchError, SsrfFetchErrorReason, SsrfFetchResult, ssrfGuardedFetch() (+14 more)
 
 ### Community 32 - "Match Logging"
-Cohesion: 0.12
-Nodes (13): MatchLogBuilder, ArbitrationLog, CandidateLog, FinalDecision, MatchLogEntry, StageLog, StageSkipReason, MatchLoggingPort (+5 more)
+Cohesion: 0.06
+Nodes (34): eSim, eX, eY, MatchLogBuilder, CreateAisleInput, CreateAislesBulkInput, DeleteAislesInput, MatchOrCreatePorts (+26 more)
 
 ### Community 33 - "List Page Routes"
 Cohesion: 0.07
-Nodes (15): allVisibleIds, handleBulkRegenerateIcon(), selectedApprovalIds, selection, topApprovalItems, allIds, selection, visibleItems (+7 more)
+Nodes (16): allVisibleIds, handleBulkApprove(), handleBulkRegenerateIcon(), selectedApprovalIds, selection, topApprovalItems, allIds, selection (+8 more)
 
 ### Community 34 - "Cloud Function Callables"
-Cohesion: 0.08
-Nodes (24): beforeMemberCreated, posthogApiKey, regenerateCanonIcon, populateEquipmentEntryFlow, reporter, reportFlowError(), registerGenkitDevTracing(), APP_CHECK_ENFORCEMENT (+16 more)
+Cohesion: 0.07
+Nodes (25): beforeMemberCreated, posthogApiKey, regenerateCanonIcon, chefChatFlow, generateChatTitleFlow, identifyEquipmentFlow, populateEquipmentEntryFlow, registerGenkitDevTracing() (+17 more)
 
 ### Community 35 - "Slider"
 Cohesion: 0.14
 Nodes (18): ../../src/primitives/Slider/Slider.svelte, activeThumbIdx, sliderState, SliderProps, SliderRangeProps, SliderThumbProps, SliderTrackProps, SliderRootVariants (+10 more)
 
 ### Community 36 - "Entities"
-Cohesion: 0.21
-Nodes (16): clearIngredientMatch(), Ingredient, IngredientGroup, MatchState, ParsedIngredient, MixedQuantity, Quantity, RangeQuantity (+8 more)
+Cohesion: 0.32
+Nodes (9): clearIngredientMatch(), Ingredient, MatchState, ParsedIngredient, MixedQuantity, Quantity, RangeQuantity, SingleQuantity (+1 more)
 
 ### Community 37 - "Lib"
 Cohesion: 0.14
 Nodes (23): ../../lib/aiModelCatalogService.js, applyCatalog(), _byRole, catalogByRole, emptyByRole(), ensureCatalog(), _fetchedAt, hasCatalog (+15 more)
 
 ### Community 38 - "Sheet"
-Cohesion: 0.13
-Nodes (13): ../../primitives/Sheet/Sheet.svelte, SheetContentProps, SheetPartProps, SheetProps, SheetSide, SheetContentVariants, ../../primitives/Sheet/SheetContent.svelte, ../../primitives/Sheet/SheetHeader.svelte (+5 more)
+Cohesion: 0.09
+Nodes (20): ../../primitives/EmptyState/EmptyState.svelte, EmptyStateProps, svelte-exmarkdown/gfm, ../../primitives/Sheet/Sheet.svelte, SheetContentProps, SheetPartProps, SheetProps, SheetSide (+12 more)
 
 ### Community 39 - "Button"
-Cohesion: 0.11
-Nodes (10): ../../primitives/Button/Button.svelte, ButtonProps, ButtonVariants, FormPageProps, ../../primitives/Spinner/Spinner.svelte, SpinnerProps, ../../headless/Button.headless.svelte, ./Button.types (+2 more)
+Cohesion: 0.07
+Nodes (17): ../../primitives/Button/Button.svelte, ButtonProps, ButtonVariants, DetailPageProps, ../../primitives/ErrorState/ErrorState.svelte, ErrorStateProps, FormPageProps, ../../primitives/Icon/Icon.svelte (+9 more)
 
 ### Community 40 - "Card"
 Cohesion: 0.22
@@ -495,16 +502,16 @@ Cohesion: 0.17
 Nodes (16): ../../src/primitives/Toast/Toast.svelte, ToastActionProps, ToastPartProps, ToastProps, ToastProviderProps, ToastViewportProps, ToastVariants, ../../src/primitives/Toast/ToastAction.svelte (+8 more)
 
 ### Community 42 - "Lib"
-Cohesion: 0.14
-Nodes (23): ../../lib/chatService.js, applySnapshot(), createChatSession(), getErrorReporter(), initChatSync(), isLoadingSessions, latestLocalEdit, newSession() (+15 more)
+Cohesion: 0.12
+Nodes (28): ../../lib/chatService.js, applySnapshot(), createChatSession(), getChatSessionsSnapshot(), getErrorReporter(), initChatSync(), isLoadingSessions, latestLocalEdit (+20 more)
 
 ### Community 43 - "Recipes"
 Cohesion: 0.08
 Nodes (19): activeSession, addToListOpen, amendBusy, canonalising, current, deleteBusy, deleteOpen, existingTags (+11 more)
 
 ### Community 44 - "Sidenav"
-Cohesion: 0.11
-Nodes (11): AppShellProps, BottomNavProps, NavItem, adminNavItem, navItems, SideNavProps, TopBarProps, ./AppShell.types (+3 more)
+Cohesion: 0.13
+Nodes (9): AppShellProps, BottomNavProps, NavItem, SideNavProps, TopBarProps, ./AppShell.types, ./BottomNav.types, ./SideNav.types (+1 more)
 
 ### Community 45 - "Radiogroup"
 Cohesion: 0.13
@@ -512,39 +519,39 @@ Nodes (16): ../../src/primitives/RadioGroup/RadioGroup.svelte, descId, described
 
 ### Community 46 - "Server"
 Cohesion: 0.17
-Nodes (21): AiGenerationEvent, AiGenerationUsage, captureAiGeneration(), captureServerEvent(), captureServerException(), flushServerObservability(), ObservabilitySpan, OTEL_SPAN (+13 more)
+Nodes (19): AiGenerationEvent, AiGenerationUsage, captureAiGeneration(), captureServerEvent(), captureServerException(), flushServerObservability(), isServerObservabilityInitialised(), ObservabilitySpan (+11 more)
 
 ### Community 47 - "Lib"
-Cohesion: 0.21
-Nodes (16): ../../lib/appSettingsService.js, buildNext(), buildNextFlow(), currentDoc(), effectiveFlowModels, effectiveModels, initAppSettingsSync(), _isCorrupt (+8 more)
+Cohesion: 0.20
+Nodes (17): ../../lib/appSettingsService.js, buildNext(), buildNextFlow(), currentDoc(), effectiveFlowModels, effectiveModels, initAppSettingsSync(), _isCorrupt (+9 more)
 
 ### Community 48 - "Design"
-Cohesion: 0.11
-Nodes (19): Adapter Sibling Non-Import Rule, AI / Genkit conventions, Data model conventions, Enforcement, Family-Shared Data Model (no user scoping), AI Access via Genkit Callables, graphify, Hard rules (+11 more)
+Cohesion: 0.10
+Nodes (21): Adapter Sibling Non-Import Rule, AI / Genkit conventions, Data model conventions, Enforcement, Family-Shared Data Model (no user scoping), AI Access via Genkit Callables, graphify, Hard rules (+13 more)
 
 ### Community 49 - "Ai"
-Cohesion: 0.18
-Nodes (13): ensureObservabilityInitialised(), initServerObservability(), isServerObservabilityInitialised(), createPosthogServerErrorReportingAdapter(), isReportableCategory(), SUPPRESSED_CATEGORIES, initObservability(), createPosthogErrorReportingAdapter() (+5 more)
+Cohesion: 0.19
+Nodes (12): ensureObservabilityInitialised(), initServerObservability(), createPosthogServerErrorReportingAdapter(), isReportableCategory(), SUPPRESSED_CATEGORIES, initObservability(), createPosthogErrorReportingAdapter(), { clientCapture, clientInit, serverCapture, FakePostHog } (+4 more)
 
 ### Community 50 - "Lib"
-Cohesion: 0.13
-Nodes (16): ../admin/AdminGuard.svelte, isAdmin, settled, tools, @salt/domain, ../../lib/titleCase.js, ../../lib/toastStore.js, AddToastOptions (+8 more)
+Cohesion: 0.12
+Nodes (17): ../admin/AdminGuard.svelte, isAdmin, settled, tools, @salt/domain, @salt/firebase-sync, ../../lib/titleCase.js, ../../lib/toastStore.js (+9 more)
 
 ### Community 51 - "Canon"
-Cohesion: 0.12
-Nodes (13): mockGet, importRecipeFromUrl(), @salt/domain/schemas, saveAppSettings(), subscribeAppSettings(), callExtractRecipeFromUrl(), classifyUrlImportError(), ErrorCallback (+5 more)
-
-### Community 52 - "Tests"
 Cohesion: 0.17
 Nodes (13): emptyIngredientGroup(), emptyRecipe(), newIngredient(), newStep(), matchedIngredient(), messyRecipe(), makeMatchedIngredient(), makeRecipe() (+5 more)
 
+### Community 52 - "Tests"
+Cohesion: 0.25
+Nodes (7): After a restore — re-apply staging-only config, One-time setup, Refreshing staging with prod data, Safety, Scope, Usage, Why managed export/import (and not a copy script)
+
 ### Community 53 - "Docs"
-Cohesion: 0.09
-Nodes (25): Cross-Project Import IAM (objectViewer + legacyBucketReader), Managed Export/Import (no triggers), Prod -> Staging Firestore Refresh Flow, Staging-Only Hard Refuse Safety Guard, Task Pilot Sidebar Tasks, Cutting a release (promote staging → production), Deploying, Firebase projects (`.firebaserc` aliases) (+17 more)
+Cohesion: 0.13
+Nodes (8): addItem(), clearCheckedItems(), createList(), deleteList(), renameList(), setDefaultList(), uncheckItem(), UncheckItemInput
 
 ### Community 54 - "Detailpage"
-Cohesion: 0.13
-Nodes (9): DetailPageProps, ../../primitives/ErrorState/ErrorState.svelte, ErrorStateProps, ../../primitives/Icon/Icon.svelte, IconProps, _bad, ./ErrorState.types, ./Icon.types (+1 more)
+Cohesion: 0.18
+Nodes (13): Cross-Project Import IAM (objectViewer + legacyBucketReader), Managed Export/Import (no triggers), Prod -> Staging Firestore Refresh Flow, Staging-Only Hard Refuse Safety Guard, Task Pilot Sidebar Tasks, Batched Embedding Cache (no stage-5 fork), matchOrCreateBatch Three-Phase Orchestrator, matchOrCreateCanon CF Callable (+5 more)
 
 ### Community 55 - "Observability"
 Cohesion: 0.11
@@ -584,15 +591,15 @@ Nodes (13): coerceDurationMinutes(), coerceServings(), coerceTags(), coerceText(
 
 ### Community 64 - "Canon"
 Cohesion: 0.10
-Nodes (15): fakeStore(), BASE, BASE, renameAisle(), reorderAisles(), Aisle, AislesDocument, ShoppingList (+7 more)
+Nodes (8): AISLES, deleteAisles(), ItemMergeChoice, mergeAisles(), MergeAislesInput, PerItemMergeChoice, CanonLocalStorePort, getAisleUsage()
 
 ### Community 65 - "Canon Matching"
 Cohesion: 0.23
 Nodes (12): canon.match PostHog Event, Fire-and-Forget Logging, MatchLogBuilder, MatchLogEntry Schema, MatchLoggingPort Contract, createPosthogMatchLoggingAdapter (browser), createPosthogServerMatchLoggingAdapter (CF), createServerMatchLoggingAdapter (firebase-functions/logger) (+4 more)
 
 ### Community 66 - "Canon"
-Cohesion: 0.17
-Nodes (6): createList(), deleteList(), editItemRawText(), EditItemRawTextInput, renameList(), setDefaultList()
+Cohesion: 0.29
+Nodes (7): 10.1 Overview, 10.2 `createListSelection(options)`, 10.3 Component props, 10.4 Behaviour, 10.5 Accessibility, 10.6 Testing requirements, 10. List selection (`createListSelection` + `SelectableList` / `SelectAllCheckbox` / `RowSelectCheckbox`)
 
 ### Community 67 - "E2E"
 Cohesion: 0.21
@@ -608,15 +615,15 @@ Nodes (12): MealPlanConfigDoc, MealPlanConfigSchema, AttendeeDoc, AttendeeSchema
 
 ### Community 70 - "Tests"
 Cohesion: 0.12
-Nodes (5): runWithExtractedTraceContext(), SyncContextManager, TEST_KEY, TestPropagator, ThrowingPropagator
+Nodes (4): SyncContextManager, TEST_KEY, TestPropagator, ThrowingPropagator
 
 ### Community 71 - "Tooltip"
-Cohesion: 0.08
-Nodes (24): Authority and runtime, Batch entry point — recipe ingredient canonicalisation, Batched embedding without forking stage 5, Canon deletion is resolved at display time — never written back, Canon Item Matching Pipeline, Edits clear the match eagerly, Flow diagram, Growing snapshot (+16 more)
+Cohesion: 0.12
+Nodes (17): Authority and runtime, Batch entry point — recipe ingredient canonicalisation, Batched embedding without forking stage 5, Canon deletion is resolved at display time — never written back, Canon Item Matching Pipeline, Edits clear the match eagerly, Flow diagram, Growing snapshot (+9 more)
 
 ### Community 72 - "Sections"
-Cohesion: 0.33
-Nodes (6): 1.1 Technology Stack, 1.2 Boundaries, 1.3 Package Surface, 1.4 Event Naming Rule, 1.5 Spec Versioning & Amendment Rule, 1. Foundations
+Cohesion: 0.10
+Nodes (13): DialogContentProps, DialogPartProps, DialogProps, DialogContentVariants, PopoverContentProps, PopoverPartProps, PopoverProps, ../../headless/Dialog.headless.svelte (+5 more)
 
 ### Community 73 - "Docs"
 Cohesion: 0.22
@@ -627,16 +634,16 @@ Cohesion: 0.13
 Nodes (14): dependencies, firebase, @salt/domain, @salt/shared-types, devDependencies, @firebase/rules-unit-testing, exports, name (+6 more)
 
 ### Community 75 - "Flows"
-Cohesion: 0.15
-Nodes (13): createFirestoreAisleStore(), createFirestoreCanonStore(), createServerArbitrationAdapter(), createServerEmbeddingAdapter(), createServerMatchLoggingAdapter(), arbitrateCanonFlow, ArbitrationResultSchema, ItemResultSchema (+5 more)
+Cohesion: 0.18
+Nodes (13): createFirestoreAisleStore(), createFirestoreCanonStore(), createServerArbitrationAdapter(), createServerEmbeddingAdapter(), createServerMatchLoggingAdapter(), ItemResultSchema, OutputSchema, buildMatchOrCreatePorts() (+5 more)
 
 ### Community 76 - "Docs"
 Cohesion: 0.12
 Nodes (17): authorRecipe librarian flow (Flash, structured), Access & admin, Architecture placement, Canon interaction — batch CF, one read per recipe, Cross-module seams (already shipped, awaiting this module), Deferred: the AI-generation epic (own issue + design session), Document, Recipe module (+9 more)
 
 ### Community 77 - "Triggers"
-Cohesion: 0.22
-Nodes (5): EMULATOR_HOST, mockEmbed, mockGenerateIcon, mockRemoveBg, mockSave
+Cohesion: 0.14
+Nodes (7): mockGet, @salt/domain/schemas, EMULATOR_HOST, mockEmbed, mockGenerateIcon, mockRemoveBg, mockSave
 
 ### Community 78 - "Docs"
 Cohesion: 0.19
@@ -656,7 +663,7 @@ Nodes (14): esbuild, fast-xml-parser, firebase-admin>uuid, form-data@>=4.0.0 <4.
 
 ### Community 82 - "Src"
 Cohesion: 0.33
-Nodes (6): 4.2 Focus Ring, 4.3 Disabled + Loading, 4.5 Dark Mode, 4. Styling System, Disabled (terminal state — no interaction), Loading (transient state — disables interaction without terminal semantics)
+Nodes (6): 4.1 Tokens, Elevation, Motion, Radius, Semantic colors, Z-index
 
 ### Community 83 - "Queries"
 Cohesion: 0.16
@@ -682,13 +689,13 @@ Nodes (11): assertPortsFree(), findHubPid(), getOccupiedPorts(), hubIsRunning(),
 Cohesion: 0.10
 Nodes (10): [], allNotesSelected, formBody, formPublished, formTitle, isSubmitting, listSelectedCount, selectableSelectionMode (+2 more)
 
-### Community 89 - "Canon"
-Cohesion: 0.40
-Nodes (5): 1. Client config — build-time, committed, **not secret**, 2. Cloud Functions runtime secrets — Secret Manager, per project, **never committed**, 3. CI / GitHub Environments, Config & secrets — what lives where, WIF identifiers (provisioned — Phase 2)
+### Community 89 - "Community 89"
+Cohesion: 0.29
+Nodes (7): 8.4 Checkbox, Accessibility, Events, Forbidden, Props, Snippets, Styling
 
 ### Community 90 - "Chat"
-Cohesion: 0.14
-Nodes (10): existingTags, inputText, isApplying, isSavingRecipe, isSending, now, stamped, streamingText (+2 more)
+Cohesion: 0.17
+Nodes (9): existingTags, inputText, isApplying, isSavingRecipe, isSending, now, stamped, streamingText (+1 more)
 
 ### Community 91 - "Domain"
 Cohesion: 0.17
@@ -700,27 +707,27 @@ Nodes (7): collections, getCollection(), mockArbitrate, mockEmbed, readCanonStor
 
 ### Community 93 - "Shared"
 Cohesion: 0.06
-Nodes (50): callAuthorRecipe(), classifyError(), callMatchOrCreate(), WireBatchResult, WireResult, callGenerateChatTitle(), getErr(), streamChefChat() (+42 more)
+Nodes (52): subscribeAisles(), saveAppSettings(), deleteCanonItem(), subscribeCanonItems(), loadChatSession(), setAiStub(), IdentifyEquipmentCandidate, IdentifyEquipmentResult (+44 more)
 
 ### Community 94 - "Text"
 Cohesion: 0.21
 Nodes (5): _bad, TextProps, TextVariants, ./Text.types, ./Text.variants
 
 ### Community 95 - "Ai"
-Cohesion: 0.22
-Nodes (12): seed, eX, failEmbedding(), makeAisleStore(), makeIds(), makePorts(), makeStore(), noMatchArbitration() (+4 more)
+Cohesion: 0.16
+Nodes (15): seed, eX, failEmbedding(), makeAisleStore(), makeIds(), makePorts(), makeStore(), noMatchArbitration() (+7 more)
 
 ### Community 96 - "Triggers"
-Cohesion: 0.11
-Nodes (21): AiTimeoutError, raceWithTimeout(), withAiTimeout(), WithAiTimeoutOptions, AiCatalogModel, bareId(), CacheEntry, CatalogModelSchema (+13 more)
+Cohesion: 0.12
+Nodes (19): AiTimeoutError, raceWithTimeout(), withAiTimeout(), WithAiTimeoutOptions, AiCatalogModel, bareId(), CacheEntry, CatalogModelSchema (+11 more)
 
 ### Community 97 - "Docs"
-Cohesion: 0.11
-Nodes (23): Domain Purity Rule, Last-Write-Wins Per Document, No IndexedDB / Firestore persistentLocalCache Rule, CanonLookupPort, Canon Module (worked example), Coordinators (cross-module workflows), Cross-Cutting Ports (ErrorReporting, MatchLogging), Module Boundary Rule (index.ts only) (+15 more)
+Cohesion: 0.12
+Nodes (21): Domain Purity Rule, No IndexedDB / Firestore persistentLocalCache Rule, CanonLookupPort, Canon Module (worked example), Coordinators (cross-module workflows), Cross-Cutting Ports (ErrorReporting, MatchLogging), Module Boundary Rule (index.ts only), Domain Module Pattern Guide (+13 more)
 
 ### Community 98 - "Commands"
-Cohesion: 0.33
-Nodes (6): 4.4 Shared Size Scale, Control Size Scale (Checkbox, Switch), Dialog Size Scale, Field Size Scale (TextField, Textarea frame, Button), Icon / Spinner sizes, Text Size Scale (Text primitive)
+Cohesion: 0.14
+Nodes (14): AisleGroup, AisleInfo, AisleRow, AmountSubtotal, buildSubtotals(), CanonInfo, GroupedShoppingList, groupItemsByAisle() (+6 more)
 
 ### Community 99 - "Progress"
 Cohesion: 0.24
@@ -751,8 +758,8 @@ Cohesion: 0.20
 Nodes (9): compilerOptions, composite, module, moduleResolution, outDir, rootDir, extends, include (+1 more)
 
 ### Community 106 - "Heading"
-Cohesion: 0.24
-Nodes (4): HeadingProps, HeadingVariants, ./Heading.types, ./Heading.variants
+Cohesion: 0.21
+Nodes (6): local, remote, mergeCanonItems(), unionSynonyms(), ConflictStrategy, resolveCanonConflict()
 
 ### Community 107 - "Lib"
 Cohesion: 0.20
@@ -791,12 +798,12 @@ Cohesion: 0.22
 Nodes (8): compilerOptions, composite, lib, outDir, rootDir, extends, include, references
 
 ### Community 116 - "Src"
-Cohesion: 0.28
-Nodes (5): getChatSessionsSnapshot(), installE2EHooks(), getEquipmentSnapshot(), registerServiceWorker(), getRecipesSnapshot()
+Cohesion: 0.14
+Nodes (23): ../../lib/aisleService.js, addAisle(), addAislesBulk(), deleteAisles(), idGen, mergeAisles(), renameAisle(), reorderAisles() (+15 more)
 
 ### Community 117 - "Src"
-Cohesion: 0.11
-Nodes (17): User, AuthProvider, authEmulatorConnected, connectAuthEmulatorOnce(), reportAuthFailure(), isAuthTransitioning(), setAuthTransitioning(), ErrorReportingPort (+9 more)
+Cohesion: 0.10
+Nodes (19): User, reportSubscriptionError(), authProvider, AuthProvider, authEmulatorConnected, connectAuthEmulatorOnce(), createFirebaseAuth(), reportAuthFailure() (+11 more)
 
 ### Community 118 - "Domain"
 Cohesion: 0.25
@@ -871,8 +878,8 @@ Cohesion: 0.29
 Nodes (6): compilerOptions, composite, outDir, rootDir, extends, include
 
 ### Community 137 - "Tests"
-Cohesion: 0.29
-Nodes (3): fs, { mockGetCanonItemsSnapshot }, parsedIngredient
+Cohesion: 0.16
+Nodes (10): IngredientGroup, Recipe, RecipeImage, RecipeMetadata, RecipeSource, Step, StepTimer, fs (+2 more)
 
 ### Community 138 - "Ui Components"
 Cohesion: 0.29
@@ -887,8 +894,8 @@ Cohesion: 0.33
 Nodes (3): FakeHttpsError, handler, { mockGet, mockDoc, mockCollection }
 
 ### Community 141 - "Combobox"
-Cohesion: 0.11
-Nodes (15): ShoppingListsConfig, subscribeAisles(), deleteCanonItem(), subscribeCanonItems(), loadShoppingListsConfig(), saveShoppingListsConfig(), subscribeShoppingListsConfig(), walkThroughCapture() (+7 more)
+Cohesion: 0.25
+Nodes (5): adminNavItem, navItems, $lib/observability, decoratedNavItems, needsApprovalCount
 
 ### Community 142 - "Design"
 Cohesion: 0.14
@@ -897,14 +904,6 @@ Nodes (15): Brand & Style, Buttons, Cards, Colors, Components, Elevation & Depth
 ### Community 143 - "Flows"
 Cohesion: 0.33
 Nodes (3): AiIngredient, mockGenerate, mockUUID
-
-### Community 144 - "Tests"
-Cohesion: 0.33
-Nodes (3): fs, parsedFlour, parseGroup
-
-### Community 145 - "Triggers"
-Cohesion: 0.12
-Nodes (8): local, remote, mergeCanonItems(), unionSynonyms(), ConflictStrategy, resolveCanonConflict(), EMULATOR_HOST, mockMatchOrCreate
 
 ### Community 146 - "Docs"
 Cohesion: 0.40
@@ -923,8 +922,8 @@ Cohesion: 0.40
 Nodes (4): CanonicaliseRecipeIngredientsInput, CanonicaliseRecipeIngredientsInputSchema, CanonicaliseRecipeIngredientsItem, CanonicaliseRecipeIngredientsItemSchema
 
 ### Community 150 - "Community 150"
-Cohesion: 0.26
-Nodes (6): PopoverContentProps, PopoverPartProps, PopoverProps, ../../headless/Popover.headless.svelte, ./Popover.types, ./Popover.variants
+Cohesion: 0.50
+Nodes (4): 8.12 Icon, Accessibility, Props, Styling
 
 ### Community 151 - "Scripts"
 Cohesion: 0.40
@@ -942,10 +941,6 @@ Nodes (4): Lucide Cooking Pot Glyph, Salt PWA Master Icon (Cooking Pot), PWA Mas
 Cohesion: 0.67
 Nodes (3): globalTeardown(), killE2eServer(), REPO_ROOT
 
-### Community 157 - "Community 157"
-Cohesion: 0.18
-Nodes (8): RecipeAddRow, CONFLICT_ERR, fs, { mockGetCanonItemsSnapshot }, NETWORK_ERR, { reportSpy }, STORAGE_ERR, SYNC_ERR
-
 ### Community 158 - "Scripts"
 Cohesion: 0.50
 Nodes (3): email, member, useEmulator
@@ -955,16 +950,16 @@ Cohesion: 0.83
 Nodes (3): functions_triggers_registered(), reachable(), healthcheck.sh script
 
 ### Community 161 - "Community 161"
-Cohesion: 0.14
-Nodes (18): readUsage(), tracedGenerate(), aiFakeEnabled(), aiModelLabel(), fakeModels, flowModel(), CacheEntry, DEFAULT_SETTINGS (+10 more)
+Cohesion: 0.13
+Nodes (20): readUsage(), tracedGenerate(), aiFakeEnabled(), aiModelLabel(), fakeModels, flowModel(), CacheEntry, DEFAULT_SETTINGS (+12 more)
 
 ### Community 162 - "Community 162"
 Cohesion: 0.24
 Nodes (9): ../../lib/devSettingsService.js, canonIconGenerationEnabled, DEFAULTS, initDevSettingsSync(), _isLoading, setCanonIconGenerationEnabled(), _settings, saveDevSettings() (+1 more)
 
 ### Community 164 - "Community 164"
-Cohesion: 0.33
-Nodes (3): loadCanonIconSeed(), GenerateCanonIconInputSchema, GenerateCanonIconOutputSchema
+Cohesion: 0.21
+Nodes (9): moveItems(), MoveItemsInput, MoveItemsResult, ShoppingListItem, CheckedBucket, GroupedByRecipe, groupItemsByRecipe(), ManualBucket (+1 more)
 
 ### Community 167 - "Assets"
 Cohesion: 1.00
@@ -995,12 +990,12 @@ Cohesion: 1.00
 Nodes (3): Task Pilot Tasks Icon, Task List Visualization, Task Pilot VS Code Extension
 
 ### Community 265 - "Community 265"
-Cohesion: 0.25
-Nodes (7): __resetShoppingListServiceForTest(), fs, NETWORK_ERR, { reportSpy }, STORAGE_ERR, SYNC_ERR, VALIDATION_ERR
+Cohesion: 0.10
+Nodes (19): ShoppingListsConfig, initShoppingListSync(), subscribeEquipmentManifest(), subscribeShoppingListsConfig(), subscribeShoppingLists(), clearFirestoreEmulator(), initFirebaseEmulator(), resetDefaultApp() (+11 more)
 
 ### Community 266 - "Community 266"
-Cohesion: 0.40
-Nodes (5): 3.5 Helpers, `src/lib/cn.ts`, `src/lib/context.ts`, `src/lib/useId.ts`, `src/lib/variants.ts`
+Cohesion: 0.18
+Nodes (8): RecipeAddRow, CONFLICT_ERR, fs, { mockGetCanonItemsSnapshot }, NETWORK_ERR, { reportSpy }, STORAGE_ERR, SYNC_ERR
 
 ### Community 267 - "Community 267"
 Cohesion: 0.12
@@ -1015,16 +1010,16 @@ Cohesion: 0.12
 Nodes (16): 9.1 Overview, 9.2 Behaviour, 9.3.1 `BulkAction` — declarative contextual bar, 9.3.2 Move / target picker, 9.3.3 Deferred bulk delete + Undo snackbar, 9.3 `ListPage` props changes, 9.4 Consuming-page contract (bindable prop), 9.5 Clearing selection on exit (+8 more)
 
 ### Community 270 - "Community 270"
-Cohesion: 0.11
-Nodes (17): Architecture Notes & Constraints, Blast Radius, Defect Spec, Definition of Done, Observed vs Expected, Open Questions / Decisions, Phase 1: [Name], Phase 2: [Name] (+9 more)
+Cohesion: 0.13
+Nodes (14): Architecture Notes & Constraints, Blast Radius, Defect Spec, Definition of Done, Observed vs Expected, Open Questions / Decisions, Reproduction, Root Cause (+6 more)
 
 ### Community 271 - "Community 271"
 Cohesion: 0.13
 Nodes (14): Architecture Notes, Behavior Contract, Current State & Motivation, Definition of Done, Open Questions / Decisions, Phase 1: [Name], Phase 2: [Name], Phases (+6 more)
 
 ### Community 272 - "Community 272"
-Cohesion: 0.15
-Nodes (14): 10.1 Overview, 10.2 `createListSelection(options)`, 10.3 Component props, 10.4 Behaviour, 10.5 Accessibility, 10.6 Testing requirements, 10. List selection (`createListSelection` + `SelectableList` / `SelectAllCheckbox` / `RowSelectCheckbox`), 13.1 `ToastViewport` — `pointer-events-none` container (+6 more)
+Cohesion: 0.18
+Nodes (12): 11.1 Overview, 11.2 Props, 11.3 Behaviour, 11.4 Testing requirements, 11. EditableRow (primitive), 13.1 `ToastViewport` — `pointer-events-none` container, 13.2 `BottomNav` — full-height tap targets (`items-stretch`), 13. Pinned interaction constraints (+4 more)
 
 ### Community 273 - "Community 273"
 Cohesion: 0.14
@@ -1047,20 +1042,24 @@ Cohesion: 0.15
 Nodes (13): A. Async settling & determinism, Appendix — evaluation of the generic best-practice list against Salt, B. Locators, C. Isolation & state, D. Realtime & cross-tab convergence  _(Salt-specific)_, E. AI & Cloud-Function trigger determinism  _(Salt-specific)_, F. Timeouts, G. Config & harness invariants (+5 more)
 
 ### Community 278 - "Community 278"
-Cohesion: 0.11
-Nodes (18): Create the working branch (once, before phase 1), Per-Phase Handoff Contract, Orchestrator/Subagent Pattern, Pause conditions (stop and wait for user), Run Issue, Setup (once), Architecture Notes, Definition of Done (+10 more)
+Cohesion: 0.17
+Nodes (11): Architecture Notes, Definition of Done, Feature Spec, Open Questions / Decisions, Phase 1: [Name], Phase 2: [Name], Phased GitHub Issue Structure, Phases (+3 more)
+
+### Community 279 - "Community 279"
+Cohesion: 0.46
+Nodes (4): AddItemInput, MatchState, SourceRef, ShoppingListItemPort
 
 ### Community 280 - "Community 280"
 Cohesion: 0.18
 Nodes (11): 10. Shared types requirements, 13. Deployment units, 14. Non-negotiables, 1.1 Schema evolution and production data, 1. Purpose, 2. Mono‑repo structure (logical modules), 4. Domain layer requirements, 5. Workspace and access model (+3 more)
 
 ### Community 281 - "Community 281"
-Cohesion: 0.40
-Nodes (5): 8.13 Layout Primitives — Stack / Inline / Grid / Divider, Divider, Grid, Inline, Stack
+Cohesion: 0.50
+Nodes (4): 8.14 Spinner, Accessibility, Props, Styling
 
 ### Community 282 - "Community 282"
-Cohesion: 0.40
-Nodes (5): 8.5 Switch, Accessibility, Events, Props, Styling
+Cohesion: 0.29
+Nodes (7): Create the working branch (once, before phase 1), Per-Phase Handoff Contract, Orchestrator/Subagent Pattern, Pause conditions (stop and wait for user), Run Issue, Setup (once), Intended Experience
 
 ### Community 283 - "Community 283"
 Cohesion: 0.20
@@ -1073,6 +1072,10 @@ Nodes (10): Authoring conventions, CI, E2E & emulator integration tests, Lifecyc
 ### Community 285 - "Community 285"
 Cohesion: 0.40
 Nodes (4): INPUT, mockFlush, mockGenerate, mockReport
+
+### Community 286 - "Community 286"
+Cohesion: 0.29
+Nodes (7): Stage 1 — Exact name match, Stage 2 — Token overlap, Stage 3 — Synonym exact match, Stage 4 — String similarity (Levenshtein), Stage 5 — Embedding cosine, Stage 6 — Merged shortlist + AI arbitration, Stage-by-stage narrative
 
 ### Community 287 - "Community 287"
 Cohesion: 0.22
@@ -1116,15 +1119,11 @@ Nodes (8): 3.1 Purpose, 3.2 Parts, 3.3 Root Props, 3.4 SelectTrigger Props, 3.5 
 
 ### Community 298 - "Community 298"
 Cohesion: 0.33
-Nodes (5): AisleDTO, AisleListDTO, CanonItemDTO, conflict, WriteResult
+Nodes (3): fs, parsedFlour, parseGroup
 
 ### Community 299 - "Community 299"
 Cohesion: 0.29
 Nodes (7): 3.1 Folder Structure, 3.2 Export Rules, 3.3 Tailwind + Token Ownership, 3.4 bits-ui / melt-ui Versions, 3.7 bits-ui Mapping Table, 3.8 Provenance Header Convention, 3. Component Architecture
-
-### Community 300 - "Community 300"
-Cohesion: 0.29
-Nodes (7): 8.4 Checkbox, Accessibility, Events, Forbidden, Props, Snippets, Styling
 
 ### Community 301 - "Community 301"
 Cohesion: 0.29
@@ -1163,20 +1162,20 @@ Cohesion: 0.29
 Nodes (6): Agentic search, Available MCP tools, Multi-Repo, Smart Features, vexp context tools <!-- vexp v2.0.23 -->, Workflow
 
 ### Community 310 - "Community 310"
-Cohesion: 0.40
-Nodes (5): 11.1 Overview, 11.2 Props, 11.3 Behaviour, 11.4 Testing requirements, 11. EditableRow (primitive)
+Cohesion: 0.33
+Nodes (6): 1.1 Technology Stack, 1.2 Boundaries, 1.3 Package Surface, 1.4 Event Naming Rule, 1.5 Spec Versioning & Amendment Rule, 1. Foundations
 
 ### Community 311 - "Community 311"
 Cohesion: 0.33
-Nodes (6): 4.1 Tokens, Elevation, Motion, Radius, Semantic colors, Z-index
+Nodes (6): 4.2 Focus Ring, 4.3 Disabled + Loading, 4.5 Dark Mode, 4. Styling System, Disabled (terminal state — no interaction), Loading (transient state — disables interaction without terminal semantics)
 
 ### Community 312 - "Community 312"
 Cohesion: 0.40
 Nodes (5): Before/after check in PostHog Error Tracking, Caught-error reporting — calibration note, Known, intentional asymmetries (NOT bugs), No raw user content in payloads, Uncaught errors — separate, automatic path
 
 ### Community 313 - "Community 313"
-Cohesion: 0.50
-Nodes (4): 8.14 Spinner, Accessibility, Props, Styling
+Cohesion: 0.33
+Nodes (6): 4.4 Shared Size Scale, Control Size Scale (Checkbox, Switch), Dialog Size Scale, Field Size Scale (TextField, Textarea frame, Button), Icon / Spinner sizes, Text Size Scale (Text primitive)
 
 ### Community 314 - "Community 314"
 Cohesion: 0.33
@@ -1190,9 +1189,25 @@ Nodes (6): 8.7 Popover, Events (Root), Parts, Props (Content), Props (Root), Sty
 Cohesion: 0.33
 Nodes (6): 12. Testing strategy, Cloud Functions, Domain, firebase-sync, observability, UI
 
-### Community 322 - "Community 322"
+### Community 317 - "Community 317"
+Cohesion: 0.40
+Nodes (5): 3.5 Helpers, `src/lib/cn.ts`, `src/lib/context.ts`, `src/lib/useId.ts`, `src/lib/variants.ts`
+
+### Community 318 - "Community 318"
+Cohesion: 0.40
+Nodes (5): 8.13 Layout Primitives — Stack / Inline / Grid / Divider, Divider, Grid, Inline, Stack
+
+### Community 319 - "Community 319"
+Cohesion: 0.40
+Nodes (5): 8.5 Switch, Accessibility, Events, Props, Styling
+
+### Community 320 - "Community 320"
 Cohesion: 0.50
-Nodes (4): 8.12 Icon, Accessibility, Props, Styling
+Nodes (3): ErrorCallback, { mockUnsubscribe, mockOnSnapshot, mockSetDoc, mockDoc, mockGetFirestore }, SnapCallback
+
+### Community 322 - "Community 322"
+Cohesion: 0.67
+Nodes (3): Phase 1: [Name], Phase 2: [Name], Phases
 
 ### Community 324 - "Community 324"
 Cohesion: 0.50
@@ -1214,25 +1229,33 @@ Nodes (4): 3. Dependency graph (allowed imports), Allowed, Forbidden, Narrow exc
 Cohesion: 0.50
 Nodes (4): 6.1 firebase-sync adapter, 6.2 observability adapter, 6.3 Common rules, 6. Adapter requirements
 
+### Community 329 - "Community 329"
+Cohesion: 0.24
+Nodes (4): HeadingProps, HeadingVariants, ./Heading.types, ./Heading.variants
+
+### Community 331 - "Community 331"
+Cohesion: 0.60
+Nodes (3): getInput(), openCombobox(), setup()
+
 ## Knowledge Gaps
-- **1372 isolated node(s):** `husky.sh script`, `name`, `version`, `private`, `type` (+1367 more)
+- **1384 isolated node(s):** `husky.sh script`, `name`, `version`, `private`, `type` (+1379 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **51 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **54 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `NavItem` connect `Sidenav` to `Combobox & ListPage Types`?**
-  _High betweenness centrality (0.152) - this node is a cross-community bridge._
-- **Why does `CanonItem` connect `Canon Matching Core` to `Firebase-Sync Shopping Config`, `Canon Approval UI`, `E2E Test Suite`, `Firestore Stores & Classify`, `Tests`, `Combobox`, `Canon Fast-Path Parity`, `Triggers`, `Community 275`, `Community 279`, `Recipe Service`, `Community 286`, `List Page Routes`, `Canon`, `Community 317`, `Community 318`, `Canon`, `Flows`, `Ai`, `Triggers`, `Tests`, `Src`?**
-  _High betweenness centrality (0.061) - this node is a cross-community bridge._
-- **Why does `../../lib/recipeService.js` connect `Recipe Service` to `Firebase-Sync Shopping Config`, `Canon Approval UI`, `Shopping List Commands`, `Shopping List UI`, `Tests`, `Canon Matching Core`, `Tests`, `Admin Routes`, `Community 157`, `Entities`, `Lib`, `Recipes`, `Lib`, `Canon`, `Tests`, `Canon`, `Chat`, `Shared`, `Recipes`, `Tests`, `Src`?**
-  _High betweenness centrality (0.061) - this node is a cross-community bridge._
+- **Why does `NavItem` connect `Sidenav` to `Combobox`, `Combobox Primitive`?**
+  _High betweenness centrality (0.142) - this node is a cross-community bridge._
+- **Why does `../../lib/recipeService.js` connect `Recipe Service` to `Canon Approval UI`, `Shopping List Commands`, `Firestore Stores & Classify`, `Shopping List UI`, `Tests`, `Community 266`, `Canon Matching Core`, `Combobox`, `Community 279`, `Entities`, `Community 298`, `Recipes`, `Lib`, `Canon`, `Docs`, `Triggers`, `Chat`, `Shared`, `Recipes`, `Tests`, `Src`, `Src`?**
+  _High betweenness centrality (0.056) - this node is a cross-community bridge._
+- **Why does `DomainError` connect `Firestore Stores & Classify` to `Meal Planner & Attendees`, `Canon Approval UI`, `Shopping List Commands`, `Shopping List UI`, `Equipment & Rules`, `Members Management`, `Canon Matching Core`, `Community 265`, `Community 266`, `Canon Fast-Path Parity`, `Community 279`, `Recipe Service`, `Match Logging`, `Community 161`, `Community 162`, `Community 164`, `Lib`, `Lib`, `Lib`, `Ai`, `Docs`, `Canon`, `Community 323`, `Queries`, `Shared`, `Ai`, `Src`, `Src`?**
+  _High betweenness centrality (0.044) - this node is a cross-community bridge._
 - **What connects `husky.sh script`, `name`, `version` to the rest of the system?**
-  _1392 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1404 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Meal Planner & Attendees` be split into smaller, more focused modules?**
-  _Cohesion score 0.05028011204481793 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.0573225516621743 - nodes in this community are weakly interconnected._
 - **Should `Aisles & Canon Stores` be split into smaller, more focused modules?**
-  _Cohesion score 0.13213213213213212 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.11764705882352941 - nodes in this community are weakly interconnected._
 - **Should `Canon Approval UI` be split into smaller, more focused modules?**
-  _Cohesion score 0.06980392156862746 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.08780487804878048 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -651,7 +651,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "apps_cloud_functions_src_boundary_tests_no_stage_internals_ts_boundary_tests_no_stage_internals",
-      "community": 7,
+      "community": 32,
       "norm_label": "no-stage-internals.ts"
     },
     {
@@ -661,7 +661,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_firestoreaislestore",
-      "community": 64,
+      "community": 7,
       "norm_label": "firestoreaislestore.ts"
     },
     {
@@ -671,7 +671,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "adapters_firestoreaislestore_classify",
-      "community": 64,
+      "community": 7,
       "norm_label": "classify()"
     },
     {
@@ -691,7 +691,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_firestorecanonstore",
-      "community": 64,
+      "community": 7,
       "norm_label": "firestorecanonstore.ts"
     },
     {
@@ -701,7 +701,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "adapters_firestorecanonstore_classify",
-      "community": 64,
+      "community": 7,
       "norm_label": "classify()"
     },
     {
@@ -851,7 +851,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "adapters_serverarbitration",
-      "community": 75,
+      "community": 32,
       "norm_label": "serverarbitration.ts"
     },
     {
@@ -1601,7 +1601,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_dev",
-      "community": 75,
+      "community": 161,
       "norm_label": "dev.ts"
     },
     {
@@ -1611,7 +1611,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_arbitratecanon",
-      "community": 75,
+      "community": 161,
       "norm_label": "arbitratecanon.ts"
     },
     {
@@ -1621,7 +1621,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "flows_arbitratecanon_arbitrationresultschema",
-      "community": 75,
+      "community": 161,
       "norm_label": "arbitrationresultschema"
     },
     {
@@ -1631,7 +1631,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "flows_arbitratecanon_arbitratecanonflow",
-      "community": 75,
+      "community": 161,
       "norm_label": "arbitratecanonflow"
     },
     {
@@ -1641,7 +1641,7 @@
       "source_location": "L101",
       "_origin": "ast",
       "id": "flows_arbitratecanon_buildprompt",
-      "community": 75,
+      "community": 161,
       "norm_label": "buildprompt()"
     },
     {
@@ -1651,7 +1651,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "assets_canoniconseed",
-      "community": 164,
+      "community": 29,
       "norm_label": "canoniconseed.ts"
     },
     {
@@ -1661,7 +1661,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "assets_canoniconseed_loadcanoniconseed",
-      "community": 164,
+      "community": 29,
       "norm_label": "loadcanoniconseed()"
     },
     {
@@ -1791,7 +1791,7 @@
       "source_location": "L99",
       "_origin": "ast",
       "id": "flows_chefchat_chefchatflow",
-      "community": 161,
+      "community": 34,
       "norm_label": "chefchatflow"
     },
     {
@@ -1821,7 +1821,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "flows_embedtext_embedtextflow",
-      "community": 161,
+      "community": 29,
       "norm_label": "embedtextflow"
     },
     {
@@ -1931,7 +1931,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_generatecanonicon",
-      "community": 164,
+      "community": 29,
       "norm_label": "generatecanonicon.ts"
     },
     {
@@ -1941,7 +1941,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "flows_generatecanonicon_buildiconprompt",
-      "community": 164,
+      "community": 29,
       "norm_label": "buildiconprompt()"
     },
     {
@@ -1951,7 +1951,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "flows_generatecanonicon_parsedataurl",
-      "community": 164,
+      "community": 29,
       "norm_label": "parsedataurl()"
     },
     {
@@ -1961,7 +1961,7 @@
       "source_location": "L47",
       "_origin": "ast",
       "id": "flows_generatecanonicon_generatecanoniconinputschema",
-      "community": 164,
+      "community": 29,
       "norm_label": "generatecanoniconinputschema"
     },
     {
@@ -1971,7 +1971,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "flows_generatecanonicon_generatecanoniconoutputschema",
-      "community": 164,
+      "community": 29,
       "norm_label": "generatecanoniconoutputschema"
     },
     {
@@ -1991,7 +1991,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "flows_generatechattitle",
-      "community": 96,
+      "community": 161,
       "norm_label": "generatechattitle.ts"
     },
     {
@@ -2001,7 +2001,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "flows_generatechattitle_inputschema",
-      "community": 96,
+      "community": 161,
       "norm_label": "inputschema"
     },
     {
@@ -2011,7 +2011,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "flows_generatechattitle_generatechattitleflow",
-      "community": 96,
+      "community": 34,
       "norm_label": "generatechattitleflow"
     },
     {
@@ -2031,7 +2031,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "flows_identifyequipment_identifyequipmentflow",
-      "community": 161,
+      "community": 34,
       "norm_label": "identifyequipmentflow"
     },
     {
@@ -2058,7 +2058,7 @@
       "label": "OutputSchema",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/matchOrCreateCanon.ts",
-      "source_location": "L31",
+      "source_location": "L32",
       "_origin": "ast",
       "id": "flows_matchorcreatecanon_outputschema",
       "community": 75,
@@ -2068,7 +2068,7 @@
       "label": "composeMatchLogging()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/matchOrCreateCanon.ts",
-      "source_location": "L45",
+      "source_location": "L46",
       "_origin": "ast",
       "id": "flows_matchorcreatecanon_composematchlogging",
       "community": 75,
@@ -2078,7 +2078,7 @@
       "label": "buildMatchOrCreatePorts()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/matchOrCreateCanon.ts",
-      "source_location": "L53",
+      "source_location": "L54",
       "_origin": "ast",
       "id": "flows_matchorcreatecanon_buildmatchorcreateports",
       "community": 75,
@@ -2088,7 +2088,7 @@
       "label": "ensureObservabilityInitialised()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/matchOrCreateCanon.ts",
-      "source_location": "L68",
+      "source_location": "L69",
       "_origin": "ast",
       "id": "flows_matchorcreatecanon_ensureobservabilityinitialised",
       "community": 49,
@@ -2098,7 +2098,7 @@
       "label": "matchOrCreateCanonFlow",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/flows/matchOrCreateCanon.ts",
-      "source_location": "L80",
+      "source_location": "L81",
       "_origin": "ast",
       "id": "flows_matchorcreatecanon_matchorcreatecanonflow",
       "community": 75,
@@ -2298,7 +2298,7 @@
       "label": "geminiApiKey",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L67",
+      "source_location": "L80",
       "_origin": "ast",
       "id": "src_index_geminiapikey",
       "community": 34,
@@ -2308,7 +2308,7 @@
       "label": "posthogApiKey",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L71",
+      "source_location": "L84",
       "_origin": "ast",
       "id": "src_index_posthogapikey",
       "community": 34,
@@ -2318,7 +2318,7 @@
       "label": "APP_CHECK_ENFORCEMENT",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L77",
+      "source_location": "L90",
       "_origin": "ast",
       "id": "src_index_app_check_enforcement",
       "community": 34,
@@ -2328,7 +2328,7 @@
       "label": "embedText",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L79",
+      "source_location": "L92",
       "_origin": "ast",
       "id": "src_index_embedtext",
       "community": 34,
@@ -2338,7 +2338,7 @@
       "label": "arbitrateCanon",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L88",
+      "source_location": "L101",
       "_origin": "ast",
       "id": "src_index_arbitratecanon",
       "community": 34,
@@ -2348,7 +2348,7 @@
       "label": "matchOrCreateCanon",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L113",
+      "source_location": "L131",
       "_origin": "ast",
       "id": "src_index_matchorcreatecanon",
       "community": 34,
@@ -2358,7 +2358,7 @@
       "label": "canonicaliseRecipeIngredients",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L155",
+      "source_location": "L173",
       "_origin": "ast",
       "id": "src_index_canonicaliserecipeingredients",
       "community": 34,
@@ -2368,7 +2368,7 @@
       "label": "identifyEquipment",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L186",
+      "source_location": "L202",
       "_origin": "ast",
       "id": "src_index_identifyequipment",
       "community": 34,
@@ -2378,7 +2378,7 @@
       "label": "populateEquipmentEntry",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L197",
+      "source_location": "L213",
       "_origin": "ast",
       "id": "src_index_populateequipmententry",
       "community": 34,
@@ -2388,7 +2388,7 @@
       "label": "parseRecipeIngredients",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L208",
+      "source_location": "L224",
       "_origin": "ast",
       "id": "src_index_parserecipeingredients",
       "community": 34,
@@ -2398,7 +2398,7 @@
       "label": "authorRecipe",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L221",
+      "source_location": "L242",
       "_origin": "ast",
       "id": "src_index_authorrecipe",
       "community": 34,
@@ -2408,7 +2408,7 @@
       "label": "mapUrlImportFailure()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L254",
+      "source_location": "L273",
       "_origin": "ast",
       "id": "src_index_mapurlimportfailure",
       "community": 34,
@@ -2418,7 +2418,7 @@
       "label": "extractRecipeFromUrl",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L276",
+      "source_location": "L295",
       "_origin": "ast",
       "id": "src_index_extractrecipefromurl",
       "community": 34,
@@ -2428,7 +2428,7 @@
       "label": "chefChat",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L314",
+      "source_location": "L332",
       "_origin": "ast",
       "id": "src_index_chefchat",
       "community": 34,
@@ -2438,7 +2438,7 @@
       "label": "generateChatTitle",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L324",
+      "source_location": "L346",
       "_origin": "ast",
       "id": "src_index_generatechattitle",
       "community": 34,
@@ -2448,7 +2448,7 @@
       "label": "reportUnexpected()",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L345",
+      "source_location": "L367",
       "_origin": "ast",
       "id": "src_index_reportunexpected",
       "community": 34,
@@ -2458,7 +2458,7 @@
       "label": "listAiModels",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L354",
+      "source_location": "L376",
       "_origin": "ast",
       "id": "src_index_listaimodels",
       "community": 34,
@@ -2468,11 +2468,41 @@
       "label": "testModel",
       "file_type": "code",
       "source_file": "apps/cloud-functions/src/index.ts",
-      "source_location": "L362",
+      "source_location": "L384",
       "_origin": "ast",
       "id": "src_index_testmodel",
       "community": 34,
       "norm_label": "testmodel"
+    },
+    {
+      "label": "environment.ts",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/src/observability/environment.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "observability_environment",
+      "community": 75,
+      "norm_label": "environment.ts"
+    },
+    {
+      "label": "PROJECT_ENVIRONMENTS",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/src/observability/environment.ts",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "observability_environment_project_environments",
+      "community": 75,
+      "norm_label": "project_environments"
+    },
+    {
+      "label": "resolveServerEnvironment()",
+      "file_type": "code",
+      "source_file": "apps/cloud-functions/src/observability/environment.ts",
+      "source_location": "L22",
+      "_origin": "ast",
+      "id": "observability_environment_resolveserverenvironment",
+      "community": 75,
+      "norm_label": "resolveserverenvironment()"
     },
     {
       "label": "reportServerError.ts",
@@ -2481,7 +2511,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "observability_reportservererror",
-      "community": 34,
+      "community": 161,
       "norm_label": "reportservererror.ts"
     },
     {
@@ -2491,7 +2521,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "observability_reportservererror_reporter",
-      "community": 34,
+      "community": 161,
       "norm_label": "reporter"
     },
     {
@@ -2511,7 +2541,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "observability_reportservererror_reportflowerror",
-      "community": 34,
+      "community": 161,
       "norm_label": "reportflowerror()"
     },
     {
@@ -2831,7 +2861,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ai_resolvemodel_test",
-      "community": 51,
+      "community": 77,
       "norm_label": "resolvemodel.test.ts"
     },
     {
@@ -2841,7 +2871,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "ai_resolvemodel_test_mockget",
-      "community": 51,
+      "community": 77,
       "norm_label": "mockget"
     },
     {
@@ -6210,7 +6240,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "apps_web_pwa_src_app_svelte_src_app",
-      "community": 20,
+      "community": 141,
       "norm_label": "app.svelte"
     },
     {
@@ -6220,7 +6250,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "src_app_needsapprovalcount",
-      "community": 20,
+      "community": 141,
       "norm_label": "needsapprovalcount"
     },
     {
@@ -6230,7 +6260,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "src_app_decoratednavitems",
-      "community": 20,
+      "community": 141,
       "norm_label": "decoratednavitems"
     },
     {
@@ -6273,7 +6303,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_nav",
-      "community": 44,
+      "community": 141,
       "norm_label": "nav.ts"
     },
     {
@@ -6415,7 +6445,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "dev_sessionoverlay",
-      "community": 20,
+      "community": 141,
       "norm_label": "sessionoverlay.svelte"
     },
     {
@@ -6425,7 +6455,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "boundary_tests_no_firebase_sync_internal",
-      "community": 141,
+      "community": 93,
       "norm_label": "no-firebase-sync-internal.ts"
     },
     {
@@ -6445,7 +6475,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "apps_web_pwa_src_boundary_tests_no_stage_internals_ts_boundary_tests_no_stage_internals",
-      "community": 7,
+      "community": 32,
       "norm_label": "no-stage-internals.ts"
     },
     {
@@ -6477,7 +6507,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "lib_firebase",
-      "community": 20,
+      "community": 117,
       "norm_label": "firebase.ts"
     },
     {
@@ -6659,7 +6689,7 @@
       "_origin": "ast",
       "confidence": "EXTRACTED",
       "id": "lib_aisleservice",
-      "community": 2,
+      "community": 116,
       "norm_label": "../../lib/aisleservice.js"
     },
     {
@@ -6669,7 +6699,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "lib_aisleservice_idgen",
-      "community": 2,
+      "community": 116,
       "norm_label": "idgen"
     },
     {
@@ -6679,7 +6709,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "lib_aisleservice_addaisle",
-      "community": 2,
+      "community": 116,
       "norm_label": "addaisle()"
     },
     {
@@ -6689,7 +6719,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "lib_aisleservice_addaislesbulk",
-      "community": 2,
+      "community": 116,
       "norm_label": "addaislesbulk()"
     },
     {
@@ -6699,7 +6729,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_aisleservice_renameaisle",
-      "community": 2,
+      "community": 116,
       "norm_label": "renameaisle()"
     },
     {
@@ -6709,7 +6739,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "lib_aisleservice_reorderaisles",
-      "community": 2,
+      "community": 116,
       "norm_label": "reorderaisles()"
     },
     {
@@ -6719,7 +6749,7 @@
       "source_location": "L68",
       "_origin": "ast",
       "id": "lib_aisleservice_deleteaisles",
-      "community": 2,
+      "community": 116,
       "norm_label": "deleteaisles()"
     },
     {
@@ -6729,7 +6759,7 @@
       "source_location": "L82",
       "_origin": "ast",
       "id": "lib_aisleservice_mergeaisles",
-      "community": 2,
+      "community": 116,
       "norm_label": "mergeaisles()"
     },
     {
@@ -7029,7 +7059,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "lib_canonservice_canonitems",
-      "community": 3,
+      "community": 116,
       "norm_label": "canonitems"
     },
     {
@@ -7039,7 +7069,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "lib_canonservice_aisles",
-      "community": 3,
+      "community": 116,
       "norm_label": "aisles"
     },
     {
@@ -7049,7 +7079,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "lib_canonservice_aisleusage",
-      "community": 3,
+      "community": 116,
       "norm_label": "aisleusage"
     },
     {
@@ -7059,7 +7089,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "lib_canonservice_isloadingaisles",
-      "community": 3,
+      "community": 116,
       "norm_label": "isloadingaisles"
     },
     {
@@ -7099,7 +7129,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "lib_canonservice_memaislestore",
-      "community": 2,
+      "community": 116,
       "norm_label": "memaislestore()"
     },
     {
@@ -7109,7 +7139,7 @@
       "source_location": "L111",
       "_origin": "ast",
       "id": "lib_canonservice_memcanonstore",
-      "community": 2,
+      "community": 116,
       "norm_label": "memcanonstore()"
     },
     {
@@ -7119,7 +7149,7 @@
       "source_location": "L136",
       "_origin": "ast",
       "id": "lib_canonservice_getaislessnapshot",
-      "community": 2,
+      "community": 116,
       "norm_label": "getaislessnapshot()"
     },
     {
@@ -7129,7 +7159,7 @@
       "source_location": "L140",
       "_origin": "ast",
       "id": "lib_canonservice_getcanonitemssnapshot",
-      "community": 2,
+      "community": 116,
       "norm_label": "getcanonitemssnapshot()"
     },
     {
@@ -7149,7 +7179,7 @@
       "source_location": "L179",
       "_origin": "ast",
       "id": "lib_canonservice_addcanonitem",
-      "community": 17,
+      "community": 3,
       "norm_label": "addcanonitem()"
     },
     {
@@ -7229,7 +7259,7 @@
       "source_location": "L293",
       "_origin": "ast",
       "id": "lib_canonservice_approvecanonitems",
-      "community": 3,
+      "community": 33,
       "norm_label": "approvecanonitems()"
     },
     {
@@ -7239,7 +7269,7 @@
       "source_location": "L306",
       "_origin": "ast",
       "id": "lib_canonservice_splitmostrecentsynonym",
-      "community": 279,
+      "community": 3,
       "norm_label": "splitmostrecentsynonym()"
     },
     {
@@ -7309,7 +7339,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "lib_chatservice_getchatsessionssnapshot",
-      "community": 116,
+      "community": 42,
       "norm_label": "getchatsessionssnapshot()"
     },
     {
@@ -7460,7 +7490,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "observability",
-      "community": 20,
+      "community": 141,
       "norm_label": "$lib/observability"
     },
     {
@@ -7790,7 +7820,7 @@
       "source_location": "L304",
       "_origin": "ast",
       "id": "lib_equipmentservice_getequipmentsnapshot",
-      "community": 116,
+      "community": 9,
       "norm_label": "getequipmentsnapshot()"
     },
     {
@@ -7810,7 +7840,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_errorreporting",
-      "community": 42,
+      "community": 117,
       "norm_label": "errorreporting.ts"
     },
     {
@@ -7820,7 +7850,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "lib_errorreporting_reportsubscriptionerror",
-      "community": 42,
+      "community": 117,
       "norm_label": "reportsubscriptionerror()"
     },
     {
@@ -7850,7 +7880,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "lib_firebase_authprovider",
-      "community": 20,
+      "community": 117,
       "norm_label": "authprovider"
     },
     {
@@ -8330,7 +8360,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "lib_membersservice_findmemberbyemail",
-      "community": 8,
+      "community": 10,
       "norm_label": "findmemberbyemail()"
     },
     {
@@ -8440,7 +8470,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "lib_nav_navitems",
-      "community": 44,
+      "community": 141,
       "norm_label": "navitems"
     },
     {
@@ -8450,24 +8480,25 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "lib_nav_adminnavitem",
-      "community": 44,
+      "community": 141,
       "norm_label": "adminnavitem"
     },
     {
-      "label": "observability.ts",
+      "label": "../../lib/observability.js",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/observability.ts",
       "source_location": "L1",
       "_origin": "ast",
+      "confidence": "EXTRACTED",
       "id": "lib_observability",
       "community": 25,
-      "norm_label": "observability.ts"
+      "norm_label": "../../lib/observability.js"
     },
     {
       "label": "_phKey",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/observability.ts",
-      "source_location": "L16",
+      "source_location": "L17",
       "_origin": "ast",
       "id": "lib_observability_phkey",
       "community": 25,
@@ -8477,7 +8508,7 @@
       "label": "identifyUser()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/observability.ts",
-      "source_location": "L29",
+      "source_location": "L41",
       "_origin": "ast",
       "id": "lib_observability_identifyuser",
       "community": 25,
@@ -8487,17 +8518,17 @@
       "label": "identifyAnonymous()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/observability.ts",
-      "source_location": "L36",
+      "source_location": "L48",
       "_origin": "ast",
       "id": "lib_observability_identifyanonymous",
-      "community": 25,
+      "community": 20,
       "norm_label": "identifyanonymous()"
     },
     {
       "label": "tagSession()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/observability.ts",
-      "source_location": "L40",
+      "source_location": "L52",
       "_origin": "ast",
       "id": "lib_observability_tagsession",
       "community": 25,
@@ -8507,7 +8538,7 @@
       "label": "getSessionURL()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/observability.ts",
-      "source_location": "L44",
+      "source_location": "L56",
       "_origin": "ast",
       "id": "lib_observability_getsessionurl",
       "community": 25,
@@ -8517,7 +8548,7 @@
       "label": "startSession()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/observability.ts",
-      "source_location": "L48",
+      "source_location": "L60",
       "_origin": "ast",
       "id": "lib_observability_startsession",
       "community": 25,
@@ -8527,7 +8558,7 @@
       "label": "stopSession()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/observability.ts",
-      "source_location": "L52",
+      "source_location": "L64",
       "_origin": "ast",
       "id": "lib_observability_stopsession",
       "community": 25,
@@ -8537,11 +8568,21 @@
       "label": "isSessionActive()",
       "file_type": "code",
       "source_file": "apps/web-pwa/src/lib/observability.ts",
-      "source_location": "L56",
+      "source_location": "L68",
       "_origin": "ast",
       "id": "lib_observability_issessionactive",
       "community": 25,
       "norm_label": "issessionactive()"
+    },
+    {
+      "label": "submitFeedback()",
+      "file_type": "code",
+      "source_file": "apps/web-pwa/src/lib/observability.ts",
+      "source_location": "L84",
+      "_origin": "ast",
+      "id": "lib_observability_submitfeedback",
+      "community": 25,
+      "norm_label": "submitfeedback()"
     },
     {
       "label": "pwa.ts",
@@ -8590,7 +8631,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "lib_recipeservice_getrecipessnapshot",
-      "community": 116,
+      "community": 24,
       "norm_label": "getrecipessnapshot()"
     },
     {
@@ -8690,7 +8731,7 @@
       "source_location": "L147",
       "_origin": "ast",
       "id": "lib_recipeservice_importrecipefromurl",
-      "community": 51,
+      "community": 24,
       "norm_label": "importrecipefromurl()"
     },
     {
@@ -8770,7 +8811,7 @@
       "source_location": "L285",
       "_origin": "ast",
       "id": "lib_recipeservice_recipeaddrow",
-      "community": 157,
+      "community": 266,
       "norm_label": "recipeaddrow"
     },
     {
@@ -8910,7 +8951,7 @@
       "source_location": "L118",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_initshoppinglistsync",
-      "community": 8,
+      "community": 265,
       "norm_label": "initshoppinglistsync()"
     },
     {
@@ -9120,7 +9161,7 @@
       "source_location": "L389",
       "_origin": "ast",
       "id": "lib_shoppinglistservice_svelte_resetshoppinglistservicefortest",
-      "community": 265,
+      "community": 8,
       "norm_label": "__resetshoppinglistservicefortest()"
     },
     {
@@ -9211,7 +9252,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "types_e2e_d",
-      "community": 51,
+      "community": 11,
       "norm_label": "e2e.d.ts"
     },
     {
@@ -9221,7 +9262,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "types_e2e_d_seedcanoniteminput",
-      "community": 51,
+      "community": 11,
       "norm_label": "seedcanoniteminput"
     },
     {
@@ -9231,7 +9272,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "types_e2e_d_e2ebridge",
-      "community": 51,
+      "community": 11,
       "norm_label": "e2ebridge"
     },
     {
@@ -9241,7 +9282,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "types_e2e_d_window",
-      "community": 51,
+      "community": 11,
       "norm_label": "window"
     },
     {
@@ -9373,7 +9414,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "schemas",
-      "community": 51,
+      "community": 77,
       "norm_label": "@salt/domain/schemas"
     },
     {
@@ -9384,7 +9425,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "admin_modelcombofield",
-      "community": 90,
+      "community": 50,
       "norm_label": "modelcombofield.svelte"
     },
     {
@@ -9404,7 +9445,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "firebase_sync",
-      "community": 90,
+      "community": 50,
       "norm_label": "@salt/firebase-sync"
     },
     {
@@ -9514,7 +9555,7 @@
       "source_location": "L111",
       "_origin": "ast",
       "id": "canon_canonlistpage_handlebulkapprove",
-      "community": 3,
+      "community": 33,
       "norm_label": "handlebulkapprove()"
     },
     {
@@ -10316,7 +10357,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "settings_settingspage",
-      "community": 50,
+      "community": 20,
       "norm_label": "settingspage.svelte"
     },
     {
@@ -10596,7 +10637,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test",
-      "community": 33,
+      "community": 9,
       "norm_label": "equipmentcapturepage.test.ts"
     },
     {
@@ -10606,7 +10647,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_mockisloadingequipment",
-      "community": 33,
+      "community": 9,
       "norm_label": "{ mockisloadingequipment }"
     },
     {
@@ -10616,7 +10657,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_makemanifest",
-      "community": 33,
+      "community": 9,
       "norm_label": "makemanifest()"
     },
     {
@@ -10626,7 +10667,7 @@
       "source_location": "L60",
       "_origin": "ast",
       "id": "tests_equipmentcapturepage_test_walkthroughcapture",
-      "community": 141,
+      "community": 265,
       "norm_label": "walkthroughcapture()"
     },
     {
@@ -10736,7 +10777,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_recipeeditpage_clearmatch_test",
-      "community": 52,
+      "community": 51,
       "norm_label": "recipeeditpage.clearmatch.test.ts"
     },
     {
@@ -10746,7 +10787,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "tests_recipeeditpage_clearmatch_test_mockrecipes",
-      "community": 52,
+      "community": 51,
       "norm_label": "{ mockrecipes }"
     },
     {
@@ -10756,7 +10797,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "tests_recipeeditpage_clearmatch_test_subscribe",
-      "community": 52,
+      "community": 51,
       "norm_label": "subscribe()"
     },
     {
@@ -10766,7 +10807,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "tests_recipeeditpage_clearmatch_test_makematchedingredient",
-      "community": 52,
+      "community": 51,
       "norm_label": "makematchedingredient()"
     },
     {
@@ -10776,7 +10817,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "tests_recipeeditpage_clearmatch_test_makerecipe",
-      "community": 52,
+      "community": 51,
       "norm_label": "makerecipe()"
     },
     {
@@ -10786,7 +10827,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_recipeeditpage_matchrow_test",
-      "community": 52,
+      "community": 51,
       "norm_label": "recipeeditpage.matchrow.test.ts"
     },
     {
@@ -10796,7 +10837,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "tests_recipeeditpage_matchrow_test_mockrecipes_mockcanonitems",
-      "community": 52,
+      "community": 51,
       "norm_label": "{ mockrecipes, mockcanonitems }"
     },
     {
@@ -10806,7 +10847,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "tests_recipeeditpage_matchrow_test_subscribe",
-      "community": 52,
+      "community": 51,
       "norm_label": "subscribe()"
     },
     {
@@ -10816,7 +10857,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "tests_recipeeditpage_matchrow_test_makependingingredient",
-      "community": 52,
+      "community": 51,
       "norm_label": "makependingingredient()"
     },
     {
@@ -10826,7 +10867,7 @@
       "source_location": "L72",
       "_origin": "ast",
       "id": "tests_recipeeditpage_matchrow_test_makerecipe",
-      "community": 52,
+      "community": 51,
       "norm_label": "makerecipe()"
     },
     {
@@ -10836,7 +10877,7 @@
       "source_location": "L95",
       "_origin": "ast",
       "id": "tests_recipeeditpage_matchrow_test_matchedingredient",
-      "community": 52,
+      "community": 51,
       "norm_label": "matchedingredient"
     },
     {
@@ -10846,7 +10887,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test",
-      "community": 317,
+      "community": 321,
       "norm_label": "shoppinglistpage.danglingcanon.test.ts"
     },
     {
@@ -10856,7 +10897,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_mockcanonitems_mockaisles_mocklists_mockitems_mockdefaultlistid_mockloading",
-      "community": 317,
+      "community": 321,
       "norm_label": "{ mockcanonitems, mockaisles, mocklists, mockitems, mockdefaultlistid, mockloading }"
     },
     {
@@ -10866,7 +10907,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_canonitem",
-      "community": 317,
+      "community": 321,
       "norm_label": "canonitem()"
     },
     {
@@ -10876,7 +10917,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_danglingcanon_test_item",
-      "community": 317,
+      "community": 321,
       "norm_label": "item()"
     },
     {
@@ -10886,7 +10927,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test",
-      "community": 318,
+      "community": 300,
       "norm_label": "shoppinglistpage.icon.test.ts"
     },
     {
@@ -10896,7 +10937,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_mockcanonitems_mockaisles_mocklists_mockitems_mockdefaultlistid_mockloading",
-      "community": 318,
+      "community": 300,
       "norm_label": "{ mockcanonitems, mockaisles, mocklists, mockitems, mockdefaultlistid, mockloading }"
     },
     {
@@ -10906,7 +10947,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_canonitem",
-      "community": 318,
+      "community": 300,
       "norm_label": "canonitem()"
     },
     {
@@ -10916,7 +10957,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "tests_shoppinglistpage_icon_test_item",
-      "community": 318,
+      "community": 300,
       "norm_label": "item()"
     },
     {
@@ -11056,7 +11097,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test",
-      "community": 3,
+      "community": 116,
       "norm_label": "canonservice.sync.test.ts"
     },
     {
@@ -11066,7 +11107,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_fs",
-      "community": 3,
+      "community": 116,
       "norm_label": "fs"
     },
     {
@@ -11076,7 +11117,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_makeitem",
-      "community": 3,
+      "community": 116,
       "norm_label": "makeitem()"
     },
     {
@@ -11086,7 +11127,7 @@
       "source_location": "L57",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_makeaisle",
-      "community": 3,
+      "community": 116,
       "norm_label": "makeaisle()"
     },
     {
@@ -11096,7 +11137,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_itemscb",
-      "community": 3,
+      "community": 116,
       "norm_label": "itemscb"
     },
     {
@@ -11106,7 +11147,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_aislescb",
-      "community": 3,
+      "community": 116,
       "norm_label": "aislescb"
     },
     {
@@ -11116,7 +11157,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "tests_canonservice_sync_test_wiresubscriptions",
-      "community": 3,
+      "community": 116,
       "norm_label": "wiresubscriptions()"
     },
     {
@@ -11266,7 +11307,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_errorreporting_test",
-      "community": 42,
+      "community": 117,
       "norm_label": "errorreporting.test.ts"
     },
     {
@@ -11276,7 +11317,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "tests_errorreporting_test_isauthtransitioning",
-      "community": 42,
+      "community": 117,
       "norm_label": "isauthtransitioning"
     },
     {
@@ -11576,7 +11617,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_recipeservice_errorreporting_test",
-      "community": 157,
+      "community": 266,
       "norm_label": "recipeservice.errorreporting.test.ts"
     },
     {
@@ -11586,7 +11627,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "tests_recipeservice_errorreporting_test_reportspy",
-      "community": 157,
+      "community": 266,
       "norm_label": "{ reportspy }"
     },
     {
@@ -11596,7 +11637,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "tests_recipeservice_errorreporting_test_mockgetcanonitemssnapshot",
-      "community": 157,
+      "community": 266,
       "norm_label": "{ mockgetcanonitemssnapshot }"
     },
     {
@@ -11606,7 +11647,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "tests_recipeservice_errorreporting_test_fs",
-      "community": 157,
+      "community": 266,
       "norm_label": "fs"
     },
     {
@@ -11616,7 +11657,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "tests_recipeservice_errorreporting_test_storage_err",
-      "community": 157,
+      "community": 266,
       "norm_label": "storage_err"
     },
     {
@@ -11626,7 +11667,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "tests_recipeservice_errorreporting_test_sync_err",
-      "community": 157,
+      "community": 266,
       "norm_label": "sync_err"
     },
     {
@@ -11636,7 +11677,7 @@
       "source_location": "L54",
       "_origin": "ast",
       "id": "tests_recipeservice_errorreporting_test_network_err",
-      "community": 157,
+      "community": 266,
       "norm_label": "network_err"
     },
     {
@@ -11646,7 +11687,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "tests_recipeservice_errorreporting_test_conflict_err",
-      "community": 157,
+      "community": 266,
       "norm_label": "conflict_err"
     },
     {
@@ -11656,7 +11697,7 @@
       "source_location": "L57",
       "_origin": "ast",
       "id": "tests_recipeservice_errorreporting_test_makerecipe",
-      "community": 157,
+      "community": 266,
       "norm_label": "makerecipe()"
     },
     {
@@ -11666,7 +11707,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "tests_recipeservice_errorreporting_test_makeingredient",
-      "community": 157,
+      "community": 266,
       "norm_label": "makeingredient()"
     },
     {
@@ -11676,7 +11717,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_recipeservice_matchingredient_test",
-      "community": 144,
+      "community": 298,
       "norm_label": "recipeservice.matchingredient.test.ts"
     },
     {
@@ -11686,7 +11727,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "tests_recipeservice_matchingredient_test_fs",
-      "community": 144,
+      "community": 298,
       "norm_label": "fs"
     },
     {
@@ -11696,7 +11737,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "tests_recipeservice_matchingredient_test_makependingingredient",
-      "community": 144,
+      "community": 298,
       "norm_label": "makependingingredient()"
     },
     {
@@ -11706,7 +11747,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "tests_recipeservice_matchingredient_test_parsedflour",
-      "community": 144,
+      "community": 298,
       "norm_label": "parsedflour"
     },
     {
@@ -11716,7 +11757,7 @@
       "source_location": "L47",
       "_origin": "ast",
       "id": "tests_recipeservice_matchingredient_test_parsegroup",
-      "community": 144,
+      "community": 298,
       "norm_label": "parsegroup"
     },
     {
@@ -11726,7 +11767,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "tests_recipeservice_matchingredient_test_makecanonitem",
-      "community": 144,
+      "community": 298,
       "norm_label": "makecanonitem()"
     },
     {
@@ -11746,7 +11787,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test",
-      "community": 265,
+      "community": 8,
       "norm_label": "shoppinglistservice.errorreporting.test.ts"
     },
     {
@@ -11756,7 +11797,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test_reportspy",
-      "community": 265,
+      "community": 8,
       "norm_label": "{ reportspy }"
     },
     {
@@ -11766,7 +11807,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test_fs",
-      "community": 265,
+      "community": 8,
       "norm_label": "fs"
     },
     {
@@ -11776,7 +11817,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test_storage_err",
-      "community": 265,
+      "community": 8,
       "norm_label": "storage_err"
     },
     {
@@ -11786,7 +11827,7 @@
       "source_location": "L56",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test_sync_err",
-      "community": 265,
+      "community": 8,
       "norm_label": "sync_err"
     },
     {
@@ -11796,7 +11837,7 @@
       "source_location": "L57",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test_network_err",
-      "community": 265,
+      "community": 8,
       "norm_label": "network_err"
     },
     {
@@ -11806,7 +11847,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "tests_shoppinglistservice_errorreporting_test_validation_err",
-      "community": 265,
+      "community": 8,
       "norm_label": "validation_err"
     },
     {
@@ -11960,30 +12001,30 @@
       "norm_label": "vite.config.ts"
     },
     {
-      "label": "gitShortSha()",
+      "label": "resolveAppVersion()",
       "file_type": "code",
       "source_file": "apps/web-pwa/vite.config.ts",
-      "source_location": "L12",
+      "source_location": "L17",
       "_origin": "ast",
-      "id": "web_pwa_vite_config_gitshortsha",
+      "id": "web_pwa_vite_config_resolveappversion",
       "community": 165,
-      "norm_label": "gitshortsha()"
+      "norm_label": "resolveappversion()"
     },
     {
-      "label": "appCommit",
+      "label": "appVersion",
       "file_type": "code",
       "source_file": "apps/web-pwa/vite.config.ts",
-      "source_location": "L21",
+      "source_location": "L28",
       "_origin": "ast",
-      "id": "web_pwa_vite_config_appcommit",
+      "id": "web_pwa_vite_config_appversion",
       "community": 165,
-      "norm_label": "appcommit"
+      "norm_label": "appversion"
     },
     {
       "label": "buildTime",
       "file_type": "code",
       "source_file": "apps/web-pwa/vite.config.ts",
-      "source_location": "L22",
+      "source_location": "L29",
       "_origin": "ast",
       "id": "web_pwa_vite_config_buildtime",
       "community": 165,
@@ -13082,7 +13123,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_aislesubscription",
-      "community": 141,
+      "community": 93,
       "norm_label": "aislesubscription.ts"
     },
     {
@@ -13092,7 +13133,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_aislesubscription_subscribeaisles",
-      "community": 141,
+      "community": 93,
       "norm_label": "subscribeaisles()"
     },
     {
@@ -13102,7 +13143,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "src_aislesubscription_saveaisles",
-      "community": 2,
+      "community": 116,
       "norm_label": "saveaisles()"
     },
     {
@@ -13112,7 +13153,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_appsettingssync",
-      "community": 51,
+      "community": 93,
       "norm_label": "appsettingssync.ts"
     },
     {
@@ -13122,7 +13163,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "src_appsettingssync_subscribeappsettings",
-      "community": 51,
+      "community": 47,
       "norm_label": "subscribeappsettings()"
     },
     {
@@ -13132,7 +13173,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_appsettingssync_saveappsettings",
-      "community": 51,
+      "community": 93,
       "norm_label": "saveappsettings()"
     },
     {
@@ -13202,7 +13243,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "src_auth_createfirebaseauth",
-      "community": 20,
+      "community": 117,
       "norm_label": "createfirebaseauth()"
     },
     {
@@ -13242,7 +13283,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_authorrecipecallable",
-      "community": 93,
+      "community": 7,
       "norm_label": "authorrecipecallable.ts"
     },
     {
@@ -13252,7 +13293,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "src_authorrecipecallable_classifyerror",
-      "community": 93,
+      "community": 7,
       "norm_label": "classifyerror()"
     },
     {
@@ -13262,7 +13303,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "src_authorrecipecallable_callauthorrecipe",
-      "community": 93,
+      "community": 7,
       "norm_label": "callauthorrecipe()"
     },
     {
@@ -13272,7 +13313,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_canonmatching",
-      "community": 93,
+      "community": 95,
       "norm_label": "canonmatching.ts"
     },
     {
@@ -13282,7 +13323,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "src_canonmatching_wireresult",
-      "community": 93,
+      "community": 95,
       "norm_label": "wireresult"
     },
     {
@@ -13292,7 +13333,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "src_canonmatching_callmatchorcreate",
-      "community": 93,
+      "community": 3,
       "norm_label": "callmatchorcreate()"
     },
     {
@@ -13302,7 +13343,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_canonmatching_wirebatchresult",
-      "community": 93,
+      "community": 95,
       "norm_label": "wirebatchresult"
     },
     {
@@ -13332,7 +13373,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_canonsubscription",
-      "community": 141,
+      "community": 93,
       "norm_label": "canonsubscription.ts"
     },
     {
@@ -13342,7 +13383,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_canonsubscription_subscribecanonitems",
-      "community": 141,
+      "community": 93,
       "norm_label": "subscribecanonitems()"
     },
     {
@@ -13352,7 +13393,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "src_canonsubscription_upsertcanonitem",
-      "community": 2,
+      "community": 116,
       "norm_label": "upsertcanonitem()"
     },
     {
@@ -13362,7 +13403,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "src_canonsubscription_deletecanonitem",
-      "community": 141,
+      "community": 93,
       "norm_label": "deletecanonitem()"
     },
     {
@@ -13372,7 +13413,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_chatcallables",
-      "community": 93,
+      "community": 42,
       "norm_label": "chatcallables.ts"
     },
     {
@@ -13382,7 +13423,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "src_chatcallables_geterr",
-      "community": 93,
+      "community": 42,
       "norm_label": "geterr()"
     },
     {
@@ -13392,7 +13433,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "src_chatcallables_callgeneratechattitle",
-      "community": 93,
+      "community": 42,
       "norm_label": "callgeneratechattitle()"
     },
     {
@@ -13402,7 +13443,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "src_chatcallables_streamchefchat",
-      "community": 93,
+      "community": 42,
       "norm_label": "streamchefchat()"
     },
     {
@@ -13412,7 +13453,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_chatsessionsubscription",
-      "community": 93,
+      "community": 42,
       "norm_label": "chatsessionsubscription.ts"
     },
     {
@@ -13422,7 +13463,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_expiresat",
-      "community": 93,
+      "community": 42,
       "norm_label": "expiresat()"
     },
     {
@@ -13452,7 +13493,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_savechatsession",
-      "community": 93,
+      "community": 42,
       "norm_label": "savechatsession()"
     },
     {
@@ -13462,7 +13503,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "src_chatsessionsubscription_deletechatsession",
-      "community": 93,
+      "community": 42,
       "norm_label": "deletechatsession()"
     },
     {
@@ -13472,7 +13513,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_devsettingssync",
-      "community": 64,
+      "community": 162,
       "norm_label": "devsettingssync.ts"
     },
     {
@@ -13572,7 +13613,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "src_equipmentcallables_callidentifyequipment",
-      "community": 93,
+      "community": 9,
       "norm_label": "callidentifyequipment()"
     },
     {
@@ -13582,7 +13623,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "src_equipmentcallables_callpopulateequipmententry",
-      "community": 93,
+      "community": 9,
       "norm_label": "callpopulateequipmententry()"
     },
     {
@@ -13592,7 +13633,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_equipmentmanifestsubscription",
-      "community": 93,
+      "community": 265,
       "norm_label": "equipmentmanifestsubscription.ts"
     },
     {
@@ -13602,7 +13643,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_equipmentmanifestsubscription_subscribeequipmentmanifest",
-      "community": 9,
+      "community": 265,
       "norm_label": "subscribeequipmentmanifest()"
     },
     {
@@ -13682,7 +13723,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "src_init_appcheckconfig",
-      "community": 20,
+      "community": 117,
       "norm_label": "appcheckconfig"
     },
     {
@@ -13712,7 +13753,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_mealplansync",
-      "community": 0,
+      "community": 93,
       "norm_label": "mealplansync.ts"
     },
     {
@@ -13722,7 +13763,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "src_mealplansync_subscribemealplanconfig",
-      "community": 0,
+      "community": 93,
       "norm_label": "subscribemealplanconfig()"
     },
     {
@@ -13732,7 +13773,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "src_mealplansync_subscribemealplantemplate",
-      "community": 0,
+      "community": 93,
       "norm_label": "subscribemealplantemplate()"
     },
     {
@@ -13742,7 +13783,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "src_mealplansync_subscribemealplanweek",
-      "community": 0,
+      "community": 93,
       "norm_label": "subscribemealplanweek()"
     },
     {
@@ -13752,7 +13793,7 @@
       "source_location": "L93",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplanconfig",
-      "community": 0,
+      "community": 93,
       "norm_label": "savemealplanconfig()"
     },
     {
@@ -13762,7 +13803,7 @@
       "source_location": "L105",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplantemplate",
-      "community": 0,
+      "community": 93,
       "norm_label": "savemealplantemplate()"
     },
     {
@@ -13772,7 +13813,7 @@
       "source_location": "L118",
       "_origin": "ast",
       "id": "src_mealplansync_savemealplanweek",
-      "community": 0,
+      "community": 93,
       "norm_label": "savemealplanweek()"
     },
     {
@@ -13792,7 +13833,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "src_memberssubscription_subscribemembers",
-      "community": 93,
+      "community": 10,
       "norm_label": "subscribemembers()"
     },
     {
@@ -13822,7 +13863,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_recipecallables",
-      "community": 51,
+      "community": 7,
       "norm_label": "recipecallables.ts"
     },
     {
@@ -13842,7 +13883,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "src_recipecallables_classifyurlimporterror",
-      "community": 51,
+      "community": 24,
       "norm_label": "classifyurlimporterror()"
     },
     {
@@ -13852,7 +13893,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "src_recipecallables_callextractrecipefromurl",
-      "community": 51,
+      "community": 24,
       "norm_label": "callextractrecipefromurl()"
     },
     {
@@ -13992,7 +14033,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "src_shoppinglistsubscription_subscribeshoppinglists",
-      "community": 93,
+      "community": 265,
       "norm_label": "subscribeshoppinglists()"
     },
     {
@@ -14042,7 +14083,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription",
-      "community": 141,
+      "community": 93,
       "norm_label": "shoppinglistsconfigsubscription.ts"
     },
     {
@@ -14052,7 +14093,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription_subscribeshoppinglistsconfig",
-      "community": 141,
+      "community": 265,
       "norm_label": "subscribeshoppinglistsconfig()"
     },
     {
@@ -14062,7 +14103,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription_loadshoppinglistsconfig",
-      "community": 141,
+      "community": 93,
       "norm_label": "loadshoppinglistsconfig()"
     },
     {
@@ -14072,7 +14113,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "src_shoppinglistsconfigsubscription_saveshoppinglistsconfig",
-      "community": 141,
+      "community": 8,
       "norm_label": "saveshoppinglistsconfig()"
     },
     {
@@ -14082,7 +14123,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_appsettingssync_test",
-      "community": 51,
+      "community": 320,
       "norm_label": "appsettingssync.test.ts"
     },
     {
@@ -14092,7 +14133,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdoc_mockgetfirestore",
-      "community": 51,
+      "community": 320,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -14102,7 +14143,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_snapcallback",
-      "community": 51,
+      "community": 320,
       "norm_label": "snapcallback"
     },
     {
@@ -14112,7 +14153,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "tests_appsettingssync_test_errorcallback",
-      "community": 51,
+      "community": 320,
       "norm_label": "errorcallback"
     },
     {
@@ -14172,7 +14213,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_emulatorhelpers",
-      "community": 117,
+      "community": 265,
       "norm_label": "emulatorhelpers.ts"
     },
     {
@@ -14182,7 +14223,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "tests_emulatorhelpers_initfirebaseemulator",
-      "community": 117,
+      "community": 265,
       "norm_label": "initfirebaseemulator()"
     },
     {
@@ -14192,7 +14233,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "tests_emulatorhelpers_resetdefaultapp",
-      "community": 117,
+      "community": 265,
       "norm_label": "resetdefaultapp()"
     },
     {
@@ -14202,7 +14243,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "tests_emulatorhelpers_clearfirestoreemulator",
-      "community": 117,
+      "community": 265,
       "norm_label": "clearfirestoreemulator()"
     },
     {
@@ -14212,7 +14253,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_equipmentmanifestsubscription_test",
-      "community": 9,
+      "community": 265,
       "norm_label": "equipmentmanifestsubscription.test.ts"
     },
     {
@@ -14222,7 +14263,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_equipmentmanifestsubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdoc_mockgetfirestore",
-      "community": 9,
+      "community": 265,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -14232,7 +14273,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "tests_equipmentmanifestsubscription_test_snapcallback",
-      "community": 9,
+      "community": 265,
       "norm_label": "snapcallback"
     },
     {
@@ -14242,7 +14283,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "tests_equipmentmanifestsubscription_test_errorcallback",
-      "community": 9,
+      "community": 265,
       "norm_label": "errorcallback"
     },
     {
@@ -14352,7 +14393,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_mealplansync_test",
-      "community": 0,
+      "community": 93,
       "norm_label": "mealplansync.test.ts"
     },
     {
@@ -14362,7 +14403,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_mealplansync_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockdoc_mockgetfirestore",
-      "community": 0,
+      "community": 93,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -14372,7 +14413,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "tests_mealplansync_test_snapcallback",
-      "community": 0,
+      "community": 93,
       "norm_label": "snapcallback"
     },
     {
@@ -14382,7 +14423,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "tests_mealplansync_test_errorcallback",
-      "community": 0,
+      "community": 93,
       "norm_label": "errorcallback"
     },
     {
@@ -14392,7 +14433,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "tests_mealplansync_test_config",
-      "community": 0,
+      "community": 93,
       "norm_label": "config"
     },
     {
@@ -14402,7 +14443,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "tests_mealplansync_test_template",
-      "community": 0,
+      "community": 93,
       "norm_label": "template"
     },
     {
@@ -14412,7 +14453,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "tests_mealplansync_test_week",
-      "community": 0,
+      "community": 93,
       "norm_label": "week"
     },
     {
@@ -14482,7 +14523,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test",
-      "community": 141,
+      "community": 265,
       "norm_label": "realtimesubscriptions.emulator.test.ts"
     },
     {
@@ -14492,7 +14533,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_writer_firestore_port",
-      "community": 141,
+      "community": 265,
       "norm_label": "writer_firestore_port"
     },
     {
@@ -14502,7 +14543,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_makeitem",
-      "community": 141,
+      "community": 265,
       "norm_label": "makeitem()"
     },
     {
@@ -14512,7 +14553,7 @@
       "source_location": "L80",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_makeaisle",
-      "community": 141,
+      "community": 265,
       "norm_label": "makeaisle()"
     },
     {
@@ -14522,7 +14563,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_createwriterapp",
-      "community": 141,
+      "community": 265,
       "norm_label": "createwriterapp()"
     },
     {
@@ -14532,7 +14573,7 @@
       "source_location": "L490",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_delay",
-      "community": 141,
+      "community": 265,
       "norm_label": "delay()"
     },
     {
@@ -14542,7 +14583,7 @@
       "source_location": "L494",
       "_origin": "ast",
       "id": "tests_realtimesubscriptions_emulator_test_waitfor",
-      "community": 141,
+      "community": 265,
       "norm_label": "waitfor()"
     },
     {
@@ -14722,7 +14763,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test",
-      "community": 141,
+      "community": 265,
       "norm_label": "shoppinglistsconfigsubscription.test.ts"
     },
     {
@@ -14732,7 +14773,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test_mockunsubscribe_mockonsnapshot_mocksetdoc_mockgetdoc_mockdoc_mockgetfirestore",
-      "community": 141,
+      "community": 265,
       "norm_label": "{ mockunsubscribe, mockonsnapshot, mocksetdoc, mockgetdoc, mockdoc, mockgetfirestore }"
     },
     {
@@ -14742,7 +14783,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test_snapcallback",
-      "community": 141,
+      "community": 265,
       "norm_label": "snapcallback"
     },
     {
@@ -14752,7 +14793,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test_errorcallback",
-      "community": 141,
+      "community": 265,
       "norm_label": "errorcallback"
     },
     {
@@ -14762,7 +14803,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "tests_shoppinglistsconfigsubscription_test_config",
-      "community": 141,
+      "community": 265,
       "norm_label": "config"
     },
     {
@@ -15179,7 +15220,7 @@
       "label": "isObservabilityReady()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/init.ts",
-      "source_location": "L22",
+      "source_location": "L32",
       "_origin": "ast",
       "id": "src_init_isobservabilityready",
       "community": 25,
@@ -15189,7 +15230,7 @@
       "label": "safePosthog()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/init.ts",
-      "source_location": "L29",
+      "source_location": "L39",
       "_origin": "ast",
       "id": "src_init_safeposthog",
       "community": 25,
@@ -15199,7 +15240,7 @@
       "label": "initObservability()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/init.ts",
-      "source_location": "L41",
+      "source_location": "L51",
       "_origin": "ast",
       "id": "src_init_initobservability",
       "community": 49,
@@ -15209,7 +15250,7 @@
       "label": "identifyObservabilityUser()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/init.ts",
-      "source_location": "L82",
+      "source_location": "L106",
       "_origin": "ast",
       "id": "src_init_identifyobservabilityuser",
       "community": 25,
@@ -15219,7 +15260,7 @@
       "label": "identifyObservabilityAnonymous()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/init.ts",
-      "source_location": "L91",
+      "source_location": "L115",
       "_origin": "ast",
       "id": "src_init_identifyobservabilityanonymous",
       "community": 25,
@@ -15229,27 +15270,57 @@
       "label": "trackObservabilityEvent()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/init.ts",
-      "source_location": "L96",
+      "source_location": "L120",
       "_origin": "ast",
       "id": "src_init_trackobservabilityevent",
       "community": 25,
       "norm_label": "trackobservabilityevent()"
     },
     {
+      "label": "SupportFeedbackTraits",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/src/init.ts",
+      "source_location": "L133",
+      "_origin": "ast",
+      "id": "src_init_supportfeedbacktraits",
+      "community": 25,
+      "norm_label": "supportfeedbacktraits"
+    },
+    {
+      "label": "ConversationsApi",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/src/init.ts",
+      "source_location": "L140",
+      "_origin": "ast",
+      "id": "src_init_conversationsapi",
+      "community": 25,
+      "norm_label": "conversationsapi"
+    },
+    {
+      "label": "sendSupportFeedback()",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/src/init.ts",
+      "source_location": "L154",
+      "_origin": "ast",
+      "id": "src_init_sendsupportfeedback",
+      "community": 25,
+      "norm_label": "sendsupportfeedback()"
+    },
+    {
       "label": "ObservabilitySpan",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/init.ts",
-      "source_location": "L109",
+      "source_location": "L180",
       "_origin": "ast",
       "id": "src_init_observabilityspan",
-      "community": 25,
+      "community": 2,
       "norm_label": "observabilityspan"
     },
     {
       "label": "NOOP_SPAN",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/init.ts",
-      "source_location": "L114",
+      "source_location": "L185",
       "_origin": "ast",
       "id": "src_init_noop_span",
       "community": 25,
@@ -15259,7 +15330,7 @@
       "label": "startSpan()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/init.ts",
-      "source_location": "L119",
+      "source_location": "L190",
       "_origin": "ast",
       "id": "src_init_startspan",
       "community": 25,
@@ -15269,7 +15340,7 @@
       "label": "extractTraceHeaders()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/init.ts",
-      "source_location": "L126",
+      "source_location": "L197",
       "_origin": "ast",
       "id": "src_init_extracttraceheaders",
       "community": 25,
@@ -15302,7 +15373,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_posthogmatchloggingadapter",
-      "community": 25,
+      "community": 2,
       "norm_label": "posthogmatchloggingadapter.ts"
     },
     {
@@ -15312,7 +15383,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_posthogmatchloggingadapter_createposthogmatchloggingadapter",
-      "community": 25,
+      "community": 2,
       "norm_label": "createposthogmatchloggingadapter()"
     },
     {
@@ -15339,17 +15410,17 @@
       "label": "isServerObservabilityInitialised()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L29",
+      "source_location": "L38",
       "_origin": "ast",
       "id": "server_init_isserverobservabilityinitialised",
-      "community": 49,
+      "community": 46,
       "norm_label": "isserverobservabilityinitialised()"
     },
     {
       "label": "whenServerObservabilityReady()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L37",
+      "source_location": "L46",
       "_origin": "ast",
       "id": "server_init_whenserverobservabilityready",
       "community": 46,
@@ -15359,7 +15430,7 @@
       "label": "initServerObservability()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L46",
+      "source_location": "L60",
       "_origin": "ast",
       "id": "server_init_initserverobservability",
       "community": 49,
@@ -15369,17 +15440,27 @@
       "label": "safePosthog()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L72",
+      "source_location": "L89",
       "_origin": "ast",
       "id": "server_init_safeposthog",
       "community": 46,
       "norm_label": "safeposthog()"
     },
     {
+      "label": "withEnvironment()",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/src/server/init.ts",
+      "source_location": "L104",
+      "_origin": "ast",
+      "id": "server_init_withenvironment",
+      "community": 46,
+      "norm_label": "withenvironment()"
+    },
+    {
       "label": "captureServerEvent()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L84",
+      "source_location": "L113",
       "_origin": "ast",
       "id": "server_init_captureserverevent",
       "community": 46,
@@ -15389,7 +15470,7 @@
       "label": "captureServerException()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L94",
+      "source_location": "L123",
       "_origin": "ast",
       "id": "server_init_captureserverexception",
       "community": 46,
@@ -15399,7 +15480,7 @@
       "label": "AiGenerationUsage",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L112",
+      "source_location": "L149",
       "_origin": "ast",
       "id": "server_init_aigenerationusage",
       "community": 46,
@@ -15409,7 +15490,7 @@
       "label": "AiGenerationEvent",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L118",
+      "source_location": "L155",
       "_origin": "ast",
       "id": "server_init_aigenerationevent",
       "community": 46,
@@ -15419,7 +15500,7 @@
       "label": "captureAiGeneration()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L134",
+      "source_location": "L171",
       "_origin": "ast",
       "id": "server_init_captureaigeneration",
       "community": 46,
@@ -15429,7 +15510,7 @@
       "label": "flushServerObservability()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L154",
+      "source_location": "L195",
       "_origin": "ast",
       "id": "server_init_flushserverobservability",
       "community": 46,
@@ -15439,7 +15520,7 @@
       "label": "OTEL_SPAN",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L171",
+      "source_location": "L212",
       "_origin": "ast",
       "id": "server_init_otel_span",
       "community": 46,
@@ -15449,7 +15530,7 @@
       "label": "ObservabilitySpan",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L173",
+      "source_location": "L214",
       "_origin": "ast",
       "id": "server_init_observabilityspan",
       "community": 46,
@@ -15459,7 +15540,7 @@
       "label": "wrap()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L179",
+      "source_location": "L220",
       "_origin": "ast",
       "id": "server_init_wrap",
       "community": 46,
@@ -15469,7 +15550,7 @@
       "label": "StartSpanOptions",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L191",
+      "source_location": "L232",
       "_origin": "ast",
       "id": "server_init_startspanoptions",
       "community": 46,
@@ -15479,7 +15560,7 @@
       "label": "setActiveSpanName()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L208",
+      "source_location": "L249",
       "_origin": "ast",
       "id": "server_init_setactivespanname",
       "community": 46,
@@ -15489,7 +15570,7 @@
       "label": "startSpan()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L219",
+      "source_location": "L260",
       "_origin": "ast",
       "id": "server_init_startspan",
       "community": 46,
@@ -15499,10 +15580,10 @@
       "label": "runWithExtractedTraceContext()",
       "file_type": "code",
       "source_file": "packages/adapters/observability/src/server/init.ts",
-      "source_location": "L245",
+      "source_location": "L286",
       "_origin": "ast",
       "id": "server_init_runwithextractedtracecontext",
-      "community": 70,
+      "community": 46,
       "norm_label": "runwithextractedtracecontext()"
     },
     {
@@ -15632,7 +15713,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shared_matchoutcomeevent",
-      "community": 46,
+      "community": 2,
       "norm_label": "matchoutcomeevent.ts"
     },
     {
@@ -15642,7 +15723,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "shared_matchoutcomeevent_canon_match_event",
-      "community": 46,
+      "community": 2,
       "norm_label": "canon_match_event"
     },
     {
@@ -15652,7 +15733,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "shared_matchoutcomeevent_canonmatchpath",
-      "community": 46,
+      "community": 2,
       "norm_label": "canonmatchpath"
     },
     {
@@ -15662,7 +15743,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "shared_matchoutcomeevent_canonmatcheventprops",
-      "community": 46,
+      "community": 2,
       "norm_label": "canonmatcheventprops"
     },
     {
@@ -15672,7 +15753,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "shared_matchoutcomeevent_scalescore",
-      "community": 46,
+      "community": 2,
       "norm_label": "scalescore()"
     },
     {
@@ -15682,7 +15763,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "shared_matchoutcomeevent_tocanonmatchevent",
-      "community": 46,
+      "community": 2,
       "norm_label": "tocanonmatchevent()"
     },
     {
@@ -15716,13 +15797,43 @@
       "norm_label": "isreportablecategory()"
     },
     {
+      "label": "environmentSuperProperty.test.ts",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/tests/environmentSuperProperty.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "tests_environmentsuperproperty_test",
+      "community": 46,
+      "norm_label": "environmentsuperproperty.test.ts"
+    },
+    {
+      "label": "{\n  register,\n  clientCapture,\n  clientCaptureException,\n  serverCapture,\n  serverCaptureException,\n  FakePostHog,\n}",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/tests/environmentSuperProperty.test.ts",
+      "source_location": "L17",
+      "_origin": "ast",
+      "id": "tests_environmentsuperproperty_test_register_clientcapture_clientcaptureexception_servercapture_servercaptureexception_fakeposthog",
+      "community": 46,
+      "norm_label": "{\n  register,\n  clientcapture,\n  clientcaptureexception,\n  servercapture,\n  servercaptureexception,\n  fakeposthog,\n}"
+    },
+    {
+      "label": "CaptureArg",
+      "file_type": "code",
+      "source_file": "packages/adapters/observability/tests/environmentSuperProperty.test.ts",
+      "source_location": "L75",
+      "_origin": "ast",
+      "id": "tests_environmentsuperproperty_test_capturearg",
+      "community": 46,
+      "norm_label": "capturearg"
+    },
+    {
       "label": "matchLogParity.test.ts",
       "file_type": "code",
       "source_file": "packages/adapters/observability/tests/matchLogParity.test.ts",
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_matchlogparity_test",
-      "community": 46,
+      "community": 2,
       "norm_label": "matchlogparity.test.ts"
     },
     {
@@ -15732,7 +15843,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "tests_matchlogparity_test_fixture",
-      "community": 46,
+      "community": 2,
       "norm_label": "fixture"
     },
     {
@@ -16342,7 +16453,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_domain_src_canon_boundary_tests_no_cross_module_subpath_ts_boundary_tests_no_cross_module_subpath",
-      "community": 36,
+      "community": 137,
       "norm_label": "no-cross-module-subpath.ts"
     },
     {
@@ -16472,7 +16583,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_createaisle",
-      "community": 64,
+      "community": 7,
       "norm_label": "createaisle.ts"
     },
     {
@@ -16482,7 +16593,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "commands_createaisle_createaisleinput",
-      "community": 7,
+      "community": 32,
       "norm_label": "createaisleinput"
     },
     {
@@ -16492,7 +16603,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createaisle_createaisle",
-      "community": 2,
+      "community": 7,
       "norm_label": "createaisle()"
     },
     {
@@ -16502,7 +16613,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_createaislesbulk",
-      "community": 64,
+      "community": 7,
       "norm_label": "createaislesbulk.ts"
     },
     {
@@ -16512,7 +16623,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "commands_createaislesbulk_createaislesbulkinput",
-      "community": 7,
+      "community": 32,
       "norm_label": "createaislesbulkinput"
     },
     {
@@ -16522,7 +16633,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createaislesbulk_createaislesbulk",
-      "community": 2,
+      "community": 7,
       "norm_label": "createaislesbulk()"
     },
     {
@@ -16552,7 +16663,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "commands_createcanonitem_createcanonitem",
-      "community": 279,
+      "community": 17,
       "norm_label": "createcanonitem()"
     },
     {
@@ -16562,7 +16673,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_deleteaisles",
-      "community": 64,
+      "community": 7,
       "norm_label": "deleteaisles.ts"
     },
     {
@@ -16572,7 +16683,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_deleteaisles_deleteaislesinput",
-      "community": 7,
+      "community": 32,
       "norm_label": "deleteaislesinput"
     },
     {
@@ -16582,7 +16693,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_deleteaisles_deleteaisles",
-      "community": 2,
+      "community": 64,
       "norm_label": "deleteaisles()"
     },
     {
@@ -16612,7 +16723,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateresult",
-      "community": 7,
+      "community": 95,
       "norm_label": "matchorcreateresult"
     },
     {
@@ -16622,7 +16733,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "commands_matchorcreate_matchorcreateports",
-      "community": 7,
+      "community": 32,
       "norm_label": "matchorcreateports"
     },
     {
@@ -16822,7 +16933,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_mergeaisles_itemmergechoice",
-      "community": 7,
+      "community": 64,
       "norm_label": "itemmergechoice"
     },
     {
@@ -16832,7 +16943,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "commands_mergeaisles_peritemmergechoice",
-      "community": 7,
+      "community": 64,
       "norm_label": "peritemmergechoice"
     },
     {
@@ -16842,7 +16953,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "commands_mergeaisles_mergeaislesinput",
-      "community": 7,
+      "community": 64,
       "norm_label": "mergeaislesinput"
     },
     {
@@ -16852,7 +16963,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "commands_mergeaisles_mergeaisles",
-      "community": 286,
+      "community": 64,
       "norm_label": "mergeaisles()"
     },
     {
@@ -16862,7 +16973,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_mergecanonitems",
-      "community": 145,
+      "community": 106,
       "norm_label": "mergecanonitems.ts"
     },
     {
@@ -16872,7 +16983,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "commands_mergecanonitems_mergecanonitems",
-      "community": 145,
+      "community": 106,
       "norm_label": "mergecanonitems()"
     },
     {
@@ -16882,7 +16993,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "commands_mergecanonitems_unionsynonyms",
-      "community": 145,
+      "community": 106,
       "norm_label": "unionsynonyms()"
     },
     {
@@ -16892,7 +17003,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_renameaisle",
-      "community": 64,
+      "community": 7,
       "norm_label": "renameaisle.ts"
     },
     {
@@ -16902,7 +17013,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_renameaisle_renameaisleinput",
-      "community": 7,
+      "community": 32,
       "norm_label": "renameaisleinput"
     },
     {
@@ -16912,7 +17023,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_renameaisle_renameaisle",
-      "community": 64,
+      "community": 7,
       "norm_label": "renameaisle()"
     },
     {
@@ -16942,7 +17053,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_reorderaisles",
-      "community": 64,
+      "community": 7,
       "norm_label": "reorderaisles.ts"
     },
     {
@@ -16952,7 +17063,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_reorderaisles_reorderaislesinput",
-      "community": 7,
+      "community": 32,
       "norm_label": "reorderaislesinput"
     },
     {
@@ -16962,7 +17073,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_reorderaisles_reorderaisles",
-      "community": 64,
+      "community": 7,
       "norm_label": "reorderaisles()"
     },
     {
@@ -16972,7 +17083,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_resolvecanonconflict",
-      "community": 145,
+      "community": 106,
       "norm_label": "resolvecanonconflict.ts"
     },
     {
@@ -16982,7 +17093,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "commands_resolvecanonconflict_conflictstrategy",
-      "community": 145,
+      "community": 106,
       "norm_label": "conflictstrategy"
     },
     {
@@ -16992,7 +17103,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_resolvecanonconflict_resolvecanonconflict",
-      "community": 145,
+      "community": 106,
       "norm_label": "resolvecanonconflict()"
     },
     {
@@ -17092,7 +17203,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_aisle",
-      "community": 64,
+      "community": 7,
       "norm_label": "aisle.ts"
     },
     {
@@ -17102,7 +17213,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_aisle_aisle",
-      "community": 64,
+      "community": 7,
       "norm_label": "aisle"
     },
     {
@@ -17112,7 +17223,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_aislesdocument",
-      "community": 64,
+      "community": 7,
       "norm_label": "aislesdocument.ts"
     },
     {
@@ -17122,7 +17233,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_aislesdocument_aislesdocument",
-      "community": 64,
+      "community": 7,
       "norm_label": "aislesdocument"
     },
     {
@@ -17152,7 +17263,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_matchcandidate",
-      "community": 7,
+      "community": 32,
       "norm_label": "matchcandidate.ts"
     },
     {
@@ -17162,7 +17273,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "entities_matchcandidate_matchstage",
-      "community": 7,
+      "community": 32,
       "norm_label": "matchstage"
     },
     {
@@ -17172,7 +17283,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_matchcandidate_matchcandidate",
-      "community": 7,
+      "community": 32,
       "norm_label": "matchcandidate"
     },
     {
@@ -17252,7 +17363,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_index",
-      "community": 7,
+      "community": 32,
       "norm_label": "index.ts"
     },
     {
@@ -17262,7 +17373,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_aislelocalstoreport",
-      "community": 64,
+      "community": 7,
       "norm_label": "aislelocalstoreport.ts"
     },
     {
@@ -17272,7 +17383,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_aislelocalstoreport_aislelocalstoreport",
-      "community": 64,
+      "community": 7,
       "norm_label": "aislelocalstoreport"
     },
     {
@@ -17282,7 +17393,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_canonarbitrationport",
-      "community": 7,
+      "community": 32,
       "norm_label": "canonarbitrationport.ts"
     },
     {
@@ -17292,7 +17403,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_canonarbitrationport_arbitrationresult",
-      "community": 7,
+      "community": 32,
       "norm_label": "arbitrationresult"
     },
     {
@@ -17302,7 +17413,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "ports_canonarbitrationport_arbitrationrequest",
-      "community": 7,
+      "community": 32,
       "norm_label": "arbitrationrequest"
     },
     {
@@ -17312,7 +17423,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "ports_canonarbitrationport_canonarbitrationport",
-      "community": 7,
+      "community": 32,
       "norm_label": "canonarbitrationport"
     },
     {
@@ -17322,7 +17433,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_canonlocalstoreport",
-      "community": 7,
+      "community": 64,
       "norm_label": "canonlocalstoreport.ts"
     },
     {
@@ -17332,7 +17443,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_canonlocalstoreport_canonlocalstoreport",
-      "community": 7,
+      "community": 64,
       "norm_label": "canonlocalstoreport"
     },
     {
@@ -17342,7 +17453,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_canonlookupport",
-      "community": 7,
+      "community": 32,
       "norm_label": "canonlookupport.ts"
     },
     {
@@ -17352,7 +17463,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "ports_canonlookupport_canonlookupport",
-      "community": 7,
+      "community": 32,
       "norm_label": "canonlookupport"
     },
     {
@@ -17362,7 +17473,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_embeddingport",
-      "community": 7,
+      "community": 32,
       "norm_label": "embeddingport.ts"
     },
     {
@@ -17372,7 +17483,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "ports_embeddingport_embeddingport",
-      "community": 7,
+      "community": 32,
       "norm_label": "embeddingport"
     },
     {
@@ -17422,7 +17533,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_canonicon",
-      "community": 7,
+      "community": 32,
       "norm_label": "canonicon.ts"
     },
     {
@@ -17432,7 +17543,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "queries_canonicon_iscanoniconrenderable",
-      "community": 7,
+      "community": 32,
       "norm_label": "iscanoniconrenderable()"
     },
     {
@@ -17442,7 +17553,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_createcanonlookup",
-      "community": 7,
+      "community": 32,
       "norm_label": "createcanonlookup.ts"
     },
     {
@@ -17452,7 +17563,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "queries_createcanonlookup_createcanonlookup",
-      "community": 7,
+      "community": 32,
       "norm_label": "createcanonlookup()"
     },
     {
@@ -17462,7 +17573,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_embedmatch",
-      "community": 7,
+      "community": 32,
       "norm_label": "embedmatch.ts"
     },
     {
@@ -17472,7 +17583,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "queries_embedmatch_embedmatch",
-      "community": 7,
+      "community": 32,
       "norm_label": "embedmatch()"
     },
     {
@@ -17482,7 +17593,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_findclosestmatch",
-      "community": 17,
+      "community": 32,
       "norm_label": "findclosestmatch.ts"
     },
     {
@@ -17492,7 +17603,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "queries_findclosestmatch_findclosestmatchresult",
-      "community": 7,
+      "community": 32,
       "norm_label": "findclosestmatchresult"
     },
     {
@@ -17512,7 +17623,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_getaisleusage",
-      "community": 64,
+      "community": 7,
       "norm_label": "getaisleusage.ts"
     },
     {
@@ -17552,7 +17663,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_listaisles",
-      "community": 64,
+      "community": 7,
       "norm_label": "listaisles.ts"
     },
     {
@@ -17562,7 +17673,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "queries_listaisles_listaisles",
-      "community": 64,
+      "community": 7,
       "norm_label": "listaisles()"
     },
     {
@@ -17572,7 +17683,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_matchthresholds",
-      "community": 7,
+      "community": 32,
       "norm_label": "matchthresholds.ts"
     },
     {
@@ -17582,7 +17693,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "queries_matchthresholds_match_thresholds",
-      "community": 7,
+      "community": 32,
       "norm_label": "match_thresholds"
     },
     {
@@ -17722,7 +17833,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_synonymmatch",
-      "community": 17,
+      "community": 11,
       "norm_label": "synonymmatch.ts"
     },
     {
@@ -17732,7 +17843,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "queries_synonymmatch_synonymmatch",
-      "community": 17,
+      "community": 11,
       "norm_label": "synonymmatch()"
     },
     {
@@ -17772,7 +17883,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addaccessory",
-      "community": 1,
+      "community": 9,
       "norm_label": "addaccessory.ts"
     },
     {
@@ -17782,7 +17893,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_addaccessory_addaccessoryinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "addaccessoryinput"
     },
     {
@@ -17802,7 +17913,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addequipment",
-      "community": 1,
+      "community": 9,
       "norm_label": "addequipment.ts"
     },
     {
@@ -17812,7 +17923,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "commands_addequipment_addequipmentinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "addequipmentinput"
     },
     {
@@ -17832,7 +17943,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_addrule",
-      "community": 1,
+      "community": 9,
       "norm_label": "addrule.ts"
     },
     {
@@ -17842,7 +17953,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_addrule_addruleinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "addruleinput"
     },
     {
@@ -17852,7 +17963,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_addrule_addrule",
-      "community": 1,
+      "community": 9,
       "norm_label": "addrule()"
     },
     {
@@ -17862,7 +17973,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_editrule",
-      "community": 1,
+      "community": 9,
       "norm_label": "editrule.ts"
     },
     {
@@ -17872,7 +17983,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_editrule_editruleinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "editruleinput"
     },
     {
@@ -17882,7 +17993,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "commands_editrule_editrule",
-      "community": 1,
+      "community": 9,
       "norm_label": "editrule()"
     },
     {
@@ -17892,7 +18003,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removeaccessory",
-      "community": 1,
+      "community": 9,
       "norm_label": "removeaccessory.ts"
     },
     {
@@ -17902,7 +18013,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removeaccessory_removeaccessoryinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "removeaccessoryinput"
     },
     {
@@ -17922,7 +18033,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removeequipment",
-      "community": 1,
+      "community": 9,
       "norm_label": "removeequipment.ts"
     },
     {
@@ -17932,7 +18043,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removeequipment_removeequipmentinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "removeequipmentinput"
     },
     {
@@ -17952,7 +18063,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_removerule",
-      "community": 1,
+      "community": 9,
       "norm_label": "removerule.ts"
     },
     {
@@ -17962,7 +18073,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_removerule_removeruleinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "removeruleinput"
     },
     {
@@ -17972,7 +18083,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_removerule_removerule",
-      "community": 1,
+      "community": 9,
       "norm_label": "removerule()"
     },
     {
@@ -17982,7 +18093,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_renameequipment",
-      "community": 1,
+      "community": 9,
       "norm_label": "renameequipment.ts"
     },
     {
@@ -17992,7 +18103,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_renameequipment_renameequipmentinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "renameequipmentinput"
     },
     {
@@ -18002,7 +18113,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_renameequipment_renameequipment",
-      "community": 1,
+      "community": 9,
       "norm_label": "renameequipment()"
     },
     {
@@ -18012,7 +18123,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_setaccessoryowned",
-      "community": 1,
+      "community": 9,
       "norm_label": "setaccessoryowned.ts"
     },
     {
@@ -18022,7 +18133,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_setaccessoryowned_setaccessoryownedinput",
-      "community": 1,
+      "community": 9,
       "norm_label": "setaccessoryownedinput"
     },
     {
@@ -18042,7 +18153,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentitem",
-      "community": 1,
+      "community": 9,
       "norm_label": "equipmentitem.ts"
     },
     {
@@ -18052,7 +18163,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentitem_accessory",
-      "community": 1,
+      "community": 9,
       "norm_label": "accessory"
     },
     {
@@ -18062,7 +18173,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "entities_equipmentitem_equipmentitem",
-      "community": 1,
+      "community": 9,
       "norm_label": "equipmentitem"
     },
     {
@@ -18072,7 +18183,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_equipmentmanifest",
-      "community": 1,
+      "community": 9,
       "norm_label": "equipmentmanifest.ts"
     },
     {
@@ -18082,7 +18193,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_equipmentmanifest_equipmentmanifest",
-      "community": 1,
+      "community": 9,
       "norm_label": "equipmentmanifest"
     },
     {
@@ -18092,7 +18203,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "equipment_index",
-      "community": 1,
+      "community": 9,
       "norm_label": "index.ts"
     },
     {
@@ -18102,7 +18213,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_equipmentmanifestport",
-      "community": 1,
+      "community": 9,
       "norm_label": "equipmentmanifestport.ts"
     },
     {
@@ -18112,7 +18223,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "ports_equipmentmanifestport_equipmentmanifestport",
-      "community": 1,
+      "community": 9,
       "norm_label": "equipmentmanifestport"
     },
     {
@@ -18712,7 +18823,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_builders",
-      "community": 36,
+      "community": 137,
       "norm_label": "builders.ts"
     },
     {
@@ -18722,7 +18833,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_builders_emptyrecipe",
-      "community": 52,
+      "community": 51,
       "norm_label": "emptyrecipe()"
     },
     {
@@ -18732,7 +18843,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "commands_builders_emptyingredientgroup",
-      "community": 52,
+      "community": 51,
       "norm_label": "emptyingredientgroup()"
     },
     {
@@ -18742,7 +18853,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "commands_builders_newingredient",
-      "community": 52,
+      "community": 51,
       "norm_label": "newingredient()"
     },
     {
@@ -18752,7 +18863,7 @@
       "source_location": "L54",
       "_origin": "ast",
       "id": "commands_builders_newstep",
-      "community": 52,
+      "community": 51,
       "norm_label": "newstep()"
     },
     {
@@ -18822,7 +18933,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "entities_ingredient_ingredientgroup",
-      "community": 36,
+      "community": 137,
       "norm_label": "ingredientgroup"
     },
     {
@@ -18882,7 +18993,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_recipe",
-      "community": 36,
+      "community": 137,
       "norm_label": "recipe.ts"
     },
     {
@@ -18892,7 +19003,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "entities_recipe_recipeimage",
-      "community": 36,
+      "community": 137,
       "norm_label": "recipeimage"
     },
     {
@@ -18902,7 +19013,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "entities_recipe_recipemetadata",
-      "community": 36,
+      "community": 137,
       "norm_label": "recipemetadata"
     },
     {
@@ -18912,7 +19023,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "entities_recipe_recipesource",
-      "community": 36,
+      "community": 137,
       "norm_label": "recipesource"
     },
     {
@@ -18922,7 +19033,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "entities_recipe_recipe",
-      "community": 36,
+      "community": 137,
       "norm_label": "recipe"
     },
     {
@@ -18932,7 +19043,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_step",
-      "community": 36,
+      "community": 137,
       "norm_label": "step.ts"
     },
     {
@@ -18942,7 +19053,7 @@
       "source_location": "L2",
       "_origin": "ast",
       "id": "entities_step_steptimer",
-      "community": 36,
+      "community": 137,
       "norm_label": "steptimer"
     },
     {
@@ -18952,7 +19063,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "entities_step_step",
-      "community": 36,
+      "community": 137,
       "norm_label": "step"
     },
     {
@@ -20792,7 +20903,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_additem",
-      "community": 4,
+      "community": 279,
       "norm_label": "additem.ts"
     },
     {
@@ -20802,7 +20913,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "commands_additem_additeminput",
-      "community": 4,
+      "community": 279,
       "norm_label": "additeminput"
     },
     {
@@ -20812,7 +20923,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "commands_additem_additem",
-      "community": 8,
+      "community": 53,
       "norm_label": "additem()"
     },
     {
@@ -20842,7 +20953,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_checkitem_checkitem",
-      "community": 8,
+      "community": 4,
       "norm_label": "checkitem()"
     },
     {
@@ -20852,7 +20963,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_clearcheckeditems",
-      "community": 4,
+      "community": 53,
       "norm_label": "clearcheckeditems.ts"
     },
     {
@@ -20862,7 +20973,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_clearcheckeditems_clearcheckeditems",
-      "community": 4,
+      "community": 53,
       "norm_label": "clearcheckeditems()"
     },
     {
@@ -20902,7 +21013,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_createlist",
-      "community": 64,
+      "community": 7,
       "norm_label": "createlist.ts"
     },
     {
@@ -20922,7 +21033,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_createlist_createlist",
-      "community": 66,
+      "community": 53,
       "norm_label": "createlist()"
     },
     {
@@ -20962,7 +21073,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_deletelist",
-      "community": 64,
+      "community": 7,
       "norm_label": "deletelist.ts"
     },
     {
@@ -20982,7 +21093,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_deletelist_deletelist",
-      "community": 66,
+      "community": 53,
       "norm_label": "deletelist()"
     },
     {
@@ -21052,7 +21163,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_edititemrawtext",
-      "community": 66,
+      "community": 323,
       "norm_label": "edititemrawtext.ts"
     },
     {
@@ -21062,7 +21173,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_edititemrawtext_edititemrawtextinput",
-      "community": 66,
+      "community": 323,
       "norm_label": "edititemrawtextinput"
     },
     {
@@ -21072,7 +21183,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_edititemrawtext_edititemrawtext",
-      "community": 66,
+      "community": 323,
       "norm_label": "edititemrawtext()"
     },
     {
@@ -21082,7 +21193,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_moveitems",
-      "community": 4,
+      "community": 164,
       "norm_label": "moveitems.ts"
     },
     {
@@ -21092,7 +21203,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_moveitems_moveitemsinput",
-      "community": 4,
+      "community": 164,
       "norm_label": "moveitemsinput"
     },
     {
@@ -21102,7 +21213,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_moveitems_moveitemsresult",
-      "community": 4,
+      "community": 164,
       "norm_label": "moveitemsresult"
     },
     {
@@ -21112,7 +21223,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "commands_moveitems_moveitems",
-      "community": 4,
+      "community": 164,
       "norm_label": "moveitems()"
     },
     {
@@ -21122,7 +21233,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_renamelist",
-      "community": 64,
+      "community": 7,
       "norm_label": "renamelist.ts"
     },
     {
@@ -21142,7 +21253,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "commands_renamelist_renamelist",
-      "community": 66,
+      "community": 53,
       "norm_label": "renamelist()"
     },
     {
@@ -21152,7 +21263,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_setdefaultlist",
-      "community": 64,
+      "community": 7,
       "norm_label": "setdefaultlist.ts"
     },
     {
@@ -21172,7 +21283,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_setdefaultlist_setdefaultlist",
-      "community": 66,
+      "community": 53,
       "norm_label": "setdefaultlist()"
     },
     {
@@ -21182,7 +21293,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_uncheckitem",
-      "community": 4,
+      "community": 53,
       "norm_label": "uncheckitem.ts"
     },
     {
@@ -21192,7 +21303,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "commands_uncheckitem_uncheckiteminput",
-      "community": 4,
+      "community": 53,
       "norm_label": "uncheckiteminput"
     },
     {
@@ -21202,7 +21313,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_uncheckitem_uncheckitem",
-      "community": 8,
+      "community": 53,
       "norm_label": "uncheckitem()"
     },
     {
@@ -21212,7 +21323,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglist",
-      "community": 64,
+      "community": 7,
       "norm_label": "shoppinglist.ts"
     },
     {
@@ -21222,7 +21333,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglist_shoppinglist",
-      "community": 64,
+      "community": 7,
       "norm_label": "shoppinglist"
     },
     {
@@ -21232,7 +21343,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglistitem",
-      "community": 4,
+      "community": 279,
       "norm_label": "shoppinglistitem.ts"
     },
     {
@@ -21242,7 +21353,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "entities_shoppinglistitem_matchstate",
-      "community": 4,
+      "community": 279,
       "norm_label": "matchstate"
     },
     {
@@ -21252,7 +21363,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "entities_shoppinglistitem_shoppinglistitem",
-      "community": 4,
+      "community": 164,
       "norm_label": "shoppinglistitem"
     },
     {
@@ -21262,7 +21373,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglistsconfig",
-      "community": 141,
+      "community": 7,
       "norm_label": "shoppinglistsconfig.ts"
     },
     {
@@ -21272,7 +21383,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_shoppinglistsconfig_shoppinglistsconfig",
-      "community": 141,
+      "community": 265,
       "norm_label": "shoppinglistsconfig"
     },
     {
@@ -21282,7 +21393,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_sourceref",
-      "community": 4,
+      "community": 279,
       "norm_label": "sourceref.ts"
     },
     {
@@ -21292,7 +21403,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "entities_sourceref_sourceref",
-      "community": 4,
+      "community": 279,
       "norm_label": "sourceref"
     },
     {
@@ -21352,7 +21463,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_shoppinglistitemport",
-      "community": 4,
+      "community": 279,
       "norm_label": "shoppinglistitemport.ts"
     },
     {
@@ -21362,7 +21473,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "ports_shoppinglistitemport_shoppinglistitemport",
-      "community": 4,
+      "community": 279,
       "norm_label": "shoppinglistitemport"
     },
     {
@@ -21372,7 +21483,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_shoppinglistport",
-      "community": 64,
+      "community": 7,
       "norm_label": "shoppinglistport.ts"
     },
     {
@@ -21392,7 +21503,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "ports_shoppinglistsconfigport",
-      "community": 141,
+      "community": 7,
       "norm_label": "shoppinglistsconfigport.ts"
     },
     {
@@ -21412,7 +21523,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle",
-      "community": 4,
+      "community": 98,
       "norm_label": "groupitemsbyaisle.ts"
     },
     {
@@ -21422,7 +21533,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_canoninfo",
-      "community": 4,
+      "community": 98,
       "norm_label": "canoninfo"
     },
     {
@@ -21432,7 +21543,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_aisleinfo",
-      "community": 4,
+      "community": 98,
       "norm_label": "aisleinfo"
     },
     {
@@ -21442,7 +21553,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_othercontributor",
-      "community": 4,
+      "community": 98,
       "norm_label": "othercontributor"
     },
     {
@@ -21452,7 +21563,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_otherbucket",
-      "community": 4,
+      "community": 98,
       "norm_label": "otherbucket"
     },
     {
@@ -21462,7 +21573,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_checkedbucket",
-      "community": 4,
+      "community": 164,
       "norm_label": "checkedbucket"
     },
     {
@@ -21472,7 +21583,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_amountsubtotal",
-      "community": 4,
+      "community": 98,
       "norm_label": "amountsubtotal"
     },
     {
@@ -21482,7 +21593,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_aislerow",
-      "community": 4,
+      "community": 98,
       "norm_label": "aislerow"
     },
     {
@@ -21492,7 +21603,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_aislegroup",
-      "community": 4,
+      "community": 98,
       "norm_label": "aislegroup"
     },
     {
@@ -21502,7 +21613,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_groupedshoppinglist",
-      "community": 4,
+      "community": 98,
       "norm_label": "groupedshoppinglist"
     },
     {
@@ -21512,7 +21623,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_groupitemsoptions",
-      "community": 4,
+      "community": 98,
       "norm_label": "groupitemsoptions"
     },
     {
@@ -21522,7 +21633,7 @@
       "source_location": "L75",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_isrecipesourced",
-      "community": 4,
+      "community": 98,
       "norm_label": "isrecipesourced()"
     },
     {
@@ -21532,7 +21643,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_buildsubtotals",
-      "community": 4,
+      "community": 98,
       "norm_label": "buildsubtotals()"
     },
     {
@@ -21542,7 +21653,7 @@
       "source_location": "L98",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_makerow",
-      "community": 4,
+      "community": 98,
       "norm_label": "makerow()"
     },
     {
@@ -21552,7 +21663,7 @@
       "source_location": "L112",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_rowcreatedat",
-      "community": 4,
+      "community": 98,
       "norm_label": "rowcreatedat()"
     },
     {
@@ -21562,7 +21673,7 @@
       "source_location": "L119",
       "_origin": "ast",
       "id": "queries_groupitemsbyaisle_groupitemsbyaisle",
-      "community": 4,
+      "community": 98,
       "norm_label": "groupitemsbyaisle()"
     },
     {
@@ -21572,7 +21683,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "queries_groupitemsbyrecipe",
-      "community": 4,
+      "community": 164,
       "norm_label": "groupitemsbyrecipe.ts"
     },
     {
@@ -21582,7 +21693,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "queries_groupitemsbyrecipe_recipegroup",
-      "community": 4,
+      "community": 164,
       "norm_label": "recipegroup"
     },
     {
@@ -21592,7 +21703,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "queries_groupitemsbyrecipe_manualbucket",
-      "community": 4,
+      "community": 164,
       "norm_label": "manualbucket"
     },
     {
@@ -21602,7 +21713,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "queries_groupitemsbyrecipe_groupedbyrecipe",
-      "community": 4,
+      "community": 164,
       "norm_label": "groupedbyrecipe"
     },
     {
@@ -21612,7 +21723,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "queries_groupitemsbyrecipe_groupitemsbyrecipe",
-      "community": 4,
+      "community": 164,
       "norm_label": "groupitemsbyrecipe()"
     },
     {
@@ -21772,7 +21883,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_appsettings_schema_test",
-      "community": 51,
+      "community": 77,
       "norm_label": "appsettings.schema.test.ts"
     },
     {
@@ -21802,7 +21913,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_aislesdocument_schema_test",
-      "community": 64,
+      "community": 7,
       "norm_label": "aislesdocument.schema.test.ts"
     },
     {
@@ -21832,7 +21943,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canonicon_test",
-      "community": 7,
+      "community": 32,
       "norm_label": "canonicon.test.ts"
     },
     {
@@ -21842,7 +21953,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_canonitem_schema_test",
-      "community": 279,
+      "community": 17,
       "norm_label": "canonitem.schema.test.ts"
     },
     {
@@ -21852,7 +21963,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_canonitem_schema_test_counterids",
-      "community": 279,
+      "community": 17,
       "norm_label": "counterids()"
     },
     {
@@ -21952,7 +22063,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_createaisle_test",
-      "community": 64,
+      "community": 7,
       "norm_label": "createaisle.test.ts"
     },
     {
@@ -21962,7 +22073,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "canon_createaisle_test_makeids",
-      "community": 64,
+      "community": 7,
       "norm_label": "makeids()"
     },
     {
@@ -21972,7 +22083,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "canon_createaisle_test_makeaislestore",
-      "community": 64,
+      "community": 7,
       "norm_label": "makeaislestore()"
     },
     {
@@ -21982,7 +22093,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_createaislesbulk_test",
-      "community": 64,
+      "community": 7,
       "norm_label": "createaislesbulk.test.ts"
     },
     {
@@ -21992,7 +22103,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "canon_createaislesbulk_test_makeids",
-      "community": 64,
+      "community": 7,
       "norm_label": "makeids()"
     },
     {
@@ -22002,7 +22113,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "canon_createaislesbulk_test_makeaislestore",
-      "community": 64,
+      "community": 7,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22012,7 +22123,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_createcanonitem_test",
-      "community": 279,
+      "community": 17,
       "norm_label": "createcanonitem.test.ts"
     },
     {
@@ -22022,7 +22133,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_createcanonitem_test_counterids",
-      "community": 279,
+      "community": 17,
       "norm_label": "counterids()"
     },
     {
@@ -22032,7 +22143,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_createcanonlookup_test",
-      "community": 64,
+      "community": 7,
       "norm_label": "createcanonlookup.test.ts"
     },
     {
@@ -22052,7 +22163,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "canon_createcanonlookup_test_fakestore",
-      "community": 64,
+      "community": 7,
       "norm_label": "fakestore()"
     },
     {
@@ -22062,7 +22173,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_deleteaisles_test",
-      "community": 2,
+      "community": 64,
       "norm_label": "deleteaisles.test.ts"
     },
     {
@@ -22072,7 +22183,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_deleteaisles_test_makeaislestore",
-      "community": 2,
+      "community": 64,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22082,7 +22193,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "canon_deleteaisles_test_makecanonstore",
-      "community": 2,
+      "community": 64,
       "norm_label": "makecanonstore()"
     },
     {
@@ -22092,7 +22203,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "canon_deleteaisles_test_canonitem",
-      "community": 2,
+      "community": 64,
       "norm_label": "canonitem()"
     },
     {
@@ -22102,7 +22213,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_embedmatch_test",
-      "community": 7,
+      "community": 32,
       "norm_label": "embedmatch.test.ts"
     },
     {
@@ -22112,7 +22223,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_embedmatch_test_item",
-      "community": 7,
+      "community": 32,
       "norm_label": "item()"
     },
     {
@@ -22122,7 +22233,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "canon_embedmatch_test_cosine",
-      "community": 7,
+      "community": 32,
       "norm_label": "cosine()"
     },
     {
@@ -22132,7 +22243,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "canon_embedmatch_test_okport",
-      "community": 7,
+      "community": 32,
       "norm_label": "okport()"
     },
     {
@@ -22142,7 +22253,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "canon_embedmatch_test_failport",
-      "community": 7,
+      "community": 32,
       "norm_label": "failport()"
     },
     {
@@ -22152,7 +22263,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "canon_embedmatch_test_ex",
-      "community": 7,
+      "community": 32,
       "norm_label": "ex"
     },
     {
@@ -22162,7 +22273,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "canon_embedmatch_test_ey",
-      "community": 7,
+      "community": 32,
       "norm_label": "ey"
     },
     {
@@ -22172,7 +22283,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "canon_embedmatch_test_esim",
-      "community": 7,
+      "community": 32,
       "norm_label": "esim"
     },
     {
@@ -22262,7 +22373,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_listaisles_test",
-      "community": 64,
+      "community": 7,
       "norm_label": "listaisles.test.ts"
     },
     {
@@ -22272,7 +22383,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_listaisles_test_makeaislestore",
-      "community": 64,
+      "community": 7,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22582,7 +22693,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_mergeaisles_test",
-      "community": 286,
+      "community": 64,
       "norm_label": "mergeaisles.test.ts"
     },
     {
@@ -22592,7 +22703,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_makeaislestore",
-      "community": 286,
+      "community": 64,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22602,7 +22713,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_makecanonstore",
-      "community": 286,
+      "community": 64,
       "norm_label": "makecanonstore()"
     },
     {
@@ -22612,7 +22723,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_canonitem",
-      "community": 286,
+      "community": 64,
       "norm_label": "canonitem()"
     },
     {
@@ -22622,7 +22733,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "canon_mergeaisles_test_aisles",
-      "community": 286,
+      "community": 64,
       "norm_label": "aisles"
     },
     {
@@ -22632,7 +22743,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_mergecanonitems_test",
-      "community": 145,
+      "community": 106,
       "norm_label": "mergecanonitems.test.ts"
     },
     {
@@ -22642,7 +22753,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_mergecanonitems_test_item",
-      "community": 145,
+      "community": 106,
       "norm_label": "item()"
     },
     {
@@ -22662,7 +22773,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_ports_contract_test",
-      "community": 64,
+      "community": 7,
       "norm_label": "ports.contract.test.ts"
     },
     {
@@ -22672,7 +22783,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_renameaisle_test",
-      "community": 64,
+      "community": 7,
       "norm_label": "renameaisle.test.ts"
     },
     {
@@ -22682,7 +22793,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "canon_renameaisle_test_makeaislestore",
-      "community": 64,
+      "community": 7,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22692,7 +22803,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "canon_renameaisle_test_base",
-      "community": 64,
+      "community": 7,
       "norm_label": "base"
     },
     {
@@ -22722,7 +22833,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_reorderaisles_test",
-      "community": 64,
+      "community": 7,
       "norm_label": "reorderaisles.test.ts"
     },
     {
@@ -22732,7 +22843,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "canon_reorderaisles_test_makeaislestore",
-      "community": 64,
+      "community": 7,
       "norm_label": "makeaislestore()"
     },
     {
@@ -22742,7 +22853,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "canon_reorderaisles_test_base",
-      "community": 64,
+      "community": 7,
       "norm_label": "base"
     },
     {
@@ -22752,7 +22863,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test",
-      "community": 145,
+      "community": 106,
       "norm_label": "resolvecanonconflict.test.ts"
     },
     {
@@ -22762,7 +22873,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test_item",
-      "community": 145,
+      "community": 106,
       "norm_label": "item()"
     },
     {
@@ -22772,7 +22883,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test_local",
-      "community": 145,
+      "community": 106,
       "norm_label": "local"
     },
     {
@@ -22782,7 +22893,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "canon_resolvecanonconflict_test_remote",
-      "community": 145,
+      "community": 106,
       "norm_label": "remote"
     },
     {
@@ -22922,7 +23033,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canon_synonymmatch_test",
-      "community": 17,
+      "community": 11,
       "norm_label": "synonymmatch.test.ts"
     },
     {
@@ -22932,7 +23043,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "canon_synonymmatch_test_items",
-      "community": 17,
+      "community": 11,
       "norm_label": "items"
     },
     {
@@ -22952,7 +23063,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_devsettings_schema_test",
-      "community": 51,
+      "community": 77,
       "norm_label": "devsettings.schema.test.ts"
     },
     {
@@ -22962,7 +23073,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "equipment_commands_test",
-      "community": 1,
+      "community": 9,
       "norm_label": "commands.test.ts"
     },
     {
@@ -22972,7 +23083,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "equipment_commands_test_makeids",
-      "community": 1,
+      "community": 9,
       "norm_label": "makeids()"
     },
     {
@@ -22982,7 +23093,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "equipment_commands_test_emptymanifest",
-      "community": 1,
+      "community": 9,
       "norm_label": "emptymanifest()"
     },
     {
@@ -22992,7 +23103,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "equipment_commands_test_manifestwith",
-      "community": 1,
+      "community": 9,
       "norm_label": "manifestwith()"
     },
     {
@@ -23002,7 +23113,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "equipment_commands_test_makeitem",
-      "community": 1,
+      "community": 9,
       "norm_label": "makeitem()"
     },
     {
@@ -23012,7 +23123,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "equipment_commands_test_makeaccessory",
-      "community": 1,
+      "community": 9,
       "norm_label": "makeaccessory()"
     },
     {
@@ -23072,7 +23183,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "recipe_clearingredientmatch_test",
-      "community": 52,
+      "community": 51,
       "norm_label": "clearingredientmatch.test.ts"
     },
     {
@@ -23082,7 +23193,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "recipe_clearingredientmatch_test_matchedingredient",
-      "community": 52,
+      "community": 51,
       "norm_label": "matchedingredient()"
     },
     {
@@ -23092,7 +23203,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "recipe_recipe_schema_test",
-      "community": 52,
+      "community": 51,
       "norm_label": "recipe.schema.test.ts"
     },
     {
@@ -23102,7 +23213,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "recipe_recipe_schema_test_messyrecipe",
-      "community": 52,
+      "community": 51,
       "norm_label": "messyrecipe()"
     },
     {
@@ -23122,7 +23233,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_commands_test",
-      "community": 66,
+      "community": 53,
       "norm_label": "commands.test.ts"
     },
     {
@@ -23132,7 +23243,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeids",
-      "community": 66,
+      "community": 53,
       "norm_label": "makeids()"
     },
     {
@@ -23142,7 +23253,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makelist",
-      "community": 66,
+      "community": 53,
       "norm_label": "makelist()"
     },
     {
@@ -23152,7 +23263,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeconfig",
-      "community": 66,
+      "community": 53,
       "norm_label": "makeconfig()"
     },
     {
@@ -23162,7 +23273,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "shoppinglist_commands_test_makeitem",
-      "community": 66,
+      "community": 53,
       "norm_label": "makeitem()"
     },
     {
@@ -23172,7 +23283,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_groupitemsbyaisle_test",
-      "community": 4,
+      "community": 98,
       "norm_label": "groupitemsbyaisle.test.ts"
     },
     {
@@ -23182,7 +23293,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "shoppinglist_groupitemsbyaisle_test_makeitem",
-      "community": 4,
+      "community": 98,
       "norm_label": "makeitem()"
     },
     {
@@ -23192,7 +23303,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "shoppinglist_groupitemsbyaisle_test_makecanonmap",
-      "community": 4,
+      "community": 98,
       "norm_label": "makecanonmap()"
     },
     {
@@ -23202,7 +23313,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "shoppinglist_groupitemsbyaisle_test_aisles",
-      "community": 4,
+      "community": 98,
       "norm_label": "aisles"
     },
     {
@@ -23212,7 +23323,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "shoppinglist_groupitemsbyrecipe_test",
-      "community": 4,
+      "community": 164,
       "norm_label": "groupitemsbyrecipe.test.ts"
     },
     {
@@ -23222,7 +23333,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "shoppinglist_groupitemsbyrecipe_test_makeitem",
-      "community": 4,
+      "community": 164,
       "norm_label": "makeitem()"
     },
     {
@@ -23232,7 +23343,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "shoppinglist_groupitemsbyrecipe_test_recipesource",
-      "community": 4,
+      "community": 164,
       "norm_label": "recipesource()"
     },
     {
@@ -23472,7 +23583,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_types_src_index_ts_src_index",
-      "community": 298,
+      "community": 7,
       "norm_label": "index.ts"
     },
     {
@@ -23482,7 +23593,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "src_index_success",
-      "community": 64,
+      "community": 7,
       "norm_label": "success"
     },
     {
@@ -23492,7 +23603,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "src_index_failure",
-      "community": 64,
+      "community": 7,
       "norm_label": "failure"
     },
     {
@@ -23502,7 +23613,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "src_index_conflict",
-      "community": 298,
+      "community": 7,
       "norm_label": "conflict"
     },
     {
@@ -23512,7 +23623,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "src_index_readresult",
-      "community": 64,
+      "community": 7,
       "norm_label": "readresult"
     },
     {
@@ -23522,7 +23633,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "src_index_writeresult",
-      "community": 298,
+      "community": 7,
       "norm_label": "writeresult"
     },
     {
@@ -23542,7 +23653,7 @@
       "source_location": "L54",
       "_origin": "ast",
       "id": "src_index_domainerror",
-      "community": 64,
+      "community": 7,
       "norm_label": "domainerror"
     },
     {
@@ -23572,7 +23683,7 @@
       "source_location": "L92",
       "_origin": "ast",
       "id": "src_index_canonitemdto",
-      "community": 298,
+      "community": 7,
       "norm_label": "canonitemdto"
     },
     {
@@ -23582,7 +23693,7 @@
       "source_location": "L107",
       "_origin": "ast",
       "id": "src_index_aisledto",
-      "community": 298,
+      "community": 7,
       "norm_label": "aisledto"
     },
     {
@@ -23592,7 +23703,7 @@
       "source_location": "L113",
       "_origin": "ast",
       "id": "src_index_aislelistdto",
-      "community": 298,
+      "community": 7,
       "norm_label": "aislelistdto"
     },
     {
@@ -23602,7 +23713,7 @@
       "source_location": "L118",
       "_origin": "ast",
       "id": "src_index_errorcode",
-      "community": 1,
+      "community": 7,
       "norm_label": "errorcode"
     },
     {
@@ -25372,7 +25483,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_ui_components_src_index_ts_src_index",
-      "community": 21,
+      "community": 14,
       "norm_label": "index.ts"
     },
     {
@@ -25392,7 +25503,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_lib_cn",
-      "community": 14,
+      "community": 38,
       "norm_label": "../../lib/cn"
     },
     {
@@ -25625,7 +25736,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_cn",
-      "community": 21,
+      "community": 332,
       "norm_label": "cn.ts"
     },
     {
@@ -25635,7 +25746,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "lib_cn_twmerge",
-      "community": 21,
+      "community": 332,
       "norm_label": "twmerge"
     },
     {
@@ -25645,7 +25756,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "lib_cn_cn",
-      "community": 21,
+      "community": 332,
       "norm_label": "cn()"
     },
     {
@@ -25695,7 +25806,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_variants",
-      "community": 23,
+      "community": 72,
       "norm_label": "variants.ts"
     },
     {
@@ -25747,7 +25858,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "spinner_spinner",
-      "community": 39,
+      "community": 38,
       "norm_label": "../../primitives/spinner/spinner.svelte"
     },
     {
@@ -25817,7 +25928,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canonicon_canonicon",
-      "community": 14,
+      "community": 38,
       "norm_label": "canonicon.svelte"
     },
     {
@@ -25827,7 +25938,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_canonicon_canonicon_types",
-      "community": 14,
+      "community": 38,
       "norm_label": "./canonicon.types"
     },
     {
@@ -25837,7 +25948,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "canonicon_canonicon_types",
-      "community": 21,
+      "community": 14,
       "norm_label": "canonicon.types.ts"
     },
     {
@@ -25847,7 +25958,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "canonicon_canonicon_types_canoniconprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "canoniconprops"
     },
     {
@@ -26038,7 +26149,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "bits_ui",
-      "community": 38,
+      "community": 72,
       "norm_label": "bits-ui"
     },
     {
@@ -26239,7 +26350,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "combobox_combobox_types",
-      "community": 21,
+      "community": 14,
       "norm_label": "combobox.types.ts"
     },
     {
@@ -26249,7 +26360,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxitem",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxitem"
     },
     {
@@ -26259,7 +26370,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxprops"
     },
     {
@@ -26269,7 +26380,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxinputprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxinputprops"
     },
     {
@@ -26279,7 +26390,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxfieldprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxfieldprops"
     },
     {
@@ -26289,7 +26400,7 @@
       "source_location": "L56",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxtriggerprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxtriggerprops"
     },
     {
@@ -26299,7 +26410,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxcontentprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxcontentprops"
     },
     {
@@ -26309,7 +26420,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxitemprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxitemprops"
     },
     {
@@ -26319,7 +26430,7 @@
       "source_location": "L73",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxgroupprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxgroupprops"
     },
     {
@@ -26329,7 +26440,7 @@
       "source_location": "L78",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxlabelprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxlabelprops"
     },
     {
@@ -26339,7 +26450,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxseparatorprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxseparatorprops"
     },
     {
@@ -26349,7 +26460,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxemptyprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxemptyprops"
     },
     {
@@ -26359,7 +26470,7 @@
       "source_location": "L92",
       "_origin": "ast",
       "id": "combobox_combobox_types_comboboxcreateprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "comboboxcreateprops"
     },
     {
@@ -26729,7 +26840,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "combobox_index",
-      "community": 21,
+      "community": 14,
       "norm_label": "index.ts"
     },
     {
@@ -26739,7 +26850,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_dialog",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialog.svelte"
     },
     {
@@ -26749,7 +26860,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_headless_dialog_headless_svelte",
-      "community": 23,
+      "community": 72,
       "norm_label": "../../headless/dialog.headless.svelte"
     },
     {
@@ -26759,7 +26870,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_dialog_dialog_types",
-      "community": 23,
+      "community": 72,
       "norm_label": "./dialog.types"
     },
     {
@@ -26769,7 +26880,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_dialog_types",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialog.types.ts"
     },
     {
@@ -26779,7 +26890,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "dialog_dialog_types_dialogprops",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialogprops"
     },
     {
@@ -26789,7 +26900,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "dialog_dialog_types_dialogcontentprops",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialogcontentprops"
     },
     {
@@ -26799,7 +26910,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "dialog_dialog_types_dialogpartprops",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialogpartprops"
     },
     {
@@ -26809,7 +26920,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_dialog_variants",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialog.variants.ts"
     },
     {
@@ -26819,7 +26930,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "dialog_dialog_variants_dialogcontentvariants",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialogcontentvariants"
     },
     {
@@ -26829,7 +26940,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_dialogclose",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialogclose.svelte"
     },
     {
@@ -26839,7 +26950,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "dialog_dialogclose_children",
-      "community": 23,
+      "community": 72,
       "norm_label": "children()"
     },
     {
@@ -26849,7 +26960,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_dialogcontent",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialogcontent.svelte"
     },
     {
@@ -26859,7 +26970,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_dialog_dialog_variants",
-      "community": 23,
+      "community": 72,
       "norm_label": "./dialog.variants"
     },
     {
@@ -26869,7 +26980,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_dialogdescription",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialogdescription.svelte"
     },
     {
@@ -26879,7 +26990,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_dialogfooter",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialogfooter.svelte"
     },
     {
@@ -26889,7 +27000,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_dialogheader",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialogheader.svelte"
     },
     {
@@ -26899,7 +27010,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_dialogtitle",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialogtitle.svelte"
     },
     {
@@ -26909,7 +27020,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_dialogtrigger",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialogtrigger.svelte"
     },
     {
@@ -26919,7 +27030,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "dialog_index",
-      "community": 23,
+      "community": 72,
       "norm_label": "index.ts"
     },
     {
@@ -27040,7 +27151,7 @@
       "_origin": "ast",
       "confidence": "EXTRACTED",
       "id": "emptystate_emptystate",
-      "community": 21,
+      "community": 38,
       "norm_label": "../../primitives/emptystate/emptystate.svelte"
     },
     {
@@ -27050,7 +27161,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_emptystate_emptystate_types",
-      "community": 21,
+      "community": 38,
       "norm_label": "./emptystate.types"
     },
     {
@@ -27060,7 +27171,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "emptystate_emptystate_types",
-      "community": 21,
+      "community": 38,
       "norm_label": "emptystate.types.ts"
     },
     {
@@ -27070,7 +27181,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "emptystate_emptystate_types_emptystateprops",
-      "community": 21,
+      "community": 38,
       "norm_label": "emptystateprops"
     },
     {
@@ -27080,7 +27191,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "emptystate_index",
-      "community": 21,
+      "community": 38,
       "norm_label": "index.ts"
     },
     {
@@ -27091,7 +27202,7 @@
       "_origin": "ast",
       "confidence": "EXTRACTED",
       "id": "errorstate_errorstate",
-      "community": 54,
+      "community": 39,
       "norm_label": "../../primitives/errorstate/errorstate.svelte"
     },
     {
@@ -27102,7 +27213,7 @@
       "_origin": "ast",
       "source_location": "L1",
       "id": "icon_icon",
-      "community": 54,
+      "community": 39,
       "norm_label": "../../primitives/icon/icon.svelte"
     },
     {
@@ -27112,7 +27223,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_errorstate_errorstate_types",
-      "community": 54,
+      "community": 39,
       "norm_label": "./errorstate.types"
     },
     {
@@ -27122,7 +27233,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "errorstate_errorstate_types",
-      "community": 54,
+      "community": 39,
       "norm_label": "errorstate.types.ts"
     },
     {
@@ -27132,7 +27243,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "errorstate_errorstate_types_errorstateprops",
-      "community": 54,
+      "community": 39,
       "norm_label": "errorstateprops"
     },
     {
@@ -27142,7 +27253,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "errorstate_index",
-      "community": 54,
+      "community": 39,
       "norm_label": "index.ts"
     },
     {
@@ -27232,7 +27343,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "heading_heading",
-      "community": 106,
+      "community": 329,
       "norm_label": "heading.svelte"
     },
     {
@@ -27242,7 +27353,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_heading_heading_variants",
-      "community": 106,
+      "community": 329,
       "norm_label": "./heading.variants"
     },
     {
@@ -27252,7 +27363,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_heading_heading_types",
-      "community": 106,
+      "community": 329,
       "norm_label": "./heading.types"
     },
     {
@@ -27262,7 +27373,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "heading_heading_types",
-      "community": 106,
+      "community": 329,
       "norm_label": "heading.types.ts"
     },
     {
@@ -27272,7 +27383,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "heading_heading_types_headingprops",
-      "community": 106,
+      "community": 329,
       "norm_label": "headingprops"
     },
     {
@@ -27282,7 +27393,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "heading_heading_variants",
-      "community": 106,
+      "community": 329,
       "norm_label": "heading.variants.ts"
     },
     {
@@ -27292,7 +27403,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "heading_heading_variants_headingvariants",
-      "community": 106,
+      "community": 329,
       "norm_label": "headingvariants"
     },
     {
@@ -27302,7 +27413,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "heading_index",
-      "community": 106,
+      "community": 329,
       "norm_label": "index.ts"
     },
     {
@@ -27312,7 +27423,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_icon_icon_types",
-      "community": 54,
+      "community": 39,
       "norm_label": "./icon.types"
     },
     {
@@ -27322,7 +27433,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "icon_icon_types",
-      "community": 54,
+      "community": 39,
       "norm_label": "icon.types.ts"
     },
     {
@@ -27332,7 +27443,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "icon_icon_types_iconprops",
-      "community": 54,
+      "community": 39,
       "norm_label": "iconprops"
     },
     {
@@ -27342,7 +27453,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "icon_index",
-      "community": 54,
+      "community": 39,
       "norm_label": "index.ts"
     },
     {
@@ -27432,7 +27543,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "markdown_markdown",
-      "community": 14,
+      "community": 38,
       "norm_label": "markdown.svelte"
     },
     {
@@ -27452,7 +27563,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "gfm",
-      "community": 14,
+      "community": 38,
       "norm_label": "svelte-exmarkdown/gfm"
     },
     {
@@ -27462,7 +27573,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_popover",
-      "community": 150,
+      "community": 72,
       "norm_label": "popover.svelte"
     },
     {
@@ -27472,7 +27583,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_headless_popover_headless_svelte",
-      "community": 150,
+      "community": 72,
       "norm_label": "../../headless/popover.headless.svelte"
     },
     {
@@ -27482,7 +27593,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_popover_popover_types",
-      "community": 150,
+      "community": 72,
       "norm_label": "./popover.types"
     },
     {
@@ -27492,7 +27603,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_popover_types",
-      "community": 150,
+      "community": 72,
       "norm_label": "popover.types.ts"
     },
     {
@@ -27502,7 +27613,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "popover_popover_types_popoverprops",
-      "community": 150,
+      "community": 72,
       "norm_label": "popoverprops"
     },
     {
@@ -27512,7 +27623,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "popover_popover_types_popovercontentprops",
-      "community": 150,
+      "community": 72,
       "norm_label": "popovercontentprops"
     },
     {
@@ -27522,7 +27633,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "popover_popover_types_popoverpartprops",
-      "community": 150,
+      "community": 72,
       "norm_label": "popoverpartprops"
     },
     {
@@ -27542,7 +27653,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_popovercontent",
-      "community": 150,
+      "community": 72,
       "norm_label": "popovercontent.svelte"
     },
     {
@@ -27552,7 +27663,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_primitives_popover_popover_variants",
-      "community": 150,
+      "community": 72,
       "norm_label": "./popover.variants"
     },
     {
@@ -27562,7 +27673,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_popovertrigger",
-      "community": 150,
+      "community": 72,
       "norm_label": "popovertrigger.svelte"
     },
     {
@@ -27572,7 +27683,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "popover_index",
-      "community": 150,
+      "community": 72,
       "norm_label": "index.ts"
     },
     {
@@ -28385,7 +28496,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "sheet_sheettrigger",
-      "community": 38,
+      "community": 72,
       "norm_label": "sheettrigger.svelte"
     },
     {
@@ -28649,7 +28760,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "sortablelist_sortablelist_types",
-      "community": 21,
+      "community": 14,
       "norm_label": "sortablelist.types.ts"
     },
     {
@@ -28659,7 +28770,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "sortablelist_sortablelist_types_sortablelistprops",
-      "community": 21,
+      "community": 14,
       "norm_label": "sortablelistprops"
     },
     {
@@ -28669,7 +28780,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "spinner_spinner_types",
-      "community": 39,
+      "community": 14,
       "norm_label": "spinner.types.ts"
     },
     {
@@ -28679,7 +28790,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "spinner_spinner_types_spinnerprops",
-      "community": 39,
+      "community": 14,
       "norm_label": "spinnerprops"
     },
     {
@@ -28689,7 +28800,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "spinner_index",
-      "community": 39,
+      "community": 14,
       "norm_label": "index.ts"
     },
     {
@@ -29586,7 +29697,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "detailpage_detailpage",
-      "community": 54,
+      "community": 39,
       "norm_label": "detailpage.svelte"
     },
     {
@@ -29596,7 +29707,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "detailpage_detailpage_titleslot",
-      "community": 54,
+      "community": 39,
       "norm_label": "titleslot()"
     },
     {
@@ -29606,7 +29717,7 @@
       "confidence": "EXTRACTED",
       "_origin": "ast",
       "id": "users_daniel_projects_salt_vscode_packages_ui_components_src_templates_detailpage_detailpage_types",
-      "community": 54,
+      "community": 39,
       "norm_label": "./detailpage.types"
     },
     {
@@ -29616,7 +29727,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "detailpage_detailpage_types",
-      "community": 54,
+      "community": 39,
       "norm_label": "detailpage.types.ts"
     },
     {
@@ -29626,7 +29737,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "detailpage_detailpage_types_detailpageprops",
-      "community": 54,
+      "community": 39,
       "norm_label": "detailpageprops"
     },
     {
@@ -29636,7 +29747,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "detailpage_index",
-      "community": 54,
+      "community": 39,
       "norm_label": "index.ts"
     },
     {
@@ -30079,7 +30190,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_canonicon_test",
-      "community": 14,
+      "community": 38,
       "norm_label": "canonicon.test.ts"
     },
     {
@@ -30119,7 +30230,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_combobox_test",
-      "community": 14,
+      "community": 331,
       "norm_label": "combobox.test.ts"
     },
     {
@@ -30129,7 +30240,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "tests_combobox_test_setup",
-      "community": 14,
+      "community": 331,
       "norm_label": "setup()"
     },
     {
@@ -30139,7 +30250,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "tests_combobox_test_getinput",
-      "community": 14,
+      "community": 331,
       "norm_label": "getinput()"
     },
     {
@@ -30149,7 +30260,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "tests_combobox_test_getlistbox",
-      "community": 14,
+      "community": 331,
       "norm_label": "getlistbox()"
     },
     {
@@ -30159,7 +30270,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "tests_combobox_test_opencombobox",
-      "community": 14,
+      "community": 331,
       "norm_label": "opencombobox()"
     },
     {
@@ -30169,7 +30280,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_dialog_test",
-      "community": 23,
+      "community": 72,
       "norm_label": "dialog.test.ts"
     },
     {
@@ -30179,7 +30290,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_heading_test",
-      "community": 106,
+      "community": 329,
       "norm_label": "heading.test.ts"
     },
     {
@@ -30189,7 +30300,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "tests_heading_test_snippet",
-      "community": 106,
+      "community": 329,
       "norm_label": "snippet()"
     },
     {
@@ -30199,7 +30310,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_icon_test",
-      "community": 54,
+      "community": 39,
       "norm_label": "icon.test.ts"
     },
     {
@@ -30209,7 +30320,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_icon_types_test_d",
-      "community": 54,
+      "community": 39,
       "norm_label": "icon.types.test-d.ts"
     },
     {
@@ -30219,7 +30330,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "tests_icon_types_test_d_bad",
-      "community": 54,
+      "community": 39,
       "norm_label": "_bad"
     },
     {
@@ -30229,7 +30340,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_popover_test",
-      "community": 150,
+      "community": 72,
       "norm_label": "popover.test.ts"
     },
     {
@@ -30369,7 +30480,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_spinner_test",
-      "community": 39,
+      "community": 38,
       "norm_label": "spinner.test.ts"
     },
     {
@@ -30539,7 +30650,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "tests_lib_cn_test",
-      "community": 21,
+      "community": 332,
       "norm_label": "lib.cn.test.ts"
     },
     {
@@ -30771,6 +30882,46 @@
       "norm_label": "cut-release.sh script"
     },
     {
+      "label": "export-prod-firestore.mjs",
+      "file_type": "code",
+      "source_file": "scripts/export-prod-firestore.mjs",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "scripts_export_prod_firestore",
+      "community": 157,
+      "norm_label": "export-prod-firestore.mjs"
+    },
+    {
+      "label": "run()",
+      "file_type": "code",
+      "source_file": "scripts/export-prod-firestore.mjs",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "scripts_export_prod_firestore_run",
+      "community": 157,
+      "norm_label": "run()"
+    },
+    {
+      "label": "commandExists()",
+      "file_type": "code",
+      "source_file": "scripts/export-prod-firestore.mjs",
+      "source_location": "L29",
+      "_origin": "ast",
+      "id": "scripts_export_prod_firestore_commandexists",
+      "community": 157,
+      "norm_label": "commandexists()"
+    },
+    {
+      "label": "stamp",
+      "file_type": "code",
+      "source_file": "scripts/export-prod-firestore.mjs",
+      "source_location": "L65",
+      "_origin": "ast",
+      "id": "scripts_export_prod_firestore_stamp",
+      "community": 157,
+      "norm_label": "stamp"
+    },
+    {
       "label": "free-ports.mjs",
       "file_type": "code",
       "source_file": "scripts/free-ports.mjs",
@@ -30887,6 +31038,56 @@
       "id": "users_daniel_projects_saltv2_scripts_grant_callable_invokers_sh__entry",
       "community": 194,
       "norm_label": "grant-callable-invokers.sh script"
+    },
+    {
+      "label": "restore-staging-from-prod.mjs",
+      "file_type": "code",
+      "source_file": "scripts/restore-staging-from-prod.mjs",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "scripts_restore_staging_from_prod",
+      "community": 144,
+      "norm_label": "restore-staging-from-prod.mjs"
+    },
+    {
+      "label": "run()",
+      "file_type": "code",
+      "source_file": "scripts/restore-staging-from-prod.mjs",
+      "source_location": "L36",
+      "_origin": "ast",
+      "id": "scripts_restore_staging_from_prod_run",
+      "community": 144,
+      "norm_label": "run()"
+    },
+    {
+      "label": "commandExists()",
+      "file_type": "code",
+      "source_file": "scripts/restore-staging-from-prod.mjs",
+      "source_location": "L40",
+      "_origin": "ast",
+      "id": "scripts_restore_staging_from_prod_commandexists",
+      "community": 144,
+      "norm_label": "commandexists()"
+    },
+    {
+      "label": "ask()",
+      "file_type": "code",
+      "source_file": "scripts/restore-staging-from-prod.mjs",
+      "source_location": "L49",
+      "_origin": "ast",
+      "id": "scripts_restore_staging_from_prod_ask",
+      "community": 144,
+      "norm_label": "ask()"
+    },
+    {
+      "label": "exportPath",
+      "file_type": "code",
+      "source_file": "scripts/restore-staging-from-prod.mjs",
+      "source_location": "L72",
+      "_origin": "ast",
+      "id": "scripts_restore_staging_from_prod_exportpath",
+      "community": 144,
+      "norm_label": "exportpath"
     },
     {
       "label": "stop-emulators.mjs",
@@ -31339,10 +31540,20 @@
       "norm_label": ".restarttask()"
     },
     {
+      "label": ".getSuiteTasks()",
+      "file_type": "code",
+      "source_file": "tools/task-pilot-extension/extension.js",
+      "source_location": "L319",
+      "_origin": "ast",
+      "id": "task_pilot_extension_extension_taskpilotprovider_getsuitetasks",
+      "community": 19,
+      "norm_label": ".getsuitetasks()"
+    },
+    {
       "label": ".startAll()",
       "file_type": "code",
       "source_file": "tools/task-pilot-extension/extension.js",
-      "source_location": "L311",
+      "source_location": "L327",
       "_origin": "ast",
       "id": "task_pilot_extension_extension_taskpilotprovider_startall",
       "community": 19,
@@ -31352,7 +31563,7 @@
       "label": ".restartAll()",
       "file_type": "code",
       "source_file": "tools/task-pilot-extension/extension.js",
-      "source_location": "L337",
+      "source_location": "L349",
       "_origin": "ast",
       "id": "task_pilot_extension_extension_taskpilotprovider_restartall",
       "community": 19,
@@ -31362,7 +31573,7 @@
       "label": ".seedAdminMember()",
       "file_type": "code",
       "source_file": "tools/task-pilot-extension/extension.js",
-      "source_location": "L346",
+      "source_location": "L358",
       "_origin": "ast",
       "id": "task_pilot_extension_extension_taskpilotprovider_seedadminmember",
       "community": 19,
@@ -31372,7 +31583,7 @@
       "label": ".waitForFirestore()",
       "file_type": "code",
       "source_file": "tools/task-pilot-extension/extension.js",
-      "source_location": "L377",
+      "source_location": "L389",
       "_origin": "ast",
       "id": "task_pilot_extension_extension_taskpilotprovider_waitforfirestore",
       "community": 19,
@@ -31382,7 +31593,7 @@
       "label": ".runSeed()",
       "file_type": "code",
       "source_file": "tools/task-pilot-extension/extension.js",
-      "source_location": "L411",
+      "source_location": "L423",
       "_origin": "ast",
       "id": "task_pilot_extension_extension_taskpilotprovider_runseed",
       "community": 19,
@@ -31392,7 +31603,7 @@
       "label": ".nuke()",
       "file_type": "code",
       "source_file": "tools/task-pilot-extension/extension.js",
-      "source_location": "L438",
+      "source_location": "L450",
       "_origin": "ast",
       "id": "task_pilot_extension_extension_taskpilotprovider_nuke",
       "community": 19,
@@ -31402,7 +31613,7 @@
       "label": ".openUrl()",
       "file_type": "code",
       "source_file": "tools/task-pilot-extension/extension.js",
-      "source_location": "L483",
+      "source_location": "L495",
       "_origin": "ast",
       "id": "task_pilot_extension_extension_taskpilotprovider_openurl",
       "community": 19,
@@ -31412,7 +31623,7 @@
       "label": ".findTerminalByLabel()",
       "file_type": "code",
       "source_file": "tools/task-pilot-extension/extension.js",
-      "source_location": "L493",
+      "source_location": "L505",
       "_origin": "ast",
       "id": "task_pilot_extension_extension_taskpilotprovider_findterminalbylabel",
       "community": 19,
@@ -31422,7 +31633,7 @@
       "label": ".findTerminalByProcessId()",
       "file_type": "code",
       "source_file": "tools/task-pilot-extension/extension.js",
-      "source_location": "L499",
+      "source_location": "L511",
       "_origin": "ast",
       "id": "task_pilot_extension_extension_taskpilotprovider_findterminalbyprocessid",
       "community": 19,
@@ -31432,7 +31643,7 @@
       "label": "openTaskConfig()",
       "file_type": "code",
       "source_file": "tools/task-pilot-extension/extension.js",
-      "source_location": "L519",
+      "source_location": "L531",
       "_origin": "ast",
       "id": "task_pilot_extension_extension_opentaskconfig",
       "community": 19,
@@ -31442,7 +31653,7 @@
       "label": "activate()",
       "file_type": "code",
       "source_file": "tools/task-pilot-extension/extension.js",
-      "source_location": "L530",
+      "source_location": "L542",
       "_origin": "ast",
       "id": "task_pilot_extension_extension_activate",
       "community": 19,
@@ -31452,7 +31663,7 @@
       "label": "deactivate()",
       "file_type": "code",
       "source_file": "tools/task-pilot-extension/extension.js",
-      "source_location": "L548",
+      "source_location": "L560",
       "_origin": "ast",
       "id": "task_pilot_extension_extension_deactivate",
       "community": 19,
@@ -31464,7 +31675,7 @@
       "source_file": "tools/task-pilot-extension/package.json",
       "source_location": "L1",
       "_origin": "ast",
-      "id": "users_daniel_projects_saltv2_tools_task_pilot_extension_package_json",
+      "id": "task_pilot_extension_package",
       "community": 22,
       "norm_label": "package.json"
     },
@@ -32185,7 +32396,7 @@
       "source_location": "L75",
       "_origin": "ast",
       "id": "commands_defect_phases",
-      "community": 270,
+      "community": 322,
       "norm_label": "phases"
     },
     {
@@ -32195,7 +32406,7 @@
       "source_location": "L80",
       "_origin": "ast",
       "id": "commands_defect_phase_1_name",
-      "community": 270,
+      "community": 322,
       "norm_label": "phase 1: [name]"
     },
     {
@@ -32205,7 +32416,7 @@
       "source_location": "L86",
       "_origin": "ast",
       "id": "commands_defect_phase_2_name",
-      "community": 270,
+      "community": 322,
       "norm_label": "phase 2: [name]"
     },
     {
@@ -32375,7 +32586,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_run",
-      "community": 278,
+      "community": 282,
       "norm_label": "run.md"
     },
     {
@@ -32385,7 +32596,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "commands_run_run_issue",
-      "community": 278,
+      "community": 282,
       "norm_label": "run issue"
     },
     {
@@ -32395,7 +32606,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "commands_run_setup_once",
-      "community": 278,
+      "community": 282,
       "norm_label": "setup (once)"
     },
     {
@@ -32405,7 +32616,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "commands_run_create_the_working_branch_once_before_phase_1",
-      "community": 278,
+      "community": 282,
       "norm_label": "create the working branch (once, before phase 1)"
     },
     {
@@ -32495,7 +32706,7 @@
       "source_location": "L169",
       "_origin": "ast",
       "id": "commands_run_pause_conditions_stop_and_wait_for_user",
-      "community": 278,
+      "community": 282,
       "norm_label": "pause conditions (stop and wait for user)"
     },
     {
@@ -32555,7 +32766,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "commands_spec_intended_experience",
-      "community": 278,
+      "community": 282,
       "norm_label": "intended experience"
     },
     {
@@ -33169,6 +33380,86 @@
       "norm_label": "proven prompt (verbatim \u2014 reproduce exactly)"
     },
     {
+      "label": "data-refresh.md",
+      "file_type": "document",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "docs_data_refresh",
+      "community": 52,
+      "norm_label": "data-refresh.md"
+    },
+    {
+      "label": "Refreshing staging with prod data",
+      "file_type": "document",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "docs_data_refresh_refreshing_staging_with_prod_data",
+      "community": 52,
+      "norm_label": "refreshing staging with prod data"
+    },
+    {
+      "label": "Why managed export/import (and not a copy script)",
+      "file_type": "document",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L13",
+      "_origin": "ast",
+      "id": "docs_data_refresh_why_managed_export_import_and_not_a_copy_script",
+      "community": 52,
+      "norm_label": "why managed export/import (and not a copy script)"
+    },
+    {
+      "label": "One-time setup",
+      "file_type": "document",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L24",
+      "_origin": "ast",
+      "id": "docs_data_refresh_one_time_setup",
+      "community": 52,
+      "norm_label": "one-time setup"
+    },
+    {
+      "label": "Usage",
+      "file_type": "document",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L59",
+      "_origin": "ast",
+      "id": "docs_data_refresh_usage",
+      "community": 52,
+      "norm_label": "usage"
+    },
+    {
+      "label": "Safety",
+      "file_type": "document",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L66",
+      "_origin": "ast",
+      "id": "docs_data_refresh_safety",
+      "community": 52,
+      "norm_label": "safety"
+    },
+    {
+      "label": "After a restore \u2014 re-apply staging-only config",
+      "file_type": "document",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L73",
+      "_origin": "ast",
+      "id": "docs_data_refresh_after_a_restore_re_apply_staging_only_config",
+      "community": 52,
+      "norm_label": "after a restore \u2014 re-apply staging-only config"
+    },
+    {
+      "label": "Scope",
+      "file_type": "document",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L88",
+      "_origin": "ast",
+      "id": "docs_data_refresh_scope",
+      "community": 52,
+      "norm_label": "scope"
+    },
+    {
       "label": "design.md",
       "file_type": "document",
       "source_file": "docs/design/design.md",
@@ -33345,7 +33636,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_foundations",
-      "community": 72,
+      "community": 310,
       "norm_label": "1. foundations"
     },
     {
@@ -33355,7 +33646,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_1_technology_stack",
-      "community": 72,
+      "community": 310,
       "norm_label": "1.1 technology stack"
     },
     {
@@ -33365,7 +33656,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_2_boundaries",
-      "community": 72,
+      "community": 310,
       "norm_label": "1.2 boundaries"
     },
     {
@@ -33375,7 +33666,7 @@
       "source_location": "L85",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_3_package_surface",
-      "community": 72,
+      "community": 310,
       "norm_label": "1.3 package surface"
     },
     {
@@ -33385,7 +33676,7 @@
       "source_location": "L137",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_4_event_naming_rule",
-      "community": 72,
+      "community": 310,
       "norm_label": "1.4 event naming rule"
     },
     {
@@ -33395,7 +33686,7 @@
       "source_location": "L147",
       "_origin": "ast",
       "id": "design_ui_spec_v02_1_5_spec_versioning_amendment_rule",
-      "community": 72,
+      "community": 310,
       "norm_label": "1.5 spec versioning & amendment rule"
     },
     {
@@ -33545,7 +33836,7 @@
       "source_location": "L383",
       "_origin": "ast",
       "id": "design_ui_spec_v02_3_5_helpers",
-      "community": 266,
+      "community": 317,
       "norm_label": "3.5 helpers"
     },
     {
@@ -33555,7 +33846,7 @@
       "source_location": "L385",
       "_origin": "ast",
       "id": "design_ui_spec_v02_src_lib_cn_ts",
-      "community": 266,
+      "community": 317,
       "norm_label": "`src/lib/cn.ts`"
     },
     {
@@ -33565,7 +33856,7 @@
       "source_location": "L396",
       "_origin": "ast",
       "id": "design_ui_spec_v02_src_lib_useid_ts",
-      "community": 266,
+      "community": 317,
       "norm_label": "`src/lib/useid.ts`"
     },
     {
@@ -33575,7 +33866,7 @@
       "source_location": "L409",
       "_origin": "ast",
       "id": "design_ui_spec_v02_src_lib_context_ts",
-      "community": 266,
+      "community": 317,
       "norm_label": "`src/lib/context.ts`"
     },
     {
@@ -33585,7 +33876,7 @@
       "source_location": "L432",
       "_origin": "ast",
       "id": "design_ui_spec_v02_src_lib_variants_ts",
-      "community": 266,
+      "community": 317,
       "norm_label": "`src/lib/variants.ts`"
     },
     {
@@ -33695,7 +33986,7 @@
       "source_location": "L669",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_styling_system",
-      "community": 82,
+      "community": 311,
       "norm_label": "4. styling system"
     },
     {
@@ -33705,7 +33996,7 @@
       "source_location": "L671",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_1_tokens",
-      "community": 311,
+      "community": 82,
       "norm_label": "4.1 tokens"
     },
     {
@@ -33715,7 +34006,7 @@
       "source_location": "L675",
       "_origin": "ast",
       "id": "design_ui_spec_v02_semantic_colors",
-      "community": 311,
+      "community": 82,
       "norm_label": "semantic colors"
     },
     {
@@ -33725,7 +34016,7 @@
       "source_location": "L689",
       "_origin": "ast",
       "id": "design_ui_spec_v02_radius",
-      "community": 311,
+      "community": 82,
       "norm_label": "radius"
     },
     {
@@ -33735,7 +34026,7 @@
       "source_location": "L698",
       "_origin": "ast",
       "id": "design_ui_spec_v02_motion",
-      "community": 311,
+      "community": 82,
       "norm_label": "motion"
     },
     {
@@ -33745,7 +34036,7 @@
       "source_location": "L707",
       "_origin": "ast",
       "id": "design_ui_spec_v02_elevation",
-      "community": 311,
+      "community": 82,
       "norm_label": "elevation"
     },
     {
@@ -33755,7 +34046,7 @@
       "source_location": "L713",
       "_origin": "ast",
       "id": "design_ui_spec_v02_z_index",
-      "community": 311,
+      "community": 82,
       "norm_label": "z-index"
     },
     {
@@ -33765,7 +34056,7 @@
       "source_location": "L721",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_2_focus_ring",
-      "community": 82,
+      "community": 311,
       "norm_label": "4.2 focus ring"
     },
     {
@@ -33775,7 +34066,7 @@
       "source_location": "L735",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_3_disabled_loading",
-      "community": 82,
+      "community": 311,
       "norm_label": "4.3 disabled + loading"
     },
     {
@@ -33785,7 +34076,7 @@
       "source_location": "L737",
       "_origin": "ast",
       "id": "design_ui_spec_v02_disabled_terminal_state_no_interaction",
-      "community": 82,
+      "community": 311,
       "norm_label": "disabled (terminal state \u2014 no interaction)"
     },
     {
@@ -33795,7 +34086,7 @@
       "source_location": "L744",
       "_origin": "ast",
       "id": "design_ui_spec_v02_loading_transient_state_disables_interaction_without_terminal_semantics",
-      "community": 82,
+      "community": 311,
       "norm_label": "loading (transient state \u2014 disables interaction without terminal semantics)"
     },
     {
@@ -33805,7 +34096,7 @@
       "source_location": "L755",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_4_shared_size_scale",
-      "community": 98,
+      "community": 313,
       "norm_label": "4.4 shared size scale"
     },
     {
@@ -33815,7 +34106,7 @@
       "source_location": "L759",
       "_origin": "ast",
       "id": "design_ui_spec_v02_field_size_scale_textfield_textarea_frame_button",
-      "community": 98,
+      "community": 313,
       "norm_label": "field size scale (textfield, textarea frame, button)"
     },
     {
@@ -33825,7 +34116,7 @@
       "source_location": "L767",
       "_origin": "ast",
       "id": "design_ui_spec_v02_control_size_scale_checkbox_switch",
-      "community": 98,
+      "community": 313,
       "norm_label": "control size scale (checkbox, switch)"
     },
     {
@@ -33835,7 +34126,7 @@
       "source_location": "L775",
       "_origin": "ast",
       "id": "design_ui_spec_v02_dialog_size_scale",
-      "community": 98,
+      "community": 313,
       "norm_label": "dialog size scale"
     },
     {
@@ -33845,7 +34136,7 @@
       "source_location": "L785",
       "_origin": "ast",
       "id": "design_ui_spec_v02_text_size_scale_text_primitive",
-      "community": 98,
+      "community": 313,
       "norm_label": "text size scale (text primitive)"
     },
     {
@@ -33855,7 +34146,7 @@
       "source_location": "L793",
       "_origin": "ast",
       "id": "design_ui_spec_v02_icon_spinner_sizes",
-      "community": 98,
+      "community": 313,
       "norm_label": "icon / spinner sizes"
     },
     {
@@ -33865,7 +34156,7 @@
       "source_location": "L799",
       "_origin": "ast",
       "id": "design_ui_spec_v02_4_5_dark_mode",
-      "community": 82,
+      "community": 311,
       "norm_label": "4.5 dark mode"
     },
     {
@@ -34175,7 +34466,7 @@
       "source_location": "L1127",
       "_origin": "ast",
       "id": "design_ui_spec_v02_8_4_checkbox",
-      "community": 300,
+      "community": 89,
       "norm_label": "8.4 checkbox"
     },
     {
@@ -34185,7 +34476,7 @@
       "source_location": "L1129",
       "_origin": "ast",
       "id": "design_ui_spec_v02_props_1129",
-      "community": 300,
+      "community": 89,
       "norm_label": "props"
     },
     {
@@ -34195,7 +34486,7 @@
       "source_location": "L1146",
       "_origin": "ast",
       "id": "design_ui_spec_v02_snippets_1146",
-      "community": 300,
+      "community": 89,
       "norm_label": "snippets"
     },
     {
@@ -34205,7 +34496,7 @@
       "source_location": "L1151",
       "_origin": "ast",
       "id": "design_ui_spec_v02_events_1151",
-      "community": 300,
+      "community": 89,
       "norm_label": "events"
     },
     {
@@ -34215,7 +34506,7 @@
       "source_location": "L1155",
       "_origin": "ast",
       "id": "design_ui_spec_v02_accessibility_1155",
-      "community": 300,
+      "community": 89,
       "norm_label": "accessibility"
     },
     {
@@ -34225,7 +34516,7 @@
       "source_location": "L1162",
       "_origin": "ast",
       "id": "design_ui_spec_v02_styling_1162",
-      "community": 300,
+      "community": 89,
       "norm_label": "styling"
     },
     {
@@ -34235,7 +34526,7 @@
       "source_location": "L1171",
       "_origin": "ast",
       "id": "design_ui_spec_v02_forbidden_1171",
-      "community": 300,
+      "community": 89,
       "norm_label": "forbidden"
     },
     {
@@ -34245,7 +34536,7 @@
       "source_location": "L1177",
       "_origin": "ast",
       "id": "design_ui_spec_v02_8_5_switch",
-      "community": 282,
+      "community": 319,
       "norm_label": "8.5 switch"
     },
     {
@@ -34255,7 +34546,7 @@
       "source_location": "L1179",
       "_origin": "ast",
       "id": "design_ui_spec_v02_props_1179",
-      "community": 282,
+      "community": 319,
       "norm_label": "props"
     },
     {
@@ -34265,7 +34556,7 @@
       "source_location": "L1195",
       "_origin": "ast",
       "id": "design_ui_spec_v02_events_1195",
-      "community": 282,
+      "community": 319,
       "norm_label": "events"
     },
     {
@@ -34275,7 +34566,7 @@
       "source_location": "L1199",
       "_origin": "ast",
       "id": "design_ui_spec_v02_accessibility_1199",
-      "community": 282,
+      "community": 319,
       "norm_label": "accessibility"
     },
     {
@@ -34285,7 +34576,7 @@
       "source_location": "L1205",
       "_origin": "ast",
       "id": "design_ui_spec_v02_styling_1205",
-      "community": 282,
+      "community": 319,
       "norm_label": "styling"
     },
     {
@@ -34605,7 +34896,7 @@
       "source_location": "L1436",
       "_origin": "ast",
       "id": "design_ui_spec_v02_8_12_icon",
-      "community": 322,
+      "community": 150,
       "norm_label": "8.12 icon"
     },
     {
@@ -34615,7 +34906,7 @@
       "source_location": "L1438",
       "_origin": "ast",
       "id": "design_ui_spec_v02_props_1438",
-      "community": 322,
+      "community": 150,
       "norm_label": "props"
     },
     {
@@ -34625,7 +34916,7 @@
       "source_location": "L1447",
       "_origin": "ast",
       "id": "design_ui_spec_v02_accessibility_1447",
-      "community": 322,
+      "community": 150,
       "norm_label": "accessibility"
     },
     {
@@ -34635,7 +34926,7 @@
       "source_location": "L1452",
       "_origin": "ast",
       "id": "design_ui_spec_v02_styling_1452",
-      "community": 322,
+      "community": 150,
       "norm_label": "styling"
     },
     {
@@ -34645,7 +34936,7 @@
       "source_location": "L1462",
       "_origin": "ast",
       "id": "design_ui_spec_v02_8_13_layout_primitives_stack_inline_grid_divider",
-      "community": 281,
+      "community": 318,
       "norm_label": "8.13 layout primitives \u2014 stack / inline / grid / divider"
     },
     {
@@ -34655,7 +34946,7 @@
       "source_location": "L1464",
       "_origin": "ast",
       "id": "design_ui_spec_v02_stack",
-      "community": 281,
+      "community": 318,
       "norm_label": "stack"
     },
     {
@@ -34665,7 +34956,7 @@
       "source_location": "L1475",
       "_origin": "ast",
       "id": "design_ui_spec_v02_inline",
-      "community": 281,
+      "community": 318,
       "norm_label": "inline"
     },
     {
@@ -34675,7 +34966,7 @@
       "source_location": "L1479",
       "_origin": "ast",
       "id": "design_ui_spec_v02_grid",
-      "community": 281,
+      "community": 318,
       "norm_label": "grid"
     },
     {
@@ -34685,7 +34976,7 @@
       "source_location": "L1489",
       "_origin": "ast",
       "id": "design_ui_spec_v02_divider",
-      "community": 281,
+      "community": 318,
       "norm_label": "divider"
     },
     {
@@ -34695,7 +34986,7 @@
       "source_location": "L1505",
       "_origin": "ast",
       "id": "design_ui_spec_v02_8_14_spinner",
-      "community": 313,
+      "community": 281,
       "norm_label": "8.14 spinner"
     },
     {
@@ -34705,7 +34996,7 @@
       "source_location": "L1507",
       "_origin": "ast",
       "id": "design_ui_spec_v02_props_1507",
-      "community": 313,
+      "community": 281,
       "norm_label": "props"
     },
     {
@@ -34715,7 +35006,7 @@
       "source_location": "L1515",
       "_origin": "ast",
       "id": "design_ui_spec_v02_accessibility_1515",
-      "community": 313,
+      "community": 281,
       "norm_label": "accessibility"
     },
     {
@@ -34725,7 +35016,7 @@
       "source_location": "L1520",
       "_origin": "ast",
       "id": "design_ui_spec_v02_styling_1520",
-      "community": 313,
+      "community": 281,
       "norm_label": "styling"
     },
     {
@@ -35665,7 +35956,7 @@
       "source_location": "L621",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_list_selection_createlistselection_selectablelist_selectallcheckbox_rowselectcheckbox",
-      "community": 272,
+      "community": 66,
       "norm_label": "10. list selection (`createlistselection` + `selectablelist` / `selectallcheckbox` / `rowselectcheckbox`)"
     },
     {
@@ -35675,7 +35966,7 @@
       "source_location": "L623",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_1_overview",
-      "community": 272,
+      "community": 66,
       "norm_label": "10.1 overview"
     },
     {
@@ -35685,7 +35976,7 @@
       "source_location": "L638",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_2_createlistselection_options",
-      "community": 272,
+      "community": 66,
       "norm_label": "10.2 `createlistselection(options)`"
     },
     {
@@ -35695,7 +35986,7 @@
       "source_location": "L664",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_3_component_props",
-      "community": 272,
+      "community": 66,
       "norm_label": "10.3 component props"
     },
     {
@@ -35705,7 +35996,7 @@
       "source_location": "L679",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_4_behaviour",
-      "community": 272,
+      "community": 66,
       "norm_label": "10.4 behaviour"
     },
     {
@@ -35715,7 +36006,7 @@
       "source_location": "L686",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_5_accessibility",
-      "community": 272,
+      "community": 66,
       "norm_label": "10.5 accessibility"
     },
     {
@@ -35725,7 +36016,7 @@
       "source_location": "L691",
       "_origin": "ast",
       "id": "design_ui_spec_v04_10_6_testing_requirements",
-      "community": 272,
+      "community": 66,
       "norm_label": "10.6 testing requirements"
     },
     {
@@ -35735,7 +36026,7 @@
       "source_location": "L700",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_editablerow_primitive",
-      "community": 310,
+      "community": 272,
       "norm_label": "11. editablerow (primitive)"
     },
     {
@@ -35745,7 +36036,7 @@
       "source_location": "L702",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_1_overview",
-      "community": 310,
+      "community": 272,
       "norm_label": "11.1 overview"
     },
     {
@@ -35755,7 +36046,7 @@
       "source_location": "L706",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_2_props",
-      "community": 310,
+      "community": 272,
       "norm_label": "11.2 props"
     },
     {
@@ -35765,7 +36056,7 @@
       "source_location": "L716",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_3_behaviour",
-      "community": 310,
+      "community": 272,
       "norm_label": "11.3 behaviour"
     },
     {
@@ -35775,7 +36066,7 @@
       "source_location": "L723",
       "_origin": "ast",
       "id": "design_ui_spec_v04_11_4_testing_requirements",
-      "community": 310,
+      "community": 272,
       "norm_label": "11.4 testing requirements"
     },
     {
@@ -36255,7 +36546,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_by_stage_narrative",
-      "community": 71,
+      "community": 286,
       "norm_label": "stage-by-stage narrative"
     },
     {
@@ -36265,7 +36556,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_1_exact_name_match",
-      "community": 71,
+      "community": 286,
       "norm_label": "stage 1 \u2014 exact name match"
     },
     {
@@ -36275,7 +36566,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_2_token_overlap",
-      "community": 71,
+      "community": 286,
       "norm_label": "stage 2 \u2014 token overlap"
     },
     {
@@ -36285,7 +36576,7 @@
       "source_location": "L91",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_3_synonym_exact_match",
-      "community": 71,
+      "community": 286,
       "norm_label": "stage 3 \u2014 synonym exact match"
     },
     {
@@ -36295,7 +36586,7 @@
       "source_location": "L95",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_4_string_similarity_levenshtein",
-      "community": 71,
+      "community": 286,
       "norm_label": "stage 4 \u2014 string similarity (levenshtein)"
     },
     {
@@ -36305,7 +36596,7 @@
       "source_location": "L99",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_5_embedding_cosine",
-      "community": 71,
+      "community": 286,
       "norm_label": "stage 5 \u2014 embedding cosine"
     },
     {
@@ -36315,7 +36606,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "docs_matching_pipeline_stage_6_merged_shortlist_ai_arbitration",
-      "community": 71,
+      "community": 286,
       "norm_label": "stage 6 \u2014 merged shortlist + ai arbitration"
     },
     {
@@ -36765,7 +37056,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_releases",
-      "community": 53,
+      "community": 1,
       "norm_label": "releases.md"
     },
     {
@@ -36775,7 +37066,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_releases_releases_environments",
-      "community": 53,
+      "community": 1,
       "norm_label": "releases & environments"
     },
     {
@@ -36785,7 +37076,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "docs_releases_firebase_projects_firebaserc_aliases",
-      "community": 53,
+      "community": 1,
       "norm_label": "firebase projects (`.firebaserc` aliases)"
     },
     {
@@ -36795,7 +37086,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "docs_releases_config_secrets_what_lives_where",
-      "community": 89,
+      "community": 1,
       "norm_label": "config & secrets \u2014 what lives where"
     },
     {
@@ -36805,7 +37096,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "docs_releases_1_client_config_build_time_committed_not_secret",
-      "community": 89,
+      "community": 1,
       "norm_label": "1. client config \u2014 build-time, committed, **not secret**"
     },
     {
@@ -36815,7 +37106,7 @@
       "source_location": "L60",
       "_origin": "ast",
       "id": "docs_releases_2_cloud_functions_runtime_secrets_secret_manager_per_project_never_committed",
-      "community": 89,
+      "community": 1,
       "norm_label": "2. cloud functions runtime secrets \u2014 secret manager, per project, **never committed**"
     },
     {
@@ -36825,7 +37116,7 @@
       "source_location": "L86",
       "_origin": "ast",
       "id": "docs_releases_3_ci_github_environments",
-      "community": 89,
+      "community": 1,
       "norm_label": "3. ci / github environments"
     },
     {
@@ -36835,7 +37126,7 @@
       "source_location": "L101",
       "_origin": "ast",
       "id": "docs_releases_wif_identifiers_provisioned_phase_2",
-      "community": 89,
+      "community": 1,
       "norm_label": "wif identifiers (provisioned \u2014 phase 2)"
     },
     {
@@ -36845,7 +37136,7 @@
       "source_location": "L115",
       "_origin": "ast",
       "id": "docs_releases_deploying",
-      "community": 53,
+      "community": 1,
       "norm_label": "deploying"
     },
     {
@@ -36855,7 +37146,7 @@
       "source_location": "L128",
       "_origin": "ast",
       "id": "docs_releases_cutting_a_release_promote_staging_production",
-      "community": 53,
+      "community": 1,
       "norm_label": "cutting a release (promote staging \u2192 production)"
     },
     {
@@ -36865,7 +37156,7 @@
       "source_location": "L147",
       "_origin": "ast",
       "id": "docs_releases_rollback_re_deploy",
-      "community": 53,
+      "community": 1,
       "norm_label": "rollback / re-deploy"
     },
     {
@@ -36875,7 +37166,7 @@
       "source_location": "L162",
       "_origin": "ast",
       "id": "docs_releases_first_deploy_to_a_fresh_project_one_time_bootstrap",
-      "community": 53,
+      "community": 1,
       "norm_label": "first deploy to a fresh project (one-time bootstrap)"
     },
     {
@@ -36885,7 +37176,7 @@
       "source_location": "L185",
       "_origin": "ast",
       "id": "docs_releases_setup_status",
-      "community": 53,
+      "community": 1,
       "norm_label": "setup status"
     },
     {
@@ -38461,7 +38752,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 278,
+      "community": 282,
       "norm_label": "per-phase handoff contract",
       "id": "commands_run_handoff_contract"
     },
@@ -38474,7 +38765,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 278,
+      "community": 282,
       "norm_label": "orchestrator/subagent pattern",
       "id": "commands_run_orchestrator_subagent_pattern"
     },
@@ -38565,7 +38856,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 97,
+      "community": 48,
       "norm_label": "last-write-wins per document",
       "id": "claude_lww_per_document"
     },
@@ -38747,7 +39038,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 54,
       "norm_label": "prod -> staging firestore refresh flow",
       "id": "data_refresh_prod_to_staging_refresh"
     },
@@ -38760,7 +39051,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 54,
       "norm_label": "managed export/import (no triggers)",
       "id": "data_refresh_managed_export_import"
     },
@@ -38773,7 +39064,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 54,
       "norm_label": "task pilot sidebar tasks",
       "id": "data_refresh_task_pilot"
     },
@@ -38786,7 +39077,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 54,
       "norm_label": "staging-only hard refuse safety guard",
       "id": "data_refresh_staging_hard_refuse"
     },
@@ -38799,7 +39090,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 54,
       "norm_label": "cross-project import iam (objectviewer + legacybucketreader)",
       "id": "data_refresh_cross_project_iam"
     },
@@ -39228,7 +39519,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 54,
       "norm_label": "matchorcreatecanon cf callable",
       "id": "matching_pipeline_match_or_create_canon_callable"
     },
@@ -39241,7 +39532,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 54,
       "norm_label": "onshoppinglistitemwrite trigger",
       "id": "matching_pipeline_on_shopping_list_item_write"
     },
@@ -39306,7 +39597,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 54,
       "norm_label": "matchorcreatebatch three-phase orchestrator",
       "id": "matching_pipeline_match_or_create_batch"
     },
@@ -39384,7 +39675,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 54,
       "norm_label": "batched embedding cache (no stage-5 fork)",
       "id": "matching_pipeline_batch_embedding_cache"
     },
@@ -39397,7 +39688,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 54,
       "norm_label": "oncanonitemwritten trigger (icon/embedding)",
       "id": "matching_pipeline_on_canon_item_written"
     },
@@ -39410,7 +39701,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 1,
       "norm_label": "trunk-based release model",
       "id": "releases_trunk_based_model"
     },
@@ -39423,7 +39714,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 54,
       "norm_label": "firebase project aliases (default/staging/production)",
       "id": "releases_firebase_projects"
     },
@@ -39436,7 +39727,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 54,
       "norm_label": "client config vs runtime secrets split",
       "id": "releases_client_config_vs_secrets"
     },
@@ -39449,7 +39740,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 1,
       "norm_label": "workload identity federation auth",
       "id": "releases_wif_auth"
     },
@@ -39462,7 +39753,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 1,
       "norm_label": "production promotion approval gate",
       "id": "releases_production_approval_gate"
     },
@@ -39488,7 +39779,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 1,
       "norm_label": "dev/staging share one google ai studio project",
       "id": "releases_gemini_shared_ai_studio"
     },
@@ -39527,7 +39818,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 97,
+      "community": 48,
       "norm_label": "schema evolution / end-of-greenfield",
       "id": "salt_architecture_schema_evolution_greenfield"
     },
@@ -39618,7 +39909,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 54,
       "norm_label": "cloud functions requirements",
       "id": "salt_architecture_cloud_functions_reqs"
     },
@@ -39644,7 +39935,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 53,
+      "community": 1,
       "norm_label": "admin-managed model selection (resolvemodel/ai_flow_roles)",
       "id": "salt_architecture_resolve_model_roles"
     },
@@ -44673,6 +44964,28 @@
       "target": "flows_matchorcreatecanon_outputschema"
     },
     {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/flows/matchOrCreateCanon.ts",
+      "source_location": "L21",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "flows_matchorcreatecanon",
+      "target": "observability_environment"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/flows/matchOrCreateCanon.ts",
+      "source_location": "L21",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "flows_matchorcreatecanon",
+      "target": "observability_environment_resolveserverenvironment"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -44748,6 +45061,17 @@
       "confidence_score": 1.0,
       "source": "triggers_onshoppinglistitemwrite",
       "target": "flows_matchorcreatecanon_buildmatchorcreateports"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/flows/matchOrCreateCanon.ts",
+      "source_location": "L78",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "flows_matchorcreatecanon_ensureobservabilityinitialised",
+      "target": "observability_environment_resolveserverenvironment"
     },
     {
       "relation": "calls",
@@ -45160,6 +45484,28 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "apps/cloud-functions/src/index.ts",
+      "source_location": "L19",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "apps_cloud_functions_src_index_ts_src_index",
+      "target": "observability_environment"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/index.ts",
+      "source_location": "L19",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "apps_cloud_functions_src_index_ts_src_index",
+      "target": "observability_environment_resolveserverenvironment"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/index.ts",
       "source_location": "L18",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -45422,6 +45768,26 @@
       "confidence_score": 1.0,
       "source": "src_index_reportunexpected",
       "target": "observability_reportservererror_reportflowerror"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/observability/environment.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "observability_environment",
+      "target": "observability_environment_project_environments"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/cloud-functions/src/observability/environment.ts",
+      "source_location": "L22",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "observability_environment",
+      "target": "observability_environment_resolveserverenvironment"
     },
     {
       "relation": "contains",
@@ -62836,11 +63202,29 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/src/lib/observability.ts",
+      "source_location": "L71",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "lib_observability",
+      "target": "lib_observability_submitfeedback"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/lib/observability.ts",
       "source_location": "L40",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "lib_observability",
       "target": "lib_observability_tagsession"
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "apps/web-pwa/src/routes/settings/SettingsPage.svelte",
+      "confidence_score": 1.0,
+      "source": "settings_settingspage",
+      "target": "lib_observability"
     },
     {
       "relation": "calls",
@@ -62918,6 +63302,17 @@
       "weight": 1.0,
       "source": "lib_observability_issessionactive",
       "target": "src_sessioncontrol_isobservabilitysessionactive"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "apps/web-pwa/src/lib/observability.ts",
+      "source_location": "L72",
+      "weight": 1.0,
+      "source": "lib_observability_submitfeedback",
+      "target": "src_init_sendsupportfeedback"
     },
     {
       "relation": "imports_from",
@@ -67600,11 +67995,11 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/vite.config.ts",
-      "source_location": "L21",
+      "source_location": "L28",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "web_pwa_vite_config",
-      "target": "web_pwa_vite_config_appcommit"
+      "target": "web_pwa_vite_config_appversion"
     },
     {
       "relation": "contains",
@@ -67620,11 +68015,11 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "apps/web-pwa/vite.config.ts",
-      "source_location": "L12",
+      "source_location": "L17",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "web_pwa_vite_config",
-      "target": "web_pwa_vite_config_gitshortsha"
+      "target": "web_pwa_vite_config_resolveappversion"
     },
     {
       "relation": "contains",
@@ -74071,7 +74466,29 @@
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "packages_adapters_observability_src_index_ts_src_index",
+      "target": "src_init_sendsupportfeedback"
+    },
+    {
+      "relation": "re_exports",
+      "context": "re-export",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/index.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "packages_adapters_observability_src_index_ts_src_index",
       "target": "src_init_startspan"
+    },
+    {
+      "relation": "re_exports",
+      "context": "re-export",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/index.ts",
+      "source_location": "L17",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "packages_adapters_observability_src_index_ts_src_index",
+      "target": "src_init_supportfeedbacktraits"
     },
     {
       "relation": "re_exports",
@@ -74220,6 +74637,16 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/adapters/observability/src/init.ts",
+      "source_location": "L133",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "packages_adapters_observability_src_init_ts_src_init",
+      "target": "src_init_conversationsapi"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/init.ts",
       "source_location": "L126",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -74310,11 +74737,31 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/adapters/observability/src/init.ts",
+      "source_location": "L147",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "packages_adapters_observability_src_init_ts_src_init",
+      "target": "src_init_sendsupportfeedback"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/init.ts",
       "source_location": "L119",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "packages_adapters_observability_src_init_ts_src_init",
       "target": "src_init_startspan"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/init.ts",
+      "source_location": "L126",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "packages_adapters_observability_src_init_ts_src_init",
+      "target": "src_init_supportfeedbacktraits"
     },
     {
       "relation": "contains",
@@ -74368,6 +74815,17 @@
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "src_init_identifyobservabilityuser",
+      "target": "src_init_safeposthog"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/init.ts",
+      "source_location": "L92",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "src_init_initobservability",
       "target": "src_init_safeposthog"
     },
     {
@@ -74479,6 +74937,17 @@
       "weight": 1.0,
       "source": "src_sessiontagging_tagobservabilitysession",
       "target": "src_init_safeposthog"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/environmentSuperProperty.test.ts",
+      "source_location": "L59",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tests_environmentsuperproperty_test",
+      "target": "src_init_initobservability"
     },
     {
       "relation": "imports",
@@ -75181,6 +75650,16 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/adapters/observability/src/server/init.ts",
+      "source_location": "L104",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "server_init",
+      "target": "server_init_withenvironment"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/src/server/init.ts",
       "source_location": "L179",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -75207,6 +75686,17 @@
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "server_posthogservermatchloggingadapter",
+      "target": "server_init"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/environmentSuperProperty.test.ts",
+      "source_location": "L60",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tests_environmentsuperproperty_test",
       "target": "server_init"
     },
     {
@@ -75252,6 +75742,17 @@
       "confidence_score": 1.0,
       "source": "tests_runwithextractedtracecontext_test",
       "target": "server_init"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/environmentSuperProperty.test.ts",
+      "source_location": "L60",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tests_environmentsuperproperty_test",
+      "target": "server_init_initserverobservability"
     },
     {
       "relation": "imports",
@@ -75334,12 +75835,45 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/environmentSuperProperty.test.ts",
+      "source_location": "L60",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tests_environmentsuperproperty_test",
+      "target": "server_init_captureserverevent"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "packages/adapters/observability/src/server/posthogServerErrorReportingAdapter.ts",
       "source_location": "L2",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "server_posthogservererrorreportingadapter",
       "target": "server_init_captureserverexception"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/environmentSuperProperty.test.ts",
+      "source_location": "L60",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tests_environmentsuperproperty_test",
+      "target": "server_init_captureserverexception"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/environmentSuperProperty.test.ts",
+      "source_location": "L60",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tests_environmentsuperproperty_test",
+      "target": "server_init_captureaigeneration"
     },
     {
       "relation": "imports",
@@ -75820,6 +76354,26 @@
       "confidence_score": 1.0,
       "source": "tests_reportablecategory_test",
       "target": "shared_reportablecategory_isreportablecategory"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/environmentSuperProperty.test.ts",
+      "source_location": "L69",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tests_environmentsuperproperty_test",
+      "target": "tests_environmentsuperproperty_test_capturearg"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/adapters/observability/tests/environmentSuperProperty.test.ts",
+      "source_location": "L17",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tests_environmentsuperproperty_test",
+      "target": "tests_environmentsuperproperty_test_register_clientcapture_clientcaptureexception_servercapture_servercaptureexception_fakeposthog"
     },
     {
       "relation": "imports",
@@ -110476,6 +111030,36 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "scripts/export-prod-firestore.mjs",
+      "source_location": "L29",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "scripts_export_prod_firestore",
+      "target": "scripts_export_prod_firestore_commandexists"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/export-prod-firestore.mjs",
+      "source_location": "L25",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "scripts_export_prod_firestore",
+      "target": "scripts_export_prod_firestore_run"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/export-prod-firestore.mjs",
+      "source_location": "L65",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "scripts_export_prod_firestore",
+      "target": "scripts_export_prod_firestore_stamp"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "scripts/free-ports.mjs",
       "source_location": "L58",
       "weight": 1.0,
@@ -110562,6 +111146,46 @@
       "confidence_score": 1.0,
       "source": "users_daniel_projects_saltv2_scripts_grant_callable_invokers_sh",
       "target": "users_daniel_projects_saltv2_scripts_grant_callable_invokers_sh__entry"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/restore-staging-from-prod.mjs",
+      "source_location": "L49",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "scripts_restore_staging_from_prod",
+      "target": "scripts_restore_staging_from_prod_ask"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/restore-staging-from-prod.mjs",
+      "source_location": "L40",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "scripts_restore_staging_from_prod",
+      "target": "scripts_restore_staging_from_prod_commandexists"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/restore-staging-from-prod.mjs",
+      "source_location": "L72",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "scripts_restore_staging_from_prod",
+      "target": "scripts_restore_staging_from_prod_exportpath"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/restore-staging-from-prod.mjs",
+      "source_location": "L36",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "scripts_restore_staging_from_prod",
+      "target": "scripts_restore_staging_from_prod_run"
     },
     {
       "relation": "contains",
@@ -111092,6 +111716,16 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "tools/task-pilot-extension/extension.js",
+      "source_location": "L319",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "task_pilot_extension_extension_taskpilotprovider",
+      "target": "task_pilot_extension_extension_taskpilotprovider_getsuitetasks"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "tools/task-pilot-extension/extension.js",
       "source_location": "L199",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -111299,6 +111933,17 @@
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "task_pilot_extension_extension_taskpilotprovider_getchildren",
+      "target": "task_pilot_extension_extension_taskpilotprovider_getconfiguredlabels"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "tools/task-pilot-extension/extension.js",
+      "source_location": "L320",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "task_pilot_extension_extension_taskpilotprovider_getsuitetasks",
       "target": "task_pilot_extension_extension_taskpilotprovider_getconfiguredlabels"
     },
     {
@@ -111537,6 +112182,28 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "tools/task-pilot-extension/extension.js",
+      "source_location": "L350",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "task_pilot_extension_extension_taskpilotprovider_restartall",
+      "target": "task_pilot_extension_extension_taskpilotprovider_getsuitetasks"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "tools/task-pilot-extension/extension.js",
+      "source_location": "L328",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "task_pilot_extension_extension_taskpilotprovider_startall",
+      "target": "task_pilot_extension_extension_taskpilotprovider_getsuitetasks"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "tools/task-pilot-extension/extension.js",
       "source_location": "L369",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -111561,7 +112228,7 @@
       "source_location": "L10",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "users_daniel_projects_saltv2_tools_task_pilot_extension_package_json",
+      "source": "task_pilot_extension_package",
       "target": "task_pilot_extension_package_categories"
     },
     {
@@ -111571,7 +112238,7 @@
       "source_location": "L14",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "users_daniel_projects_saltv2_tools_task_pilot_extension_package_json",
+      "source": "task_pilot_extension_package",
       "target": "task_pilot_extension_package_contributes"
     },
     {
@@ -111581,7 +112248,7 @@
       "source_location": "L4",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "users_daniel_projects_saltv2_tools_task_pilot_extension_package_json",
+      "source": "task_pilot_extension_package",
       "target": "task_pilot_extension_package_description"
     },
     {
@@ -111591,7 +112258,7 @@
       "source_location": "L3",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "users_daniel_projects_saltv2_tools_task_pilot_extension_package_json",
+      "source": "task_pilot_extension_package",
       "target": "task_pilot_extension_package_displayname"
     },
     {
@@ -111601,7 +112268,7 @@
       "source_location": "L7",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "users_daniel_projects_saltv2_tools_task_pilot_extension_package_json",
+      "source": "task_pilot_extension_package",
       "target": "task_pilot_extension_package_engines"
     },
     {
@@ -111611,7 +112278,7 @@
       "source_location": "L13",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "users_daniel_projects_saltv2_tools_task_pilot_extension_package_json",
+      "source": "task_pilot_extension_package",
       "target": "task_pilot_extension_package_main"
     },
     {
@@ -111621,7 +112288,7 @@
       "source_location": "L2",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "users_daniel_projects_saltv2_tools_task_pilot_extension_package_json",
+      "source": "task_pilot_extension_package",
       "target": "task_pilot_extension_package_name"
     },
     {
@@ -111631,7 +112298,7 @@
       "source_location": "L6",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "users_daniel_projects_saltv2_tools_task_pilot_extension_package_json",
+      "source": "task_pilot_extension_package",
       "target": "task_pilot_extension_package_publisher"
     },
     {
@@ -111641,7 +112308,7 @@
       "source_location": "L5",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "users_daniel_projects_saltv2_tools_task_pilot_extension_package_json",
+      "source": "task_pilot_extension_package",
       "target": "task_pilot_extension_package_version"
     },
     {
@@ -113423,6 +114090,76 @@
       "confidence_score": 1.0,
       "source": "docs_canon_icons_rendering",
       "target": "docs_canon_icons_canonicon_props"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_data_refresh",
+      "target": "docs_data_refresh_refreshing_staging_with_prod_data"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L73",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_data_refresh_refreshing_staging_with_prod_data",
+      "target": "docs_data_refresh_after_a_restore_re_apply_staging_only_config"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L24",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_data_refresh_refreshing_staging_with_prod_data",
+      "target": "docs_data_refresh_one_time_setup"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L66",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_data_refresh_refreshing_staging_with_prod_data",
+      "target": "docs_data_refresh_safety"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L88",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_data_refresh_refreshing_staging_with_prod_data",
+      "target": "docs_data_refresh_scope"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L59",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_data_refresh_refreshing_staging_with_prod_data",
+      "target": "docs_data_refresh_usage"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/data-refresh.md",
+      "source_location": "L13",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "docs_data_refresh_refreshing_staging_with_prod_data",
+      "target": "docs_data_refresh_why_managed_export_import_and_not_a_copy_script"
     },
     {
       "relation": "contains",
@@ -116540,9 +117277,9 @@
       "source_file": "docs/error-reporting-calibration.md",
       "source_location": "L48",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "docs_error_reporting_calibration_caught_error_reporting_calibration_note",
-      "target": "docs_error_reporting_calibration_uncaught_errors_separate_automatic_path",
-      "confidence_score": 1.0
+      "target": "docs_error_reporting_calibration_uncaught_errors_separate_automatic_path"
     },
     {
       "relation": "contains",
@@ -119631,5 +120368,5 @@
       "source_file": ".claude/commands/spec.md"
     }
   ],
-  "built_at_commit": "585c82e89e2fbb11a94c1c45fb924101f1ef947b"
+  "built_at_commit": "e6bdb0fd61c8c17bec03b507e5a0bcaadd86bb44"
 }

--- a/packages/adapters/observability/src/index.ts
+++ b/packages/adapters/observability/src/index.ts
@@ -10,10 +10,11 @@ export {
   identifyObservabilityUser,
   identifyObservabilityAnonymous,
   trackObservabilityEvent,
+  sendSupportFeedback,
   startSpan,
   extractTraceHeaders,
 } from './init.js';
-export type { ObservabilityOptions, ObservabilitySpan } from './init.js';
+export type { ObservabilityOptions, ObservabilitySpan, SupportFeedbackTraits } from './init.js';
 export {
   createPosthogMatchLoggingAdapter as createObservabilityMatchLoggingAdapter,
   createPosthogMatchLoggingAdapter,

--- a/packages/adapters/observability/src/init.ts
+++ b/packages/adapters/observability/src/init.ts
@@ -17,6 +17,11 @@ export interface ObservabilityOptions {
   // SDK emits — autocapture, pageviews, manual captures, exceptions, and replay
   // metadata — without each call site having to attach it.
   environment?: string;
+  // App version stamp (the release tag / __APP_VERSION__). Like `environment`, it
+  // is registered as a super property so EVERY event carries the version the user
+  // was running — invaluable for "which release introduced this exception?" and
+  // for triaging feedback against a specific build.
+  version?: string;
 }
 
 // True once initObservability has successfully called posthog.init. Adapter
@@ -82,14 +87,16 @@ export function initObservability(key: string, opts?: ObservabilityOptions): voi
     ready = false;
   }
 
-  // Register the environment as a super property so it persists in the SDK and
-  // is attached to every subsequent event. Guarded via safePosthog so a register
+  // Register environment + app version as super properties so they persist in the
+  // SDK and ride on every subsequent event. Guarded via safePosthog so a register
   // failure can never unset readiness or throw at startup, and so it no-ops when
-  // init above failed (ready === false). Captured into a const so the value stays
-  // narrowed to string inside the closure.
-  const environment = opts?.environment;
-  if (environment) {
-    safePosthog((ph) => ph.register({ environment }));
+  // init above failed (ready === false). Built into a local bag so both register
+  // in a single call and so absent values are simply omitted.
+  const superProperties: Record<string, string> = {};
+  if (opts?.environment) superProperties.environment = opts.environment;
+  if (opts?.version) superProperties.app_version = opts.version;
+  if (Object.keys(superProperties).length > 0) {
+    safePosthog((ph) => ph.register(superProperties));
   }
 }
 
@@ -112,6 +119,53 @@ export function identifyObservabilityAnonymous(): void {
 
 export function trackObservabilityEvent(key: string, data?: Record<string, unknown>): void {
   safePosthog((ph) => ph.capture(key, data));
+}
+
+// ── Support feedback (PostHog Conversations) ─────────────────────────────────
+// posthog-js exposes `posthog.conversations` once the Support product is enabled
+// for the project (conversations_enabled) AND the conversations module has lazily
+// loaded from remote config. sendMessage opens a support ticket that lands in the
+// PostHog inbox with the session replay + exceptions attached. The web-pwa
+// settings-page feedback box uses this in place of the floating chat widget.
+
+// Public traits shape for the adapter API — intentionally NOT posthog-js's
+// UserProvidedTraits, so the SDK type never leaks across the package boundary.
+export interface SupportFeedbackTraits {
+  name?: string;
+  email?: string;
+}
+
+// posthog-js types `conversations` as a tree-shakeable handle; narrow it to the
+// methods we use at this single SDK seam rather than depend on that wrapper type.
+interface ConversationsApi {
+  isAvailable(): boolean;
+  sendMessage(
+    message: string,
+    userTraits?: SupportFeedbackTraits,
+    newTicket?: boolean,
+  ): Promise<unknown>;
+}
+
+// Sends a one-off feedback message as a NEW support ticket. Resolves true on a
+// confirmed send; false when observability is inert, the conversations module is
+// unavailable (not yet loaded, Support disabled, or blocked by CSP), or the send
+// fails. Best-effort and never throws across the boundary (CLAUDE.md Rule 10) —
+// the caller renders success/error from the boolean.
+export async function sendSupportFeedback(
+  message: string,
+  traits?: SupportFeedbackTraits,
+): Promise<boolean> {
+  if (!ready) return false;
+  const conversations = posthog.conversations as unknown as ConversationsApi | undefined;
+  if (!conversations?.isAvailable()) return false;
+  try {
+    // newTicket=true so each submission is its own ticket instead of appending
+    // to a stale thread.
+    const response = await conversations.sendMessage(message, traits, true);
+    return Boolean(response);
+  } catch {
+    return false;
+  }
 }
 
 // ── Span/trace compatibility shims ──────────────────────────────────────────

--- a/tools/task-pilot-extension/extension.js
+++ b/tools/task-pilot-extension/extension.js
@@ -308,23 +308,38 @@ class TaskPilotProvider {
     await this.startTask(label);
   }
 
-  async startAll() {
+  // The configured labels that Start All / Restart All act on: the long-running
+  // background dev services (Firebase Emulators, Vite Dev Server, Genkit Admin
+  // UI). One-shot ops tasks like "Export Prod Firestore" / "Restore Staging from
+  // Prod" are intentionally EXCLUDED — they're `isBackground: false`, run to
+  // completion, and the staging restore is destructive, so they must never be
+  // swept into a bulk start/restart. They stay individually runnable from the
+  // sidebar rows. Filtering on `isBackground` keeps this self-maintaining: any
+  // future one-shot task added to the sidebar is automatically excluded.
+  async getSuiteTasks() {
     const labels = this.getConfiguredLabels();
     const allTasks = await vscode.tasks.fetchTasks();
+    return labels
+      .map((label) => ({
+        label,
+        task: allTasks.find((candidate) => getTaskLabel(candidate) === label),
+      }))
+      .filter(({ task }) => task && task.isBackground);
+  }
+
+  async startAll() {
+    const suite = await this.getSuiteTasks();
     const running = new Set(
       vscode.tasks.taskExecutions.map((execution) => getTaskLabel(execution.task)),
     );
 
     let started = 0;
-    for (const label of labels) {
+    for (const { label, task } of suite) {
       if (running.has(label)) {
         continue;
       }
-      const task = allTasks.find((candidate) => getTaskLabel(candidate) === label);
-      if (task) {
-        await vscode.tasks.executeTask(task);
-        started += 1;
-      }
+      await vscode.tasks.executeTask(task);
+      started += 1;
     }
 
     vscode.window.showInformationMessage(
@@ -335,8 +350,8 @@ class TaskPilotProvider {
   }
 
   async restartAll() {
-    const labels = this.getConfiguredLabels();
-    await Promise.all(labels.map((label) => this.restartTask(label)));
+    const suite = await this.getSuiteTasks();
+    await Promise.all(suite.map(({ label }) => this.restartTask(label)));
     vscode.window.showInformationMessage('Task Pilot: restarted the suite.');
   }
 

--- a/tools/task-pilot-extension/package.json
+++ b/tools/task-pilot-extension/package.json
@@ -141,7 +141,7 @@
       "properties": {
         "taskPilot.labels": {
           "type": "array",
-          "description": "Task labels to show, in order. Defaults to Firebase, Vite, and Genkit tasks.",
+          "description": "Task labels to show in the sidebar, in order. Defaults to Firebase, Vite, and Genkit tasks. Start All / Restart All act only on the long-running background services here; one-shot tasks (e.g. prod export, staging restore) stay listed and individually runnable but are excluded from bulk start/restart.",
           "items": {
             "type": "string"
           },


### PR DESCRIPTION
Bundled per request — three unrelated changes on one PR (not best practice, intentional). Four commits, each reviewable in isolation.

## `fix(cf)`: 512MiB memory floor for every function
Everything OOM'd at the 256MiB default. The resting footprint (firebase-admin + Genkit/OTel + posthog-node, all loaded at module init) sits just under 256, so functions die on their first real context read — chefChat at "263 MiB used", and `generateChatTitle` / `identifyEquipment` were still silently at 256.

- `memory: '512MiB'` added to `setGlobalOptions` → covers the 13 callables defined inline in `index.ts` (incl. the next-candidate `matchOrCreateCanon`).
- The 4 top-imported modules (`onShoppingListItemWrite`, `onCanonItemWritten`, `regenerateCanonIcon`, `beforeMemberCreated`) keep **inline** pins — their modules evaluate before `setGlobalOptions` runs and firebase-functions bakes options in eagerly, so the global never reaches them (same reason `region` is already pinned inline there).
- `onCanonItemWritten` keeps its `1GiB` upward override; the now-redundant inline 512 pins on the inline callables are removed.

**Deploy impact:** every function gets a new revision on the next prod deploy.

## `feat(observability)`: app_version super property + settings feedback box
Follow-up to #351. Derives a release version (GitHub Release tag via `APP_VERSION` in CI, else `git describe --tags --always`) and registers it as the `app_version` super property on every event; renames the build stamp `__APP_COMMIT__` → `__APP_VERSION__`. Adds a Settings feedback box wired to PostHog Support (session replay + exceptions attached; non-prod tickets self-label with env + version).

## `chore(task-pilot)`: scope Start All / Restart All to background services
Bulk start/restart now filters to `isBackground` tasks, so one-shot ops tasks (prod export, destructive staging restore) are never swept into a bulk action — they stay individually runnable.

## `chore(graphify)`: refresh code graph
AST-only regen reflecting the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
